### PR TITLE
Set up Alembic database migrations with initial schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: pip install -e .[dev]
 
       - name: Run migrations
-        run: cd engine && alembic upgrade head
+        run: alembic upgrade head
         env:
           NEXUS_DATABASE_URL: postgresql+asyncpg://nexus:test_password@localhost:5432/nexus_test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Install dependencies
         run: pip install -e .[dev]
 
+      - name: Run migrations
+        run: cd engine && alembic upgrade head
+        env:
+          NEXUS_DATABASE_URL: postgresql+asyncpg://nexus:test_password@localhost:5432/nexus_test
+
       - name: Run tests
         env:
           NEXUS_DATABASE_URL: postgresql+asyncpg://nexus:test_password@localhost:5432/nexus_test

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,5 +1,5 @@
 [alembic]
-script_location = alembic
+script_location = engine/db/migrations
 sqlalchemy.url = driver://user:pass@localhost/dbname
 
 [loggers]

--- a/engine/db/migrations/env.py
+++ b/engine/db/migrations/env.py
@@ -5,18 +5,15 @@ Alembic migrations environment.
 import asyncio
 from logging.config import fileConfig
 
-from config import get_settings
-from db.models import *  # noqa: Import all models so Alembic sees them
-from db.session import Base
+from db.models import Base
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
+from engine.config import settings as app_settings
 
 config = context.config
-settings = get_settings()
-
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", app_settings.database_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/engine/db/migrations/env.py
+++ b/engine/db/migrations/env.py
@@ -5,12 +5,12 @@ Alembic migrations environment.
 import asyncio
 from logging.config import fileConfig
 
-from db.models import Base
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 from engine.config import settings as app_settings
+from engine.db.models import Base
 
 config = context.config
 config.set_main_option("sqlalchemy.url", app_settings.database_url)

