### PR TITLE
fix(frontend): Phase 5b — resolve all code review findings (B1 B3 B4 M3 M4 M5 M7)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.40.0",
         "clsx": "^2.1.0",
+        "dompurify": "^3.4.0",
         "lucide-react": "^0.383.0",
         "marked": "^18.0.1",
         "react": "^18.3.0",
@@ -1539,6 +1540,13 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2138,6 +2146,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.40.0",
     "clsx": "^2.1.0",
+    "dompurify": "^3.4.0",
     "lucide-react": "^0.383.0",
     "marked": "^18.0.1",
     "react": "^18.3.0",

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -20,7 +20,7 @@ export async function apiFetch(path, options = {}) {
 
   if (response.status === 451) {
     const body = await response.json().catch(() => ({}));
-    const pending = body.pending_documents || [];
+    const pending = body.detail?.documents || [];
     window.dispatchEvent(
       new CustomEvent("legal:consent-required", { detail: pending })
     );

--- a/frontend/src/components/feedback/Modal.jsx
+++ b/frontend/src/components/feedback/Modal.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useId, useRef } from "react";
 import { X } from "lucide-react";
 import clsx from "clsx";
 
@@ -12,6 +12,7 @@ export function Modal({
 }) {
   const dialogRef = useRef(null);
   const previousFocus = useRef(null);
+  const headingId = useId();
 
   const getFocusableElements = useCallback(() => {
     if (!dialogRef.current) return [];
@@ -75,7 +76,8 @@ export function Modal({
       className="fixed inset-0 z-50 flex items-center justify-center"
       role="dialog"
       aria-modal="true"
-      aria-label={title}
+      aria-label={title || undefined}
+      aria-labelledby={!title ? headingId : undefined}
     >
       <div
         className="absolute inset-0 bg-black/80"
@@ -94,7 +96,7 @@ export function Modal({
         )}
       >
         <div className="flex items-center justify-between mb-lg">
-          <h2 className="text-subheading font-display text-nx-text-display">
+          <h2 id={!title ? headingId : undefined} className="text-subheading font-display text-nx-text-display">
             {title}
           </h2>
           {onClose && (

--- a/frontend/src/components/feedback/Modal.jsx
+++ b/frontend/src/components/feedback/Modal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import clsx from "clsx";
 
@@ -13,23 +13,60 @@ export function Modal({
   const dialogRef = useRef(null);
   const previousFocus = useRef(null);
 
+  const getFocusableElements = useCallback(() => {
+    if (!dialogRef.current) return [];
+    return Array.from(
+      dialogRef.current.querySelectorAll(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((el) => !el.hasAttribute("disabled"));
+  }, []);
+
   useEffect(() => {
     if (open) {
       previousFocus.current = document.activeElement;
-      dialogRef.current?.focus();
+      requestAnimationFrame(() => {
+        const focusable = getFocusableElements();
+        if (focusable.length > 0) {
+          focusable[0].focus();
+        } else {
+          dialogRef.current?.focus();
+        }
+      });
     } else {
       previousFocus.current?.focus();
     }
-  }, [open]);
+  }, [open, getFocusableElements]);
 
   useEffect(() => {
     if (!open) return;
     const handleEsc = (e) => {
       if (e.key === "Escape") onClose?.();
     };
+    const handleTab = (e) => {
+      if (e.key !== "Tab") return;
+      const focusable = getFocusableElements();
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
     window.addEventListener("keydown", handleEsc);
-    return () => window.removeEventListener("keydown", handleEsc);
-  }, [open, onClose]);
+    window.addEventListener("keydown", handleTab);
+    return () => {
+      window.removeEventListener("keydown", handleEsc);
+      window.removeEventListener("keydown", handleTab);
+    };
+  }, [open, onClose, getFocusableElements]);
 
   if (!open) return null;
 

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -6,6 +6,7 @@ const LEGAL_LINKS = [
   { to: "/legal/privacy-policy", label: "Privacy Policy" },
   { to: "/legal/eula", label: "EULA" },
   { to: "/legal/marketplace-eula", label: "Marketplace EULA" },
+  { to: "/legal/data-provider-attributions", label: "Data Providers" },
 ];
 
 export function Footer() {

--- a/frontend/src/components/legal/ConsentModal.jsx
+++ b/frontend/src/components/legal/ConsentModal.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import DOMPurify from "dompurify";
 import { marked } from "marked";
 import { Modal } from "../feedback/Modal";
 import { useLegalContext } from "../../context/LegalContext";
@@ -14,9 +15,11 @@ export function ConsentModal() {
   const { data: docContent } = useLegalDocument(activeSlug);
 
   const htmlContent = useMemo(() => {
-    if (!docContent?.content) return "";
-    return marked.parse(docContent.content, { async: false });
-  }, [docContent?.content]);
+    const raw = docContent?.content_markdown;
+    if (!raw) return "";
+    const html = marked.parse(raw, { async: false });
+    return DOMPurify.sanitize(html);
+  }, [docContent?.content_markdown]);
 
   useEffect(() => {
     setChecked(false);

--- a/frontend/src/components/legal/LegalDocumentViewer.jsx
+++ b/frontend/src/components/legal/LegalDocumentViewer.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import DOMPurify from "dompurify";
 import { marked } from "marked";
 import { useLegalDocument } from "../../hooks/useLegal";
 import { LoadingSpinner } from "../feedback/LoadingSpinner";
@@ -7,9 +8,11 @@ export function LegalDocumentViewer({ slug }) {
   const { data, isLoading, error } = useLegalDocument(slug);
 
   const htmlContent = useMemo(() => {
-    if (!data?.content) return "";
-    return marked.parse(data.content, { async: false });
-  }, [data?.content]);
+    const raw = data?.content_markdown;
+    if (!raw) return "";
+    const html = marked.parse(raw, { async: false });
+    return DOMPurify.sanitize(html);
+  }, [data?.content_markdown]);
 
   if (isLoading) {
     return (

--- a/frontend/src/components/legal/LiveTradingModal.jsx
+++ b/frontend/src/components/legal/LiveTradingModal.jsx
@@ -1,14 +1,18 @@
 import { useState } from "react";
 import { Modal } from "../feedback/Modal";
-import { useAcceptLegal } from "../../hooks/useLegal";
+import { useAcceptLegal, useLegalDocuments } from "../../hooks/useLegal";
 
 export function LiveTradingModal({ open, onAccept, onClose }) {
   const [checked, setChecked] = useState(false);
   const acceptMutation = useAcceptLegal();
+  const { data: documents = [] } = useLegalDocuments();
+
+  const riskDoc = documents.find((d) => d.slug === "risk-disclaimer");
+  const riskVersion = riskDoc?.current_version || "1.0.0";
 
   const handleAccept = async () => {
     await acceptMutation.mutateAsync([
-      { document_slug: "risk-disclaimer", version: "latest" },
+      { document_slug: "risk-disclaimer", document_version: riskVersion },
     ]);
     onAccept();
   };

--- a/frontend/src/context/LegalContext.jsx
+++ b/frontend/src/context/LegalContext.jsx
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { useLegalDocuments, useAcceptLegal } from "../hooks/useLegal";
@@ -12,31 +13,42 @@ const LegalContext = createContext(null);
 export function LegalProvider({ children }) {
   const [showConsentModal, setShowConsentModal] = useState(false);
   const [pendingDocs, setPendingDocs] = useState([]);
-  const { data: documents = [] } = useLegalDocuments();
+  const documents = useLegalDocuments().data || [];
   const acceptMutation = useAcceptLegal();
 
+  const requiredPending = useMemo(
+    () =>
+      documents.filter(
+        (d) => d.needs_re_acceptance || (d.requires_acceptance && !d.accepted)
+      ),
+    [documents]
+  );
+
   useEffect(() => {
-    if (!Array.isArray(documents)) return;
-    const required = documents.filter((d) => d.requires_acceptance);
-    if (required.length > 0) {
-      setPendingDocs(required);
+    if (requiredPending.length > 0) {
+      setPendingDocs(requiredPending);
       setShowConsentModal(true);
     }
-  }, [documents]);
+  }, [requiredPending]);
 
   useEffect(() => {
     const handler = (e) => {
-      setPendingDocs(e.detail);
+      const slugs = Array.isArray(e.detail) ? e.detail : [];
+      const docs = slugs.map((slug) => {
+        const found = documents.find((d) => d.slug === slug);
+        return found || { slug, title: slug, current_version: "0.0.0" };
+      });
+      setPendingDocs(docs);
       setShowConsentModal(true);
     };
     window.addEventListener("legal:consent-required", handler);
     return () => window.removeEventListener("legal:consent-required", handler);
-  }, []);
+  }, [documents]);
 
   const handleAccept = useCallback(async () => {
     const acceptances = pendingDocs.map((d) => ({
       document_slug: d.slug,
-      version: d.version,
+      document_version: d.current_version,
     }));
     await acceptMutation.mutateAsync(acceptances);
     setPendingDocs([]);

--- a/frontend/src/context/LegalContext.jsx
+++ b/frontend/src/context/LegalContext.jsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useLegalDocuments, useAcceptLegal } from "../hooks/useLegal";
@@ -15,6 +16,7 @@ export function LegalProvider({ children }) {
   const [pendingDocs, setPendingDocs] = useState([]);
   const documents = useLegalDocuments().data || [];
   const acceptMutation = useAcceptLegal();
+  const consentedThisSession = useRef(false);
 
   const requiredPending = useMemo(
     () =>
@@ -25,7 +27,7 @@ export function LegalProvider({ children }) {
   );
 
   useEffect(() => {
-    if (requiredPending.length > 0) {
+    if (requiredPending.length > 0 && !consentedThisSession.current) {
       setPendingDocs(requiredPending);
       setShowConsentModal(true);
     }
@@ -50,6 +52,7 @@ export function LegalProvider({ children }) {
       document_slug: d.slug,
       document_version: d.current_version,
     }));
+    consentedThisSession.current = true;
     await acceptMutation.mutateAsync(acceptances);
     setPendingDocs([]);
     setShowConsentModal(false);

--- a/frontend/src/hooks/useLegal.js
+++ b/frontend/src/hooks/useLegal.js
@@ -11,6 +11,7 @@ export function useLegalDocuments() {
   return useQuery({
     queryKey: ["legal", "documents"],
     queryFn: fetchLegalDocuments,
+    select: (data) => data.documents || [],
   });
 }
 

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
@@ -30,6 +30,12 @@ export default function Onboarding() {
 
   const allAccepted = requiredDocs.every((d) => accepted[d.slug]);
 
+  useEffect(() => {
+    if (!isLoading && requiredDocs.length === 0) {
+      navigate("/");
+    }
+  }, [isLoading, requiredDocs.length, navigate]);
+
   const handleAcceptDoc = () => {
     const doc = requiredDocs[currentIdx];
     setAccepted((prev) => ({ ...prev, [doc.slug]: true }));
@@ -56,7 +62,6 @@ export default function Onboarding() {
   }
 
   if (requiredDocs.length === 0) {
-    navigate("/");
     return null;
   }
 

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -1,20 +1,32 @@
 import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import DOMPurify from "dompurify";
 import { marked } from "marked";
-import { useLegalDocuments, useAcceptLegal } from "../hooks/useLegal";
+import { useLegalDocuments, useLegalDocument, useAcceptLegal } from "../hooks/useLegal";
 import { LoadingSpinner } from "../components/feedback/LoadingSpinner";
 
 export default function Onboarding() {
   const navigate = useNavigate();
-  const { data: documents = [], isLoading } = useLegalDocuments();
+  const documents = useLegalDocuments().data || [];
+  const isLoading = useLegalDocuments().isLoading;
   const acceptMutation = useAcceptLegal();
   const [currentIdx, setCurrentIdx] = useState(0);
   const [accepted, setAccepted] = useState({});
 
   const requiredDocs = useMemo(
-    () => (Array.isArray(documents) ? documents.filter((d) => d.requires_acceptance) : []),
+    () => documents.filter((d) => d.requires_acceptance),
     [documents]
   );
+
+  const currentDoc = requiredDocs[currentIdx];
+  const { data: docDetail } = useLegalDocument(currentDoc?.slug);
+
+  const htmlContent = useMemo(() => {
+    const raw = docDetail?.content_markdown;
+    if (!raw) return "";
+    const html = marked.parse(raw, { async: false });
+    return DOMPurify.sanitize(html);
+  }, [docDetail?.content_markdown]);
 
   const allAccepted = requiredDocs.every((d) => accepted[d.slug]);
 
@@ -29,7 +41,7 @@ export default function Onboarding() {
   const handleFinish = async () => {
     const acceptances = requiredDocs.map((d) => ({
       document_slug: d.slug,
-      version: d.version,
+      document_version: d.current_version,
     }));
     await acceptMutation.mutateAsync(acceptances);
     navigate("/");
@@ -47,8 +59,6 @@ export default function Onboarding() {
     navigate("/");
     return null;
   }
-
-  const currentDoc = requiredDocs[currentIdx];
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-nx-black p-xl">
@@ -92,14 +102,20 @@ export default function Onboarding() {
                 {currentDoc.title || currentDoc.slug}
               </h2>
               <span className="text-label font-mono uppercase text-nx-text-disabled">
-                v{currentDoc.version}
+                v{currentDoc.current_version}
               </span>
             </div>
             <div className="max-h-64 overflow-y-auto mb-lg text-body-sm font-body text-nx-text-primary">
-              <p className="text-nx-text-secondary">
-                Document content will be loaded from the server. Please review
-                the full document before accepting.
-              </p>
+              {htmlContent ? (
+                <div
+                  className="prose prose-sm prose-invert max-w-none [&_h1]:text-subheading [&_h1]:font-display [&_h1]:text-nx-text-display [&_h1]:mb-md [&_h2]:text-body [&_h2]:font-display [&_h2]:text-nx-text-primary [&_h2]:mb-sm [&_p]:mb-sm [&_ul]:list-disc [&_ul]:pl-md"
+                  dangerouslySetInnerHTML={{ __html: htmlContent }}
+                />
+              ) : (
+                <div className="flex items-center justify-center py-xl">
+                  <LoadingSpinner />
+                </div>
+              )}
             </div>
             <button
               type="button"

--- a/frontend/src/screens/Settings.jsx
+++ b/frontend/src/screens/Settings.jsx
@@ -3,7 +3,8 @@ import { LoadingSpinner } from "../components/feedback/LoadingSpinner";
 import { Link } from "react-router-dom";
 
 export default function Settings() {
-  const { data: documents = [], isLoading: docsLoading } = useLegalDocuments();
+  const documents = useLegalDocuments().data || [];
+  const docsLoading = useLegalDocuments().isLoading;
   const { data: acceptancesData, isLoading: accLoading } = useMyAcceptances();
   const acceptances = acceptancesData?.acceptances || [];
 
@@ -39,7 +40,7 @@ export default function Settings() {
                     {doc.title || doc.slug}
                   </span>
                   <span className="text-label font-mono uppercase text-nx-text-disabled">
-                    v{doc.version}
+                    v{doc.current_version}
                   </span>
                 </Link>
               ))}
@@ -68,17 +69,17 @@ export default function Settings() {
             </span>
           ) : (
             <div className="bg-nx-surface border border-nx-border rounded-2xl">
-              {acceptances.map((acc, i) => (
+              {acceptances.map((acc) => (
                 <div
-                  key={`${acc.document_slug}-${acc.accepted_at}-${i}`}
+                  key={acc.id || `${acc.document_slug}-${acc.accepted_at}`}
                   className="flex items-center justify-between p-lg border-b border-nx-border last:border-b-0"
                 >
                   <div>
                     <span className="text-body font-body text-nx-text-primary block">
-                      {acc.document_title || acc.document_slug}
+                      {acc.document_slug}
                     </span>
                     <span className="text-label font-mono text-nx-text-disabled">
-                      v{acc.version}
+                      v{acc.document_version}
                     </span>
                   </div>
                   <span className="text-label font-mono text-nx-text-secondary">


### PR DESCRIPTION
## Summary

Fixes all frontend findings from Phase 5 code review ([SEV-502](mention://issue/4b6b6f96-40a2-4a22-90f6-66fdcfe2f5ae)).

### Blockers
- **B1** — XSS via `dangerouslySetInnerHTML`: Added `DOMPurify.sanitize()` in ConsentModal, LegalDocumentViewer, and Onboarding
- **B3** — Infinite consent modal: Now only triggers for docs where `needs_re_acceptance || (requires_acceptance && !accepted)`
- **B4** — Field name mismatch: Fixed `docContent?.content` → `docContent?.content_markdown`

### Majors
- **M3** — `LiveTradingModal` now fetches actual risk-disclaimer `current_version` instead of sending `"latest"`
- **M4** — `useLegalDocuments` uses `select` to unwrap `{ documents: [...] }` response
- **M5** — 451 handler reads `body.detail.documents` (matching backend shape) and maps slug strings to full doc objects
- **M7** — Onboarding renders real markdown content via `useLegalDocument` instead of placeholder text

### Minors
- **m3** — Added data-provider-attributions link to Footer
- **m4** — Added keyboard focus trap (Tab/Shift+Tab cycling) to Modal component

### Additional fixes discovered during implementation
- Accept payload uses `document_version` (not `version`) per backend `AcceptanceItem` schema
- Document list references `current_version` (not `version`) per `DocumentSummary` schema
- Settings acceptance history uses `document_version` per `AcceptanceRecord` schema
- 451 response maps bare slug strings to full doc objects from query cache

Closes #154