### PR TITLE
fix: apply all review fixes for SEV-291 tax lot tracking

### DIFF
--- a/engine/core/cost_model.py
+++ b/engine/core/cost_model.py
@@ -153,6 +153,7 @@ class ICostModel(ABC):
         quantity: int,
         lots: list[TaxLot],
         method: TaxMethod = TaxMethod.FIFO,
+        sell_date: datetime | None = None,
     ) -> Money:
         """Estimate capital gains tax for selling from given lots."""
         ...

--- a/engine/core/portfolio.py
+++ b/engine/core/portfolio.py
@@ -50,6 +50,7 @@ class SellRecord:
     sell_price: float
     cost_basis: float
     gain: float
+    remaining_disallowed: float = 0.0
 
 
 @dataclass
@@ -116,12 +117,15 @@ class Portfolio:
                 continue
             if sell.gain >= 0:
                 continue
+            if sell.remaining_disallowed <= 0:
+                continue
             window_start = purchase_date - timedelta(days=self._cost_model.wash_sale_window_days)
             if window_start <= sell.sell_date <= purchase_date:
-                disallowed = abs(sell.gain)
-                per_share = disallowed / sell.quantity
-                applicable = min(quantity, sell.quantity) * per_share
+                original_per_share = abs(sell.gain) / sell.quantity
+                applicable = min(quantity, sell.quantity) * original_per_share
+                applicable = min(applicable, sell.remaining_disallowed)
                 total_adjustment += applicable
+                sell.remaining_disallowed -= applicable
 
         if total_adjustment > 0:
             adjusted_price = price + (total_adjustment / quantity)
@@ -235,9 +239,17 @@ class Portfolio:
         sell_proceeds = quantity * price
         self._cash += sell_proceeds - cost - tax
 
-        gain = sell_proceeds - total_cost_basis - cost - tax
+        gain = sell_proceeds - total_cost_basis - cost
         self.realized_pnl += gain
 
+        buy_then_sell_consumed = 0.0
+        if gain < 0:
+            buy_then_sell_consumed = self._apply_buy_then_sell_wash_sale(
+                symbol, sell_date, gain, quantity
+            )
+            self.realized_pnl += buy_then_sell_consumed
+
+        disallowed_amount = abs(gain) - buy_then_sell_consumed
         self._sell_history.append(
             SellRecord(
                 symbol=symbol,
@@ -246,6 +258,7 @@ class Portfolio:
                 sell_price=price,
                 cost_basis=total_cost_basis,
                 gain=gain,
+                remaining_disallowed=max(0.0, disallowed_amount),
             )
         )
 
@@ -263,6 +276,31 @@ class Portfolio:
         )
 
         return consumed_lots
+
+    def _apply_buy_then_sell_wash_sale(
+        self, symbol: str, sell_date: datetime, loss: float, sell_qty: int
+    ) -> float:
+        """IRS Pub 550: if a loss sale occurs within 30 days after buying the same
+        symbol, the loss is disallowed and added to the purchased lot's cost basis.
+        Returns the total disallowed amount consumed across all lots."""
+        remaining_loss = abs(loss)
+        total_consumed = 0.0
+        window_start = sell_date - timedelta(days=self._cost_model.wash_sale_window_days)
+        lots = self._tax_lots.get(symbol, [])
+        for lot in lots:
+            if remaining_loss <= 0:
+                break
+            if lot.quantity <= 0:
+                continue
+            if not (window_start <= lot.purchase_date <= sell_date):
+                continue
+            original_per_share = abs(loss) / sell_qty
+            applicable = lot.quantity * original_per_share
+            applicable = min(applicable, remaining_loss)
+            lot.purchase_price += applicable / lot.quantity
+            total_consumed += applicable
+            remaining_loss -= applicable
+        return total_consumed
 
     def update_prices(self, prices: dict[str, float]) -> None:
         """Update current market prices for positions (for P&L calculation)."""

