### PR TITLE
feat: legal documents, consent tracking & compliance surfaces (gh#154)

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -4,7 +4,9 @@ from fastapi import APIRouter
 
 from engine.api.routes.backtest import router as backtest_router
 from engine.api.routes.health import router as health_router
+from engine.api.routes.legal import router as legal_router
 
 api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
 api_router.include_router(backtest_router, prefix="/api/v1/backtest", tags=["backtest"])
+api_router.include_router(legal_router, prefix="/api/v1/legal", tags=["legal"])

--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from engine.api.routes.backtest import router as backtest_router
 from engine.api.routes.health import router as health_router
 from engine.api.routes.legal import router as legal_router
+from engine.legal.dependencies import require_legal_acceptance
 
 api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
-api_router.include_router(backtest_router, prefix="/api/v1/backtest", tags=["backtest"])
+api_router.include_router(
+    backtest_router,
+    prefix="/api/v1/backtest",
+    tags=["backtest"],
+    dependencies=[Depends(require_legal_acceptance)],
+)
 api_router.include_router(legal_router, prefix="/api/v1/legal", tags=["legal"])

--- a/engine/api/routes/legal.py
+++ b/engine/api/routes/legal.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import Path as PathParam
 
 from engine.deps import get_db
 from engine.legal.schemas import (
@@ -48,7 +49,7 @@ async def get_documents(
 
 @router.get("/documents/{slug}", response_model=LegalDocumentDetail)
 async def get_document_by_slug(
-    slug: str,
+    slug: str = PathParam(pattern=r"^[a-z0-9-]+$"),
     version: str | None = Query(None),
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ) -> LegalDocumentDetail:

--- a/engine/api/routes/legal.py
+++ b/engine/api/routes/legal.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from engine.deps import get_db
+from engine.legal.schemas import (
+    AcceptanceListResponse,
+    AcceptanceRecord,
+    AcceptedItem,
+    AcceptRequest,
+    AcceptResponse,
+    AttributionItem,
+    AttributionListResponse,
+    LegalDocumentDetail,
+    LegalDocumentListResponse,
+    LegalDocumentSummary,
+)
+from engine.legal.service import (
+    get_document_content,
+    get_user_acceptances,
+    list_attributions,
+    list_documents,
+    record_acceptances,
+)
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+@router.get("/documents", response_model=LegalDocumentListResponse)
+async def get_documents(
+    category: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> LegalDocumentListResponse:
+    user_id: uuid.UUID | None = None
+
+    summaries = await list_documents(db, user_id=user_id, category=category)
+    return LegalDocumentListResponse(documents=[LegalDocumentSummary(**s) for s in summaries])
+
+
+@router.get("/documents/{slug}", response_model=LegalDocumentDetail)
+async def get_document_by_slug(
+    slug: str,
+    version: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> LegalDocumentDetail:
+    result = await get_document_content(db, slug, version=version)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Document '{slug}' not found")
+    return LegalDocumentDetail(**result)
+
+
+@router.post("/accept", response_model=AcceptResponse)
+async def accept_documents(
+    request: Request,
+    body: AcceptRequest,
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> AcceptResponse:
+    user_id: uuid.UUID | None = None
+
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    ip_address = request.headers.get(
+        "x-forwarded-for", request.client.host if request.client else "unknown"
+    )
+    user_agent = request.headers.get("user-agent", "unknown")
+
+    accepted = await record_acceptances(
+        db,
+        user_id=user_id,
+        acceptances=[a.model_dump() for a in body.acceptances],
+        ip_address=ip_address,
+        user_agent=user_agent,
+    )
+
+    return AcceptResponse(accepted=[AcceptedItem(**a) for a in accepted])
+
+
+@router.get("/acceptances/me", response_model=AcceptanceListResponse)
+async def get_my_acceptances(
+    document_slug: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> AcceptanceListResponse:
+    user_id: uuid.UUID | None = None
+
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    records = await get_user_acceptances(db, user_id, document_slug=document_slug)
+    return AcceptanceListResponse(
+        acceptances=[
+            AcceptanceRecord(
+                id=str(r.id),
+                document_slug=r.document_slug,
+                document_version=r.document_version,
+                accepted_at=r.accepted_at,
+                context=r.context,
+                revoked_at=r.revoked_at,
+            )
+            for r in records
+        ]
+    )
+
+
+@router.get("/attributions", response_model=AttributionListResponse)
+async def get_attributions(
+    context: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> AttributionListResponse:
+    attributions = await list_attributions(db, context=context)
+    return AttributionListResponse(
+        attributions=[
+            AttributionItem(
+                provider_slug=a.provider_slug,
+                provider_name=a.provider_name,
+                attribution_text=a.attribution_text,
+                attribution_url=a.attribution_url,
+                logo_path=a.logo_path,
+            )
+            for a in attributions
+        ]
+    )

--- a/engine/app.py
+++ b/engine/app.py
@@ -9,7 +9,7 @@ from valkey.asyncio import Valkey
 
 from engine.api.router import api_router
 from engine.config import settings
-from engine.db.session import dispose_engine
+from engine.db.session import dispose_engine, get_session_factory
 from engine.observability.logging import setup_logging
 from engine.observability.tracing import setup_tracing
 
@@ -22,6 +22,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     setup_logging()
     setup_tracing()
     app.state.valkey = Valkey.from_url(settings.valkey_url)
+
+    if not settings.is_test:
+        try:
+            from engine.legal.sync import sync_legal_documents  # noqa: PLC0415
+
+            session_factory = get_session_factory()
+            async with session_factory() as session:
+                await sync_legal_documents(session)
+                await session.commit()
+        except Exception:
+            import structlog  # noqa: PLC0415
+
+            structlog.get_logger().exception("legal.sync_failed_on_startup")
+
     yield
     await app.state.valkey.aclose()
     await dispose_engine()

--- a/engine/config.py
+++ b/engine/config.py
@@ -32,6 +32,12 @@ class Settings(BaseSettings):
     # Worker
     worker_concurrency: int = 4
 
+    # Operator (for legal doc substitution)
+    operator_name: str = "Nexus Trade Engine"
+    operator_email: str = "legal@nexus-trade.example"
+    operator_url: str = "https://nexus-trade.example"
+    operator_jurisdiction: str = "United States"
+
     @property
     def is_production(self) -> bool:
         return self.app_env == "production"

--- a/engine/db/migrations/versions/004_legal_documents.py
+++ b/engine/db/migrations/versions/004_legal_documents.py
@@ -1,0 +1,115 @@
+"""legal_documents, legal_acceptances, data_provider_attributions tables
+
+Revision ID: 004_legal_documents
+Revises: 003_bt_result_nullable_pid
+Create Date: 2026-04-18
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "004_legal_documents"
+down_revision: str | Sequence[str] | None = "003_bt_result_nullable_pid"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "legal_documents",
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("slug", sa.String(length=50), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("current_version", sa.String(length=20), nullable=False),
+        sa.Column("effective_date", sa.Date(), nullable=False),
+        sa.Column("requires_acceptance", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("category", sa.String(length=30), nullable=False, server_default="general"),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("file_path", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+    )
+    op.create_index(op.f("ix_legal_documents_slug"), "legal_documents", ["slug"], unique=True)
+    op.create_index(
+        op.f("ix_legal_documents_category"), "legal_documents", ["category"], unique=False
+    )
+
+    op.create_table(
+        "legal_acceptances",
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("document_slug", sa.String(length=50), nullable=False),
+        sa.Column("document_version", sa.String(length=20), nullable=False),
+        sa.Column(
+            "accepted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("ip_address", sa.String(length=45), nullable=False),
+        sa.Column("user_agent", sa.String(length=500), nullable=False),
+        sa.Column("context", sa.String(length=50), nullable=False, server_default="onboarding"),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_acceptance_user_doc", "legal_acceptances", ["user_id", "document_slug"])
+    op.create_index(
+        "ix_acceptance_user_doc_ver",
+        "legal_acceptances",
+        ["user_id", "document_slug", "document_version"],
+    )
+    op.create_index("ix_acceptance_time", "legal_acceptances", ["accepted_at"])
+
+    op.create_table(
+        "data_provider_attributions",
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("provider_slug", sa.String(length=50), nullable=False),
+        sa.Column("provider_name", sa.String(length=100), nullable=False),
+        sa.Column("attribution_text", sa.Text(), nullable=False),
+        sa.Column("attribution_url", sa.String(length=500), nullable=True),
+        sa.Column("logo_path", sa.String(length=255), nullable=True),
+        sa.Column(
+            "display_contexts",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("provider_slug"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("data_provider_attributions")
+    op.drop_table("legal_acceptances")
+    op.drop_table("legal_documents")

--- a/engine/db/migrations/versions/004_legal_documents.py
+++ b/engine/db/migrations/versions/004_legal_documents.py
@@ -89,7 +89,7 @@ def upgrade() -> None:
             "display_contexts",
             postgresql.JSONB(astext_type=sa.Text()),
             nullable=False,
-            server_default="[]",
+            server_default=sa.text("'[]'::jsonb"),
         ),
         sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
         sa.Column(

--- a/engine/db/migrations/versions/005_legal_acceptances_immutable.py
+++ b/engine/db/migrations/versions/005_legal_acceptances_immutable.py
@@ -1,0 +1,36 @@
+"""Add immutability trigger on legal_acceptances
+
+Revision ID: 005_legal_acceptances_immutable
+Revises: 004_legal_documents
+Create Date: 2026-04-18
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "005_legal_acceptances_immutable"
+down_revision: str | Sequence[str] | None = "004_legal_documents"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE OR REPLACE FUNCTION prevent_acceptance_modification()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            RAISE EXCEPTION 'legal_acceptances records are immutable';
+        END;
+        $$ LANGUAGE plpgsql;
+    """)
+    op.execute("""
+        CREATE TRIGGER no_acceptance_update
+        BEFORE UPDATE OR DELETE ON legal_acceptances
+        FOR EACH ROW EXECUTE FUNCTION prevent_acceptance_modification();
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS no_acceptance_update ON legal_acceptances")
+    op.execute("DROP FUNCTION IF EXISTS prevent_acceptance_modification()")

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from enum import Enum
 
-from sqlalchemy import ForeignKey, Index, Numeric, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, ForeignKey, Index, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -161,3 +161,56 @@ class OHLCVBar(Base):
         Index("ix_ohlcv_symbol_timestamp", "symbol", "timestamp"),
         UniqueConstraint("symbol", "timestamp", name="uq_ohlcv_symbol_timestamp"),
     )
+
+
+class LegalDocument(Base):
+    __tablename__ = "legal_documents"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    slug: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    title: Mapped[str] = mapped_column(String(200))
+    current_version: Mapped[str] = mapped_column(String(20))
+    effective_date: Mapped[datetime] = mapped_column()
+    requires_acceptance: Mapped[bool] = mapped_column(Boolean, default=True)
+    category: Mapped[str] = mapped_column(String(30), default="general", index=True)
+    display_order: Mapped[int] = mapped_column(default=0)
+    file_path: Mapped[str] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
+
+
+class LegalAcceptance(Base):
+    __tablename__ = "legal_acceptances"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="RESTRICT"), index=True
+    )
+    document_slug: Mapped[str] = mapped_column(String(50))
+    document_version: Mapped[str] = mapped_column(String(20))
+    accepted_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    ip_address: Mapped[str] = mapped_column(String(45))
+    user_agent: Mapped[str] = mapped_column(String(500))
+    context: Mapped[str] = mapped_column(String(50), default="onboarding")
+    revoked_at: Mapped[datetime | None] = mapped_column(nullable=True)
+
+    __table_args__ = (
+        Index("ix_acceptance_user_doc", "user_id", "document_slug"),
+        Index("ix_acceptance_user_doc_ver", "user_id", "document_slug", "document_version"),
+        Index("ix_acceptance_time", "accepted_at"),
+    )
+
+
+class DataProviderAttribution(Base):
+    __tablename__ = "data_provider_attributions"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    provider_slug: Mapped[str] = mapped_column(String(50), unique=True)
+    provider_name: Mapped[str] = mapped_column(String(100))
+    attribution_text: Mapped[str] = mapped_column(Text)
+    attribution_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    logo_path: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    display_contexts: Mapped[dict] = mapped_column(JSONB, default=list)  # type: ignore[assignment]
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)

--- a/engine/legal/dependencies.py
+++ b/engine/legal/dependencies.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import structlog
 from fastapi import Depends, HTTPException
 
 from engine.deps import get_db
@@ -11,13 +12,31 @@ if TYPE_CHECKING:
 
     from engine.db.models import LegalDocument, User
 
+logger = structlog.get_logger()
+
+_AUTH_NOT_WIRED = (
+    "Legal consent enforcement requires an authenticated user. "
+    "Wire get_current_user (ADR-0002) into this dependency before shipping. "
+    "See SEV-206 / gh#154 for tracking."
+)
+
+
+async def _placeholder_get_current_user() -> None:
+    """Placeholder until ADR-0002 (auth) lands.
+
+    Returns None so that ``require_legal_acceptance`` raises 401,
+    making the auth gap visible rather than silently bypassing consent.
+    Remove this once get_current_user is implemented.
+    """
+    logger.warning("legal.auth_not_wired")
+
 
 async def require_legal_acceptance(
-    user: User | None = None,
+    user: User | None = Depends(_placeholder_get_current_user),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ) -> User | None:
     if user is None:
-        return None
+        raise HTTPException(status_code=401, detail=_AUTH_NOT_WIRED)
 
     from engine.legal.service import get_pending_acceptances  # noqa: PLC0415
 

--- a/engine/legal/dependencies.py
+++ b/engine/legal/dependencies.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import Depends, HTTPException
+
+from engine.deps import get_db
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from engine.db.models import LegalDocument, User
+
+
+async def require_legal_acceptance(
+    user: User | None = None,
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> User | None:
+    if user is None:
+        return None
+
+    from engine.legal.service import get_pending_acceptances  # noqa: PLC0415
+
+    pending: list[LegalDocument] = await get_pending_acceptances(db, user.id)
+    if pending:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "legal_re_acceptance_required",
+                "documents": [p.slug for p in pending],
+            },
+        )
+    return user

--- a/engine/legal/schemas.py
+++ b/engine/legal/schemas.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from datetime import date, datetime
+
+
+class LegalDocumentSummary(BaseModel):
+    slug: str
+    title: str
+    current_version: str
+    effective_date: date
+    requires_acceptance: bool
+    category: str
+    accepted: bool = False
+    accepted_version: str | None = None
+    needs_re_acceptance: bool = False
+
+
+class LegalDocumentListResponse(BaseModel):
+    documents: list[LegalDocumentSummary]
+
+
+class LegalDocumentDetail(BaseModel):
+    slug: str
+    title: str
+    version: str
+    effective_date: date
+    content_markdown: str
+    requires_acceptance: bool
+
+
+class AcceptanceItem(BaseModel):
+    document_slug: str
+    document_version: str
+
+
+class AcceptRequest(BaseModel):
+    acceptances: list[AcceptanceItem]
+
+
+class AcceptedItem(BaseModel):
+    document_slug: str
+    document_version: str
+    accepted_at: datetime
+
+
+class AcceptResponse(BaseModel):
+    accepted: list[AcceptedItem]
+
+
+class AcceptanceRecord(BaseModel):
+    id: str
+    document_slug: str
+    document_version: str
+    accepted_at: datetime
+    context: str
+    revoked_at: datetime | None = None
+
+    model_config: dict[str, Any] = {"from_attributes": True}
+
+
+class AcceptanceListResponse(BaseModel):
+    acceptances: list[AcceptanceRecord]
+
+
+class AttributionItem(BaseModel):
+    provider_slug: str
+    provider_name: str
+    attribution_text: str
+    attribution_url: str | None = None
+    logo_path: str | None = None
+
+
+class AttributionListResponse(BaseModel):
+    attributions: list[AttributionItem]
+
+
+class PendingAcceptanceDetail(BaseModel):
+    code: str = "legal_re_acceptance_required"
+    documents: list[str]

--- a/engine/legal/service.py
+++ b/engine/legal/service.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import and_, func, select
+
+from engine.db.models import DataProviderAttribution, LegalAcceptance, LegalDocument
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def list_documents(
+    session: AsyncSession,
+    user_id: uuid.UUID | None = None,
+    category: str | None = None,
+) -> list[dict]:
+    stmt = select(LegalDocument).order_by(LegalDocument.display_order)
+    if category:
+        stmt = stmt.where(LegalDocument.category == category)
+    result = await session.execute(stmt)
+    documents = result.scalars().all()
+
+    response = []
+    for doc in documents:
+        item = {
+            "slug": doc.slug,
+            "title": doc.title,
+            "current_version": doc.current_version,
+            "effective_date": doc.effective_date,
+            "requires_acceptance": doc.requires_acceptance,
+            "category": doc.category,
+            "accepted": False,
+            "accepted_version": None,
+            "needs_re_acceptance": False,
+        }
+
+        if user_id and doc.requires_acceptance:
+            acc_stmt = (
+                select(LegalAcceptance)
+                .where(
+                    and_(
+                        LegalAcceptance.user_id == user_id,
+                        LegalAcceptance.document_slug == doc.slug,
+                        LegalAcceptance.revoked_at.is_(None),
+                    )
+                )
+                .order_by(LegalAcceptance.accepted_at.desc())
+                .limit(1)
+            )
+            acc_result = await session.execute(acc_stmt)
+            latest = acc_result.scalar_one_or_none()
+
+            if latest:
+                item["accepted"] = True
+                item["accepted_version"] = latest.document_version
+                if latest.document_version != doc.current_version:
+                    item["needs_re_acceptance"] = True
+        elif user_id and not doc.requires_acceptance:
+            item["accepted"] = True
+
+        response.append(item)
+
+    return response
+
+
+async def get_document_content(
+    session: AsyncSession,
+    slug: str,
+    version: str | None = None,
+) -> dict | None:
+    stmt = select(LegalDocument).where(LegalDocument.slug == slug)
+    result = await session.execute(stmt)
+    doc = result.scalar_one_or_none()
+    if doc is None:
+        return None
+
+    _target_version = version or doc.current_version
+
+    from pathlib import Path  # noqa: PLC0415
+
+    base_dir = Path(__file__).resolve().parent.parent.parent
+    file_path = base_dir / doc.file_path
+
+    if not file_path.is_file():
+        return None
+
+    content = file_path.read_text(encoding="utf-8")
+
+    from engine.legal.sync import apply_substitutions, parse_front_matter  # noqa: PLC0415
+
+    try:
+        _, body = parse_front_matter(content)
+    except ValueError:
+        body = content
+
+    rendered = apply_substitutions(body, effective_date=str(doc.effective_date))
+
+    return {
+        "slug": doc.slug,
+        "title": doc.title,
+        "version": _target_version,
+        "effective_date": doc.effective_date,
+        "content_markdown": rendered,
+        "requires_acceptance": doc.requires_acceptance,
+    }
+
+
+async def record_acceptances(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    acceptances: list[dict],
+    ip_address: str,
+    user_agent: str,
+    context: str | None = None,
+) -> list[dict]:
+    accepted = []
+    for item in acceptances:
+        slug = item["document_slug"]
+        ver = item["document_version"]
+
+        doc_stmt = select(LegalDocument).where(LegalDocument.slug == slug)
+        doc_result = await session.execute(doc_stmt)
+        doc = doc_result.scalar_one_or_none()
+        if doc is None:
+            continue
+        if doc.current_version != ver:
+            continue
+
+        existing_stmt = select(LegalAcceptance).where(
+            and_(
+                LegalAcceptance.user_id == user_id,
+                LegalAcceptance.document_slug == slug,
+                LegalAcceptance.document_version == ver,
+                LegalAcceptance.revoked_at.is_(None),
+            )
+        )
+        existing_result = await session.execute(existing_stmt)
+        existing = existing_result.scalar_one_or_none()
+
+        if existing:
+            accepted.append(
+                {
+                    "document_slug": slug,
+                    "document_version": ver,
+                    "accepted_at": existing.accepted_at,
+                }
+            )
+            continue
+
+        if context is None:
+            any_prior_stmt = (
+                select(func.count())
+                .select_from(LegalAcceptance)
+                .where(
+                    and_(
+                        LegalAcceptance.user_id == user_id,
+                        LegalAcceptance.document_slug == slug,
+                        LegalAcceptance.revoked_at.is_(None),
+                    )
+                )
+            )
+            any_prior_result = await session.execute(any_prior_stmt)
+            has_prior = any_prior_result.scalar() > 0
+            detected_context = "re-acceptance" if has_prior else "onboarding"
+        else:
+            detected_context = context
+
+        record = LegalAcceptance(
+            user_id=user_id,
+            document_slug=slug,
+            document_version=ver,
+            ip_address=ip_address,
+            user_agent=user_agent,
+            context=detected_context,
+        )
+        session.add(record)
+        await session.flush()
+
+        accepted.append(
+            {
+                "document_slug": slug,
+                "document_version": ver,
+                "accepted_at": record.accepted_at,
+            }
+        )
+
+    return accepted
+
+
+async def get_user_acceptances(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    document_slug: str | None = None,
+) -> list[LegalAcceptance]:
+    stmt = select(LegalAcceptance).where(LegalAcceptance.user_id == user_id)
+    if document_slug:
+        stmt = stmt.where(LegalAcceptance.document_slug == document_slug)
+    stmt = stmt.order_by(LegalAcceptance.accepted_at.desc())
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_pending_acceptances(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[LegalDocument]:
+    docs_stmt = select(LegalDocument).where(LegalDocument.requires_acceptance.is_(True))
+    docs_result = await session.execute(docs_stmt)
+    docs = docs_result.scalars().all()
+
+    pending = []
+    for doc in docs:
+        acc_stmt = select(LegalAcceptance).where(
+            and_(
+                LegalAcceptance.user_id == user_id,
+                LegalAcceptance.document_slug == doc.slug,
+                LegalAcceptance.document_version == doc.current_version,
+                LegalAcceptance.revoked_at.is_(None),
+            )
+        )
+        acc_result = await session.execute(acc_stmt)
+        has_accepted = acc_result.scalar_one_or_none() is not None
+        if not has_accepted:
+            pending.append(doc)
+
+    return pending
+
+
+async def list_attributions(
+    session: AsyncSession,
+    context: str | None = None,
+) -> list[DataProviderAttribution]:
+    stmt = select(DataProviderAttribution).where(DataProviderAttribution.is_active.is_(True))
+    if context:
+        stmt = stmt.where(DataProviderAttribution.display_contexts.contains([context]))
+    result = await session.execute(stmt)
+    return list(result.scalars().all())

--- a/engine/legal/service.py
+++ b/engine/legal/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sqlalchemy import and_, func, select
+from sqlalchemy.orm import aliased
 
 from engine.db.models import DataProviderAttribution, LegalAcceptance, LegalDocument
 
@@ -10,6 +11,24 @@ if TYPE_CHECKING:
     import uuid
 
     from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for part in version.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def _version_lt(a: str, b: str) -> bool:
+    return _parse_version(a) < _parse_version(b)
+
+
+def _version_eq(a: str, b: str) -> bool:
+    return _parse_version(a) == _parse_version(b)
 
 
 async def list_documents(
@@ -22,6 +41,31 @@ async def list_documents(
         stmt = stmt.where(LegalDocument.category == category)
     result = await session.execute(stmt)
     documents = result.scalars().all()
+
+    latest_acceptances: dict[str, LegalAcceptance] = {}
+    if user_id:
+        sub = (
+            select(
+                LegalAcceptance.document_slug,
+                LegalAcceptance.document_version,
+                LegalAcceptance.accepted_at,
+            )
+            .where(
+                and_(
+                    LegalAcceptance.user_id == user_id,
+                    LegalAcceptance.revoked_at.is_(None),
+                )
+            )
+            .distinct(LegalAcceptance.document_slug)
+            .order_by(
+                LegalAcceptance.document_slug,
+                LegalAcceptance.accepted_at.desc(),
+            )
+        )
+        sub_alias = aliased(LegalAcceptance, sub.subquery())
+        la_result = await session.execute(select(sub_alias))
+        for row in la_result.scalars().all():
+            latest_acceptances[row.document_slug] = row
 
     response = []
     for doc in documents:
@@ -38,25 +82,11 @@ async def list_documents(
         }
 
         if user_id and doc.requires_acceptance:
-            acc_stmt = (
-                select(LegalAcceptance)
-                .where(
-                    and_(
-                        LegalAcceptance.user_id == user_id,
-                        LegalAcceptance.document_slug == doc.slug,
-                        LegalAcceptance.revoked_at.is_(None),
-                    )
-                )
-                .order_by(LegalAcceptance.accepted_at.desc())
-                .limit(1)
-            )
-            acc_result = await session.execute(acc_stmt)
-            latest = acc_result.scalar_one_or_none()
-
+            latest = latest_acceptances.get(doc.slug)
             if latest:
                 item["accepted"] = True
                 item["accepted_version"] = latest.document_version
-                if latest.document_version != doc.current_version:
+                if _version_lt(latest.document_version, doc.current_version):
                     item["needs_re_acceptance"] = True
         elif user_id and not doc.requires_acceptance:
             item["accepted"] = True
@@ -82,12 +112,16 @@ async def get_document_content(
     from pathlib import Path  # noqa: PLC0415
 
     base_dir = Path(__file__).resolve().parent.parent.parent
-    file_path = base_dir / doc.file_path
+    resolved_path = (base_dir / doc.file_path).resolve()
+    legal_root = (base_dir / "legal").resolve()
 
-    if not file_path.is_file():
+    if not resolved_path.is_relative_to(legal_root):
+        raise ValueError(f"file_path escapes legal directory: {doc.file_path}")
+
+    if not resolved_path.is_file():
         return None
 
-    content = file_path.read_text(encoding="utf-8")
+    content = resolved_path.read_text(encoding="utf-8")
 
     from engine.legal.sync import apply_substitutions, parse_front_matter  # noqa: PLC0415
 
@@ -116,30 +150,54 @@ async def record_acceptances(
     user_agent: str,
     context: str | None = None,
 ) -> list[dict]:
+    slugs = [a["document_slug"] for a in acceptances]
+    doc_stmt = select(LegalDocument).where(LegalDocument.slug.in_(slugs))
+    doc_result = await session.execute(doc_stmt)
+    doc_map = {d.slug: d for d in doc_result.scalars().all()}
+
+    existing_stmt = select(LegalAcceptance).where(
+        and_(
+            LegalAcceptance.user_id == user_id,
+            LegalAcceptance.document_slug.in_(slugs),
+            LegalAcceptance.revoked_at.is_(None),
+        )
+    )
+    existing_result = await session.execute(existing_stmt)
+    existing_map: dict[str, LegalAcceptance] = {}
+    for acc in existing_result.scalars().all():
+        key = f"{acc.document_slug}:{acc.document_version}"
+        existing_map[key] = acc
+
+    prior_count_stmt = (
+        select(
+            LegalAcceptance.document_slug,
+            func.count(),
+        )
+        .where(
+            and_(
+                LegalAcceptance.user_id == user_id,
+                LegalAcceptance.document_slug.in_(slugs),
+                LegalAcceptance.revoked_at.is_(None),
+            )
+        )
+        .group_by(LegalAcceptance.document_slug)
+    )
+    prior_result = await session.execute(prior_count_stmt)
+    prior_counts: dict[str, int] = dict(prior_result.all())
+
     accepted = []
     for item in acceptances:
         slug = item["document_slug"]
         ver = item["document_version"]
 
-        doc_stmt = select(LegalDocument).where(LegalDocument.slug == slug)
-        doc_result = await session.execute(doc_stmt)
-        doc = doc_result.scalar_one_or_none()
+        doc = doc_map.get(slug)
         if doc is None:
             continue
-        if doc.current_version != ver:
+        if not _version_eq(doc.current_version, ver):
             continue
 
-        existing_stmt = select(LegalAcceptance).where(
-            and_(
-                LegalAcceptance.user_id == user_id,
-                LegalAcceptance.document_slug == slug,
-                LegalAcceptance.document_version == ver,
-                LegalAcceptance.revoked_at.is_(None),
-            )
-        )
-        existing_result = await session.execute(existing_stmt)
-        existing = existing_result.scalar_one_or_none()
-
+        key = f"{slug}:{ver}"
+        existing = existing_map.get(key)
         if existing:
             accepted.append(
                 {
@@ -151,20 +209,7 @@ async def record_acceptances(
             continue
 
         if context is None:
-            any_prior_stmt = (
-                select(func.count())
-                .select_from(LegalAcceptance)
-                .where(
-                    and_(
-                        LegalAcceptance.user_id == user_id,
-                        LegalAcceptance.document_slug == slug,
-                        LegalAcceptance.revoked_at.is_(None),
-                    )
-                )
-            )
-            any_prior_result = await session.execute(any_prior_stmt)
-            has_prior = any_prior_result.scalar() > 0
-            detected_context = "re-acceptance" if has_prior else "onboarding"
+            detected_context = "re-acceptance" if prior_counts.get(slug, 0) > 0 else "onboarding"
         else:
             detected_context = context
 
@@ -207,23 +252,36 @@ async def get_pending_acceptances(
     session: AsyncSession,
     user_id: uuid.UUID,
 ) -> list[LegalDocument]:
+    accepted_stmt = (
+        select(
+            LegalAcceptance.document_slug,
+            LegalAcceptance.document_version,
+        )
+        .where(
+            and_(
+                LegalAcceptance.user_id == user_id,
+                LegalAcceptance.revoked_at.is_(None),
+            )
+        )
+        .distinct(LegalAcceptance.document_slug)
+        .order_by(
+            LegalAcceptance.document_slug,
+            LegalAcceptance.accepted_at.desc(),
+        )
+    )
+    accepted_result = await session.execute(accepted_stmt)
+    accepted_versions: dict[str, str] = {
+        row.document_slug: row.document_version for row in accepted_result.all()
+    }
+
     docs_stmt = select(LegalDocument).where(LegalDocument.requires_acceptance.is_(True))
     docs_result = await session.execute(docs_stmt)
     docs = docs_result.scalars().all()
 
     pending = []
     for doc in docs:
-        acc_stmt = select(LegalAcceptance).where(
-            and_(
-                LegalAcceptance.user_id == user_id,
-                LegalAcceptance.document_slug == doc.slug,
-                LegalAcceptance.document_version == doc.current_version,
-                LegalAcceptance.revoked_at.is_(None),
-            )
-        )
-        acc_result = await session.execute(acc_stmt)
-        has_accepted = acc_result.scalar_one_or_none() is not None
-        if not has_accepted:
+        accepted_ver = accepted_versions.get(doc.slug)
+        if accepted_ver is None or _version_lt(accepted_ver, doc.current_version):
             pending.append(doc)
 
     return pending

--- a/engine/legal/sync.py
+++ b/engine/legal/sync.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import re
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 
 from engine.config import settings
 from engine.db.models import LegalDocument
@@ -18,13 +19,19 @@ logger = structlog.get_logger()
 
 LEGAL_DIR = Path(__file__).resolve().parent.parent.parent / "legal"
 
+_MARKDOWN_SPECIAL = re.compile(r"([\\`*_{\}\[\]()#+\-.!|])")
+
+
+def _escape_markdown(value: str) -> str:
+    return _MARKDOWN_SPECIAL.sub(r"\\\1", value)
+
 
 def _get_substitutions() -> dict[str, str]:
     return {
-        "{{OPERATOR_NAME}}": settings.operator_name,
-        "{{OPERATOR_EMAIL}}": settings.operator_email,
-        "{{OPERATOR_URL}}": settings.operator_url,
-        "{{JURISDICTION}}": settings.operator_jurisdiction,
+        "{{OPERATOR_NAME}}": _escape_markdown(settings.operator_name),
+        "{{OPERATOR_EMAIL}}": _escape_markdown(settings.operator_email),
+        "{{OPERATOR_URL}}": _escape_markdown(settings.operator_url),
+        "{{JURISDICTION}}": _escape_markdown(settings.operator_jurisdiction),
     }
 
 
@@ -61,8 +68,6 @@ async def sync_legal_documents(session: AsyncSession) -> list[LegalDocument]:
         logger.warning("legal_dir_not_found", path=str(LEGAL_DIR))
         return []
 
-    docs: list[LegalDocument] = []
-
     for md_file in sorted(LEGAL_DIR.glob("*.md")):
         try:
             content = md_file.read_text(encoding="utf-8")
@@ -72,59 +77,50 @@ async def sync_legal_documents(session: AsyncSession) -> list[LegalDocument]:
             title = meta.get("title", slug.replace("-", " ").title())
             version = str(meta.get("version", "1.0.0"))
             eff_date_raw = meta.get("effective_date", "2026-04-20")
-            effective_date = (
-                eff_date_raw
-                if isinstance(eff_date_raw, date)
-                else date.fromisoformat(str(eff_date_raw))
-            )
+            try:
+                effective_date = (
+                    eff_date_raw
+                    if isinstance(eff_date_raw, date)
+                    else date.fromisoformat(str(eff_date_raw))
+                )
+            except (ValueError, TypeError):
+                logger.warning("legal.invalid_date", slug=slug, raw=eff_date_raw)
+                effective_date = datetime.now(tz=UTC).date()
             requires_acceptance = bool(meta.get("requires_acceptance", True))
             category = str(meta.get("category", "general"))
             display_order = int(meta.get("display_order", 0))
             file_path = f"legal/{md_file.name}"
 
-            stmt = select(LegalDocument).where(LegalDocument.slug == slug)
-            result = await session.execute(stmt)
-            existing = result.scalar_one_or_none()
+            upsert_stmt = insert(LegalDocument).values(
+                slug=slug,
+                title=title,
+                current_version=version,
+                effective_date=effective_date,
+                requires_acceptance=requires_acceptance,
+                category=category,
+                display_order=display_order,
+                file_path=file_path,
+            )
+            upsert_stmt = upsert_stmt.on_conflict_do_update(
+                index_elements=["slug"],
+                set_={
+                    "title": title,
+                    "current_version": version,
+                    "effective_date": effective_date,
+                    "requires_acceptance": requires_acceptance,
+                    "category": category,
+                    "display_order": display_order,
+                    "file_path": file_path,
+                },
+            )
+            await session.execute(upsert_stmt)
 
-            if existing is None:
-                doc = LegalDocument(
-                    slug=slug,
-                    title=title,
-                    current_version=version,
-                    effective_date=effective_date,
-                    requires_acceptance=requires_acceptance,
-                    category=category,
-                    display_order=display_order,
-                    file_path=file_path,
-                )
-                session.add(doc)
-                docs.append(doc)
-                logger.info(
-                    "legal.document_registered",
-                    slug=slug,
-                    version=version,
-                )
-            elif existing.current_version != version:
-                old_version = existing.current_version
-                existing.current_version = version
-                existing.effective_date = effective_date
-                existing.title = title
-                existing.requires_acceptance = requires_acceptance
-                existing.category = category
-                existing.display_order = display_order
-                existing.file_path = file_path
-                docs.append(existing)
-                logger.info(
-                    "legal.version_changed",
-                    slug=slug,
-                    old_version=old_version,
-                    new_version=version,
-                )
-            else:
-                docs.append(existing)
+            logger.info("legal.document_synced", slug=slug, version=version)
 
         except Exception:
             logger.exception("legal.sync_file_failed", file=md_file.name)
 
     await session.flush()
-    return docs
+
+    result = await session.execute(select(LegalDocument).order_by(LegalDocument.display_order))
+    return list(result.scalars().all())

--- a/engine/legal/sync.py
+++ b/engine/legal/sync.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from sqlalchemy import select
+
+from engine.config import settings
+from engine.db.models import LegalDocument
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger()
+
+LEGAL_DIR = Path(__file__).resolve().parent.parent.parent / "legal"
+
+
+def _get_substitutions() -> dict[str, str]:
+    return {
+        "{{OPERATOR_NAME}}": settings.operator_name,
+        "{{OPERATOR_EMAIL}}": settings.operator_email,
+        "{{OPERATOR_URL}}": settings.operator_url,
+        "{{JURISDICTION}}": settings.operator_jurisdiction,
+    }
+
+
+def parse_front_matter(content: str) -> tuple[dict[str, Any], str]:
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)", content, re.DOTALL)
+    if not match:
+        raise ValueError("Missing or malformed YAML front-matter")
+
+    import yaml  # noqa: PLC0415
+
+    meta = yaml.safe_load(match.group(1))
+    if not isinstance(meta, dict):
+        raise TypeError("Front-matter must be a YAML mapping")
+
+    body = match.group(2)
+    return meta, body
+
+
+def apply_substitutions(text: str, effective_date: str | None = None) -> str:
+    subs = _get_substitutions()
+    if effective_date:
+        subs["{{EFFECTIVE_DATE}}"] = effective_date
+    for marker, value in subs.items():
+        text = text.replace(marker, value)
+    return text
+
+
+def slug_from_filename(filename: str) -> str:
+    return Path(filename).stem
+
+
+async def sync_legal_documents(session: AsyncSession) -> list[LegalDocument]:
+    if not LEGAL_DIR.is_dir():
+        logger.warning("legal_dir_not_found", path=str(LEGAL_DIR))
+        return []
+
+    docs: list[LegalDocument] = []
+
+    for md_file in sorted(LEGAL_DIR.glob("*.md")):
+        try:
+            content = md_file.read_text(encoding="utf-8")
+            meta, _ = parse_front_matter(content)
+
+            slug = slug_from_filename(md_file.name)
+            title = meta.get("title", slug.replace("-", " ").title())
+            version = str(meta.get("version", "1.0.0"))
+            eff_date_raw = meta.get("effective_date", "2026-04-20")
+            effective_date = (
+                eff_date_raw
+                if isinstance(eff_date_raw, date)
+                else date.fromisoformat(str(eff_date_raw))
+            )
+            requires_acceptance = bool(meta.get("requires_acceptance", True))
+            category = str(meta.get("category", "general"))
+            display_order = int(meta.get("display_order", 0))
+            file_path = f"legal/{md_file.name}"
+
+            stmt = select(LegalDocument).where(LegalDocument.slug == slug)
+            result = await session.execute(stmt)
+            existing = result.scalar_one_or_none()
+
+            if existing is None:
+                doc = LegalDocument(
+                    slug=slug,
+                    title=title,
+                    current_version=version,
+                    effective_date=effective_date,
+                    requires_acceptance=requires_acceptance,
+                    category=category,
+                    display_order=display_order,
+                    file_path=file_path,
+                )
+                session.add(doc)
+                docs.append(doc)
+                logger.info(
+                    "legal.document_registered",
+                    slug=slug,
+                    version=version,
+                )
+            elif existing.current_version != version:
+                old_version = existing.current_version
+                existing.current_version = version
+                existing.effective_date = effective_date
+                existing.title = title
+                existing.requires_acceptance = requires_acceptance
+                existing.category = category
+                existing.display_order = display_order
+                existing.file_path = file_path
+                docs.append(existing)
+                logger.info(
+                    "legal.version_changed",
+                    slug=slug,
+                    old_version=old_version,
+                    new_version=version,
+                )
+            else:
+                docs.append(existing)
+
+        except Exception:
+            logger.exception("legal.sync_file_failed", file=md_file.name)
+
+    await session.flush()
+    return docs

--- a/legal/data-provider-attributions.md
+++ b/legal/data-provider-attributions.md
@@ -1,0 +1,53 @@
+---
+title: "Data Provider Attributions"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: false
+category: "data"
+display_order: 6
+---
+
+# Data Provider Attributions
+
+> **NOTICE:** This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize this document for their jurisdiction before deployment.
+
+{{OPERATOR_NAME}} uses market data from the following third-party providers. Attribution must be displayed where provider data is consumed, as required by each provider's terms of service.
+
+## Polygon.io
+
+**Attribution text:** "Market data provided by Polygon.io"
+**Required contexts:** data-feed, backtest-result, chart, export
+
+Polygon.io provides real-time and historical market data for US equities, forex, and cryptocurrencies. Data is sourced from exchanges and consolidated via SIP feeds.
+
+## Financial Modeling Prep (FMP)
+
+**Attribution text:** "Financial data provided by Financial Modeling Prep"
+**Required contexts:** data-feed, backtest-result
+
+FMP provides fundamental financial data, company profiles, financial statements, and market data for global exchanges.
+
+## Display Requirements
+
+Data provider attributions must be displayed:
+
+1. **Data feeds** — Below any chart or data table sourced from the provider
+2. **Backtest results** — In the results footer
+3. **Charts** — As a watermark or footer element
+4. **Exports** (CSV/PDF) — In the export header or footer
+
+Attribution text must be visible and legible. Linking to the provider's website is recommended where applicable.
+
+## Adding New Providers
+
+When integrating a new data provider:
+
+1. Add the provider's attribution text to this document
+2. Create a `data_provider_attributions` record via admin API or seed script
+3. Ensure attribution is rendered in all applicable display contexts
+4. Review the provider's terms for any additional attribution requirements
+
+---
+
+*Effective Date: {{EFFECTIVE_DATE}}*
+*Contact: {{OPERATOR_EMAIL}}*

--- a/legal/eula.md
+++ b/legal/eula.md
@@ -1,0 +1,69 @@
+---
+title: "End User License Agreement"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "general"
+display_order: 4
+---
+
+# End User License Agreement
+
+> **NOTICE:** This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize this document for their jurisdiction before deployment.
+
+**Effective Date:** {{EFFECTIVE_DATE}}
+**Operator:** {{OPERATOR_NAME}}
+**Contact:** {{OPERATOR_EMAIL}}
+
+## 1. License Grant
+
+Subject to your compliance with this End User License Agreement ("EULA"), {{OPERATOR_NAME}} ("we") grants you a limited, non-exclusive, non-transferable, revocable license to access and use the {{OPERATOR_NAME}} Platform ("the Platform") for your personal or internal business use.
+
+## 2. License Restrictions
+
+You may not:
+
+- Copy, modify, or distribute the Platform or any part thereof
+- Use the Platform for any unlawful purpose
+- Remove, alter, or obscure any proprietary notices
+- Use automated tools to scrape or extract data from the Platform beyond documented APIs
+- Sublicense, sell, lease, or rent access to the Platform
+- Bypass or circumvent any security measures or access controls
+
+## 3. Intellectual Property
+
+The Platform and all its contents, features, and functionality (including but not limited to software, text, graphics, logos, and design) are owned by {{OPERATOR_NAME}} or its licensors and are protected by copyright, trademark, and other intellectual property laws.
+
+## 4. User Content
+
+You retain ownership of any strategies, configurations, and other content you create on the Platform. By uploading content to the marketplace, you grant us a license to host, display, and distribute that content to other users per the Marketplace EULA.
+
+## 5. Disclaimer of Warranties
+
+THE PLATFORM IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
+
+WE DO NOT WARRANT THAT:
+
+- THE PLATFORM WILL BE ERROR-FREE OR UNINTERRUPTED
+- TRADING RESULTS WILL BE ACCURATE OR PROFITABLE
+- DEFECTS OR ERRORS WILL BE CORRECTED
+
+## 6. Limitation of Liability
+
+IN NO EVENT SHALL {{OPERATOR_NAME}} OR ITS AFFILIATES BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING LOSS OF PROFITS, DATA, OR BUSINESS OPPORTUNITIES, ARISING OUT OF OR RELATED TO THIS EULA OR THE PLATFORM, REGARDLESS OF THE CAUSE OF ACTION OR THE THEORY OF LIABILITY.
+
+## 7. Term and Termination
+
+This EULA is effective until terminated. We may terminate your access at any time for any reason, including violation of these terms. You may stop using the Platform at any time. Upon termination, the license granted herein ceases immediately.
+
+## 8. Governing Law
+
+This EULA shall be governed by the laws of {{JURISDICTION}}.
+
+## 9. Contact
+
+For questions about this EULA, contact {{OPERATOR_EMAIL}}.
+
+---
+
+*Effective Date: {{EFFECTIVE_DATE}}*

--- a/legal/marketplace-eula.md
+++ b/legal/marketplace-eula.md
@@ -1,0 +1,96 @@
+---
+title: "Marketplace End User License Agreement"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "marketplace"
+display_order: 5
+---
+
+# Marketplace End User License Agreement
+
+> **NOTICE:** This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize this document for their jurisdiction before deployment.
+
+**Effective Date:** {{EFFECTIVE_DATE}}
+**Operator:** {{OPERATOR_NAME}}
+**Contact:** {{OPERATOR_EMAIL}}
+
+This Marketplace End User License Agreement ("Marketplace EULA") governs your use of the {{OPERATOR_NAME}} Strategy Marketplace ("Marketplace") and the third-party strategies ("Strategies") available through it.
+
+## 1. Strategy Author Intellectual Property
+
+Strategies published on the Marketplace are the intellectual property of their respective authors. Authors retain all rights to their strategies. {{OPERATOR_NAME}} acts as a platform host and does not claim ownership of any strategy content.
+
+## 2. Licensing
+
+### 2.1 User License
+
+When you install a strategy from the Marketplace, the author grants you a limited, non-exclusive, non-transferable license to use that strategy on the Platform for your personal trading purposes.
+
+### 2.2 Licensing Options
+
+Strategy authors may choose from the following licensing options:
+
+- **Free** — No cost to install and use
+- **One-time purchase** — Single payment for perpetual use
+- **Subscription** — Recurring payment for continued access
+
+The licensing terms for each strategy are displayed on its Marketplace listing.
+
+## 3. Revenue Share
+
+{{OPERATOR_NAME}} retains a percentage of each strategy sale as a platform fee. The current platform fee is [REVENUE_SHARE_PERCENTAGE]% of the sale price. Strategy authors receive the remaining balance.
+
+## 4. Author Warranties
+
+Strategy authors represent and warrant that:
+
+- They have the right to publish and license their strategy
+- The strategy does not infringe on any third-party intellectual property
+- The strategy description accurately represents its functionality
+- The strategy does not contain malicious code
+
+{{OPERATOR_NAME}} does not independently verify these warranties. Authors are solely responsible for their strategies.
+
+## 5. User Obligations
+
+As a Marketplace user, you agree to:
+
+- Use strategies only for their intended purpose
+- Not redistribute, resell, or share strategy source code
+- Not reverse-engineer strategies beyond what is necessary for platform integration
+- Report bugs, security issues, or policy violations to {{OPERATOR_EMAIL}}
+
+## 6. No Guarantee of Performance
+
+{{OPERATOR_NAME}} does not guarantee the profitability, accuracy, or safety of any Marketplace strategy. Past performance (including backtested results) does not guarantee future results. You assume all risk associated with using third-party strategies.
+
+## 7. Dispute Resolution
+
+### 7.1 Between Users and Authors
+
+Disputes between users and strategy authors should first be resolved through direct communication facilitated by the Platform.
+
+### 7.2 Mediation
+
+If direct resolution fails, disputes may be submitted to mediation under the rules of {{JURISDICTION}}. Each party bears its own mediation costs.
+
+### 7.3 Platform Discretion
+
+{{OPERATOR_NAME}} reserves the right to remove any strategy from the Marketplace that violates these terms or receives sustained negative feedback, at our sole discretion.
+
+## 8. Takedown and Refund Policy
+
+{{OPERATOR_NAME}} may remove strategies that violate these terms. Users who purchased a removed strategy may be eligible for a prorated refund at our discretion.
+
+## 9. Modifications
+
+{{OPERATOR_NAME}} may update this Marketplace EULA at any time. Changes will be communicated through the Platform. Continued use of the Marketplace constitutes acceptance of the modified terms.
+
+## 10. Contact
+
+For Marketplace-related inquiries, contact {{OPERATOR_EMAIL}}.
+
+---
+
+*Effective Date: {{EFFECTIVE_DATE}}*

--- a/legal/privacy-policy.md
+++ b/legal/privacy-policy.md
@@ -1,0 +1,111 @@
+---
+title: "Privacy Policy"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "general"
+display_order: 3
+---
+
+# Privacy Policy
+
+> **NOTICE:** This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize this document for their jurisdiction before deployment.
+
+**Effective Date:** {{EFFECTIVE_DATE}}
+**Operator:** {{OPERATOR_NAME}}
+**Contact:** {{OPERATOR_EMAIL}}
+
+## 1. Data We Collect
+
+### 1.1 Information You Provide
+
+- **Account data:** Email address, display name, password (hashed)
+- **Trading data:** Portfolio configurations, strategy settings, order history
+- **Communication:** Support requests, feedback
+
+### 1.2 Data Collected Automatically
+
+- **Usage data:** Feature interactions, pages viewed, session duration
+- **Device data:** Browser type, operating system, IP address, user agent
+- **Legal compliance:** Document acceptance records (document version, timestamp, IP address, user agent)
+
+### 1.3 Third-Party Data
+
+- **Market data:** Financial data from providers (see Data Provider Attributions)
+- **Analytics data:** Aggregated usage patterns
+
+## 2. How We Use Your Data
+
+We process your data for the following purposes:
+
+- Providing and maintaining the Platform
+- Processing trades and managing portfolios
+- Ensuring legal and regulatory compliance
+- Improving the Platform through analytics
+- Communicating with you about your account
+- Detecting and preventing fraud or abuse
+
+## 3. Legal Basis for Processing (GDPR)
+
+We process your data based on:
+
+- **Contractual necessity** — To provide the Platform services you requested
+- **Legitimate interests** — Security, fraud prevention, and Platform improvement
+- **Legal obligations** — Regulatory compliance and record-keeping requirements
+- **Consent** — Where explicitly obtained for specific purposes
+
+## 4. Data Retention
+
+| Data Category | Retention Period |
+|---------------|-----------------|
+| Account data | Duration of account + 30 days |
+| Trading records | Duration of account + 7 years (regulatory) |
+| Legal acceptance records | Duration of account + 7 years (compliance) |
+| Usage analytics | 2 years (anonymized after 90 days) |
+| Support communications | 3 years |
+
+## 5. Your Rights
+
+Depending on your jurisdiction, you may have the right to:
+
+- **Access** — Request a copy of your personal data
+- **Rectification** — Correct inaccurate data
+- **Erasure** — Request deletion of your data (note: legal acceptance records and trading records may be retained under legitimate interest or regulatory requirements; in such cases your record will be pseudonymized)
+- **Restriction** — Limit how we process your data
+- **Portability** — Receive your data in a structured format
+- **Objection** — Object to processing based on legitimate interests
+- **Withdraw consent** — Withdraw consent where processing is based on consent
+
+To exercise any of these rights, contact {{OPERATOR_EMAIL}}.
+
+## 6. Data Sharing
+
+We do not sell your personal data. We may share data with:
+
+- **Service providers** who assist in operating the Platform (hosting, data providers, analytics)
+- **Legal authorities** when required by law or to protect our rights
+- **Business transferees** in connection with a merger, acquisition, or sale of assets
+
+## 7. Data Security
+
+We implement industry-standard measures to protect your data, including encryption at rest and in transit, access controls, and regular security assessments. However, no system is completely secure.
+
+## 8. International Transfers
+
+If your data is transferred outside your jurisdiction, we ensure appropriate safeguards are in place, including standard contractual clauses or adequacy decisions.
+
+## 9. Children's Privacy
+
+The Platform is not intended for individuals under the age of 18. We do not knowingly collect data from children.
+
+## 10. Changes to This Policy
+
+We may update this Privacy Policy periodically. Material changes will be communicated through the Platform. Continued use after changes constitutes acceptance.
+
+## 11. Contact
+
+For privacy-related inquiries, contact our Data Protection Officer at {{OPERATOR_EMAIL}}.
+
+---
+
+*Effective Date: {{EFFECTIVE_DATE}}*

--- a/legal/risk-disclaimer.md
+++ b/legal/risk-disclaimer.md
@@ -1,0 +1,53 @@
+---
+title: "Risk Disclaimer"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "trading"
+display_order: 1
+---
+
+# Risk Disclaimer
+
+> **NOTICE:** This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize this document for their jurisdiction before deployment.
+
+By using {{OPERATOR_NAME}} ("the Platform"), you acknowledge and accept the risks described below.
+
+## 1. General Trading Risks
+
+Trading in financial instruments involves substantial risk of loss. You should not trade with money you cannot afford to lose. Past performance is not indicative of future results.
+
+## 2. Backtesting Limitations
+
+Backtesting results are hypothetical and are provided for informational purposes only. Backtested performance:
+
+- **Look-ahead bias** may cause strategies to appear more profitable than they would be in live markets.
+- **Survivorship bias** may overstate returns because delisted or bankrupt securities are excluded from historical datasets.
+- **Transaction costs** including slippage, commissions, and market impact are estimated and may differ materially from live execution.
+- **Market conditions** change over time; a strategy profitable in historical periods may not be profitable in the future.
+
+## 3. Paper Trading vs. Live Trading
+
+Paper (simulated) trading does not involve real money and has key differences from live trading:
+
+- **Execution quality** — Paper orders fill at assumed prices; live orders may experience slippage, partial fills, or rejection.
+- **Market impact** — Simulated trades do not move the market; large live orders can affect price.
+- **Emotional factors** — Real money at risk introduces psychological pressures absent in simulation.
+- **Latency** — Paper trading may not reflect real-world order routing and exchange latency.
+
+## 4. Marketplace Strategy Risks
+
+Strategies available on the {{OPERATOR_NAME}} marketplace are authored by third parties. {{OPERATOR_NAME}} does not guarantee the accuracy, profitability, or safety of any strategy. Strategy authors are solely responsible for their strategies' performance. You assume all risk when installing and running third-party strategies.
+
+## 5. Data Provider Limitations
+
+Market data is provided by third-party data providers and may contain errors, delays, or omissions. {{OPERATOR_NAME}} is not responsible for the accuracy or timeliness of data. Decisions based on inaccurate or delayed data may result in losses.
+
+## 6. No Guarantee of Results
+
+{{OPERATOR_NAME}}, its operators, and its affiliates make no guarantees regarding trading outcomes. The Platform is provided "as is" without warranty of any kind, express or implied.
+
+---
+
+*Effective Date: {{EFFECTIVE_DATE}}*
+*Contact: {{OPERATOR_EMAIL}}*

--- a/legal/terms-of-service.md
+++ b/legal/terms-of-service.md
@@ -1,0 +1,73 @@
+---
+title: "Terms of Service"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "general"
+display_order: 2
+---
+
+# Terms of Service
+
+> **NOTICE:** This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize this document for their jurisdiction before deployment.
+
+**Effective Date:** {{EFFECTIVE_DATE}}
+**Operator:** {{OPERATOR_NAME}}
+**Contact:** {{OPERATOR_EMAIL}}
+
+## 1. Acceptance of Terms
+
+By accessing or using {{OPERATOR_NAME}} ("the Platform"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree, do not use the Platform.
+
+## 2. Description of Service
+
+{{OPERATOR_NAME}} provides algorithmic trading tools including backtesting, paper trading, live trading, and a strategy marketplace. The Platform is operated by {{OPERATOR_NAME}} ("we", "us", "our").
+
+## 3. User Accounts
+
+You are responsible for maintaining the confidentiality of your account credentials. You must provide accurate information when creating an account and update it as necessary. You are responsible for all activity under your account.
+
+## 4. Acceptable Use
+
+You agree not to:
+
+- Violate any applicable law or regulation
+- Attempt to gain unauthorized access to the Platform or its systems
+- Interfere with or disrupt the Platform's operation
+- Use the Platform for market manipulation or any illegal trading activity
+- Reverse-engineer, decompile, or disassemble any part of the Platform
+- Resell or sublicense access to the Platform without written permission
+
+## 5. Disclaimers
+
+The Platform is provided "as is" and "as available" without warranties of any kind, either express or implied, including but not limited to implied warranties of merchantability, fitness for a particular purpose, and non-infringement.
+
+We do not guarantee:
+
+- The Platform will be uninterrupted, timely, or error-free
+- Trading results will be profitable
+- Data provided will be accurate, complete, or current
+
+## 6. Limitation of Liability
+
+To the maximum extent permitted by law, {{OPERATOR_NAME}} and its affiliates shall not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits or revenues, whether incurred directly or indirectly, or any loss of data, use, goodwill, or other intangible losses resulting from your use of the Platform.
+
+## 7. Indemnification
+
+You agree to indemnify and hold harmless {{OPERATOR_NAME}}, its affiliates, and their respective officers, directors, employees, and agents from any claims, damages, losses, or expenses arising from your use of the Platform or violation of these Terms.
+
+## 8. Modifications
+
+We reserve the right to modify these Terms at any time. Material changes will be communicated through the Platform. Continued use after changes constitutes acceptance of the modified Terms.
+
+## 9. Governing Law
+
+These Terms shall be governed by and construed in accordance with the laws of {{JURISDICTION}}, without regard to its conflict of law provisions.
+
+## 10. Contact
+
+For questions about these Terms, contact us at {{OPERATOR_EMAIL}}.
+
+---
+
+*Effective Date: {{EFFECTIVE_DATE}}*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,14 @@ from engine.app import create_app
 from engine.config import settings
 from engine.db.models import Base
 from engine.deps import get_db
+from engine.legal.dependencies import require_legal_acceptance
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+
+async def _bypass_legal_acceptance():
+    return None
 
 
 @pytest.fixture(scope="session")
@@ -23,6 +28,7 @@ def anyio_backend():
 @pytest.fixture
 async def client() -> AsyncIterator[AsyncClient]:
     app = create_app()
+    app.dependency_overrides[require_legal_acceptance] = _bypass_legal_acceptance
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
@@ -60,6 +66,7 @@ async def db_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
         yield db_session
 
     app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_legal_acceptance] = _bypass_legal_acceptance
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from engine.app import create_app
+from engine.db.models import (
+    DataProviderAttribution,
+    LegalAcceptance,
+    LegalDocument,
+)
+from engine.deps import get_db
+from engine.legal.service import (
+    get_pending_acceptances,
+    get_user_acceptances,
+    list_documents,
+    record_acceptances,
+)
+from engine.legal.sync import (
+    apply_substitutions,
+    parse_front_matter,
+    slug_from_filename,
+    sync_legal_documents,
+)
+from tests.factories import make_user
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+HTTP_OK = 200
+HTTP_NOT_FOUND = 404
+HTTP_UNAUTHORIZED = 401
+NUM_LEGAL_DOCS = 6
+
+
+@pytest.fixture
+async def legal_client(db_session: AsyncSession) -> AsyncClient:
+    app = create_app()
+
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestLegalDocumentSync:
+    async def test_parse_front_matter(self):
+        content = '---\ntitle: "Test Doc"\nversion: "1.0.0"\n---\n\nBody text'
+        meta, body = parse_front_matter(content)
+        assert meta["title"] == "Test Doc"
+        assert meta["version"] == "1.0.0"
+        assert "Body text" in body
+
+    async def test_parse_front_matter_invalid(self):
+        with pytest.raises(ValueError, match="front-matter"):
+            parse_front_matter("no front matter here")
+
+    async def test_slug_from_filename(self):
+        assert slug_from_filename("risk-disclaimer.md") == "risk-disclaimer"
+        assert slug_from_filename("terms-of-service.md") == "terms-of-service"
+
+    async def test_apply_substitutions(self):
+        text = "{{OPERATOR_NAME}} provides this platform."
+        result = apply_substitutions(text)
+        assert "Nexus Trade Engine" in result
+        assert "{{OPERATOR_NAME}}" not in result
+
+    async def test_sync_creates_documents(self, db_session: AsyncSession):
+        docs = await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        slugs = {d.slug for d in docs}
+        assert "risk-disclaimer" in slugs
+        assert "terms-of-service" in slugs
+        assert "privacy-policy" in slugs
+        assert "eula" in slugs
+        assert "marketplace-eula" in slugs
+        assert "data-provider-attributions" in slugs
+
+    async def test_sync_upsert_no_duplicate(self, db_session: AsyncSession):
+        docs1 = await sync_legal_documents(db_session)
+        await db_session.flush()
+        count_after_first = len(docs1)
+
+        docs2 = await sync_legal_documents(db_session)
+        await db_session.flush()
+        assert len(docs2) == count_after_first
+
+    async def test_sync_detects_version_change(self, db_session: AsyncSession):
+        await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        doc = await db_session.execute(
+            LegalDocument.__table__.select().where(LegalDocument.slug == "risk-disclaimer")
+        )
+        row = doc.first()
+        assert row is not None
+
+        await db_session.execute(
+            LegalDocument.__table__.update()
+            .where(LegalDocument.slug == "risk-disclaimer")
+            .values(current_version="0.9.0")
+        )
+        await db_session.flush()
+
+        docs = await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        risk_doc = next(d for d in docs if d.slug == "risk-disclaimer")
+        assert risk_doc.current_version == "1.0.0"
+
+
+class TestLegalDocumentAPI:
+    async def test_list_documents(self, legal_client: AsyncClient, db_session: AsyncSession):
+        await sync_legal_documents(db_session)
+        await db_session.commit()
+
+        resp = await legal_client.get("/api/v1/legal/documents")
+        assert resp.status_code == HTTP_OK
+        data = resp.json()
+        assert "documents" in data
+        assert len(data["documents"]) >= NUM_LEGAL_DOCS
+
+    async def test_list_documents_filter_category(
+        self, legal_client: AsyncClient, db_session: AsyncSession
+    ):
+        await sync_legal_documents(db_session)
+        await db_session.commit()
+
+        resp = await legal_client.get("/api/v1/legal/documents?category=trading")
+        assert resp.status_code == HTTP_OK
+        data = resp.json()
+        assert all(d["category"] == "trading" for d in data["documents"])
+
+    async def test_get_document_content(self, legal_client: AsyncClient, db_session: AsyncSession):
+        await sync_legal_documents(db_session)
+        await db_session.commit()
+
+        resp = await legal_client.get("/api/v1/legal/documents/risk-disclaimer")
+        assert resp.status_code == HTTP_OK
+        data = resp.json()
+        assert data["slug"] == "risk-disclaimer"
+        assert data["title"] == "Risk Disclaimer"
+        assert "content_markdown" in data
+        assert "Nexus Trade Engine" in data["content_markdown"]
+        assert data["requires_acceptance"] is True
+
+    async def test_get_document_not_found(
+        self, legal_client: AsyncClient, db_session: AsyncSession
+    ):
+        await sync_legal_documents(db_session)
+        await db_session.commit()
+
+        resp = await legal_client.get("/api/v1/legal/documents/nonexistent")
+        assert resp.status_code == HTTP_NOT_FOUND
+
+    async def test_attributions_empty(self, legal_client: AsyncClient):
+        resp = await legal_client.get("/api/v1/legal/attributions")
+        assert resp.status_code == HTTP_OK
+        data = resp.json()
+        assert "attributions" in data
+        assert len(data["attributions"]) == 0
+
+    async def test_attributions_with_data(
+        self, legal_client: AsyncClient, db_session: AsyncSession
+    ):
+        attr = DataProviderAttribution(
+            provider_slug="polygon-io",
+            provider_name="Polygon.io",
+            attribution_text="Market data provided by Polygon.io",
+            attribution_url="https://polygon.io",
+            display_contexts=["data-feed", "backtest-result"],
+        )
+        db_session.add(attr)
+        await db_session.commit()
+
+        resp = await legal_client.get("/api/v1/legal/attributions")
+        assert resp.status_code == HTTP_OK
+        data = resp.json()
+        assert len(data["attributions"]) == 1
+        assert data["attributions"][0]["provider_slug"] == "polygon-io"
+
+    async def test_attributions_filter_context(
+        self, legal_client: AsyncClient, db_session: AsyncSession
+    ):
+        attr = DataProviderAttribution(
+            provider_slug="polygon-io",
+            provider_name="Polygon.io",
+            attribution_text="Market data provided by Polygon.io",
+            display_contexts=["data-feed", "backtest-result"],
+        )
+        db_session.add(attr)
+        await db_session.commit()
+
+        resp = await legal_client.get("/api/v1/legal/attributions?context=data-feed")
+        assert resp.status_code == HTTP_OK
+        assert len(resp.json()["attributions"]) == 1
+
+        resp2 = await legal_client.get("/api/v1/legal/attributions?context=nonexistent")
+        assert resp2.status_code == HTTP_OK
+        assert len(resp2.json()["attributions"]) == 0
+
+    async def test_accept_requires_auth(self, legal_client: AsyncClient):
+        resp = await legal_client.post(
+            "/api/v1/legal/accept",
+            json={
+                "acceptances": [{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}]
+            },
+        )
+        assert resp.status_code == HTTP_UNAUTHORIZED
+
+    async def test_acceptances_me_requires_auth(self, legal_client: AsyncClient):
+        resp = await legal_client.get("/api/v1/legal/acceptances/me")
+        assert resp.status_code == HTTP_UNAUTHORIZED
+
+
+class TestLegalAcceptanceService:
+    async def test_record_acceptance(self, db_session: AsyncSession):
+        user = make_user()
+        db_session.add(user)
+        await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        accepted = await record_acceptances(
+            db_session,
+            user_id=user.id,
+            acceptances=[{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}],
+            ip_address="127.0.0.1",
+            user_agent="test-agent",
+        )
+        await db_session.flush()
+
+        assert len(accepted) == 1
+        assert accepted[0]["document_slug"] == "risk-disclaimer"
+        assert accepted[0]["document_version"] == "1.0.0"
+        assert accepted[0]["accepted_at"] is not None
+
+    async def test_record_acceptance_idempotent(self, db_session: AsyncSession):
+        user = make_user()
+        db_session.add(user)
+        await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        await record_acceptances(
+            db_session,
+            user_id=user.id,
+            acceptances=[{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}],
+            ip_address="127.0.0.1",
+            user_agent="test-agent",
+        )
+        await db_session.flush()
+
+        accepted2 = await record_acceptances(
+            db_session,
+            user_id=user.id,
+            acceptances=[{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}],
+            ip_address="127.0.0.1",
+            user_agent="test-agent",
+        )
+        await db_session.flush()
+
+        assert len(accepted2) == 1
+
+        count_result = await db_session.execute(
+            LegalAcceptance.__table__.select().where(LegalAcceptance.user_id == user.id)
+        )
+        rows = count_result.fetchall()
+        assert len(rows) == 1
+
+    async def test_acceptance_context_detection(self, db_session: AsyncSession):
+        user = make_user()
+        db_session.add(user)
+        await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        await record_acceptances(
+            db_session,
+            user_id=user.id,
+            acceptances=[{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}],
+            ip_address="127.0.0.1",
+            user_agent="test-agent",
+        )
+        await db_session.flush()
+
+        records = await get_user_acceptances(db_session, user.id)
+        assert len(records) == 1
+        assert records[0].context == "onboarding"
+
+    async def test_get_pending_acceptances(self, db_session: AsyncSession):
+        user = make_user()
+        db_session.add(user)
+        await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        pending = await get_pending_acceptances(db_session, user.id)
+        pending_slugs = {p.slug for p in pending}
+        assert "risk-disclaimer" in pending_slugs
+        assert "terms-of-service" in pending_slugs
+
+    async def test_get_pending_acceptances_after_accept(self, db_session: AsyncSession):
+        user = make_user()
+        db_session.add(user)
+        await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        await record_acceptances(
+            db_session,
+            user_id=user.id,
+            acceptances=[{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}],
+            ip_address="127.0.0.1",
+            user_agent="test-agent",
+        )
+        await db_session.flush()
+
+        pending = await get_pending_acceptances(db_session, user.id)
+        pending_slugs = {p.slug for p in pending}
+        assert "risk-disclaimer" not in pending_slugs
+
+    async def test_list_documents_with_user_acceptance_status(self, db_session: AsyncSession):
+        user = make_user()
+        db_session.add(user)
+        await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        await record_acceptances(
+            db_session,
+            user_id=user.id,
+            acceptances=[{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}],
+            ip_address="127.0.0.1",
+            user_agent="test-agent",
+        )
+        await db_session.flush()
+
+        docs = await list_documents(db_session, user_id=user.id)
+        risk_doc = next(d for d in docs if d["slug"] == "risk-disclaimer")
+        assert risk_doc["accepted"] is True
+        assert risk_doc["accepted_version"] == "1.0.0"
+        assert risk_doc["needs_re_acceptance"] is False
+
+    async def test_needs_re_acceptance_after_version_bump(self, db_session: AsyncSession):
+        user = make_user()
+        db_session.add(user)
+        await sync_legal_documents(db_session)
+        await db_session.flush()
+
+        await record_acceptances(
+            db_session,
+            user_id=user.id,
+            acceptances=[{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}],
+            ip_address="127.0.0.1",
+            user_agent="test-agent",
+        )
+        await db_session.flush()
+
+        await db_session.execute(
+            LegalDocument.__table__.update()
+            .where(LegalDocument.slug == "risk-disclaimer")
+            .values(current_version="2.0.0")
+        )
+        await db_session.flush()
+
+        docs = await list_documents(db_session, user_id=user.id)
+        risk_doc = next(d for d in docs if d["slug"] == "risk-disclaimer")
+        assert risk_doc["accepted"] is True
+        assert risk_doc["accepted_version"] == "1.0.0"
+        assert risk_doc["needs_re_acceptance"] is True


### PR DESCRIPTION
## Summary

Implements **Phase 2 (Backend)** of [SEV-206](https://github.com/SevFle/nexus-trade-engine/issues/154) — Legal documents, consent tracking, and compliance surfaces, per ADR-0003.

### What's included

- **6 legal document templates** in `legal/` with YAML front-matter and operator substitution markers (`{{OPERATOR_NAME}}`, `{{JURISDICTION}}`, etc.)
- **3 new SQLAlchemy models**: `LegalDocument` (registry), `LegalAcceptance` (append-only audit trail), `DataProviderAttribution`
- **Alembic migration** `004_legal_documents` — creates all 3 tables with proper indexes and FK constraints
- **5 API endpoints** under `/api/v1/legal`:
  - `GET /documents` — list with versions and acceptance status
  - `GET /documents/{slug}` — fetch rendered content with substitution
  - `POST /accept` — record acceptance (batch, idempotent)
  - `GET /acceptances/me` — user acceptance history
  - `GET /attributions` — data provider attributions
- **Startup sync** — parses `legal/*.md` front-matter, upserts `legal_documents` table, detects version changes
- **Consent enforcement** — `require_legal_acceptance` dependency returning HTTP 403 with pending document list
- **Operator config** — new `Settings` fields for `operator_name`, `operator_email`, `operator_url`, `operator_jurisdiction`
- **Integration tests** — covering sync, API routes, service layer, acceptance idempotency, re-acceptance detection

### Design decisions (per ADR-0003)

- Hybrid file+DB approach: content in git-versioned Markdown, metadata in queryable DB registry
- Append-only acceptance records — no UPDATE/DELETE on `legal_acceptances`
- `ondelete='RESTRICT'` on user FK — GDPR erasure pseudonymizes user record instead of deleting
- Auth endpoints return 401 placeholder until ADR-0002 (auth) lands

Closes #154