--- a/engine/db/migrations/versions/001_initial_schema.py
+++ b/engine/db/migrations/versions/001_initial_schema.py
@@ -21,7 +21,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.create_table(
         "users",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("email", sa.String(length=255), nullable=False),
         sa.Column("hashed_password", sa.String(length=255), nullable=False),
         sa.Column("display_name", sa.String(length=100), nullable=False),
@@ -34,8 +34,8 @@ def upgrade() -> None:
 
     op.create_table(
         "portfolios",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
-        sa.Column("user_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("name", sa.String(length=200), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("initial_capital", sa.Numeric(precision=18, scale=4), nullable=True),
@@ -47,8 +47,8 @@ def upgrade() -> None:
 
     op.create_table(
         "positions",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
-        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("portfolio_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("symbol", sa.String(length=20), nullable=False),
         sa.Column("quantity", sa.Numeric(precision=18, scale=8), nullable=True),
         sa.Column("avg_entry_price", sa.Numeric(precision=18, scale=8), nullable=True),
@@ -63,8 +63,8 @@ def upgrade() -> None:
 
     op.create_table(
         "orders",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
-        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("portfolio_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("symbol", sa.String(length=20), nullable=False),
         sa.Column("side", sa.String(length=10), nullable=False),
         sa.Column("order_type", sa.String(length=20), nullable=False),
@@ -81,8 +81,8 @@ def upgrade() -> None:
 
     op.create_table(
         "installed_strategies",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
-        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("portfolio_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("strategy_name", sa.String(length=100), nullable=False),
         sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("is_active", sa.Boolean(), nullable=True),
@@ -99,8 +99,8 @@ def upgrade() -> None:
 
     op.create_table(
         "backtest_results",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
-        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("portfolio_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("strategy_name", sa.String(length=100), nullable=False),
         sa.Column("start_date", sa.DateTime(timezone=True), nullable=False),
         sa.Column("end_date", sa.DateTime(timezone=True), nullable=False),
@@ -118,7 +118,6 @@ def upgrade() -> None:
 
     op.create_table(
         "ohlcv_bars",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
         sa.Column("symbol", sa.String(length=20), nullable=False),
         sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
         sa.Column("open", sa.Numeric(precision=18, scale=8), nullable=False),
@@ -126,7 +125,7 @@ def upgrade() -> None:
         sa.Column("low", sa.Numeric(precision=18, scale=8), nullable=False),
         sa.Column("close", sa.Numeric(precision=18, scale=8), nullable=False),
         sa.Column("volume", sa.Numeric(precision=24, scale=4), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("symbol", "timestamp"),
         sa.UniqueConstraint("symbol", "timestamp", name="uq_ohlcv_symbol_timestamp"),
     )
     op.create_index(

--- a/engine/db/migrations/versions/001_initial_schema.py
+++ b/engine/db/migrations/versions/001_initial_schema.py
@@ -1,0 +1,146 @@
+"""initial schema
+
+Revision ID: 001_initial_schema
+Revises:
+Create Date: 2026-04-16
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "001_initial_schema"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("hashed_password", sa.String(length=255), nullable=False),
+        sa.Column("display_name", sa.String(length=100), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_users_email"), "users", ["email"], unique=True)
+
+    op.create_table(
+        "portfolios",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("user_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("initial_capital", sa.Numeric(precision=18, scale=4), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_portfolios_user_id"), "portfolios", ["user_id"], unique=False)
+
+    op.create_table(
+        "positions",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("quantity", sa.Numeric(precision=18, scale=8), nullable=True),
+        sa.Column("avg_entry_price", sa.Numeric(precision=18, scale=8), nullable=True),
+        sa.Column("current_price", sa.Numeric(precision=18, scale=8), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("portfolio_id", "symbol", name="uq_position_portfolio_symbol"),
+    )
+    op.create_index(op.f("ix_positions_portfolio_id"), "positions", ["portfolio_id"], unique=False)
+    op.create_index(op.f("ix_positions_symbol"), "positions", ["symbol"], unique=False)
+
+    op.create_table(
+        "orders",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("side", sa.String(length=10), nullable=False),
+        sa.Column("order_type", sa.String(length=20), nullable=False),
+        sa.Column("quantity", sa.Numeric(precision=18, scale=8), nullable=False),
+        sa.Column("price", sa.Numeric(precision=18, scale=8), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=True),
+        sa.Column("filled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_orders_portfolio_id"), "orders", ["portfolio_id"], unique=False)
+    op.create_index(op.f("ix_orders_symbol"), "orders", ["symbol"], unique=False)
+
+    op.create_table(
+        "installed_strategies",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("strategy_name", sa.String(length=100), nullable=False),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=True),
+        sa.Column("installed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_installed_strategies_portfolio_id"),
+        "installed_strategies",
+        ["portfolio_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "backtest_results",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("strategy_name", sa.String(length=100), nullable=False),
+        sa.Column("start_date", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("end_date", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metrics", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_backtest_results_portfolio_id"),
+        "backtest_results",
+        ["portfolio_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "ohlcv_bars",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("open", sa.Numeric(precision=18, scale=8), nullable=False),
+        sa.Column("high", sa.Numeric(precision=18, scale=8), nullable=False),
+        sa.Column("low", sa.Numeric(precision=18, scale=8), nullable=False),
+        sa.Column("close", sa.Numeric(precision=18, scale=8), nullable=False),
+        sa.Column("volume", sa.Numeric(precision=24, scale=4), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("symbol", "timestamp", name="uq_ohlcv_symbol_timestamp"),
+    )
+    op.create_index(
+        "ix_ohlcv_symbol_timestamp", "ohlcv_bars", ["symbol", "timestamp"], unique=False
+    )
+
+    op.execute("SELECT create_hypertable('ohlcv_bars', 'timestamp', if_not_exists => TRUE)")
+
+
+def downgrade() -> None:
+    op.drop_table("ohlcv_bars")
+    op.drop_table("backtest_results")
+    op.drop_table("installed_strategies")
+    op.drop_table("orders")
+    op.drop_table("positions")
+    op.drop_table("portfolios")
+    op.drop_table("users")

--- a/engine/db/migrations/versions/002_additional_tables.py
+++ b/engine/db/migrations/versions/002_additional_tables.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
     op.create_table(
         "portfolio_snapshots",
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
-        sa.Column("portfolio_id", sa.Integer(), nullable=False),
+        sa.Column("portfolio_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column(
             "timestamp",
             sa.DateTime(timezone=True),
@@ -34,7 +34,8 @@ def upgrade() -> None:
         sa.Column("unrealized_pnl", sa.Float(), nullable=True, server_default="0"),
         sa.Column("realized_pnl", sa.Float(), nullable=True, server_default="0"),
         sa.Column("num_positions", sa.Integer(), nullable=True, server_default="0"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id", "timestamp"),
     )
     op.create_index(
         "ix_portfolio_snapshots_pid",
@@ -56,12 +57,13 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
         ),
         sa.Column("strategy_id", sa.String(length=100), nullable=False),
-        sa.Column("portfolio_id", sa.Integer(), nullable=False),
+        sa.Column("portfolio_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("signals_emitted", sa.Integer(), nullable=True, server_default="0"),
         sa.Column("evaluation_ms", sa.Float(), nullable=True, server_default="0"),
         sa.Column("market_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("signals", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id", "timestamp"),
     )
     op.create_index(
         "ix_eval_log_strategy",
@@ -73,8 +75,8 @@ def upgrade() -> None:
 
     op.create_table(
         "tax_lots",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
-        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("portfolio_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("symbol", sa.String(length=20), nullable=False),
         sa.Column("quantity", sa.Numeric(precision=18, scale=8), nullable=False),
         sa.Column("cost_basis", sa.Numeric(precision=18, scale=4), nullable=False),
@@ -90,7 +92,7 @@ def upgrade() -> None:
 
     op.create_table(
         "marketplace_entries",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("strategy_name", sa.String(length=100), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("price", sa.Numeric(precision=18, scale=4), nullable=True),
@@ -101,9 +103,9 @@ def upgrade() -> None:
 
     op.create_table(
         "marketplace_reviews",
-        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
-        sa.Column("entry_id", postgresql.UUID(asnative="native"), nullable=False),
-        sa.Column("user_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("entry_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.UUID(as_uuid=True), nullable=False),
         sa.Column("rating", sa.Integer(), nullable=False),
         sa.Column("comment", sa.Text(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
@@ -112,7 +114,10 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
-        op.f("ix_marketplace_reviews_entry_id"), "marketplace_reviews", ["entry_id"], unique=False
+        op.f("ix_marketplace_reviews_entry_id"),
+        "marketplace_reviews",
+        ["entry_id"],
+        unique=False,
     )
 
 

--- a/engine/db/migrations/versions/002_additional_tables.py
+++ b/engine/db/migrations/versions/002_additional_tables.py
@@ -1,0 +1,124 @@
+"""additional_tables
+
+Revision ID: 002_additional_tables
+Revises: 001_initial_schema
+Create Date: 2026-04-16
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "002_additional_tables"
+down_revision: str | Sequence[str] | None = "001_initial_schema"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portfolio_snapshots",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("portfolio_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("total_value", sa.Float(), nullable=False),
+        sa.Column("cash", sa.Float(), nullable=False),
+        sa.Column("unrealized_pnl", sa.Float(), nullable=True, server_default="0"),
+        sa.Column("realized_pnl", sa.Float(), nullable=True, server_default="0"),
+        sa.Column("num_positions", sa.Integer(), nullable=True, server_default="0"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_portfolio_snapshots_pid",
+        "portfolio_snapshots",
+        ["portfolio_id", sa.text("timestamp DESC")],
+        unique=False,
+    )
+    op.execute(
+        "SELECT create_hypertable('portfolio_snapshots', 'timestamp', if_not_exists => TRUE)"
+    )
+
+    op.create_table(
+        "evaluation_log",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("strategy_id", sa.String(length=100), nullable=False),
+        sa.Column("portfolio_id", sa.Integer(), nullable=False),
+        sa.Column("signals_emitted", sa.Integer(), nullable=True, server_default="0"),
+        sa.Column("evaluation_ms", sa.Float(), nullable=True, server_default="0"),
+        sa.Column("market_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("signals", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_eval_log_strategy",
+        "evaluation_log",
+        ["strategy_id", sa.text("timestamp DESC")],
+        unique=False,
+    )
+    op.execute("SELECT create_hypertable('evaluation_log', 'timestamp', if_not_exists => TRUE)")
+
+    op.create_table(
+        "tax_lots",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("portfolio_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("quantity", sa.Numeric(precision=18, scale=8), nullable=False),
+        sa.Column("cost_basis", sa.Numeric(precision=18, scale=4), nullable=False),
+        sa.Column("acquired_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sold_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("realized_pnl", sa.Numeric(precision=18, scale=4), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_tax_lots_portfolio_id"), "tax_lots", ["portfolio_id"], unique=False)
+    op.create_index(op.f("ix_tax_lots_symbol"), "tax_lots", ["symbol"], unique=False)
+
+    op.create_table(
+        "marketplace_entries",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("strategy_name", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("price", sa.Numeric(precision=18, scale=4), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "marketplace_reviews",
+        sa.Column("id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("entry_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("user_id", postgresql.UUID(asnative="native"), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=False),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["entry_id"], ["marketplace_entries.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_marketplace_reviews_entry_id"), "marketplace_reviews", ["entry_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("marketplace_reviews")
+    op.drop_table("marketplace_entries")
+    op.drop_table("tax_lots")
+    op.drop_table("evaluation_log")
+    op.drop_table("portfolio_snapshots")

--- a/engine/db/session.py
+++ b/engine/db/session.py
@@ -40,3 +40,20 @@ async def dispose_engine() -> None:
         await _engine.dispose()
         _engine = None
         _session_factory = None
+
+
+async def init_db() -> None:
+    """Initialize database schema.
+
+    Note: Use Alembic migrations instead of create_all() for schema management.
+    Run migrations with: alembic upgrade head
+
+    This function is kept for backwards compatibility but now delegates to Alembic.
+    For new deployments, run migrations manually or via CI/CD.
+    """
+    from alembic.config import Config  # noqa: PLC0415
+
+    from alembic import command  # noqa: PLC0415
+
+    alembic_cfg = Config("alembic.ini")
+    command.upgrade(alembic_cfg, "head")

--- a/engine/db/session.py
+++ b/engine/db/session.py
@@ -43,17 +43,20 @@ async def dispose_engine() -> None:
 
 
 async def init_db() -> None:
-    """Initialize database schema.
+    """Run pending Alembic migrations.
 
-    Note: Use Alembic migrations instead of create_all() for schema management.
-    Run migrations with: alembic upgrade head
-
-    This function is kept for backwards compatibility but now delegates to Alembic.
-    For new deployments, run migrations manually or via CI/CD.
+    Delegates the synchronous ``alembic upgrade head`` to a thread so the
+    async event loop is not blocked.  Prefer running migrations as a
+    separate CLI / CI step (``alembic upgrade head`` or ``make migrate``).
     """
+    import asyncio  # noqa: PLC0415
+
     from alembic.config import Config  # noqa: PLC0415
 
     from alembic import command  # noqa: PLC0415
 
-    alembic_cfg = Config("alembic.ini")
-    command.upgrade(alembic_cfg, "head")
+    def _run() -> None:
+        alembic_cfg = Config("alembic.ini")
+        command.upgrade(alembic_cfg, "head")
+
+    await asyncio.get_event_loop().run_in_executor(None, _run)


### PR DESCRIPTION
## Summary
- Adds initial Alembic migration from SQLAlchemy models (users, portfolios, positions, orders, installed_strategies, backtest_results, ohlcv_bars)
- Adds TimescaleDB hypertable creation for ohlcv_bars
- Adds second migration for additional tables (portfolio_snapshots, evaluation_log, tax_lots, marketplace_entries, marketplace_reviews)
- Updates session.py to document migration usage and adds init_db() function
- Adds migration step to CI workflow

## Changes
- New: `engine/db/migrations/versions/001_initial_schema.py`
- New: `engine/db/migrations/versions/002_additional_tables.py`
- Edit: `engine/db/migrations/env.py` — fix import path
- Edit: `engine/db/session.py` — document migration usage
- Edit: `.github/workflows/ci.yml` — add migration step

## Acceptance Criteria
- [x] alembic upgrade head creates all tables from clean DB
- [x] TimescaleDB hypertables created correctly  
- [x] CI runs migrations before tests
- [x] New model changes can be captured with alembic revision --autogenerate