--- a/engine/db/migrations/versions/003_tax_lots.py
+++ b/engine/db/migrations/versions/003_tax_lots.py
@@ -1,8 +1,8 @@
 """add tax_lot_records table
 
-Revision ID: 001_tax_lots
-Revises:
-Create Date: 2026-04-16 13:30:00.000000
+Revision ID: 003_tax_lots
+Revises: 002_additional_tables
+Create Date: 2026-04-17 03:30:00.000000
 """
 
 from typing import Sequence, Union
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "001_tax_lots"
-down_revision: Union[str, None] = None
+revision: str = "003_tax_lots"
+down_revision: Union[str, None] = "002_additional_tables"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -63,14 +63,16 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
+        if_not_exists=True,
     )
     op.create_index(
         "ix_tax_lot_portfolio_symbol",
         "tax_lot_records",
         ["portfolio_id", "symbol"],
+        if_not_exists=True,
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_tax_lot_portfolio_symbol", table_name="tax_lot_records")
-    op.drop_table("tax_lot_records")
+    op.drop_index("ix_tax_lot_portfolio_symbol", table_name="tax_lot_records", if_exists=True)
+    op.drop_table("tax_lot_records", if_exists=True)

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -106,8 +106,8 @@ class BacktestResult(Base):
     __tablename__ = "backtest_results"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    portfolio_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("portfolios.id", ondelete="CASCADE"), index=True
+    portfolio_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("portfolios.id", ondelete="CASCADE"), index=True, nullable=True
     )
     strategy_name: Mapped[str] = mapped_column(String(100))
     start_date: Mapped[datetime]

--- a/tests/test_tax_lots.py
+++ b/tests/test_tax_lots.py
@@ -101,7 +101,7 @@ class TestHoldingPeriod:
                 purchase_date=now - timedelta(days=400),
             )
         ]
-        tax = cost_model.estimate_tax("AAPL", 150.0, 100, lots, TaxMethod.FIFO)
+        tax = cost_model.estimate_tax("AAPL", 150.0, 100, lots, TaxMethod.FIFO, sell_date=now)
         expected = (150.0 - 100.0) * 100 * 0.20
         assert abs(tax.amount - expected) < 1e-6
 
@@ -207,25 +207,19 @@ class TestPortfolioWashSale:
     def test_portfolio_wash_sale_adjusts_replacement_lot_cost_basis(self):
         p = Portfolio(initial_cash=200_000)
 
-        # Day 0: Buy 100 shares at $150
         p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
         p.open_position("AAPL", 100, 150.0)
 
-        # Day 60: Sell 100 shares at $140 → $1000 loss
         p.transaction_date = datetime(2026, 3, 1, tzinfo=UTC)
         p.close_position("AAPL", 100, 140.0, cost=0.0)
         assert p.realized_pnl < 0
 
-        # Day 65 (5 days later, within 30-day window): Buy 100 shares at $145
         p.transaction_date = datetime(2026, 3, 6, tzinfo=UTC)
         p.open_position("AAPL", 100, 145.0)
 
-        # The replacement lot should have its cost basis adjusted upward
-        # by the disallowed loss ($1000 / 100 shares = $10/share)
         lots = p.get_tax_lots("AAPL")
         assert len(lots) == 1
-        assert lots[0].purchase_price > 145.0
-        expected_adjusted_price = 145.0 + (abs(p._sell_history[-1].gain) / 100)
+        expected_adjusted_price = 145.0 + 10.0
         assert abs(lots[0].purchase_price - expected_adjusted_price) < 1e-6
 
     def test_portfolio_no_wash_sale_outside_window(self):
@@ -237,13 +231,105 @@ class TestPortfolioWashSale:
         p.transaction_date = datetime(2026, 3, 1, tzinfo=UTC)
         p.close_position("AAPL", 100, 140.0)
 
-        # 60 days later — outside wash sale window
         p.transaction_date = datetime(2026, 5, 1, tzinfo=UTC)
         p.open_position("AAPL", 100, 145.0)
 
         lots = p.get_tax_lots("AAPL")
         assert len(lots) == 1
         assert lots[0].purchase_price == 145.0
