### PR TITLE
fix(frontend): resolve code review blockers from PR #214

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.40.0",
         "clsx": "^2.1.0",
+        "dompurify": "^3.4.0",
         "lucide-react": "^0.383.0",
         "marked": "^18.0.1",
         "react": "^18.3.0",
@@ -1539,6 +1540,13 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2138,6 +2146,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.40.0",
     "clsx": "^2.1.0",
+    "dompurify": "^3.4.0",
     "lucide-react": "^0.383.0",
     "marked": "^18.0.1",
     "react": "^18.3.0",

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -20,7 +20,7 @@ export async function apiFetch(path, options = {}) {
 
   if (response.status === 451) {
     const body = await response.json().catch(() => ({}));
-    const pending = body.pending_documents || [];
+    const pending = body.detail?.documents || [];
     window.dispatchEvent(
       new CustomEvent("legal:consent-required", { detail: pending })
     );

--- a/frontend/src/components/feedback/Modal.jsx
+++ b/frontend/src/components/feedback/Modal.jsx
@@ -1,6 +1,16 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useCallback } from "react";
 import { X } from "lucide-react";
 import clsx from "clsx";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container) {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute("disabled") && el.tabIndex >= 0
+  );
+}
 
 export function Modal({
   open,
@@ -31,6 +41,33 @@ export function Modal({
     return () => window.removeEventListener("keydown", handleEsc);
   }, [open, onClose]);
 
+  const handleKeyDown = useCallback(
+    (e) => {
+      if (e.key !== "Tab") return;
+      const container = dialogRef.current;
+      if (!container) return;
+      const focusable = getFocusableElements(container);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    []
+  );
+
   if (!open) return null;
 
   return (
@@ -48,6 +85,7 @@ export function Modal({
       <div
         ref={dialogRef}
         tabIndex={-1}
+        onKeyDown={handleKeyDown}
         className={clsx(
           "relative bg-nx-surface border border-nx-border-visible rounded-2xl p-xl w-full",
           maxWidth,

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -6,6 +6,7 @@ const LEGAL_LINKS = [
   { to: "/legal/privacy-policy", label: "Privacy Policy" },
   { to: "/legal/eula", label: "EULA" },
   { to: "/legal/marketplace-eula", label: "Marketplace EULA" },
+  { to: "/legal/data-provider-attributions", label: "Data Provider Attributions" },
 ];
 
 export function Footer() {

--- a/frontend/src/components/legal/ConsentModal.jsx
+++ b/frontend/src/components/legal/ConsentModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { marked } from "marked";
+import DOMPurify from "dompurify";
 import { Modal } from "../feedback/Modal";
 import { useLegalContext } from "../../context/LegalContext";
 import { useLegalDocument } from "../../hooks/useLegal";
@@ -14,9 +15,10 @@ export function ConsentModal() {
   const { data: docContent } = useLegalDocument(activeSlug);
 
   const htmlContent = useMemo(() => {
-    if (!docContent?.content) return "";
-    return marked.parse(docContent.content, { async: false });
-  }, [docContent?.content]);
+    if (!docContent?.content_markdown) return "";
+    const raw = marked.parse(docContent.content_markdown, { async: false });
+    return DOMPurify.sanitize(raw);
+  }, [docContent?.content_markdown]);
 
   useEffect(() => {
     setChecked(false);

--- a/frontend/src/components/legal/LegalDocumentViewer.jsx
+++ b/frontend/src/components/legal/LegalDocumentViewer.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { marked } from "marked";
+import DOMPurify from "dompurify";
 import { useLegalDocument } from "../../hooks/useLegal";
 import { LoadingSpinner } from "../feedback/LoadingSpinner";
 
@@ -7,9 +8,10 @@ export function LegalDocumentViewer({ slug }) {
   const { data, isLoading, error } = useLegalDocument(slug);
 
   const htmlContent = useMemo(() => {
-    if (!data?.content) return "";
-    return marked.parse(data.content, { async: false });
-  }, [data?.content]);
+    if (!data?.content_markdown) return "";
+    const raw = marked.parse(data.content_markdown, { async: false });
+    return DOMPurify.sanitize(raw);
+  }, [data?.content_markdown]);
 
   if (isLoading) {
     return (

--- a/frontend/src/components/legal/LiveTradingModal.jsx
+++ b/frontend/src/components/legal/LiveTradingModal.jsx
@@ -1,14 +1,17 @@
 import { useState } from "react";
 import { Modal } from "../feedback/Modal";
-import { useAcceptLegal } from "../../hooks/useLegal";
+import { useAcceptLegal, useLegalDocument } from "../../hooks/useLegal";
 
 export function LiveTradingModal({ open, onAccept, onClose }) {
   const [checked, setChecked] = useState(false);
   const acceptMutation = useAcceptLegal();
+  const { data: doc } = useLegalDocument("risk-disclaimer");
 
   const handleAccept = async () => {
+    const version = doc?.version;
+    if (!version) return;
     await acceptMutation.mutateAsync([
-      { document_slug: "risk-disclaimer", version: "latest" },
+      { document_slug: "risk-disclaimer", version },
     ]);
     onAccept();
   };
@@ -54,10 +57,10 @@ export function LiveTradingModal({ open, onAccept, onClose }) {
           </button>
           <button
             type="button"
-            disabled={!checked}
+            disabled={!checked || !doc?.version}
             onClick={handleAccept}
             className={`flex-1 px-xl py-md text-label font-mono uppercase rounded-full border transition-colors ${
-              checked
+              checked && doc?.version
                 ? "bg-nx-accent text-nx-black border-nx-accent hover:bg-nx-accent/80"
                 : "bg-nx-text-disabled/30 text-nx-text-disabled border-nx-text-disabled/30 cursor-not-allowed"
             }`}

--- a/frontend/src/context/LegalContext.jsx
+++ b/frontend/src/context/LegalContext.jsx
@@ -12,12 +12,15 @@ const LegalContext = createContext(null);
 export function LegalProvider({ children }) {
   const [showConsentModal, setShowConsentModal] = useState(false);
   const [pendingDocs, setPendingDocs] = useState([]);
-  const { data: documents = [] } = useLegalDocuments();
+  const { data } = useLegalDocuments();
+  const documents = data ?? [];
   const acceptMutation = useAcceptLegal();
 
   useEffect(() => {
     if (!Array.isArray(documents)) return;
-    const required = documents.filter((d) => d.requires_acceptance);
+    const required = documents.filter(
+      (d) => d.needs_re_acceptance || (d.requires_acceptance && !d.accepted)
+    );
     if (required.length > 0) {
       setPendingDocs(required);
       setShowConsentModal(true);

--- a/frontend/src/hooks/useLegal.js
+++ b/frontend/src/hooks/useLegal.js
@@ -11,6 +11,7 @@ export function useLegalDocuments() {
   return useQuery({
     queryKey: ["legal", "documents"],
     queryFn: fetchLegalDocuments,
+    select: (data) => data?.documents ?? [],
   });
 }
 

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -1,7 +1,12 @@
 import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { marked } from "marked";
-import { useLegalDocuments, useAcceptLegal } from "../hooks/useLegal";
+import DOMPurify from "dompurify";
+import {
+  useLegalDocuments,
+  useLegalDocument,
+  useAcceptLegal,
+} from "../hooks/useLegal";
 import { LoadingSpinner } from "../components/feedback/LoadingSpinner";
 
 export default function Onboarding() {
@@ -15,6 +20,15 @@ export default function Onboarding() {
     () => (Array.isArray(documents) ? documents.filter((d) => d.requires_acceptance) : []),
     [documents]
   );
+
+  const currentDoc = requiredDocs[currentIdx];
+  const { data: docDetail } = useLegalDocument(currentDoc?.slug);
+
+  const htmlContent = useMemo(() => {
+    if (!docDetail?.content_markdown) return "";
+    const raw = marked.parse(docDetail.content_markdown, { async: false });
+    return DOMPurify.sanitize(raw);
+  }, [docDetail?.content_markdown]);
 
   const allAccepted = requiredDocs.every((d) => accepted[d.slug]);
 
@@ -47,8 +61,6 @@ export default function Onboarding() {
     navigate("/");
     return null;
   }
-
-  const currentDoc = requiredDocs[currentIdx];
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-nx-black p-xl">
@@ -96,10 +108,16 @@ export default function Onboarding() {
               </span>
             </div>
             <div className="max-h-64 overflow-y-auto mb-lg text-body-sm font-body text-nx-text-primary">
-              <p className="text-nx-text-secondary">
-                Document content will be loaded from the server. Please review
-                the full document before accepting.
-              </p>
+              {htmlContent ? (
+                <div
+                  className="prose prose-sm prose-invert max-w-none [&_h1]:text-subheading [&_h1]:font-display [&_h1]:text-nx-text-display [&_h1]:mb-md [&_h2]:text-body [&_h2]:font-display [&_h2]:text-nx-text-primary [&_h2]:mb-sm [&_p]:mb-sm [&_ul]:list-disc [&_ul]:pl-md"
+                  dangerouslySetInnerHTML={{ __html: htmlContent }}
+                />
+              ) : (
+                <div className="flex items-center justify-center py-xl">
+                  <LoadingSpinner />
+                </div>
+              )}
             </div>
             <button
               type="button"


### PR DESCRIPTION
## Summary

Fixes all blockers, majors, and minors from code review [SEV-497](mention://issue/36d862d1-e763-4bd6-8bc5-94b168d3d158) of PR #214.

### Blockers
- **B1**: XSS via `dangerouslySetInnerHTML` — added `DOMPurify.sanitize()` to `ConsentModal.jsx` and `LegalDocumentViewer.jsx`
- **B3**: ConsentModal always shows for all `requires_acceptance` docs — now filters to `needs_re_acceptance || (requires_acceptance && !accepted)`
- **B4**: Field name mismatch — `content` → `content_markdown`

### Majors
- **M3**: `LiveTradingModal` sends actual version from API instead of `"latest"`
- **M4**: `useLegalDocuments` uses `select` to unwrap `data.documents`
- **M5**: `apiFetch` 451 handler reads `body.detail?.documents`
- **M7**: Onboarding screen renders real legal markdown via `useLegalDocument` + DOMPurify

### Minors
- **m3**: Added `data-provider-attributions` link to Footer
- **m4**: Added keyboard focus trap to `Modal` component for a11y

Closes [SEV-502](mention://issue/4b6b6f96-40a2-4a22-90f6-66fdcfe2f5ae)