### PR TITLE
fix: apply review round 2-4 fixes for tax lot tracking (SEV-459)

### DIFF
--- a/engine/core/cost_model.py
+++ b/engine/core/cost_model.py
@@ -153,6 +153,7 @@ class ICostModel(ABC):
         quantity: int,
         lots: list[TaxLot],
         method: TaxMethod = TaxMethod.FIFO,
+        sell_date: datetime | None = None,
     ) -> Money:
         """Estimate capital gains tax for selling from given lots."""
         ...

--- a/engine/core/portfolio.py
+++ b/engine/core/portfolio.py
@@ -50,6 +50,7 @@ class SellRecord:
     sell_price: float
     cost_basis: float
     gain: float
+    remaining_disallowed: float = 0.0
 
 
 @dataclass
@@ -164,14 +165,16 @@ class Portfolio:
         for sell in self._sell_history:
             if sell.symbol != symbol:
                 continue
-            if sell.gain >= 0:
+            if sell.remaining_disallowed <= 0:
                 continue
             window_start = purchase_date - timedelta(days=self._cost_model.wash_sale_window_days)
             if window_start <= sell.sell_date <= purchase_date:
-                disallowed = abs(sell.gain)
-                per_share = disallowed / sell.quantity
-                applicable = min(quantity, sell.quantity) * per_share
+                per_share = abs(sell.gain) / sell.quantity
+                applicable_shares = min(quantity, sell.quantity)
+                applicable = applicable_shares * per_share
+                applicable = min(applicable, sell.remaining_disallowed)
                 total_adjustment += applicable
+                sell.remaining_disallowed -= applicable
 
         if total_adjustment > 0:
             adjusted_price = price + (total_adjustment / quantity)
@@ -248,8 +251,12 @@ class Portfolio:
         sell_proceeds = quantity * price
         self._cash += sell_proceeds - cost - tax
 
-        gain = sell_proceeds - total_cost_basis - cost - tax
+        gain = sell_proceeds - total_cost_basis - cost
         self.realized_pnl += gain
+
+        if gain < 0:
+            adjustment = self._apply_buy_then_sell_wash_sale(symbol, sell_date, gain, quantity)
+            self.realized_pnl += adjustment
 
         self._sell_history.append(
             SellRecord(
@@ -259,6 +266,7 @@ class Portfolio:
                 sell_price=price,
                 cost_basis=total_cost_basis,
                 gain=gain,
+                remaining_disallowed=abs(gain) if gain < 0 else 0.0,
             )
         )
 
@@ -276,6 +284,19 @@ class Portfolio:
         )
 
         return consumed_lots
+
+    def _apply_buy_then_sell_wash_sale(
+        self, symbol: str, sell_date: datetime, loss: float, sold_quantity: int
+    ) -> float:
+        remaining_lots = self._tax_lots.get(symbol, [])
+        window_start = sell_date - timedelta(days=self._cost_model.wash_sale_window_days)
+        disallowed_per_share = abs(loss) / sold_quantity
+        total_disallowed = 0.0
+        for lot in remaining_lots:
+            if window_start <= lot.purchase_date <= sell_date:
+                lot.purchase_price += disallowed_per_share
+                total_disallowed += lot.quantity * disallowed_per_share
+        return total_disallowed
 
     def update_prices(self, prices: dict[str, float]) -> None:
         """Update current market prices for positions (for P&L calculation)."""

