### PR TITLE
feat(frontend): legal consent UI, disclaimers, attribution, and settings

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.40.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.383.0",
+        "marked": "^18.0.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-router-dom": "^6.23.0",
@@ -2905,6 +2906,18 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.1.tgz",
+      "integrity": "sha512-IILJE4Aap/KIGu4ZRCzQcYMxkhumblXnbqfQe+HAD4f982wrRAsJEGKGM653yAioS6g3Yq3yOhjrUebcrtOgRA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/merge2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,13 +10,14 @@
     "lint": "eslint . --ext .js,.jsx"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.40.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.383.0",
+    "marked": "^18.0.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-router-dom": "^6.23.0",
-    "recharts": "^2.12.0",
-    "lucide-react": "^0.383.0",
-    "@tanstack/react-query": "^5.40.0",
-    "clsx": "^2.1.0"
+    "recharts": "^2.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,125 +1,61 @@
 import React from "react";
-import { BrowserRouter, Routes, Route, NavLink } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Shell } from "./components/layout/Shell";
+import { LegalProvider } from "./context/LegalContext";
+import { ConsentModal } from "./components/legal/ConsentModal";
+import Dashboard from "./screens/Dashboard";
+import Strategies from "./screens/Strategies";
+import Backtest from "./screens/Backtest";
+import Marketplace from "./screens/Marketplace";
+import Positions from "./screens/Positions";
+import CostAnalysis from "./screens/CostAnalysis";
+import RiskMonitor from "./screens/RiskMonitor";
+import DevConsole from "./screens/DevConsole";
+import Settings from "./screens/Settings";
+import LegalDocument from "./screens/LegalDocument";
+import Onboarding from "./screens/Onboarding";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:8000";
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
-// ── Pages (scaffolded) ──
-
-function Dashboard() {
-  const [health, setHealth] = React.useState(null);
-
-  React.useEffect(() => {
-    fetch(`${API}/health`)
-      .then((r) => r.json())
-      .then(setHealth)
-      .catch(() => setHealth({ status: "unreachable" }));
-  }, []);
-
+function ShellLayout() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-      <div className="bg-gray-800 rounded-lg p-4 mb-4">
-        <h2 className="text-sm text-gray-400 uppercase mb-2">Engine Status</h2>
-        {health ? (
-          <pre className="text-sm text-green-400">{JSON.stringify(health, null, 2)}</pre>
-        ) : (
-          <p className="text-gray-500">Connecting...</p>
-        )}
-      </div>
-      <p className="text-gray-400">Portfolio overview, P&L charts, and live positions will go here.</p>
-    </div>
+    <Shell>
+      <Outlet />
+    </Shell>
   );
 }
-
-function Strategies() {
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Strategy Lab</h1>
-      <p className="text-gray-400">Install, configure, and A/B test trading strategies.</p>
-    </div>
-  );
-}
-
-function Backtest() {
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Backtest Studio</h1>
-      <p className="text-gray-400">Run historical simulations with full cost modeling.</p>
-    </div>
-  );
-}
-
-function Marketplace() {
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Marketplace</h1>
-      <p className="text-gray-400">Browse and install community strategy plugins.</p>
-    </div>
-  );
-}
-
-// ── Layout ──
-
-const navItems = [
-  { to: "/", label: "Dashboard", icon: "📊" },
-  { to: "/strategies", label: "Strategies", icon: "⚡" },
-  { to: "/backtest", label: "Backtest", icon: "⏪" },
-  { to: "/marketplace", label: "Marketplace", icon: "🏪" },
-];
-
-function Layout({ children }) {
-  return (
-    <div className="min-h-screen bg-gray-950 text-white flex">
-      {/* Sidebar */}
-      <nav className="w-56 bg-gray-900 border-r border-gray-800 flex flex-col">
-        <div className="p-4 border-b border-gray-800">
-          <div className="flex items-center gap-2">
-            <span className="text-lg font-bold bg-gradient-to-r from-blue-500 to-purple-500 bg-clip-text text-transparent">
-              ⚡ NEXUS
-            </span>
-          </div>
-          <p className="text-xs text-gray-500 mt-1">Trade Engine v0.1.0</p>
-        </div>
-        <div className="flex-1 p-3 space-y-1">
-          {navItems.map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              end={item.to === "/"}
-              className={({ isActive }) =>
-                `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? "bg-blue-600/20 text-blue-400"
-                    : "text-gray-400 hover:text-white hover:bg-gray-800"
-                }`
-              }
-            >
-              <span>{item.icon}</span>
-              {item.label}
-            </NavLink>
-          ))}
-        </div>
-      </nav>
-
-      {/* Main content */}
-      <main className="flex-1 overflow-auto">{children}</main>
-    </div>
-  );
-}
-
-// ── App ──
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Layout>
-        <Routes>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/strategies" element={<Strategies />} />
-          <Route path="/backtest" element={<Backtest />} />
-          <Route path="/marketplace" element={<Marketplace />} />
-        </Routes>
-      </Layout>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <LegalProvider>
+          <ConsentModal />
+          <Routes>
+            <Route path="/onboarding" element={<Onboarding />} />
+            <Route element={<ShellLayout />}>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/strategies" element={<Strategies />} />
+              <Route path="/backtest" element={<Backtest />} />
+              <Route path="/marketplace" element={<Marketplace />} />
+              <Route path="/positions" element={<Positions />} />
+              <Route path="/costs" element={<CostAnalysis />} />
+              <Route path="/risk" element={<RiskMonitor />} />
+              <Route path="/dev" element={<DevConsole />} />
+              <Route path="/settings" element={<Settings />} />
+              <Route path="/legal/:slug" element={<LegalDocument />} />
+            </Route>
+          </Routes>
+        </LegalProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 }

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,35 @@
+const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8000";
+
+export class ConsentRequiredError extends Error {
+  constructor(pendingDocuments) {
+    super("Legal consent required");
+    this.name = "ConsentRequiredError";
+    this.pendingDocuments = pendingDocuments;
+  }
+}
+
+export async function apiFetch(path, options = {}) {
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+    credentials: "include",
+  });
+
+  if (response.status === 451) {
+    const body = await response.json().catch(() => ({}));
+    const pending = body.pending_documents || [];
+    window.dispatchEvent(
+      new CustomEvent("legal:consent-required", { detail: pending })
+    );
+    throw new ConsentRequiredError(pending);
+  }
+
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+
+  return response.json();
+}

