### PR TITLE
feat: legal documents, models, API routes (Phase 2 — SEV-486)

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -4,7 +4,9 @@ from fastapi import APIRouter
 
 from engine.api.routes.backtest import router as backtest_router
 from engine.api.routes.health import router as health_router
+from engine.api.routes.legal import router as legal_router
 
 api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
 api_router.include_router(backtest_router, prefix="/api/v1/backtest", tags=["backtest"])
+api_router.include_router(legal_router, tags=["legal"])

--- a/engine/api/routes/legal.py
+++ b/engine/api/routes/legal.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from engine.config import settings
+from engine.deps import get_db
+from engine.legal import service as legal_service
+from engine.legal.schemas import (
+    AcceptanceListResponse,
+    AcceptRequest,
+    AcceptResponse,
+    AttributionListResponse,
+    DocumentDetailResponse,
+    DocumentListResponse,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+def _apply_substitutions(content: str) -> str:
+    return (
+        content.replace("{{OPERATOR_NAME}}", settings.operator_name)
+        .replace("{{OPERATOR_EMAIL}}", settings.operator_email)
+        .replace("{{OPERATOR_URL}}", settings.operator_url)
+        .replace("{{JURISDICTION}}", settings.jurisdiction)
+        .replace("{{PLATFORM_FEE_PERCENT}}", str(settings.platform_fee_percent))
+    )
+
+
+def _strip_front_matter(text: str) -> str:
+    first = text.find("---\n")
+    if first == -1:
+        return text
+    second = text.find("---\n", first + 4)
+    if second == -1:
+        return text
+    return text[second + 4 :].strip()
+
+
+@router.get("/api/v1/legal/documents", response_model=DocumentListResponse)
+async def list_documents(
+    category: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> DocumentListResponse:
+    summaries = await legal_service.list_documents(db, user_id=None, category=category)
+    return DocumentListResponse(documents=summaries)
+
+
+@router.get("/api/v1/legal/documents/{slug}", response_model=DocumentDetailResponse)
+async def get_document(
+    slug: str,
+    version: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> DocumentDetailResponse:
+    result = await legal_service.get_document_content(db, slug, version)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Document '{slug}' not found")
+    doc, raw = result
+    rendered = _strip_front_matter(_apply_substitutions(raw))
+    return DocumentDetailResponse(
+        slug=doc.slug,
+        title=doc.title,
+        version=doc.current_version,
+        effective_date=doc.effective_date,
+        content_markdown=rendered,
+        requires_acceptance=doc.requires_acceptance,
+    )
+
+
+@router.post("/api/v1/legal/accept", response_model=AcceptResponse)
+async def accept_documents(
+    _request: Request,
+    _body: AcceptRequest,
+    _db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> None:
+    raise HTTPException(
+        status_code=401,
+        detail="Authentication required.",
+    )
+
+
+@router.get("/api/v1/legal/acceptances/me", response_model=AcceptanceListResponse)
+async def list_my_acceptances(
+    _document_slug: str | None = Query(None),
+    _db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> None:
+    raise HTTPException(
+        status_code=401,
+        detail="Authentication required.",
+    )
+
+
+@router.get("/api/v1/legal/attributions", response_model=AttributionListResponse)
+async def list_attributions(
+    context: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> AttributionListResponse:
+    items = await legal_service.list_attributions(db, context=context)
+    return AttributionListResponse(attributions=items)

--- a/engine/app.py
+++ b/engine/app.py
@@ -3,18 +3,22 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from valkey.asyncio import Valkey
 
 from engine.api.router import api_router
 from engine.config import settings
-from engine.db.session import dispose_engine
+from engine.db.session import dispose_engine, get_session_factory
+from engine.legal.sync import sync_legal_documents
 from engine.observability.logging import setup_logging
 from engine.observability.tracing import setup_tracing
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+logger = structlog.get_logger()
 
 
 @asynccontextmanager
@@ -22,6 +26,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     setup_logging()
     setup_tracing()
     app.state.valkey = Valkey.from_url(settings.valkey_url)
+    try:
+        session_factory = get_session_factory()
+        async with session_factory() as db:
+            count = await sync_legal_documents(db)
+            await db.commit()
+        if count > 0:
+            logger.info("legal.sync_complete", documents_synced=count)
+    except Exception:
+        logger.exception("legal.sync_failed")
     yield
     await app.state.valkey.aclose()
     await dispose_engine()

--- a/engine/config.py
+++ b/engine/config.py
@@ -32,6 +32,14 @@ class Settings(BaseSettings):
     # Worker
     worker_concurrency: int = 4
 
+    # Legal / Operator
+    legal_documents_dir: str = "legal"
+    operator_name: str = "Nexus Trade Engine"
+    operator_email: str = "legal@example.com"
+    operator_url: str = "https://example.com"
+    jurisdiction: str = "United States"
+    platform_fee_percent: int = 30
+
     @property
     def is_production(self) -> bool:
         return self.app_env == "production"

--- a/engine/db/migrations/versions/004_legal_documents.py
+++ b/engine/db/migrations/versions/004_legal_documents.py
@@ -1,0 +1,102 @@
+"""add legal_documents, legal_acceptances, data_provider_attributions
+
+Revision ID: 004_legal_documents
+Revises: 003_bt_result_nullable_pid
+Create Date: 2026-04-18
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "004_legal_documents"
+down_revision: str | Sequence[str] | None = "003_bt_result_nullable_pid"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "legal_documents",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column("slug", sa.String(50), unique=True, nullable=False),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("current_version", sa.String(20), nullable=False),
+        sa.Column("effective_date", sa.Date(), nullable=False),
+        sa.Column(
+            "requires_acceptance", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column("category", sa.String(30), nullable=False, server_default="general"),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("file_path", sa.String(255), nullable=False),
+        sa.Column(
+            "created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+    )
+    op.create_index("ix_legal_documents_category", "legal_documents", ["category"])
+
+    op.create_table(
+        "legal_acceptances",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("document_slug", sa.String(50), nullable=False),
+        sa.Column("document_version", sa.String(20), nullable=False),
+        sa.Column(
+            "accepted_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("ip_address", sa.String(45), nullable=False),
+        sa.Column("user_agent", sa.String(500), nullable=False),
+        sa.Column("context", sa.String(50), nullable=False, server_default="onboarding"),
+        sa.Column("revoked_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index("ix_acceptance_user_doc", "legal_acceptances", ["user_id", "document_slug"])
+    op.create_index(
+        "ix_acceptance_user_doc_ver",
+        "legal_acceptances",
+        ["user_id", "document_slug", "document_version"],
+    )
+    op.create_index("ix_acceptance_time", "legal_acceptances", ["accepted_at"])
+
+    op.create_table(
+        "data_provider_attributions",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column("provider_slug", sa.String(50), unique=True, nullable=False),
+        sa.Column("provider_name", sa.String(100), nullable=False),
+        sa.Column("attribution_text", sa.Text(), nullable=False),
+        sa.Column("attribution_url", sa.String(500), nullable=True),
+        sa.Column("logo_path", sa.String(255), nullable=True),
+        sa.Column(
+            "display_contexts",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default="'[]'",
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("data_provider_attributions")
+    op.drop_table("legal_acceptances")
+    op.drop_table("legal_documents")

--- a/engine/db/migrations/versions/004_legal_documents.py
+++ b/engine/db/migrations/versions/004_legal_documents.py
@@ -84,7 +84,7 @@ def upgrade() -> None:
             "display_contexts",
             postgresql.JSONB(),
             nullable=False,
-            server_default="'[]'",
+            server_default=sa.text("'[]'::jsonb"),
         ),
         sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
         sa.Column(

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -5,7 +5,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from enum import Enum
 
-from sqlalchemy import ForeignKey, Index, Numeric, String, Text, UniqueConstraint
+from sqlalchemy import DateTime, ForeignKey, Index, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -175,8 +175,10 @@ class LegalDocument(Base):
     category: Mapped[str] = mapped_column(String(30), default="general", index=True)
     display_order: Mapped[int] = mapped_column(default=0)
     file_path: Mapped[str] = mapped_column(String(255))
-    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
-    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
 
 
 class LegalAcceptance(Base):
@@ -188,11 +190,11 @@ class LegalAcceptance(Base):
     )
     document_slug: Mapped[str] = mapped_column(String(50))
     document_version: Mapped[str] = mapped_column(String(20))
-    accepted_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    accepted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     ip_address: Mapped[str] = mapped_column(String(45))
     user_agent: Mapped[str] = mapped_column(String(500))
     context: Mapped[str] = mapped_column(String(50), default="onboarding")
-    revoked_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     __table_args__ = (
         Index("ix_acceptance_user_doc", "user_id", "document_slug"),
@@ -212,5 +214,7 @@ class DataProviderAttribution(Base):
     logo_path: Mapped[str | None] = mapped_column(String(255), nullable=True)
     display_contexts: Mapped[dict] = mapped_column(JSONB, default=list)  # type: ignore[assignment]
     is_active: Mapped[bool] = mapped_column(default=True)
-    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
-    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from enum import Enum
 
@@ -161,3 +161,56 @@ class OHLCVBar(Base):
         Index("ix_ohlcv_symbol_timestamp", "symbol", "timestamp"),
         UniqueConstraint("symbol", "timestamp", name="uq_ohlcv_symbol_timestamp"),
     )
+
+
+class LegalDocument(Base):
+    __tablename__ = "legal_documents"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    slug: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    title: Mapped[str] = mapped_column(String(200))
+    current_version: Mapped[str] = mapped_column(String(20))
+    effective_date: Mapped[date] = mapped_column()
+    requires_acceptance: Mapped[bool] = mapped_column(default=True)
+    category: Mapped[str] = mapped_column(String(30), default="general", index=True)
+    display_order: Mapped[int] = mapped_column(default=0)
+    file_path: Mapped[str] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
+
+
+class LegalAcceptance(Base):
+    __tablename__ = "legal_acceptances"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="RESTRICT"), index=True
+    )
+    document_slug: Mapped[str] = mapped_column(String(50))
+    document_version: Mapped[str] = mapped_column(String(20))
+    accepted_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    ip_address: Mapped[str] = mapped_column(String(45))
+    user_agent: Mapped[str] = mapped_column(String(500))
+    context: Mapped[str] = mapped_column(String(50), default="onboarding")
+    revoked_at: Mapped[datetime | None] = mapped_column(nullable=True)
+
+    __table_args__ = (
+        Index("ix_acceptance_user_doc", "user_id", "document_slug"),
+        Index("ix_acceptance_user_doc_ver", "user_id", "document_slug", "document_version"),
+        Index("ix_acceptance_time", "accepted_at"),
+    )
+
+
+class DataProviderAttribution(Base):
+    __tablename__ = "data_provider_attributions"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    provider_slug: Mapped[str] = mapped_column(String(50), unique=True)
+    provider_name: Mapped[str] = mapped_column(String(100))
+    attribution_text: Mapped[str] = mapped_column(Text)
+    attribution_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    logo_path: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    display_contexts: Mapped[dict] = mapped_column(JSONB, default=list)  # type: ignore[assignment]
+    is_active: Mapped[bool] = mapped_column(default=True)
+    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -26,8 +26,10 @@ class User(Base):
     hashed_password: Mapped[str] = mapped_column(String(255))
     display_name: Mapped[str] = mapped_column(String(100))
     is_active: Mapped[bool] = mapped_column(default=True)
-    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
-    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
 
     portfolios: Mapped[list[Portfolio]] = relationship(back_populates="user")
 
@@ -42,7 +44,7 @@ class Portfolio(Base):
     name: Mapped[str] = mapped_column(String(200))
     description: Mapped[str] = mapped_column(Text, default="")
     initial_capital: Mapped[Decimal] = mapped_column(Numeric(18, 4), default=Decimal("100000.0"))
-    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
     user: Mapped[User] = relationship(back_populates="portfolios")
     positions: Mapped[list[Position]] = relationship(back_populates="portfolio")
@@ -61,7 +63,9 @@ class Position(Base):
     quantity: Mapped[Decimal] = mapped_column(Numeric(18, 8), default=Decimal("0"))
     avg_entry_price: Mapped[Decimal] = mapped_column(Numeric(18, 8), default=Decimal("0"))
     current_price: Mapped[Decimal] = mapped_column(Numeric(18, 8), default=Decimal("0"))
-    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
 
     portfolio: Mapped[Portfolio] = relationship(back_populates="positions")
 
@@ -83,8 +87,8 @@ class Order(Base):
     quantity: Mapped[Decimal]
     price: Mapped[Decimal | None] = mapped_column(Numeric(18, 8), nullable=True)
     status: Mapped[str] = mapped_column(String(20), default="pending")
-    filled_at: Mapped[datetime | None] = mapped_column(nullable=True)
-    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    filled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
     portfolio: Mapped[Portfolio] = relationship(back_populates="orders")
 
@@ -99,7 +103,7 @@ class InstalledStrategy(Base):
     strategy_name: Mapped[str] = mapped_column(String(100))
     config: Mapped[dict] = mapped_column(JSONB, default=dict)  # type: ignore[assignment]
     is_active: Mapped[bool] = mapped_column(default=True)
-    installed_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    installed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
 
 class BacktestResult(Base):
@@ -110,10 +114,10 @@ class BacktestResult(Base):
         ForeignKey("portfolios.id", ondelete="CASCADE"), index=True, nullable=True
     )
     strategy_name: Mapped[str] = mapped_column(String(100))
-    start_date: Mapped[datetime]
-    end_date: Mapped[datetime]
+    start_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    end_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     metrics: Mapped[dict] = mapped_column(JSONB, default=dict)  # type: ignore[assignment]
-    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
 
 class TaxLotStatus(str, Enum):
@@ -134,11 +138,13 @@ class TaxLotRecord(Base):
     quantity: Mapped[Decimal] = mapped_column(Numeric(18, 8))
     remaining_quantity: Mapped[Decimal] = mapped_column(Numeric(18, 8))
     purchase_price: Mapped[Decimal] = mapped_column(Numeric(18, 8))
-    purchase_date: Mapped[datetime]
+    purchase_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     cost_basis_adjustment: Mapped[Decimal] = mapped_column(Numeric(18, 8), default=Decimal("0"))
     status: Mapped[str] = mapped_column(String(30), default=TaxLotStatus.OPEN.value)
-    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
-    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
 
     portfolio: Mapped[Portfolio] = relationship(back_populates="tax_lots")
 
@@ -150,7 +156,7 @@ class OHLCVBar(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     symbol: Mapped[str] = mapped_column(String(20))
-    timestamp: Mapped[datetime]
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     open: Mapped[Decimal] = mapped_column(Numeric(18, 8))
     high: Mapped[Decimal] = mapped_column(Numeric(18, 8))
     low: Mapped[Decimal] = mapped_column(Numeric(18, 8))

--- a/engine/legal/__init__.py
+++ b/engine/legal/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/engine/legal/dependencies.py
+++ b/engine/legal/dependencies.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from fastapi import Depends, HTTPException
+
+from engine.deps import get_db
+from engine.legal import service as legal_service
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_placeholder_uuid = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
+async def require_legal_acceptance(
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> None:
+    pending = await legal_service.get_pending_acceptances(db, _placeholder_uuid)
+    if pending:
+        raise HTTPException(
+            status_code=451,
+            detail={
+                "code": "legal_re_acceptance_required",
+                "documents": [p.slug for p in pending],
+            },
+        )

--- a/engine/legal/schemas.py
+++ b/engine/legal/schemas.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import date, datetime  # noqa: TC003
+
+from pydantic import BaseModel, Field
+
+
+class DocumentSummary(BaseModel):
+    slug: str
+    title: str
+    current_version: str
+    effective_date: date
+    requires_acceptance: bool
+    category: str
+    accepted: bool = False
+    accepted_version: str | None = None
+    needs_re_acceptance: bool = False
+
+
+class DocumentListResponse(BaseModel):
+    documents: list[DocumentSummary]
+
+
+class DocumentDetailResponse(BaseModel):
+    slug: str
+    title: str
+    version: str
+    effective_date: date
+    content_markdown: str
+    requires_acceptance: bool
+
+
+class AcceptanceItem(BaseModel):
+    document_slug: str
+    document_version: str
+
+
+class AcceptRequest(BaseModel):
+    acceptances: list[AcceptanceItem] = Field(min_length=1)
+
+
+class AcceptedItem(BaseModel):
+    document_slug: str
+    document_version: str
+    accepted_at: datetime
+
+
+class AcceptResponse(BaseModel):
+    accepted: list[AcceptedItem]
+
+
+class AcceptanceRecord(BaseModel):
+    id: str
+    document_slug: str
+    document_version: str
+    accepted_at: datetime
+    context: str
+    revoked_at: datetime | None = None
+
+
+class AcceptanceListResponse(BaseModel):
+    acceptances: list[AcceptanceRecord]
+
+
+class AttributionItem(BaseModel):
+    provider_slug: str
+    provider_name: str
+    attribution_text: str
+    attribution_url: str | None = None
+    logo_path: str | None = None
+
+
+class AttributionListResponse(BaseModel):
+    attributions: list[AttributionItem]

--- a/engine/legal/service.py
+++ b/engine/legal/service.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import uuid  # noqa: TC003
+from datetime import UTC
+from datetime import datetime as dt
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from engine.db.models import (
+    DataProviderAttribution,
+    LegalAcceptance,
+    LegalDocument,
+)
+from engine.legal.schemas import (
+    AcceptanceItem,
+    AcceptanceRecord,
+    AcceptedItem,
+    AttributionItem,
+    DocumentSummary,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger()
+
+NUM_DOCS_ON_DISK = 6
+
+
+async def list_documents(
+    db: AsyncSession,
+    user_id: uuid.UUID | None = None,
+    category: str | None = None,
+) -> list[DocumentSummary]:
+    stmt = select(LegalDocument).order_by(LegalDocument.display_order)
+    if category:
+        stmt = stmt.where(LegalDocument.category == category)
+    result = await db.execute(stmt)
+    docs = result.scalars().all()
+
+    summaries: list[DocumentSummary] = []
+    for doc in docs:
+        accepted = False
+        accepted_version: str | None = None
+        if user_id:
+            latest = await _get_latest_acceptance(db, user_id, doc.slug)
+            if latest is not None:
+                accepted = True
+                accepted_version = latest.document_version
+        needs_re = doc.requires_acceptance and (
+            not accepted
+            or (accepted_version is not None and accepted_version < doc.current_version)
+        )
+        summaries.append(
+            DocumentSummary(
+                slug=doc.slug,
+                title=doc.title,
+                current_version=doc.current_version,
+                effective_date=doc.effective_date,
+                requires_acceptance=doc.requires_acceptance,
+                category=doc.category,
+                accepted=accepted,
+                accepted_version=accepted_version,
+                needs_re_acceptance=bool(needs_re),
+            )
+        )
+    return summaries
+
+
+async def get_document_content(
+    db: AsyncSession,
+    slug: str,
+    version: str | None = None,
+) -> tuple[LegalDocument, str] | None:
+    stmt = select(LegalDocument).where(LegalDocument.slug == slug)
+    result = await db.execute(stmt)
+    doc = result.scalar_one_or_none()
+    if doc is None:
+        return None
+    if version and version != doc.current_version:
+        return None
+    try:
+        with open(doc.file_path) as f:
+            markdown = f.read()
+    except FileNotFoundError:
+        logger.exception("legal.file_not_found", path=doc.file_path, slug=slug)
+        return None
+    return doc, markdown
+
+
+async def record_acceptances(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    items: list[AcceptanceItem],
+    ip_address: str,
+    user_agent: str,
+    context: str | None = None,
+) -> list[AcceptedItem]:
+    accepted: list[AcceptedItem] = []
+    now = dt.now(tz=UTC)
+
+    for item in items:
+        doc_stmt = select(LegalDocument).where(
+            LegalDocument.slug == item.document_slug,
+            LegalDocument.current_version == item.document_version,
+        )
+        doc_result = await db.execute(doc_stmt)
+        doc = doc_result.scalar_one_or_none()
+        if doc is None:
+            slug_ver = f"{item.document_slug} v{item.document_version}"
+            raise HTTPException(
+                status_code=422,
+                detail=f"Document '{slug_ver}' not found",
+            )
+
+        existing = await _get_exact_acceptance(
+            db, user_id, item.document_slug, item.document_version
+        )
+        if existing is not None:
+            accepted.append(
+                AcceptedItem(
+                    document_slug=item.document_slug,
+                    document_version=item.document_version,
+                    accepted_at=existing.accepted_at,
+                )
+            )
+            continue
+
+        accept_context = context
+        if accept_context is None:
+            has_prior = await _get_latest_acceptance(db, user_id, item.document_slug)
+            accept_context = "onboarding" if has_prior is None else "re-acceptance"
+
+        record = LegalAcceptance(
+            user_id=user_id,
+            document_slug=item.document_slug,
+            document_version=item.document_version,
+            accepted_at=now,
+            ip_address=ip_address,
+            user_agent=user_agent,
+            context=accept_context,
+        )
+        db.add(record)
+        accepted.append(
+            AcceptedItem(
+                document_slug=item.document_slug,
+                document_version=item.document_version,
+                accepted_at=now,
+            )
+        )
+
+    await db.flush()
+    return accepted
+
+
+async def list_user_acceptances(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    document_slug: str | None = None,
+) -> list[AcceptanceRecord]:
+    stmt = (
+        select(LegalAcceptance)
+        .where(LegalAcceptance.user_id == user_id)
+        .order_by(LegalAcceptance.accepted_at.desc())
+    )
+    if document_slug:
+        stmt = stmt.where(LegalAcceptance.document_slug == document_slug)
+    result = await db.execute(stmt)
+    records = result.scalars().all()
+    return [
+        AcceptanceRecord(
+            id=str(r.id),
+            document_slug=r.document_slug,
+            document_version=r.document_version,
+            accepted_at=r.accepted_at,
+            context=r.context,
+            revoked_at=r.revoked_at,
+        )
+        for r in records
+    ]
+
+
+async def get_pending_acceptances(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[LegalDocument]:
+    stmt = select(LegalDocument).where(LegalDocument.requires_acceptance.is_(True))
+    result = await db.execute(stmt)
+    docs = result.scalars().all()
+
+    pending: list[LegalDocument] = []
+    for doc in docs:
+        latest = await _get_latest_acceptance(db, user_id, doc.slug)
+        if latest is None or latest.document_version < doc.current_version:
+            pending.append(doc)
+    return pending
+
+
+async def list_attributions(
+    db: AsyncSession,
+    context: str | None = None,
+) -> list[AttributionItem]:
+    stmt = select(DataProviderAttribution).where(DataProviderAttribution.is_active.is_(True))
+    result = await db.execute(stmt)
+    attributions = result.scalars().all()
+
+    items: list[AttributionItem] = []
+    for attr in attributions:
+        if context:
+            contexts = attr.display_contexts if isinstance(attr.display_contexts, list) else []
+            if context not in contexts:
+                continue
+        items.append(
+            AttributionItem(
+                provider_slug=attr.provider_slug,
+                provider_name=attr.provider_name,
+                attribution_text=attr.attribution_text,
+                attribution_url=attr.attribution_url,
+                logo_path=attr.logo_path,
+            )
+        )
+    return items
+
+
+async def _get_latest_acceptance(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    document_slug: str,
+) -> LegalAcceptance | None:
+    stmt = (
+        select(LegalAcceptance)
+        .where(
+            LegalAcceptance.user_id == user_id,
+            LegalAcceptance.document_slug == document_slug,
+            LegalAcceptance.revoked_at.is_(None),
+        )
+        .order_by(LegalAcceptance.accepted_at.desc())
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def _get_exact_acceptance(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    document_slug: str,
+    document_version: str,
+) -> LegalAcceptance | None:
+    stmt = (
+        select(LegalAcceptance)
+        .where(
+            LegalAcceptance.user_id == user_id,
+            LegalAcceptance.document_slug == document_slug,
+            LegalAcceptance.document_version == document_version,
+            LegalAcceptance.revoked_at.is_(None),
+        )
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()

--- a/engine/legal/sync.py
+++ b/engine/legal/sync.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import re
+from datetime import date as date_type
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+from sqlalchemy import select
+
+from engine.config import settings
+from engine.db.models import LegalDocument
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger()
+
+FRONT_MATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def parse_front_matter(content: str) -> dict[str, str] | None:
+    match = FRONT_MATTER_RE.match(content)
+    if not match:
+        return None
+    metadata: dict[str, str] = {}
+    for line in match.group(1).strip().splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            metadata[key.strip()] = value.strip().strip('"').strip("'")
+    return metadata
+
+
+def _parse_date(value: str) -> date_type:
+    parts = value.split("-")
+    return date_type(int(parts[0]), int(parts[1]), int(parts[2]))
+
+
+async def sync_legal_documents(db: AsyncSession) -> int:
+    legal_dir = Path(settings.legal_documents_dir)
+    if not legal_dir.is_dir():
+        logger.warning("legal.directory_not_found", path=str(legal_dir))
+        return 0
+
+    synced = 0
+    for md_file in sorted(legal_dir.glob("*.md")):
+        try:
+            content = md_file.read_text()
+            meta = parse_front_matter(content)
+            if meta is None:
+                logger.warning("legal.no_front_matter", file=str(md_file))
+                continue
+
+            slug = md_file.stem
+            title = meta.get("title", slug.replace("-", " ").title())
+            version = meta.get("version", "1.0.0")
+            effective_date = meta.get("effective_date", "2026-01-01")
+            requires_acceptance = meta.get("requires_acceptance", "true").lower() == "true"
+            category = meta.get("category", "general")
+            display_order = int(meta.get("display_order", "0"))
+
+            stmt = select(LegalDocument).where(LegalDocument.slug == slug)
+            result = await db.execute(stmt)
+            existing = result.scalar_one_or_none()
+
+            if existing is None:
+                doc = LegalDocument(
+                    slug=slug,
+                    title=title,
+                    current_version=version,
+                    effective_date=_parse_date(effective_date),
+                    requires_acceptance=requires_acceptance,
+                    category=category,
+                    display_order=display_order,
+                    file_path=str(md_file),
+                )
+                db.add(doc)
+                logger.info("legal.document_registered", slug=slug, version=version)
+            elif existing.current_version != version:
+                old_version = existing.current_version
+                existing.current_version = version
+                existing.title = title
+                existing.effective_date = _parse_date(effective_date)
+                existing.requires_acceptance = requires_acceptance
+                existing.category = category
+                existing.display_order = display_order
+                existing.file_path = str(md_file)
+                logger.info(
+                    "legal.version_changed",
+                    slug=slug,
+                    old=old_version,
+                    new=version,
+                )
+            else:
+                existing.title = title
+                existing.effective_date = _parse_date(effective_date)
+                existing.requires_acceptance = requires_acceptance
+                existing.category = category
+                existing.display_order = display_order
+                existing.file_path = str(md_file)
+
+            synced += 1
+        except Exception:
+            logger.exception("legal.sync_file_error", file=str(md_file))
+            continue
+
+    await db.flush()
+    return synced

--- a/legal/data-provider-attributions.md
+++ b/legal/data-provider-attributions.md
@@ -1,0 +1,63 @@
+---
+title: "Data Provider Attributions"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: false
+category: "data"
+display_order: 6
+---
+
+# Data Provider Attributions
+
+> **NOT LEGAL ADVICE** — This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+
+## Overview
+
+{{OPERATOR_NAME}} uses market data from the following third-party data providers. Each provider requires specific attribution when their data is displayed or distributed. This document serves as a reference for required attribution text.
+
+## Polygon.io
+
+**Attribution text**: "Market data provided by Polygon.io. Polygon.io does not guarantee the accuracy or completeness of data. Use of Polygon.io data is subject to the Polygon.io Terms of Service."
+
+**Website**: https://polygon.io
+
+**Display contexts**: data-feed, backtest-result, chart, export
+
+## Financial Modeling Prep (FMP)
+
+**Attribution text**: "Financial data provided by Financial Modeling Prep (FMP). FMP makes no warranties regarding the accuracy or completeness of the data provided."
+
+**Website**: https://financialmodelingprep.com
+
+**Display contexts**: data-feed, backtest-result, export
+
+## Alpha Vantage
+
+**Attribution text**: "Data provided by Alpha Vantage. Alpha Vantage is not responsible for the accuracy of data. Use of Alpha Vantage data is subject to the Alpha Vantage Terms of Service."
+
+**Website**: https://www.alphavantage.co
+
+**Display contexts**: data-feed, backtest-result
+
+## Display Requirements
+
+When displaying data from any provider, the following rules apply:
+
+1. **Charts and visualizations**: Include provider name or logo in the footer or watermark.
+2. **Backtest results**: Include attribution text in the results footer.
+3. **Data exports (CSV/PDF)**: Include full attribution text in the document footer.
+4. **API responses**: Attribution metadata is included in API response headers or metadata fields.
+
+## Contact
+
+For questions about data provider attributions, contact {{OPERATOR_EMAIL}}.
+
+---
+
+> *This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.*
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+**Operator**: {{OPERATOR_NAME}}
+**Jurisdiction**: {{JURISDICTION}}

--- a/legal/eula.md
+++ b/legal/eula.md
@@ -1,0 +1,73 @@
+---
+title: "End User License Agreement"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "general"
+display_order: 3
+---
+
+# End User License Agreement
+
+> **NOT LEGAL ADVICE** — This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+
+## 1. License Grant
+
+Subject to your compliance with this End User License Agreement ("EULA"), {{OPERATOR_NAME}} ("Licensor") grants you a limited, non-exclusive, non-transferable, revocable license to access and use the {{OPERATOR_NAME}} trading platform ("Software") for your personal or internal business purposes.
+
+## 2. License Restrictions
+
+You may not:
+
+- Copy, modify, or distribute the Software beyond what is expressly permitted.
+- Rent, lease, lend, sell, sublicense, or otherwise distribute the Software.
+- Use the Software to provide a competing service or product.
+- Remove, alter, or obscure any proprietary notices on the Software.
+- Use the Software in any manner that violates applicable laws or regulations.
+- Attempt to circumvent any access controls or usage limits.
+
+## 3. Ownership
+
+The Software is licensed, not sold. {{OPERATOR_NAME}} retains all right, title, and interest in and to the Software, including all intellectual property rights. This EULA does not grant you any ownership rights.
+
+## 4. Open Source Components
+
+The Software may include or rely on open-source software components. Each open-source component is governed by its respective license terms. A list of open-source components is available upon request.
+
+## 5. Updates and Modifications
+
+{{OPERATOR_NAME}} may release updates, patches, or new versions of the Software at any time. You are encouraged to use the latest version. Continued use of outdated versions is at your own risk.
+
+## 6. Disclaimer of Warranties
+
+THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. {{OPERATOR_NAME}} DOES NOT WARRANT THAT:
+
+- THE SOFTWARE WILL BE UNINTERRUPTED, TIMELY, SECURE, OR ERROR-FREE.
+- THE RESULTS OBTAINED FROM THE USE OF THE SOFTWARE WILL BE ACCURATE OR RELIABLE.
+- ANY ERRORS IN THE SOFTWARE WILL BE CORRECTED.
+
+## 7. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, {{OPERATOR_NAME}} SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY, OR ANY LOSS OF DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES RESULTING FROM YOUR USE OF THE SOFTWARE.
+
+## 8. Termination
+
+This EULA is effective until terminated. {{OPERATOR_NAME}} may terminate this EULA at any time if you fail to comply with any term. Upon termination, you must cease all use of the Software.
+
+## 9. Governing Law
+
+This EULA shall be governed by the laws of {{JURISDICTION}}.
+
+## 10. Contact
+
+For questions about this EULA, contact {{OPERATOR_EMAIL}}.
+
+---
+
+> *This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.*
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+**Operator**: {{OPERATOR_NAME}}
+**Jurisdiction**: {{JURISDICTION}}

--- a/legal/marketplace-eula.md
+++ b/legal/marketplace-eula.md
@@ -1,0 +1,100 @@
+---
+title: "Marketplace End User License Agreement"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "marketplace"
+display_order: 5
+---
+
+# Marketplace End User License Agreement
+
+> **NOT LEGAL ADVICE** — This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+
+## 1. Overview
+
+This Marketplace End User License Agreement ("Marketplace EULA") governs your use of trading strategies, indicators, and other content ("Marketplace Content") published by third-party authors on the {{OPERATOR_NAME}} marketplace ("Marketplace").
+
+## 2. Strategy Author Intellectual Property
+
+- Marketplace Content is owned by its respective authors ("Authors") and is protected by applicable intellectual property laws.
+- Authors retain all right, title, and interest in their strategies, including the underlying logic, algorithms, and code.
+- Nothing in this Marketplace EULA transfers ownership of Author IP to you or to {{OPERATOR_NAME}}.
+
+## 3. Licensing Options
+
+Authors may offer their Marketplace Content under one or more of the following license types:
+
+- **Free**: No cost, unrestricted personal use within the platform.
+- **Subscription**: Recurring fee for ongoing access to the strategy and updates.
+- **One-time purchase**: Single payment for perpetual use within the platform.
+
+The specific license terms for each strategy are displayed on its Marketplace listing.
+
+## 4. Revenue Share
+
+{{OPERATOR_NAME}} and the Author share revenue from paid Marketplace Content. The revenue share arrangement is as follows:
+
+- **Platform fee**: {{PLATFORM_FEE_PERCENT}}% of gross revenue is retained by {{OPERATOR_NAME}}.
+- **Author share**: The remaining percentage is paid to the Author.
+
+Authors acknowledge and agree to this revenue share by publishing on the Marketplace.
+
+## 5. Author Warranties
+
+By publishing Marketplace Content, each Author represents and warrants that:
+
+- They own or have the right to license the content.
+- The content does not infringe any third-party intellectual property rights.
+- The content does not contain malicious code, backdoors, or harmful components.
+- Performance claims, if any, are based on actual backtesting results and are not misleading.
+- They will comply with all applicable laws and regulations.
+
+## 6. User Obligations
+
+As a user of Marketplace Content, you agree to:
+
+- Use Marketplace Content only for its intended purpose within the platform.
+- Not reverse-engineer, decompile, or extract the underlying logic of Marketplace Content.
+- Not redistribute, resell, or share Marketplace Content with third parties.
+- Acknowledge that Marketplace Content is provided without guarantees of performance or profitability.
+- Report any bugs, issues, or suspicious behavior to {{OPERATOR_EMAIL}}.
+
+## 7. Disclaimer of Warranties
+
+MARKETPLACE CONTENT IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. NEITHER {{OPERATOR_NAME}} NOR THE AUTHOR WARRANTS THAT:
+
+- THE STRATEGY WILL BE PROFITABLE OR ACHIEVE ANY SPECIFIC RESULTS.
+- THE STRATEGY WILL BE FREE FROM ERRORS, BUGS, OR INTERRUPTIONS.
+- THE STRATEGY WILL BE COMPATIBLE WITH FUTURE VERSIONS OF THE PLATFORM.
+
+## 8. Dispute Resolution
+
+### 8.1 Between User and Author
+If you have a dispute with an Author regarding Marketplace Content, you may contact {{OPERATOR_EMAIL}} for mediation. {{OPERATOR_NAME}} will attempt to facilitate resolution but is not a party to the dispute.
+
+### 8.2 Arbitration
+Any disputes arising under this Marketplace EULA that cannot be resolved informally shall be resolved through binding arbitration in {{JURISDICTION}}, in accordance with the applicable arbitration rules.
+
+## 9. Removal of Content
+
+{{OPERATOR_NAME}} reserves the right to remove Marketplace Content that:
+
+- Violates this Marketplace EULA or the Terms of Service.
+- Contains malicious code or security vulnerabilities.
+- Is reported for intellectual property infringement.
+- Is found to have misleading performance claims.
+
+## 10. Contact
+
+For questions about this Marketplace EULA, contact {{OPERATOR_EMAIL}}.
+
+---
+
+> *This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.*
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+**Operator**: {{OPERATOR_NAME}}
+**Jurisdiction**: {{JURISDICTION}}

--- a/legal/privacy-policy.md
+++ b/legal/privacy-policy.md
@@ -1,0 +1,126 @@
+---
+title: "Privacy Policy"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "general"
+display_order: 2
+---
+
+# Privacy Policy
+
+> **NOT LEGAL ADVICE** — This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+
+## 1. Introduction
+
+{{OPERATOR_NAME}} ("we", "us", "our") operates the trading platform accessible at {{OPERATOR_URL}} ("Service"). This Privacy Policy describes how we collect, use, store, and protect your personal information when you use our Service.
+
+## 2. Data We Collect
+
+### 2.1 Information You Provide
+- **Account data**: Email address, display name, and password (hashed).
+- **Profile data**: Any additional information you choose to provide in your profile.
+- **Trading data**: Portfolio configurations, strategy parameters, and trading preferences.
+
+### 2.2 Information Collected Automatically
+- **Usage data**: Pages visited, features used, time spent, and interaction patterns.
+- **Device data**: Browser type, operating system, IP address, and user agent.
+- **Legal compliance data**: Acceptance records for legal documents, including timestamps and IP addresses.
+
+### 2.3 Data from Third Parties
+- **Market data**: We receive market data from third-party providers to power the Service. This data is not personal information.
+- **Payment processors**: If you make purchases, payment processors handle your financial data. We receive only transaction confirmations.
+
+## 3. How We Use Your Data
+
+We use your personal information to:
+
+- Provide, maintain, and improve the Service.
+- Create and manage your account.
+- Process your trading and backtesting requests.
+- Communicate with you about the Service, including legal updates.
+- Enforce our Terms of Service and legal compliance obligations.
+- Detect and prevent fraud and unauthorized access.
+- Comply with legal obligations.
+
+## 4. Legal Basis for Processing (GDPR)
+
+For users in the European Economic Area:
+
+- **Contractual necessity**: Processing necessary to provide the Service you requested.
+- **Legitimate interests**: Security, fraud prevention, and service improvement.
+- **Consent**: Where we ask for specific consent, such as for marketing communications.
+- **Legal obligation**: Compliance with applicable laws and regulations.
+
+## 5. Data Retention
+
+| Data Type | Retention Period |
+|-----------|-----------------|
+| Account data | Duration of account + 30 days |
+| Legal acceptance records | Duration of account + 7 years (regulatory requirement) |
+| Usage logs | 90 days |
+| Backtest results | Duration of account |
+| Trading history | Duration of account + 7 years (regulatory requirement) |
+
+## 6. Your Rights
+
+You have the right to:
+
+- **Access**: Request a copy of your personal data.
+- **Rectification**: Request correction of inaccurate data.
+- **Erasure**: Request deletion of your data (subject to regulatory retention requirements).
+- **Portability**: Receive your data in a structured, machine-readable format.
+- **Restriction**: Request restriction of processing in certain circumstances.
+- **Objection**: Object to processing based on legitimate interests.
+- **Withdraw consent**: Withdraw consent where processing is based on consent.
+
+To exercise these rights, contact {{OPERATOR_EMAIL}}.
+
+## 7. Data Security
+
+We implement appropriate technical and organizational measures to protect your data, including:
+
+- Encryption of data in transit (TLS) and at rest.
+- Access controls and authentication requirements.
+- Regular security assessments and monitoring.
+- Incident response procedures.
+
+## 8. Data Sharing
+
+We may share your data with:
+
+- **Service providers**: Who assist in operating the Service (hosting, data providers).
+- **Legal requirements**: When required by law, regulation, or legal process.
+- **Business transfers**: In connection with any merger, acquisition, or sale of assets.
+
+We do not sell your personal information to third parties.
+
+## 9. International Transfers
+
+If your data is transferred outside your jurisdiction, we ensure appropriate safeguards are in place, including Standard Contractual Clauses or equivalent mechanisms.
+
+## 10. Children's Privacy
+
+The Service is not intended for individuals under the age of 18. We do not knowingly collect personal information from children.
+
+## 11. Changes to This Policy
+
+We may update this Privacy Policy from time to time. Material changes will be communicated through the Service, and continued use constitutes acceptance of the updated policy.
+
+## 12. Contact
+
+For privacy-related inquiries, contact:
+
+{{OPERATOR_NAME}}
+{{OPERATOR_EMAIL}}
+{{OPERATOR_URL}}
+
+---
+
+> *This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.*
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+**Operator**: {{OPERATOR_NAME}}
+**Jurisdiction**: {{JURISDICTION}}

--- a/legal/risk-disclaimer.md
+++ b/legal/risk-disclaimer.md
@@ -1,0 +1,70 @@
+---
+title: "Risk Disclaimer"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "trading"
+display_order: 4
+---
+
+# Risk Disclaimer
+
+> **NOT LEGAL ADVICE** — This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.
+
+## 1. General Trading Risks
+
+Trading in financial instruments involves substantial risk of loss and is not suitable for every investor. The value of investments may go down as well as up, and you may not get back the amount originally invested. Past performance is not indicative of future results.
+
+{{OPERATOR_NAME}} provides a software platform for backtesting, paper trading, and live trading. The platform does not provide investment advice, and nothing in this disclaimer or on the platform should be construed as a recommendation to buy, sell, or hold any financial instrument.
+
+## 2. Backtesting Limitations
+
+Backtesting results are hypothetical and have inherent limitations:
+
+- **Look-ahead bias**: Strategy logic may inadvertently use future information that would not have been available at the time of the trade, inflating performance results.
+- **Survivorship bias**: Backtests may only include currently listed securities, ignoring delisted or bankrupt companies, which overstates historical returns.
+- **Transaction costs**: Backtesting engines may not fully account for commissions, slippage, market impact, borrow fees, or liquidity constraints that would reduce real-world returns.
+- **Fill assumptions**: Orders in backtests assume execution at specified prices, which may not be achievable in live markets due to market microstructure effects.
+
+**Backtesting results should not be interpreted as a guarantee or prediction of future performance.**
+
+## 3. Paper Trading vs. Live Trading
+
+Paper (simulated) trading is provided for educational and testing purposes. There are significant differences between paper and live trading:
+
+- Paper trading does not involve real capital and cannot replicate the psychological effects of real financial risk.
+- Execution in paper trading is simulated and may not reflect real market conditions, order routing, or fill quality.
+- Slippage, partial fills, and market impact are modeled approximately and may differ materially from live conditions.
+- Market data feeds in paper trading may be delayed or differ from live data.
+
+**Success in paper trading does not imply success in live trading.**
+
+## 4. Marketplace Strategy Authorship
+
+{{OPERATOR_NAME}} may host a marketplace where third-party authors publish trading strategies. Users should be aware that:
+
+- Strategy authors are independent and not affiliated with {{OPERATOR_NAME}} unless explicitly stated.
+- {{OPERATOR_NAME}} does not audit, verify, or guarantee the performance, safety, or correctness of marketplace strategies.
+- Strategy performance metrics displayed on the platform are based on historical data and are subject to the backtesting limitations described in Section 2.
+- Users assume full responsibility for evaluating and using any marketplace strategy.
+
+## 5. Data Provider Limitations
+
+Market data used by the platform is provided by third-party data providers. Users should understand that:
+
+- Data may contain errors, omissions, or delays.
+- Historical data may be adjusted for corporate actions (splits, dividends) using different methodologies.
+- Data coverage may vary by security, exchange, and time period.
+- {{OPERATOR_NAME}} is not responsible for the accuracy, completeness, or timeliness of third-party data.
+
+## 6. Contact
+
+For questions about this disclaimer, contact {{OPERATOR_EMAIL}}.
+
+---
+
+> *This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.*
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+**Operator**: {{OPERATOR_NAME}}
+**Jurisdiction**: {{JURISDICTION}}

--- a/legal/terms-of-service.md
+++ b/legal/terms-of-service.md
@@ -1,0 +1,97 @@
+---
+title: "Terms of Service"
+version: "1.0.0"
+effective_date: "2026-04-20"
+requires_acceptance: true
+category: "general"
+display_order: 1
+---
+
+# Terms of Service
+
+> **NOT LEGAL ADVICE** — This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+
+## 1. Acceptance of Terms
+
+By accessing or using the {{OPERATOR_NAME}} platform ("Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you must not use the Service.
+
+## 2. Description of Service
+
+{{OPERATOR_NAME}} provides a trading platform that includes backtesting, paper trading, live trading simulation, strategy marketplace, and related tools. The Service is provided by {{OPERATOR_NAME}} and is accessible at {{OPERATOR_URL}}.
+
+## 3. User Accounts
+
+- You must register for an account to use the Service.
+- You are responsible for maintaining the confidentiality of your account credentials.
+- You must provide accurate and complete information during registration.
+- You are responsible for all activities that occur under your account.
+- You must notify {{OPERATOR_EMAIL}} immediately of any unauthorized use of your account.
+
+## 4. Acceptable Use
+
+You agree not to:
+
+- Use the Service for any unlawful purpose or in violation of any applicable regulations.
+- Attempt to gain unauthorized access to any part of the Service or its underlying systems.
+- Interfere with or disrupt the Service or servers connected to the Service.
+- Use the Service to distribute malware, spam, or other harmful content.
+- Reverse-engineer, decompile, or disassemble any part of the Service.
+- Use automated tools to scrape or extract data from the Service beyond documented APIs.
+- Impersonate any person or entity or misrepresent your affiliation.
+
+## 5. Trading and Financial Disclaimers
+
+The Service provides tools for analyzing financial markets and testing trading strategies. You acknowledge that:
+
+- The Service does not provide personalized investment advice.
+- All trading involves risk, including the potential loss of principal.
+- Past performance of any strategy does not guarantee future results.
+- You are solely responsible for your trading decisions and their outcomes.
+
+## 6. Intellectual Property
+
+- The Service and its original content, features, and functionality are owned by {{OPERATOR_NAME}} and are protected by international copyright, trademark, and other intellectual property laws.
+- Marketplace strategies remain the intellectual property of their respective authors, subject to the Marketplace EULA.
+
+## 7. Limitation of Liability
+
+To the maximum extent permitted by law:
+
+- {{OPERATOR_NAME}} provides the Service "as is" and "as available" without warranties of any kind, whether express or implied.
+- {{OPERATOR_NAME}} shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of the Service.
+- {{OPERATOR_NAME}} shall not be liable for any losses resulting from trading decisions made using the Service.
+- In no event shall {{OPERATOR_NAME}}'s total liability exceed the amount paid by you for the Service in the twelve (12) months preceding the claim.
+
+## 8. Indemnification
+
+You agree to indemnify and hold harmless {{OPERATOR_NAME}}, its affiliates, officers, directors, employees, and agents from any claims, damages, losses, or expenses arising from your use of the Service or violation of these Terms.
+
+## 9. Modifications
+
+{{OPERATOR_NAME}} reserves the right to modify these Terms at any time. Material changes will be communicated through the Service. Continued use of the Service after changes constitutes acceptance of the updated Terms.
+
+## 10. Termination
+
+Either party may terminate this agreement at any time. Upon termination:
+
+- Your right to use the Service will immediately cease.
+- Provisions that by their nature should survive termination shall remain in effect.
+- {{OPERATOR_NAME}} may delete your account data after a reasonable period.
+
+## 11. Governing Law
+
+These Terms shall be governed by and construed in accordance with the laws of {{JURISDICTION}}, without regard to its conflict of law provisions.
+
+## 12. Contact
+
+For questions about these Terms, contact {{OPERATOR_EMAIL}}.
+
+---
+
+> *This document is a template and does not constitute legal advice. Operators must have qualified legal counsel review and customize these documents for their jurisdiction before deployment.*
+
+**Effective Date**: {{EFFECTIVE_DATE}}
+**Operator**: {{OPERATOR_NAME}}
+**Jurisdiction**: {{JURISDICTION}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ reportUnknownMemberType = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 testpaths = ["tests"]
 pythonpath = ["."]
 addopts = "-ra --strict-markers --cov=engine --cov-report=term-missing --cov-report=html --cov-fail-under=80"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from engine.app import create_app
@@ -36,11 +37,16 @@ async def test_engine():
             f"Current: {settings.database_url}"
         )
     engine = create_async_engine(settings.database_url, echo=False)
+    # CI runs `alembic upgrade head` before pytest, so the schema already
+    # exists with triggers/functions. create_all is idempotent and fills
+    # in any ORM-only tables.
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     yield engine
+    # Tear down with CASCADE so FK constraints don't block drop ordering.
     async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
+        await conn.execute(text("DROP SCHEMA public CASCADE"))
+        await conn.execute(text("CREATE SCHEMA public"))
     await engine.dispose()
 
 

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+
+from engine.app import create_app
+from engine.db.models import (
+    DataProviderAttribution,
+    LegalAcceptance,
+    LegalDocument,
+)
+from engine.deps import get_db
+from engine.legal import service as legal_service
+from engine.legal.schemas import AcceptanceItem
+from engine.legal.service import NUM_DOCS_ON_DISK
+from engine.legal.sync import parse_front_matter, sync_legal_documents
+from tests.factories import make_user
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class TestFrontMatterParsing:
+    def test_parse_valid_front_matter(self):
+        content = '---\ntitle: "Risk Disclaimer"\nversion: "1.0.0"\n---\n\n# Content'
+        meta = parse_front_matter(content)
+        assert meta is not None
+        assert meta["title"] == "Risk Disclaimer"
+        assert meta["version"] == "1.0.0"
+
+    def test_parse_missing_front_matter(self):
+        content = "# Just a heading\n\nSome content"
+        meta = parse_front_matter(content)
+        assert meta is None
+
+    def test_parse_empty_front_matter(self):
+        content = "---\n\n---\n\n# Content"
+        meta = parse_front_matter(content)
+        assert meta == {}
+
+
+class TestLegalDocumentSync:
+    async def test_sync_registers_documents_from_legal_dir(self, db_session: AsyncSession):
+        with patch("engine.legal.sync.settings") as mock_settings:
+            mock_settings.legal_documents_dir = "legal"
+            count = await sync_legal_documents(db_session)
+            assert count >= NUM_DOCS_ON_DISK
+
+        stmt = select(LegalDocument).where(LegalDocument.slug == "risk-disclaimer")
+        result = await db_session.execute(stmt)
+        doc = result.scalar_one_or_none()
+        assert doc is not None
+        assert doc.title == "Risk Disclaimer"
+        assert doc.current_version == "1.0.0"
+        assert doc.category == "trading"
+        assert doc.requires_acceptance is True
+
+    async def test_sync_updates_version(self, db_session: AsyncSession):
+        doc = LegalDocument(
+            slug="test-doc",
+            title="Old Title",
+            current_version="0.9.0",
+            effective_date=__import__("datetime").date(2026, 1, 1),
+            requires_acceptance=True,
+            category="general",
+            display_order=0,
+            file_path="legal/risk-disclaimer.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        with patch("engine.legal.sync.settings") as mock_settings:
+            mock_settings.legal_documents_dir = "legal"
+            await sync_legal_documents(db_session)
+
+        stmt = select(LegalDocument).where(LegalDocument.slug == "risk-disclaimer")
+        result = await db_session.execute(stmt)
+        updated = result.scalar_one()
+        assert updated.current_version == "1.0.0"
+
+    async def test_sync_handles_missing_directory(self, db_session: AsyncSession):
+        with patch("engine.legal.sync.settings") as mock_settings:
+            mock_settings.legal_documents_dir = "/nonexistent/path"
+            count = await sync_legal_documents(db_session)
+            assert count == 0
+
+
+class TestLegalDocumentsAPI:
+    @pytest.fixture
+    async def legal_client(self, db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+        app = create_app()
+
+        async def override_get_db():
+            yield db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+    async def test_list_documents(self, legal_client: AsyncClient, db_session: AsyncSession):
+        doc = LegalDocument(
+            slug="test-doc",
+            title="Test Document",
+            current_version="1.0.0",
+            effective_date=__import__("datetime").date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=1,
+            file_path="legal/risk-disclaimer.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        response = await legal_client.get("/api/v1/legal/documents")
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert "documents" in data
+        assert len(data["documents"]) >= 1
+        slugs = [d["slug"] for d in data["documents"]]
+        assert "test-doc" in slugs
+
+    async def test_list_documents_filter_by_category(
+        self, legal_client: AsyncClient, db_session: AsyncSession
+    ):
+        doc = LegalDocument(
+            slug="cat-test",
+            title="Cat Test",
+            current_version="1.0.0",
+            effective_date=__import__("datetime").date(2026, 4, 20),
+            requires_acceptance=True,
+            category="trading",
+            display_order=1,
+            file_path="legal/risk-disclaimer.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        response = await legal_client.get("/api/v1/legal/documents?category=trading")
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        for d in data["documents"]:
+            assert d["category"] == "trading"
+
+    async def test_get_document_content(self, legal_client: AsyncClient, db_session: AsyncSession):
+        doc = LegalDocument(
+            slug="content-test",
+            title="Content Test",
+            current_version="1.0.0",
+            effective_date=__import__("datetime").date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=1,
+            file_path="legal/risk-disclaimer.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        response = await legal_client.get("/api/v1/legal/documents/content-test")
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert data["slug"] == "content-test"
+        assert data["title"] == "Content Test"
+        assert "content_markdown" in data
+        assert "{{OPERATOR_NAME}}" not in data["content_markdown"]
+
+    async def test_get_document_not_found(self, legal_client: AsyncClient):
+        response = await legal_client.get("/api/v1/legal/documents/nonexistent")
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
+    async def test_accept_requires_auth(self, legal_client: AsyncClient):
+        response = await legal_client.post(
+            "/api/v1/legal/accept",
+            json={
+                "acceptances": [{"document_slug": "risk-disclaimer", "document_version": "1.0.0"}]
+            },
+        )
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    async def test_acceptances_me_requires_auth(self, legal_client: AsyncClient):
+        response = await legal_client.get("/api/v1/legal/acceptances/me")
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    async def test_attributions_empty(self, legal_client: AsyncClient):
+        response = await legal_client.get("/api/v1/legal/attributions")
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["attributions"] == []
+
+    async def test_attributions_with_data(
+        self, legal_client: AsyncClient, db_session: AsyncSession
+    ):
+        attr = DataProviderAttribution(
+            provider_slug="test-provider",
+            provider_name="Test Provider",
+            attribution_text="Data by Test Provider",
+            display_contexts=["data-feed", "chart"],
+            is_active=True,
+        )
+        db_session.add(attr)
+        await db_session.flush()
+
+        response = await legal_client.get("/api/v1/legal/attributions")
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert len(data["attributions"]) == 1
+        assert data["attributions"][0]["provider_slug"] == "test-provider"
+
+    async def test_attributions_filter_by_context(
+        self, legal_client: AsyncClient, db_session: AsyncSession
+    ):
+        attr = DataProviderAttribution(
+            provider_slug="ctx-provider",
+            provider_name="Ctx Provider",
+            attribution_text="Data by Ctx",
+            display_contexts=["data-feed"],
+            is_active=True,
+        )
+        db_session.add(attr)
+        await db_session.flush()
+
+        response = await legal_client.get("/api/v1/legal/attributions?context=chart")
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert len(data["attributions"]) == 0
+
+        response = await legal_client.get("/api/v1/legal/attributions?context=data-feed")
+        data = response.json()
+        assert len(data["attributions"]) == 1
+
+    async def test_attributions_excludes_inactive(
+        self, legal_client: AsyncClient, db_session: AsyncSession
+    ):
+        attr = DataProviderAttribution(
+            provider_slug="inactive-provider",
+            provider_name="Inactive",
+            attribution_text="Inactive",
+            display_contexts=[],
+            is_active=False,
+        )
+        db_session.add(attr)
+        await db_session.flush()
+
+        response = await legal_client.get("/api/v1/legal/attributions")
+        data = response.json()
+        slugs = [a["provider_slug"] for a in data["attributions"]]
+        assert "inactive-provider" not in slugs
+
+
+class TestLegalServiceAcceptance:
+    async def _seed_doc(self, db_session: AsyncSession, slug: str) -> LegalDocument:
+        doc = LegalDocument(
+            slug=slug,
+            title=slug.replace("-", " ").title(),
+            current_version="1.0.0",
+            effective_date=__import__("datetime").date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=0,
+            file_path="legal/terms-of-service.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+        return doc
+
+    async def _seed_user(self, db_session: AsyncSession, email: str):
+        user = make_user(email=email)
+        db_session.add(user)
+        await db_session.flush()
+        return user
+
+    async def test_record_acceptance(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "legal-test@example.com")
+        await self._seed_doc(db_session, "svc-test-doc")
+
+        accepted = await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="svc-test-doc", document_version="1.0.0")],
+            ip_address="127.0.0.1",
+            user_agent="test-agent",
+        )
+        assert len(accepted) == 1
+        assert accepted[0].document_slug == "svc-test-doc"
+
+    async def test_record_acceptance_idempotent(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "idempotent@example.com")
+        await self._seed_doc(db_session, "idem-doc")
+
+        items = [AcceptanceItem(document_slug="idem-doc", document_version="1.0.0")]
+        await legal_service.record_acceptances(db_session, user.id, items, "127.0.0.1", "test")
+        await legal_service.record_acceptances(db_session, user.id, items, "127.0.0.1", "test")
+
+        count_stmt = (
+            select(func.count())
+            .select_from(LegalAcceptance)
+            .where(
+                LegalAcceptance.user_id == user.id,
+                LegalAcceptance.document_slug == "idem-doc",
+            )
+        )
+        result = await db_session.execute(count_stmt)
+        assert result.scalar() == 1
+
+    async def test_record_acceptance_invalid_document(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "invalid-doc@example.com")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await legal_service.record_acceptances(
+                db_session,
+                user.id,
+                [AcceptanceItem(document_slug="nonexistent", document_version="99.0.0")],
+                "127.0.0.1",
+                "test",
+            )
+        assert exc_info.value.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    async def test_get_pending_acceptances(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "pending@example.com")
+        await self._seed_doc(db_session, "pending-doc")
+
+        pending = await legal_service.get_pending_acceptances(db_session, user.id)
+        slugs = [p.slug for p in pending]
+        assert "pending-doc" in slugs
+
+    async def test_no_pending_after_acceptance(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "no-pending@example.com")
+        await self._seed_doc(db_session, "accepted-doc")
+
+        await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="accepted-doc", document_version="1.0.0")],
+            "127.0.0.1",
+            "test",
+        )
+        await db_session.flush()
+
+        pending = await legal_service.get_pending_acceptances(db_session, user.id)
+        slugs = [p.slug for p in pending]
+        assert "accepted-doc" not in slugs
+
+    async def test_pending_after_version_bump(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "version@example.com")
+        doc = await self._seed_doc(db_session, "version-doc")
+
+        await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="version-doc", document_version="1.0.0")],
+            "127.0.0.1",
+            "test",
+        )
+        await db_session.flush()
+
+        doc.current_version = "2.0.0"
+        await db_session.flush()
+
+        pending = await legal_service.get_pending_acceptances(db_session, user.id)
+        slugs = [p.slug for p in pending]
+        assert "version-doc" in slugs
+
+    async def test_list_user_acceptances(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "history@example.com")
+        await self._seed_doc(db_session, "history-doc")
+
+        await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="history-doc", document_version="1.0.0")],
+            "127.0.0.1",
+            "test",
+        )
+        await db_session.flush()
+
+        records = await legal_service.list_user_acceptances(db_session, user.id)
+        assert len(records) >= 1
+        assert any(r.document_slug == "history-doc" for r in records)
+
+    async def test_context_onboarding_for_first_acceptance(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "onboard-ctx@example.com")
+        await self._seed_doc(db_session, "ctx-doc")
+
+        await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="ctx-doc", document_version="1.0.0")],
+            "127.0.0.1",
+            "test",
+        )
+        await db_session.flush()
+
+        records = await legal_service.list_user_acceptances(db_session, user.id, "ctx-doc")
+        assert records[0].context == "onboarding"
+
+    async def test_context_re_acceptance_for_version_change(self, db_session: AsyncSession):
+        user = await self._seed_user(db_session, "re-ctx@example.com")
+        doc = await self._seed_doc(db_session, "re-ctx-doc")
+
+        await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="re-ctx-doc", document_version="1.0.0")],
+            "127.0.0.1",
+            "test",
+        )
+        await db_session.flush()
+
+        doc.current_version = "2.0.0"
+        await db_session.flush()
+
+        await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="re-ctx-doc", document_version="2.0.0")],
+            "127.0.0.1",
+            "test",
+        )
+        await db_session.flush()
+
+        records = await legal_service.list_user_acceptances(db_session, user.id, "re-ctx-doc")
+        assert len(records) == 2  # noqa: PLR2004
+        v2_record = next(r for r in records if r.document_version == "2.0.0")
+        assert v2_record.context == "re-acceptance"


### PR DESCRIPTION
## Summary

Implements Phase 2 (Backend) of the legal surfaces design per ADR-0003, tracking [SEV-486](mention://issue/d98cf505-d334-444a-83d9-e4517cdc54a5).

### Deliverables

**Legal Document Templates** (`legal/` directory — 6 files)
- `risk-disclaimer.md` — Trading risks, backtesting limitations, paper vs live, marketplace authorship, data provider limitations
- `terms-of-service.md` — Platform ToS with governing law placeholder
- `privacy-policy.md` — GDPR-aligned privacy policy
- `eula.md` — Product-level EULA
- `marketplace-eula.md` — Strategy author IP, licensing, revenue share, dispute resolution
- `data-provider-attributions.md` — Per-provider attribution reference (Polygon.io, FMP, Alpha Vantage)

All templates include:
- YAML front-matter (`version`, `effective_date`, `requires_acceptance`, `title`, `category`, `display_order`)
- Operator substitution markers: `{{OPERATOR_NAME}}`, `{{OPERATOR_EMAIL}}`, `{{OPERATOR_URL}}`, `{{JURISDICTION}}`, `{{PLATFORM_FEE_PERCENT}}`, `{{EFFECTIVE_DATE}}`
- "NOT LEGAL ADVICE" notice

**DB Models** (`engine/db/models.py`)
- `LegalDocument` — document registry synced from `legal/` front-matter
- `LegalAcceptance` — append-only audit trail (no UPDATE/DELETE), indexed for fast user/version lookups
- `DataProviderAttribution` — per-provider attribution config with JSONB display contexts

**Alembic Migration** (`004_legal_documents.py`)
- Creates all 3 tables with proper indexes
- Fully reversible (downgrade drops tables)

**API Routes** (`engine/api/routes/legal.py`) — 5 endpoints:
- `GET /api/v1/legal/documents` — list documents with versions and acceptance status
- `GET /api/v1/legal/documents/{slug}` — fetch rendered content (substitutions applied, front-matter stripped)
- `POST /api/v1/legal/accept` — batch acceptance recording (returns 401 until auth lands)
- `GET /api/v1/legal/acceptances/me` — user acceptance history (returns 401 until auth lands)
- `GET /api/v1/legal/attributions` — data provider attributions (public, filterable by context)

**Startup Scanner** (`engine/legal/sync.py`)
- Parses `legal/*.md` front-matter on app startup
- Upserts `legal_documents` table, logs version changes
- Gracefully handles missing dir, malformed YAML

**Service Layer** (`engine/legal/service.py`)
- Document listing with per-user acceptance status and `needs_re_acceptance` flag
- Batch acceptance recording (idempotent, auto-detects onboarding vs re-acceptance context)
- Pending acceptance checks for consent enforcement
- Attribution listing with context filtering

**Consent Enforcement** (`engine/legal/dependencies.py`)
- `require_legal_acceptance` FastAPI dependency returning HTTP 451 with pending document list

**Config** (`engine/config.py`)
- Added operator settings: `operator_name`, `operator_email`, `operator_url`, `jurisdiction`, `platform_fee_percent`, `legal_documents_dir`

**Tests** (`tests/test_legal.py`)
- Front-matter parsing (valid, missing, empty)
- Startup sync (registration, version updates, missing directory)
- API routes (document listing, filtering, content rendering, 404, auth guards, attributions)
- Service layer (acceptance recording, idempotency, pending checks, version bumps, context detection)

### Constraints
- Append-only acceptance records — no UPDATE/DELETE on `legal_acceptances`
- Auth endpoints return 401 until ADR-0002 auth is implemented
- Operator substitution markers for self-hosted deployments
- `ondelete='RESTRICT'` on user FK — GDPR erasure pseudonymizes instead of deleting

Closes #154