+
+    def test_sell_then_buy_two_partial_buys_equal_per_share(self):
+        """sell 100 @ -$1000 loss, buy 50 (day 5), buy 50 (day 10).
+        Both buys should get $10/share adjustment. Total = $1000."""
+        p = Portfolio(initial_cash=500_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 150.0)
+
+        p.transaction_date = datetime(2026, 3, 1, tzinfo=UTC)
+        p.close_position("AAPL", 100, 140.0)
+        assert abs(p.realized_pnl - (-1000.0)) < 1e-6
+
+        p.transaction_date = datetime(2026, 3, 6, tzinfo=UTC)
+        p.open_position("AAPL", 50, 145.0)
+
+        p.transaction_date = datetime(2026, 3, 11, tzinfo=UTC)
+        p.open_position("AAPL", 50, 145.0)
+
+        lots = p.get_tax_lots("AAPL")
+        assert len(lots) == 2
+        assert abs(lots[0].purchase_price - 155.0) < 1e-6
+        assert abs(lots[1].purchase_price - 155.0) < 1e-6
+
+        total_adj = sum((lot.purchase_price - 145.0) * lot.quantity for lot in lots)
+        assert abs(total_adj - 1000.0) < 1e-6
+
+    def test_buy_then_sell_wash_sale_adjusts_existing_lot(self):
+        """Buy first, then sell at loss within 30 days.
+        The existing lot's cost basis should be adjusted upward."""
+        p = Portfolio(initial_cash=500_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 150.0)
+
+        p.transaction_date = datetime(2026, 1, 11, tzinfo=UTC)
+        p.open_position("AAPL", 100, 140.0)
+
+        p.transaction_date = datetime(2026, 1, 21, tzinfo=UTC)
+        p.close_position("AAPL", 100, 130.0)
+
+        lots = p.get_tax_lots("AAPL")
+        assert len(lots) == 1
+        expected_adjustment_per_share = 10.0
+        expected_price = 150.0 + expected_adjustment_per_share
+        assert abs(lots[0].purchase_price - expected_price) < 1e-6
+
+    def test_buy_then_sell_reverses_realized_pnl(self):
+        """Buy-then-sell wash sale should reverse the disallowed loss from realized_pnl."""
+        p = Portfolio(initial_cash=500_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 150.0)
+
+        p.transaction_date = datetime(2026, 1, 11, tzinfo=UTC)
+        p.open_position("AAPL", 100, 140.0)
+
+        p.transaction_date = datetime(2026, 1, 21, tzinfo=UTC)
+        p.close_position("AAPL", 100, 130.0)
+
+        raw_gain = 100 * 130.0 - 100 * 150.0
+        assert raw_gain == -2000.0
+        assert p.realized_pnl > raw_gain
+
+    def test_gain_does_not_subtract_tax(self):
+        """gain = proceeds - cost_basis - fees. Tax NOT subtracted from gain."""
+        p = Portfolio(initial_cash=100_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 100.0)
+
+        p.transaction_date = datetime(2026, 2, 1, tzinfo=UTC)
+        p.close_position("AAPL", 100, 120.0, cost=10.0, tax=500.0)
+
+        sell_proceeds = 100 * 120.0
+        cost_basis = 100 * 100.0
+        fees = 10.0
+        expected_gain = sell_proceeds - cost_basis - fees
+        assert abs(p.realized_pnl - expected_gain) < 1e-6
+
+    def test_tax_deducted_from_cash_on_sell(self):
+        p = Portfolio(initial_cash=100_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 100.0)
+
+        cash_before = p.cash
+        p.transaction_date = datetime(2026, 2, 1, tzinfo=UTC)
+        p.close_position("AAPL", 100, 120.0, cost=10.0, tax=500.0)
+
+        sell_proceeds = 100 * 120.0
+        expected_cash = cash_before + sell_proceeds - 10.0 - 500.0
+        assert abs(p.cash - expected_cash) < 1e-6
 
 
 class TestCrossLotConsumption:


### PR DESCRIPTION
## Summary

Applies all review fixes from rounds 1-4 on [SEV-291](mention://issue/5815e65a-804b-418a-a991-b3c1afc0bf52) on top of current `main` (preserves changes from PR #191 and #192).

PR #188 was merged before these fixes landed. This PR carries them forward.

## Changes

- **Wash sale double-count prevention**: `remaining_disallowed` on `SellRecord`, consumed per replacement buy
- **Per-share rate fix**: `original_per_share` from `abs(sell.gain)` (no decay across partial buys)
- **Buy-then-sell direction**: `_apply_buy_then_sell_wash_sale` with `remaining_loss` tracking
- **PnL reversal**: disallowed loss added back to `realized_pnl` on buy-then-sell
- **Migration**: moved to `engine/db/migrations/versions/003_tax_lots.py` with correct chain
- **ABC fix**: `sell_date` param on `ICostModel.estimate_tax`
- **BacktestResult.portfolio_id**: nullable
- **Gain formula**: excludes tax (tax deducted from cash only)
- **SPECIFIC_LOT mutation fix**: `list(lots)` copy preserved from PR #191
- **PortfolioState alias** preserved from PR #192

## Tests

132 tests passing, 0 regressions. New tests: equal per-share for split buys, buy-then-sell PnL reversal, gain-excludes-tax, tax-deducted-from-cash.

Closes #188 review findings.