--- a/engine/db/migrations/versions/003_tax_lots.py
+++ b/engine/db/migrations/versions/003_tax_lots.py
@@ -1,20 +1,21 @@
 """add tax_lot_records table
 
-Revision ID: 001_tax_lots
-Revises:
-Create Date: 2026-04-16 13:30:00.000000
+Revision ID: 003_tax_lots
+Revises: 003_bt_result_nullable_pid
+Create Date: 2026-04-17
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "001_tax_lots"
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+from alembic import op
+
+revision: str = "003_tax_lots"
+down_revision: str | Sequence[str] | None = "003_bt_result_nullable_pid"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
@@ -63,14 +64,16 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
+        if_not_exists=True,
     )
     op.create_index(
         "ix_tax_lot_portfolio_symbol",
         "tax_lot_records",
         ["portfolio_id", "symbol"],
+        if_not_exists=True,
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_tax_lot_portfolio_symbol", table_name="tax_lot_records")
-    op.drop_table("tax_lot_records")
+    op.drop_index("ix_tax_lot_portfolio_symbol", table_name="tax_lot_records", if_exists=True)
+    op.drop_table("tax_lot_records", if_exists=True)

--- a/tests/test_tax_lots.py
+++ b/tests/test_tax_lots.py
@@ -101,7 +101,7 @@ class TestHoldingPeriod:
                 purchase_date=now - timedelta(days=400),
             )
         ]
-        tax = cost_model.estimate_tax("AAPL", 150.0, 100, lots, TaxMethod.FIFO)
+        tax = cost_model.estimate_tax("AAPL", 150.0, 100, lots, TaxMethod.FIFO, sell_date=now)
         expected = (150.0 - 100.0) * 100 * 0.20
         assert abs(tax.amount - expected) < 1e-6
 
@@ -427,3 +427,126 @@ class TestConsumeLotsOffByOne:
         remaining = p.get_tax_lots("AAPL")
         assert len(remaining) == 1
         assert remaining[0].quantity == 9
+
+
+class TestWashSaleDoubleCountPrevention:
+    """Verify that multiple replacement buys don't exceed the original loss.
+
+    Without remaining_disallowed tracking, two buys after one losing sell
+    would each apply the full loss, causing total adjustment > actual loss.
+    """
+
+    def test_two_buys_after_one_loss_dont_exceed_original_loss(self):
+        p = Portfolio(initial_cash=500_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 150.0)
+
+        p.transaction_date = datetime(2026, 3, 1, tzinfo=UTC)
+        p.close_position("AAPL", 100, 140.0)
+        assert abs(p.realized_pnl - (-1000.0)) < 1e-6
+
+        p.transaction_date = datetime(2026, 3, 6, tzinfo=UTC)
+        p.open_position("AAPL", 50, 145.0)
+
+        p.transaction_date = datetime(2026, 3, 11, tzinfo=UTC)
+        p.open_position("AAPL", 50, 145.0)
+
+        lots = p.get_tax_lots("AAPL")
+        assert len(lots) == 2
+        assert abs(lots[0].purchase_price - 155.0) < 1e-6
+        assert abs(lots[1].purchase_price - 155.0) < 1e-6
+
+        total_adj = sum((lot.purchase_price - 145.0) * lot.quantity for lot in lots)
+        assert abs(total_adj - 1000.0) < 1e-6
+
+    def test_large_buys_dont_exceed_original_loss(self):
+        """Buy quantities larger than sell — total adjustment still equals original loss."""
+        p = Portfolio(initial_cash=1_000_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 50, 150.0)
+
+        p.transaction_date = datetime(2026, 3, 1, tzinfo=UTC)
+        p.close_position("AAPL", 50, 140.0)
+
+        p.transaction_date = datetime(2026, 3, 6, tzinfo=UTC)
+        p.open_position("AAPL", 200, 145.0)
+
+        p.transaction_date = datetime(2026, 3, 11, tzinfo=UTC)
+        p.open_position("AAPL", 200, 145.0)
+
+        lots = p.get_tax_lots("AAPL")
+        original_loss = 500.0
+        total_adj = sum((lot.purchase_price - 145.0) * lot.quantity for lot in lots)
+        assert abs(total_adj - original_loss) < 1e-6
+
+
+class TestBuyThenSellWashSale:
+    """IRS Pub 550: loss disallowed if replacement bought within 30 days BEFORE sale."""
+
+    def test_buy_then_sell_adjusts_existing_lot(self):
+        p = Portfolio(initial_cash=500_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 150.0)
+
+        p.transaction_date = datetime(2026, 1, 11, tzinfo=UTC)
+        p.open_position("AAPL", 100, 140.0)
+
+        p.transaction_date = datetime(2026, 1, 21, tzinfo=UTC)
+        p.close_position("AAPL", 100, 130.0)
+
+        lots = p.get_tax_lots("AAPL")
+        assert len(lots) == 1
+        expected_price = 150.0 + 10.0
+        assert abs(lots[0].purchase_price - expected_price) < 1e-6
+
+    def test_buy_then_sell_reverses_realized_pnl(self):
+        p = Portfolio(initial_cash=500_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 150.0)
+
+        p.transaction_date = datetime(2026, 1, 11, tzinfo=UTC)
+        p.open_position("AAPL", 100, 140.0)
+
+        p.transaction_date = datetime(2026, 1, 21, tzinfo=UTC)
+        p.close_position("AAPL", 100, 130.0)
+
+        raw_gain = 100 * 130.0 - 100 * 150.0
+        assert raw_gain == -2000.0
+        assert p.realized_pnl > raw_gain
+
+
+class TestGainExcludesTax:
+    """gain = proceeds - cost_basis - fees. Tax NOT subtracted from gain."""
+
+    def test_gain_does_not_subtract_tax(self):
+        p = Portfolio(initial_cash=100_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 100.0)
+
+        p.transaction_date = datetime(2026, 2, 1, tzinfo=UTC)
+        p.close_position("AAPL", 100, 120.0, cost=10.0, tax=500.0)
+
+        sell_proceeds = 100 * 120.0
+        cost_basis = 100 * 100.0
+        fees = 10.0
+        expected_gain = sell_proceeds - cost_basis - fees
+        assert abs(p.realized_pnl - expected_gain) < 1e-6
+
+    def test_tax_deducted_from_cash_on_sell(self):
+        p = Portfolio(initial_cash=100_000)
+
+        p.transaction_date = datetime(2026, 1, 1, tzinfo=UTC)
+        p.open_position("AAPL", 100, 100.0)
+
+        cash_before = p.cash
+        p.transaction_date = datetime(2026, 2, 1, tzinfo=UTC)
+        p.close_position("AAPL", 100, 120.0, cost=10.0, tax=500.0)
+
+        sell_proceeds = 100 * 120.0
+        expected_cash = cash_before + sell_proceeds - 10.0 - 500.0
+        assert abs(p.cash - expected_cash) < 1e-6


### PR DESCRIPTION
## Summary
Follow-up PR with all 7 fixes from review rounds 2-4 that were missing from PR #188 merge.

## Fixes Applied

| # | Fix | File |
|---|-----|------|
| F1 | Wash sale double-count prevention via `remaining_disallowed` field | `engine/core/portfolio.py` |
| F2 | Buy-then-sell wash sale detection in `close_position()` | `engine/core/portfolio.py` |
| F3 | Remove tax from gain formula | `engine/core/portfolio.py` |
| F4 | Migration in correct directory with proper chain | `engine/db/migrations/versions/003_tax_lots.py` |
| F5 | `sell_date` in `ICostModel.estimate_tax` ABC | `engine/core/cost_model.py` |
| F6 | Stronger double-count test with large buy quantities | `tests/test_tax_lots.py` |
| F7 | `remaining_disallowed = 0.0` on gain sells | `engine/core/portfolio.py` |

## Verification Output

```
=== V1: remaining_disallowed ===
53:    remaining_disallowed: float = 0.0
168:            if sell.remaining_disallowed <= 0:
175:                applicable = min(applicable, sell.remaining_disallowed)
177:                sell.remaining_disallowed -= applicable
269:                remaining_disallowed=abs(gain) if gain < 0 else 0.0,

=== V2: migration file ===
engine/db/migrations/versions/003_tax_lots.py

=== V3: ABC sell_date (line 156 ABC, line 257 impl) ===
156:        sell_date: datetime | None = None,  (ICostModel ABC)
257:        sell_date: datetime | None = None,  (DefaultCostModel impl)

=== V4: buy_then_sell ===
_call:     adjustment = self._apply_buy_then_sell_wash_sale(symbol, sell_date, gain, quantity)
_method:   def _apply_buy_then_sell_wash_sale(
```

## Tests
- 136 passing, 0 regressions
- New tests: double-count prevention, buy-then-sell wash sale, gain-excludes-tax, tax-deducted-from-cash

Closes SevFle/nexus-trade-engine#4