### PR TITLE
ci: run on self-hosted nexus runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-engine:
     name: Engine Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nexus]
 
     services:
       postgres:
@@ -67,7 +67,7 @@ jobs:
 
   test-frontend:
     name: Frontend Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nexus]
 
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
 
   docker:
     name: Docker Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nexus]
     needs: [test-engine]
 
     steps:


### PR DESCRIPTION
## Summary
- Switches all three CI jobs (engine tests, frontend lint, docker build) from `ubuntu-latest` to `[self-hosted, nexus]`
- Targets the new `nexus-1` / `nexus-2` runners registered against this repo today

## Why
- Cuts cold-start (no GH-hosted runner provisioning)
- Removes GH Actions minute burn for this project
- The runners sit on the same host used for deployment — already has docker, python, node

## Test plan
- [ ] CI triggers on this PR
- [ ] Engine Tests job picks up postgres + valkey service containers (docker reachable as root)
- [ ] Frontend Lint installs node via setup-node
- [ ] Docker Build builds both images
- [ ] All three turn green

If any job fails, roll back this PR and investigate runner toolchain gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)