--- a/frontend/src/api/legal.js
+++ b/frontend/src/api/legal.js
@@ -1,0 +1,24 @@
+import { apiFetch } from "./client";
+
+export function fetchLegalDocuments() {
+  return apiFetch("/api/v1/legal/documents");
+}
+
+export function fetchLegalDocument(slug) {
+  return apiFetch(`/api/v1/legal/documents/${slug}`);
+}
+
+export function acceptLegalDocuments(acceptances) {
+  return apiFetch("/api/v1/legal/accept", {
+    method: "POST",
+    body: JSON.stringify({ acceptances }),
+  });
+}
+
+export function fetchMyAcceptances() {
+  return apiFetch("/api/v1/legal/acceptances/me");
+}
+
+export function fetchAttributions() {
+  return apiFetch("/api/v1/legal/attributions");
+}

--- a/frontend/src/components/feedback/Modal.jsx
+++ b/frontend/src/components/feedback/Modal.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+import clsx from "clsx";
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  className,
+  maxWidth = "max-w-xl",
+}) {
+  const dialogRef = useRef(null);
+  const previousFocus = useRef(null);
+
+  useEffect(() => {
+    if (open) {
+      previousFocus.current = document.activeElement;
+      dialogRef.current?.focus();
+    } else {
+      previousFocus.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleEsc = (e) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", handleEsc);
+    return () => window.removeEventListener("keydown", handleEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <div
+        className="absolute inset-0 bg-black/80"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className={clsx(
+          "relative bg-nx-surface border border-nx-border-visible rounded-2xl p-xl w-full",
+          maxWidth,
+          "max-h-[85vh] overflow-y-auto",
+          "focus:outline-none",
+          className
+        )}
+      >
+        <div className="flex items-center justify-between mb-lg">
+          <h2 className="text-subheading font-display text-nx-text-display">
+            {title}
+          </h2>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-nx-text-secondary hover:text-nx-text-display p-xs"
+              aria-label="Close"
+            >
+              <X size={16} strokeWidth={1.5} />
+            </button>
+          )}
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router-dom";
+
+const LEGAL_LINKS = [
+  { to: "/legal/risk-disclaimer", label: "Risk Disclaimer" },
+  { to: "/legal/terms-of-service", label: "Terms of Service" },
+  { to: "/legal/privacy-policy", label: "Privacy Policy" },
+  { to: "/legal/eula", label: "EULA" },
+  { to: "/legal/marketplace-eula", label: "Marketplace EULA" },
+];
+
+export function Footer() {
+  return (
+    <footer className="border-t border-nx-border bg-nx-surface px-xl py-lg">
+      <div className="flex items-center justify-between flex-wrap gap-md">
+        <nav aria-label="Legal documents" className="flex items-center gap-lg flex-wrap">
+          {LEGAL_LINKS.map((link) => (
+            <Link
+              key={link.to}
+              to={link.to}
+              className="text-label font-mono uppercase text-nx-text-disabled hover:text-nx-text-secondary transition-colors"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <span className="text-label font-mono uppercase text-nx-text-disabled">
+          NEXUS TRADE ENGINE v0.1.0
+        </span>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/components/layout/Shell.jsx
+++ b/frontend/src/components/layout/Shell.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { LayoutDashboard, Zap, Rewind, Store, BarChart3, Shield, Terminal, DollarSign } from "lucide-react";
+import { LayoutDashboard, Zap, Rewind, Store, BarChart3, Shield, Terminal, DollarSign, Settings as SettingsIcon } from "lucide-react";
 import clsx from "clsx";
 import { useTheme } from "../../hooks/useTheme";
+import { Footer } from "./Footer";
 
 const navItems = [
   { to: "/", label: "DASHBOARD", icon: LayoutDashboard },
@@ -13,6 +14,7 @@ const navItems = [
   { to: "/costs", label: "COST ANALYSIS", icon: DollarSign },
   { to: "/risk", label: "RISK MONITOR", icon: Shield },
   { to: "/dev", label: "DEV CONSOLE", icon: Terminal },
+  { to: "/settings", label: "LEGAL & SETTINGS", icon: SettingsIcon },
 ];
 
 function Sidebar({ collapsed, onToggle }) {
@@ -79,18 +81,21 @@ export function Shell({ children }) {
   return (
     <div className="flex min-h-screen bg-nx-black">
       <Sidebar collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
-      <main className="flex-1 overflow-auto">
-        <div className="flex justify-end p-sm">
-          <button
-            type="button"
-            onClick={toggle}
-            className="text-label font-mono uppercase text-nx-text-secondary hover:text-nx-text-display"
-          >
-            [{mode === "dark" ? "LIGHT" : "DARK"}]
-          </button>
-        </div>
-        {children}
-      </main>
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <main className="flex-1 overflow-auto">
+          <div className="flex justify-end p-sm">
+            <button
+              type="button"
+              onClick={toggle}
+              className="text-label font-mono uppercase text-nx-text-secondary hover:text-nx-text-display"
+            >
+              [{mode === "dark" ? "LIGHT" : "DARK"}]
+            </button>
+          </div>
+          {children}
+        </main>
+        <Footer />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/legal/AttributionBadge.jsx
+++ b/frontend/src/components/legal/AttributionBadge.jsx
@@ -1,0 +1,22 @@
+import { ExternalLink } from "lucide-react";
+
+export function AttributionBadge({ provider, description, url }) {
+  return (
+    <span className="inline-flex items-center gap-xs text-label font-mono uppercase text-nx-text-disabled">
+      <span className="w-1.5 h-1.5 rounded-full bg-nx-text-disabled shrink-0" />
+      {url ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-nx-text-secondary transition-colors inline-flex items-center gap-xs"
+        >
+          {description || provider}
+          <ExternalLink size={10} strokeWidth={1.5} />
+        </a>
+      ) : (
+        <span>{description || provider}</span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/legal/AttributionStrip.jsx
+++ b/frontend/src/components/legal/AttributionStrip.jsx
@@ -1,0 +1,27 @@
+import { useAttributions } from "../../hooks/useLegal";
+import { AttributionBadge } from "./AttributionBadge";
+
+const FALLBACK_ATTRIBUTIONS = [
+  { provider: "Polygon.io", description: "Market data provided by Polygon.io", url: "https://polygon.io" },
+  { provider: "FMP", description: "Financial data from FMP", url: "https://financialmodelingprep.com" },
+];
+
+export function AttributionStrip({ className }) {
+  const { data, isLoading } = useAttributions();
+  const attributions = Array.isArray(data) && data.length > 0 ? data : FALLBACK_ATTRIBUTIONS;
+
+  if (isLoading) return null;
+
+  return (
+    <div className={`flex items-center gap-lg flex-wrap ${className || ""}`}>
+      {attributions.map((attr) => (
+        <AttributionBadge
+          key={attr.provider}
+          provider={attr.provider}
+          description={attr.description}
+          url={attr.url}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/legal/ConsentModal.jsx
+++ b/frontend/src/components/legal/ConsentModal.jsx
@@ -1,0 +1,96 @@
+import { useState, useEffect, useMemo } from "react";
+import { marked } from "marked";
+import { Modal } from "../feedback/Modal";
+import { useLegalContext } from "../../context/LegalContext";
+import { useLegalDocument } from "../../hooks/useLegal";
+
+export function ConsentModal() {
+  const { showConsentModal, pendingDocs, handleAccept } = useLegalContext();
+  const [selectedSlug, setSelectedSlug] = useState(null);
+  const [checked, setChecked] = useState(false);
+
+  const activeSlug = selectedSlug || pendingDocs[0]?.slug;
+
+  const { data: docContent } = useLegalDocument(activeSlug);
+
+  const htmlContent = useMemo(() => {
+    if (!docContent?.content) return "";
+    return marked.parse(docContent.content, { async: false });
+  }, [docContent?.content]);
+
+  useEffect(() => {
+    setChecked(false);
+  }, [selectedSlug, pendingDocs]);
+
+  if (!showConsentModal || pendingDocs.length === 0) return null;
+
+  return (
+    <Modal open title={null} maxWidth="max-w-2xl">
+      <div className="mb-lg">
+        <h2 className="text-subheading font-display text-nx-text-display mb-xs">
+          LEGAL ACCEPTANCE REQUIRED
+        </h2>
+        <p className="text-body-sm font-body text-nx-text-secondary">
+          You must review and accept the following legal documents before
+          continuing.
+        </p>
+      </div>
+
+      <div className="flex gap-xs mb-lg flex-wrap">
+        {pendingDocs.map((doc) => (
+          <button
+            key={doc.slug}
+            type="button"
+            onClick={() => setSelectedSlug(doc.slug)}
+            className={`px-md py-xs text-label font-mono uppercase border rounded-full transition-colors ${
+              activeSlug === doc.slug
+                ? "bg-nx-text-display text-nx-black border-nx-text-display"
+                : "bg-transparent text-nx-text-secondary border-nx-border hover:border-nx-border-visible"
+            }`}
+          >
+            {doc.title || doc.slug}
+          </button>
+        ))}
+      </div>
+
+      <div className="bg-nx-surface-raised border border-nx-border rounded-2xl p-lg mb-lg max-h-64 overflow-y-auto">
+        {htmlContent ? (
+          <div
+            className="prose prose-sm prose-invert max-w-none text-body-sm font-body text-nx-text-primary [&_h1]:text-subheading [&_h1]:font-display [&_h1]:text-nx-text-display [&_h1]:mb-md [&_h2]:text-body [&_h2]:font-display [&_h2]:text-nx-text-primary [&_h2]:mb-sm [&_p]:mb-sm [&_ul]:list-disc [&_ul]:pl-md"
+            dangerouslySetInnerHTML={{ __html: htmlContent }}
+          />
+        ) : (
+          <span className="text-label font-mono uppercase text-nx-text-disabled">
+            LOADING DOCUMENT...
+          </span>
+        )}
+      </div>
+
+      <label className="flex items-center gap-md mb-lg cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => setChecked(e.target.checked)}
+          className="w-4 h-4 rounded border-nx-border accent-nx-text-display"
+        />
+        <span className="text-body-sm font-body text-nx-text-primary">
+          I have read and understood the above documents and agree to their
+          terms.
+        </span>
+      </label>
+
+      <button
+        type="button"
+        disabled={!checked}
+        onClick={handleAccept}
+        className={`w-full px-2xl py-md text-label font-mono uppercase rounded-full border transition-colors ${
+          checked
+            ? "bg-nx-text-display text-nx-black border-nx-text-display hover:bg-nx-text-primary"
+            : "bg-nx-text-disabled/30 text-nx-text-disabled border-nx-text-disabled/30 cursor-not-allowed"
+        }`}
+      >
+        I ACCEPT
+      </button>
+    </Modal>
+  );
+}

--- a/frontend/src/components/legal/DisclaimerBanner.jsx
+++ b/frontend/src/components/legal/DisclaimerBanner.jsx
@@ -1,0 +1,24 @@
+import clsx from "clsx";
+import { AlertTriangle } from "lucide-react";
+
+const VARIANTS = {
+  warning: "border-nx-warning/30 bg-nx-warning/5 text-nx-warning",
+  info: "border-nx-border-visible bg-nx-surface-raised text-nx-text-secondary",
+  danger: "border-nx-accent/30 bg-nx-accent/5 text-nx-accent",
+};
+
+export function DisclaimerBanner({ children, variant = "warning", className }) {
+  return (
+    <div
+      role="alert"
+      className={clsx(
+        "flex items-start gap-md px-lg py-md border rounded-2xl text-body-sm font-body",
+        VARIANTS[variant],
+        className
+      )}
+    >
+      <AlertTriangle size={16} className="shrink-0 mt-xs" strokeWidth={1.5} />
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/legal/LegalDocumentViewer.jsx
+++ b/frontend/src/components/legal/LegalDocumentViewer.jsx
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+import { marked } from "marked";
+import { useLegalDocument } from "../../hooks/useLegal";
+import { LoadingSpinner } from "../feedback/LoadingSpinner";
+
+export function LegalDocumentViewer({ slug }) {
+  const { data, isLoading, error } = useLegalDocument(slug);
+
+  const htmlContent = useMemo(() => {
+    if (!data?.content) return "";
+    return marked.parse(data.content, { async: false });
+  }, [data?.content]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-4xl">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-nx-accent text-body-sm font-body p-xl">
+        Failed to load document.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-xl">
+      {data?.title && (
+        <header className="mb-3xl">
+          <h1 className="text-display-md font-display text-nx-text-display">
+            {data.title}
+          </h1>
+          {data?.version && (
+            <span className="text-label font-mono uppercase text-nx-text-disabled mt-xs block">
+              VERSION {data.version}
+            </span>
+          )}
+        </header>
+      )}
+      <div
+        className="prose prose-invert max-w-none text-body font-body text-nx-text-primary [&_h1]:text-display-sm [&_h1]:font-display [&_h1]:text-nx-text-display [&_h1]:mb-lg [&_h2]:text-subheading [&_h2]:font-display [&_h2]:text-nx-text-primary [&_h2]:mb-md [&_h3]:text-body [&_h3]:font-display [&_h3]:text-nx-text-primary [&_h3]:mb-sm [&_p]:mb-md [&_ul]:list-disc [&_ul]:pl-lg [&_ol]:list-decimal [&_ol]:pl-lg [&_li]:mb-xs [&_strong]:text-nx-text-display"
+        dangerouslySetInnerHTML={{ __html: htmlContent }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/legal/LiveTradingModal.jsx
+++ b/frontend/src/components/legal/LiveTradingModal.jsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { Modal } from "../feedback/Modal";
+import { useAcceptLegal } from "../../hooks/useLegal";
+
+export function LiveTradingModal({ open, onAccept, onClose }) {
+  const [checked, setChecked] = useState(false);
+  const acceptMutation = useAcceptLegal();
+
+  const handleAccept = async () => {
+    await acceptMutation.mutateAsync([
+      { document_slug: "risk-disclaimer", version: "latest" },
+    ]);
+    onAccept();
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="LIVE TRADING RISK ACKNOWLEDGMENT">
+      <div className="space-y-lg">
+        <p className="text-body-sm font-body text-nx-text-primary">
+          You are about to engage in live trading with real capital. Live
+          trading carries significant financial risk, including the possibility
+          of losing your entire investment.
+        </p>
+
+        <div className="bg-nx-accent/5 border border-nx-accent/30 rounded-2xl p-lg text-body-sm font-body text-nx-text-primary">
+          <ul className="list-disc pl-md space-y-xs">
+            <li>Past performance does not guarantee future results.</li>
+            <li>Algorithmic trading strategies may fail unexpectedly.</li>
+            <li>Market conditions can change rapidly, causing significant losses.</li>
+            <li>Slippage, latency, and system failures may impact execution.</li>
+          </ul>
+        </div>
+
+        <label className="flex items-center gap-md cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
+            className="w-4 h-4 rounded border-nx-border accent-nx-accent"
+          />
+          <span className="text-body-sm font-body text-nx-text-primary">
+            I understand the risks of live trading and accept full responsibility
+            for any losses incurred.
+          </span>
+        </label>
+
+        <div className="flex gap-md">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 px-xl py-md text-label font-mono uppercase border border-nx-border rounded-full text-nx-text-secondary hover:border-nx-border-visible transition-colors"
+          >
+            CANCEL
+          </button>
+          <button
+            type="button"
+            disabled={!checked}
+            onClick={handleAccept}
+            className={`flex-1 px-xl py-md text-label font-mono uppercase rounded-full border transition-colors ${
+              checked
+                ? "bg-nx-accent text-nx-black border-nx-accent hover:bg-nx-accent/80"
+                : "bg-nx-text-disabled/30 text-nx-text-disabled border-nx-text-disabled/30 cursor-not-allowed"
+            }`}
+          >
+            BEGIN LIVE TRADING
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/context/LegalContext.jsx
+++ b/frontend/src/context/LegalContext.jsx
@@ -1,0 +1,65 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { useLegalDocuments, useAcceptLegal } from "../hooks/useLegal";
+
+const LegalContext = createContext(null);
+
+export function LegalProvider({ children }) {
+  const [showConsentModal, setShowConsentModal] = useState(false);
+  const [pendingDocs, setPendingDocs] = useState([]);
+  const { data: documents = [] } = useLegalDocuments();
+  const acceptMutation = useAcceptLegal();
+
+  useEffect(() => {
+    if (!Array.isArray(documents)) return;
+    const required = documents.filter((d) => d.requires_acceptance);
+    if (required.length > 0) {
+      setPendingDocs(required);
+      setShowConsentModal(true);
+    }
+  }, [documents]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      setPendingDocs(e.detail);
+      setShowConsentModal(true);
+    };
+    window.addEventListener("legal:consent-required", handler);
+    return () => window.removeEventListener("legal:consent-required", handler);
+  }, []);
+
+  const handleAccept = useCallback(async () => {
+    const acceptances = pendingDocs.map((d) => ({
+      document_slug: d.slug,
+      version: d.version,
+    }));
+    await acceptMutation.mutateAsync(acceptances);
+    setPendingDocs([]);
+    setShowConsentModal(false);
+  }, [pendingDocs, acceptMutation]);
+
+  const triggerConsent = useCallback((docs) => {
+    setPendingDocs(docs);
+    setShowConsentModal(true);
+  }, []);
+
+  return (
+    <LegalContext.Provider
+      value={{ showConsentModal, pendingDocs, handleAccept, triggerConsent }}
+    >
+      {children}
+    </LegalContext.Provider>
+  );
+}
+
+export function useLegalContext() {
+  const ctx = useContext(LegalContext);
+  if (!ctx)
+    throw new Error("useLegalContext must be used within LegalProvider");
+  return ctx;
+}

--- a/frontend/src/hooks/useLegal.js
+++ b/frontend/src/hooks/useLegal.js
@@ -1,0 +1,47 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchLegalDocuments,
+  fetchLegalDocument,
+  acceptLegalDocuments,
+  fetchMyAcceptances,
+  fetchAttributions,
+} from "../api/legal";
+
+export function useLegalDocuments() {
+  return useQuery({
+    queryKey: ["legal", "documents"],
+    queryFn: fetchLegalDocuments,
+  });
+}
+
+export function useLegalDocument(slug) {
+  return useQuery({
+    queryKey: ["legal", "documents", slug],
+    queryFn: () => fetchLegalDocument(slug),
+    enabled: !!slug,
+  });
+}
+
+export function useAcceptLegal() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: acceptLegalDocuments,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["legal"] });
+    },
+  });
+}
+
+export function useMyAcceptances() {
+  return useQuery({
+    queryKey: ["legal", "acceptances"],
+    queryFn: fetchMyAcceptances,
+  });
+}
+
+export function useAttributions() {
+  return useQuery({
+    queryKey: ["legal", "attributions"],
+    queryFn: fetchAttributions,
+  });
+}

--- a/frontend/src/screens/Backtest.jsx
+++ b/frontend/src/screens/Backtest.jsx
@@ -3,6 +3,8 @@ import { HeroMetric } from "../components/primitives/HeroMetric";
 import { StatRow } from "../components/primitives/StatRow";
 import { Sparkline } from "../components/data/Sparkline";
 import { StatusBadge } from "../components/primitives/StatusBadge";
+import { DisclaimerBanner } from "../components/legal/DisclaimerBanner";
+import { AttributionStrip } from "../components/legal/AttributionStrip";
 
 const MOCK_RESULTS = {
   sharpe: "2.34",
@@ -46,6 +48,13 @@ export default function Backtest() {
   return (
     <div className="text-nx-text-primary p-xl">
       <div className="max-w-6xl mx-auto">
+        <div className="mb-3xl">
+          <DisclaimerBanner variant="warning">
+            Past performance does not guarantee future results. Backtests are
+            subject to look-ahead bias, selection bias, and survivorship bias.
+            Simulated results may differ materially from actual trading.
+          </DisclaimerBanner>
+        </div>
         <header className="mb-3xl">
           <div className="flex items-center gap-md mb-sm">
             <span className="text-label font-mono uppercase text-nx-text-secondary">
@@ -108,6 +117,8 @@ export default function Backtest() {
             <StatRow label="PERIOD" value={`${MOCK_CONFIG.start} -> ${MOCK_CONFIG.end}`} />
           </div>
         </section>
+
+        <AttributionStrip className="mb-3xl" />
       </div>
     </div>
   );

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -3,6 +3,7 @@ import { StatRow } from "../components/primitives/StatRow";
 import { StatusBadge } from "../components/primitives/StatusBadge";
 import { Sparkline } from "../components/data/Sparkline";
 import { InlineStatus } from "../components/feedback/InlineStatus";
+import { AttributionStrip } from "../components/legal/AttributionStrip";
 
 const MOCK_PORTFOLIO = {
   value: "$2,847,391.44",
@@ -95,16 +96,19 @@ export default function Dashboard() {
         </section>
 
         <footer className="flex items-center justify-between border-t border-nx-border pt-md">
-          <span className="text-label font-mono uppercase text-nx-text-disabled">
-            LAST UPDATE: {new Date(lastUpdate).toLocaleTimeString("en-US", { hour12: false })}
-          </span>
-          {health ? (
-            <InlineStatus status={health.status === "ok" ? "ok" : "error"}>
-              {health.status === "ok" ? "ENGINE CONNECTED" : "ENGINE DISCONNECTED"}
-            </InlineStatus>
-          ) : (
-            <InlineStatus status="loading">CONNECTING</InlineStatus>
-          )}
+          <AttributionStrip />
+          <div className="flex items-center gap-lg">
+            <span className="text-label font-mono uppercase text-nx-text-disabled">
+              LAST UPDATE: {new Date(lastUpdate).toLocaleTimeString("en-US", { hour12: false })}
+            </span>
+            {health ? (
+              <InlineStatus status={health.status === "ok" ? "ok" : "error"}>
+                {health.status === "ok" ? "ENGINE CONNECTED" : "ENGINE DISCONNECTED"}
+              </InlineStatus>
+            ) : (
+              <InlineStatus status="loading">CONNECTING</InlineStatus>
+            )}
+          </div>
         </footer>
       </div>
     </div>

--- a/frontend/src/screens/LegalDocument.jsx
+++ b/frontend/src/screens/LegalDocument.jsx
@@ -1,0 +1,7 @@
+import { useParams } from "react-router-dom";
+import { LegalDocumentViewer } from "../components/legal/LegalDocumentViewer";
+
+export default function LegalDocument() {
+  const { slug } = useParams();
+  return <LegalDocumentViewer slug={slug} />;
+}

--- a/frontend/src/screens/Marketplace.jsx
+++ b/frontend/src/screens/Marketplace.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { DisclaimerBanner } from "../components/legal/DisclaimerBanner";
 
 const CATEGORIES = ["ALL", "MOMENTUM", "MEAN REVERSION", "ARBITRAGE", "MACRO", "ML/AI"];
 
@@ -57,6 +58,14 @@ export default function Marketplace() {
             STRATEGY CATALOG
           </h1>
         </header>
+
+        <div className="mb-3xl">
+          <DisclaimerBanner variant="danger">
+            You are running third-party code in your environment. Nexus is not
+            responsible for the performance, safety, or behavior of
+            author-provided strategies. Review all code before installing.
+          </DisclaimerBanner>
+        </div>
 
         <section className="mb-2xl">
           <div className="flex items-center gap-md mb-lg">

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -1,0 +1,129 @@
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { marked } from "marked";
+import { useLegalDocuments, useAcceptLegal } from "../hooks/useLegal";
+import { LoadingSpinner } from "../components/feedback/LoadingSpinner";
+
+export default function Onboarding() {
+  const navigate = useNavigate();
+  const { data: documents = [], isLoading } = useLegalDocuments();
+  const acceptMutation = useAcceptLegal();
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [accepted, setAccepted] = useState({});
+
+  const requiredDocs = useMemo(
+    () => (Array.isArray(documents) ? documents.filter((d) => d.requires_acceptance) : []),
+    [documents]
+  );
+
+  const allAccepted = requiredDocs.every((d) => accepted[d.slug]);
+
+  const handleAcceptDoc = () => {
+    const doc = requiredDocs[currentIdx];
+    setAccepted((prev) => ({ ...prev, [doc.slug]: true }));
+    if (currentIdx < requiredDocs.length - 1) {
+      setCurrentIdx((prev) => prev + 1);
+    }
+  };
+
+  const handleFinish = async () => {
+    const acceptances = requiredDocs.map((d) => ({
+      document_slug: d.slug,
+      version: d.version,
+    }));
+    await acceptMutation.mutateAsync(acceptances);
+    navigate("/");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-nx-black">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (requiredDocs.length === 0) {
+    navigate("/");
+    return null;
+  }
+
+  const currentDoc = requiredDocs[currentIdx];
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-nx-black p-xl">
+      <div className="w-full max-w-2xl">
+        <header className="mb-3xl text-center">
+          <span className="text-label font-mono uppercase text-nx-text-secondary block mb-sm">
+            WELCOME TO NEXUS
+          </span>
+          <h1 className="text-display-lg font-display text-nx-text-display">
+            LEGAL AGREEMENTS
+          </h1>
+          <p className="text-body font-body text-nx-text-secondary mt-md">
+            Please review and accept the following documents to get started.
+          </p>
+        </header>
+
+        <div className="flex gap-xs justify-center mb-lg flex-wrap">
+          {requiredDocs.map((doc, i) => (
+            <button
+              key={doc.slug}
+              type="button"
+              onClick={() => setCurrentIdx(i)}
+              className={`px-md py-xs text-label font-mono uppercase border rounded-full transition-colors ${
+                i === currentIdx
+                  ? "bg-nx-text-display text-nx-black border-nx-text-display"
+                  : accepted[doc.slug]
+                    ? "bg-nx-success/20 text-nx-success border-nx-success"
+                    : "bg-transparent text-nx-text-secondary border-nx-border"
+              }`}
+            >
+              {accepted[doc.slug] ? "\u2713 " : ""}
+              {doc.title || doc.slug}
+            </button>
+          ))}
+        </div>
+
+        {currentDoc && (
+          <div className="bg-nx-surface border border-nx-border rounded-2xl p-xl mb-lg">
+            <div className="flex items-center justify-between mb-lg">
+              <h2 className="text-subheading font-display text-nx-text-display">
+                {currentDoc.title || currentDoc.slug}
+              </h2>
+              <span className="text-label font-mono uppercase text-nx-text-disabled">
+                v{currentDoc.version}
+              </span>
+            </div>
+            <div className="max-h-64 overflow-y-auto mb-lg text-body-sm font-body text-nx-text-primary">
+              <p className="text-nx-text-secondary">
+                Document content will be loaded from the server. Please review
+                the full document before accepting.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleAcceptDoc}
+              className="w-full px-2xl py-md text-label font-mono uppercase rounded-full border bg-nx-text-display text-nx-black border-nx-text-display hover:bg-nx-text-primary transition-colors"
+            >
+              I ACCEPT &mdash; {currentDoc.title || currentDoc.slug}
+            </button>
+          </div>
+        )}
+
+        <button
+          type="button"
+          disabled={!allAccepted}
+          onClick={handleFinish}
+          className={`w-full px-2xl py-md text-label font-mono uppercase rounded-full border transition-colors ${
+            allAccepted
+              ? "bg-nx-accent text-nx-black border-nx-accent hover:bg-nx-accent/80"
+              : "bg-nx-text-disabled/30 text-nx-text-disabled border-nx-text-disabled/30 cursor-not-allowed"
+          }`}
+        >
+          {allAccepted ? "CONTINUE TO NEXUS" : "ACCEPT ALL DOCUMENTS TO CONTINUE"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/Settings.jsx
+++ b/frontend/src/screens/Settings.jsx
@@ -1,0 +1,101 @@
+import { useLegalDocuments, useMyAcceptances } from "../hooks/useLegal";
+import { LoadingSpinner } from "../components/feedback/LoadingSpinner";
+import { Link } from "react-router-dom";
+
+export default function Settings() {
+  const { data: documents = [], isLoading: docsLoading } = useLegalDocuments();
+  const { data: acceptancesData, isLoading: accLoading } = useMyAcceptances();
+  const acceptances = acceptancesData?.acceptances || [];
+
+  return (
+    <div className="text-nx-text-primary p-xl">
+      <div className="max-w-4xl mx-auto">
+        <header className="mb-3xl">
+          <span className="text-label font-mono uppercase text-nx-text-secondary block mb-sm">
+            SETTINGS
+          </span>
+          <h1 className="text-display-md font-display text-nx-text-display">
+            LEGAL &amp; COMPLIANCE
+          </h1>
+        </header>
+
+        <section className="mb-3xl">
+          <span className="text-label font-mono uppercase text-nx-text-secondary block mb-md">
+            LEGAL DOCUMENTS
+          </span>
+          {docsLoading ? (
+            <div className="flex items-center justify-center py-lg">
+              <LoadingSpinner />
+            </div>
+          ) : (
+            <div className="bg-nx-surface border border-nx-border rounded-2xl">
+              {documents.map((doc) => (
+                <Link
+                  key={doc.slug}
+                  to={`/legal/${doc.slug}`}
+                  className="flex items-center justify-between p-lg border-b border-nx-border last:border-b-0 hover:bg-nx-surface-raised transition-colors"
+                >
+                  <span className="text-body font-body text-nx-text-primary">
+                    {doc.title || doc.slug}
+                  </span>
+                  <span className="text-label font-mono uppercase text-nx-text-disabled">
+                    v{doc.version}
+                  </span>
+                </Link>
+              ))}
+              {documents.length === 0 && (
+                <div className="p-lg text-center">
+                  <span className="text-label font-mono uppercase text-nx-text-disabled">
+                    NO DOCUMENTS AVAILABLE
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+
+        <section>
+          <span className="text-label font-mono uppercase text-nx-text-secondary block mb-md">
+            ACCEPTANCE HISTORY
+          </span>
+          {accLoading ? (
+            <div className="flex items-center justify-center py-lg">
+              <LoadingSpinner />
+            </div>
+          ) : acceptances.length === 0 ? (
+            <span className="text-label font-mono uppercase text-nx-text-disabled">
+              NO ACCEPTANCE RECORDS FOUND
+            </span>
+          ) : (
+            <div className="bg-nx-surface border border-nx-border rounded-2xl">
+              {acceptances.map((acc, i) => (
+                <div
+                  key={`${acc.document_slug}-${acc.accepted_at}-${i}`}
+                  className="flex items-center justify-between p-lg border-b border-nx-border last:border-b-0"
+                >
+                  <div>
+                    <span className="text-body font-body text-nx-text-primary block">
+                      {acc.document_title || acc.document_slug}
+                    </span>
+                    <span className="text-label font-mono text-nx-text-disabled">
+                      v{acc.version}
+                    </span>
+                  </div>
+                  <span className="text-label font-mono text-nx-text-secondary">
+                    {new Date(acc.accepted_at).toLocaleDateString(undefined, {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/Strategies.jsx
+++ b/frontend/src/screens/Strategies.jsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { StatusBadge } from "../components/primitives/StatusBadge";
 import { StatRow } from "../components/primitives/StatRow";
+import { DisclaimerBanner } from "../components/legal/DisclaimerBanner";
+import { LiveTradingModal } from "../components/legal/LiveTradingModal";
 
 const STRATEGIES = [
   { id: "momentum-alpha", name: "MOMENTUM ALPHA v3.2", status: "idle" },
@@ -26,10 +28,21 @@ export default function Strategies() {
     Object.fromEntries(MOCK_PARAMS.map((p) => [p.key, p.value]))
   );
   const [running, setRunning] = useState(false);
+  const [showLiveModal, setShowLiveModal] = useState(false);
 
   const strategy = STRATEGIES.find((s) => s.id === activeStrategy);
 
   const handleRun = () => {
+    if (mode === "LIVE") {
+      setShowLiveModal(true);
+      return;
+    }
+    setRunning(true);
+    setTimeout(() => setRunning(false), 3000);
+  };
+
+  const handleLiveAccept = () => {
+    setShowLiveModal(false);
     setRunning(true);
     setTimeout(() => setRunning(false), 3000);
   };
@@ -66,6 +79,18 @@ export default function Strategies() {
               </button>
             ))}
           </div>
+          {mode === "PAPER" && (
+            <DisclaimerBanner variant="info" className="mt-md">
+              Paper trading results may differ materially from live trading.
+              Slippage, fill rates, and latency are simulated.
+            </DisclaimerBanner>
+          )}
+          {mode === "LIVE" && (
+            <DisclaimerBanner variant="danger" className="mt-md">
+              Live trading uses real capital. You will be required to acknowledge
+              risks before each session.
+            </DisclaimerBanner>
+          )}
         </section>
 
         <section className="mb-2xl">
@@ -136,6 +161,12 @@ export default function Strategies() {
             <StatusBadge status="loading">EXECUTING</StatusBadge>
           )}
         </section>
+
+        <LiveTradingModal
+          open={showLiveModal}
+          onAccept={handleLiveAccept}
+          onClose={() => setShowLiveModal(false)}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Phase 3 of [gh#154](https://github.com/SevFle/nexus-trade-engine/issues/154) — Frontend legal surfaces implementation.

Closes #154 (frontend phase)
Parent spec: [SEV-206](mention://issue/5ed3b8b2-937b-4ff3-abd2-86d140e7f8e7)

## Changes

### API Layer
- `frontend/src/api/client.js` — Base fetch wrapper with HTTP 451 interception, dispatches `legal:consent-required` custom event
- `frontend/src/api/legal.js` — Legal API client (documents, accept, acceptances/me, attributions)
- `frontend/src/hooks/useLegal.js` — React Query hooks (`useLegalDocuments`, `useLegalDocument`, `useAcceptLegal`, `useMyAcceptances`, `useAttributions`)

### State Management
- `frontend/src/context/LegalContext.jsx` — `LegalProvider` with global consent state, 451 event listener, document acceptance flow

### Components
- **Modal** (`components/feedback/Modal.jsx`) — Accessible dialog with backdrop, ESC close, focus management, ARIA attributes
- **ConsentModal** (`components/legal/ConsentModal.jsx`) — Multi-document tab viewer, markdown rendering via `marked`, checkbox acceptance
- **LiveTradingModal** (`components/legal/LiveTradingModal.jsx`) — Pre-flight risk acknowledgment with explicit checkbox, calls accept API
- **DisclaimerBanner** (`components/legal/DisclaimerBanner.jsx`) — Inline disclaimer with warning/info/danger variants
- **AttributionBadge** (`components/legal/AttributionBadge.jsx`) — Single provider attribution with external link
- **AttributionStrip** (`components/legal/AttributionStrip.jsx`) — Combined provider attributions with API fallback
- **LegalDocumentViewer** (`components/legal/LegalDocumentViewer.jsx`) — Full-page legal doc renderer with markdown-to-HTML
- **Footer** (`components/layout/Footer.jsx`) — Footer with links to all 5 legal documents

### Screens
- **Onboarding** (`screens/Onboarding.jsx`) — First-run consent wizard with per-document tab acceptance, blocks until all accepted
- **Settings** (`screens/Settings.jsx`) — Legal & Compliance section with document list (versioned) and acceptance history
- **LegalDocument** (`screens/LegalDocument.jsx`) — Dynamic route `/legal/:slug` for viewing any legal document

### Modified Screens
- **Backtest** — Added risk disclaimer banner + data provider attribution strip
- **Marketplace** — Added third-party code warning disclaimer
- **Strategies** — Added paper trading disclaimer (info), live trading disclaimer (danger), and LiveTradingModal pre-flight gate
- **Dashboard** — Added data provider attribution strip in footer

### Infrastructure
- **App.jsx** — Restructured with `QueryClientProvider`, `BrowserRouter`, `LegalProvider`, `ShellLayout` using `<Outlet />`
- **Shell.jsx** — Added Settings nav item, integrated Footer, restructured layout to flex column
- Added `marked` dependency for markdown rendering

## API Contracts (consumed from Phase 2, PR #206)
| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/api/v1/legal/documents` | GET | List all documents with versions, `requires_acceptance` flag |
| `/api/v1/legal/documents/{slug}` | GET | Fetch document content (markdown) |
| `/api/v1/legal/accept` | POST | Batch accept documents |
| `/api/v1/legal/acceptances/me` | GET | User's acceptance history |
| `/api/v1/legal/attributions` | GET | Data provider attributions |

## Testing
- Build passes (`npm run build`)
- ESLint config was never set up in this repo (pre-existing)
- No frontend test infrastructure exists yet (pre-existing)