### PR TITLE
fix: resolve 6 security findings from SEV-507 audit (C2, H3, M1, M2, L1, L2)

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from engine.api.routes.auth import router as auth_router
 from engine.api.routes.backtest import router as backtest_router
@@ -9,11 +9,17 @@ from engine.api.routes.legal import router as legal_router
 from engine.api.routes.marketplace import router as marketplace_router
 from engine.api.routes.portfolio import router as portfolio_router
 from engine.api.routes.strategies import router as strategies_router
+from engine.legal.dependencies import require_legal_acceptance
 
 api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
 api_router.include_router(auth_router, prefix="/api/v1/auth", tags=["auth"])
-api_router.include_router(backtest_router, prefix="/api/v1/backtest", tags=["backtest"])
+api_router.include_router(
+    backtest_router,
+    prefix="/api/v1/backtest",
+    tags=["backtest"],
+    dependencies=[Depends(require_legal_acceptance)],
+)
 api_router.include_router(legal_router, tags=["legal"])
 api_router.include_router(portfolio_router, prefix="/api/v1/portfolio", tags=["portfolio"])
 api_router.include_router(strategies_router, prefix="/api/v1/strategies", tags=["strategies"])

--- a/engine/api/routes/legal.py
+++ b/engine/api/routes/legal.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 
 from engine.config import settings
 from engine.deps import get_db
@@ -23,14 +24,20 @@ if TYPE_CHECKING:
 router = APIRouter()
 logger = structlog.get_logger()
 
+_MD_SPECIAL_RE = re.compile(r"([\\`*_{}\[\]()#+\-.!|~>])")
+
+
+def _escape_markdown(value: str) -> str:
+    return _MD_SPECIAL_RE.sub(r"\\\1", value)
+
 
 def _apply_substitutions(content: str, effective_date: str = "") -> str:
     return (
-        content.replace("{{OPERATOR_NAME}}", settings.operator_name)
-        .replace("{{OPERATOR_EMAIL}}", settings.operator_email)
-        .replace("{{OPERATOR_URL}}", settings.operator_url)
-        .replace("{{JURISDICTION}}", settings.jurisdiction)
-        .replace("{{PLATFORM_FEE_PERCENT}}", str(settings.platform_fee_percent))
+        content.replace("{{OPERATOR_NAME}}", _escape_markdown(settings.operator_name))
+        .replace("{{OPERATOR_EMAIL}}", _escape_markdown(settings.operator_email))
+        .replace("{{OPERATOR_URL}}", _escape_markdown(settings.operator_url))
+        .replace("{{JURISDICTION}}", _escape_markdown(settings.jurisdiction))
+        .replace("{{PLATFORM_FEE_PERCENT}}", _escape_markdown(str(settings.platform_fee_percent)))
         .replace("{{EFFECTIVE_DATE}}", effective_date)
     )
 
@@ -54,9 +61,12 @@ async def list_documents(
     return DocumentListResponse(documents=summaries)
 
 
-@router.get("/api/v1/legal/documents/{slug}", response_model=DocumentDetailResponse)
+@router.get(
+    "/api/v1/legal/documents/{slug}",
+    response_model=DocumentDetailResponse,
+)
 async def get_document(
-    slug: str,
+    slug: str = Path(pattern=r"^[a-z0-9-]+$"),
     version: str | None = Query(None),
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ) -> DocumentDetailResponse:

--- a/engine/api/routes/marketplace.py
+++ b/engine/api/routes/marketplace.py
@@ -7,8 +7,9 @@ from pydantic import BaseModel
 
 from engine.api.auth.dependency import get_current_user, require_role
 from engine.db.models import User
+from engine.legal.dependencies import require_legal_acceptance
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_legal_acceptance)])
 
 
 class MarketplaceEntry(BaseModel):

--- a/engine/api/routes/portfolio.py
+++ b/engine/api/routes/portfolio.py
@@ -6,8 +6,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from engine.api.auth.dependency import get_current_user
 from engine.db.models import Portfolio, User
 from engine.deps import get_db
+from engine.legal.dependencies import require_legal_acceptance
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_legal_acceptance)])
 
 
 class CreatePortfolioRequest(BaseModel):

--- a/engine/api/routes/strategies.py
+++ b/engine/api/routes/strategies.py
@@ -7,8 +7,9 @@ from pydantic import BaseModel, Field
 
 from engine.api.auth.dependency import get_current_user
 from engine.db.models import User
+from engine.legal.dependencies import require_legal_acceptance
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_legal_acceptance)])
 
 
 class StrategyConfigRequest(BaseModel):

--- a/engine/db/migrations/versions/005_legal_acceptance_immutable.py
+++ b/engine/db/migrations/versions/005_legal_acceptance_immutable.py
@@ -26,9 +26,10 @@ def upgrade() -> None:
         $$ LANGUAGE plpgsql
         """
     )
+    op.execute("DROP TRIGGER IF EXISTS no_acceptance_update ON legal_acceptances")
     op.execute(
         """
-        CREATE TRIGGER IF NOT EXISTS no_acceptance_update
+        CREATE TRIGGER no_acceptance_update
         BEFORE UPDATE OR DELETE ON legal_acceptances
         FOR EACH ROW EXECUTE FUNCTION prevent_acceptance_modification()
         """

--- a/engine/db/migrations/versions/005_legal_acceptance_immutable.py
+++ b/engine/db/migrations/versions/005_legal_acceptance_immutable.py
@@ -1,0 +1,40 @@
+"""add immutability trigger on legal_acceptances
+
+Revision ID: 005_legal_acceptance_immutable
+Revises: 004_legal_documents
+Create Date: 2026-04-18
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "005_legal_acceptance_immutable"
+down_revision: str | Sequence[str] | None = "004_legal_documents"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION prevent_acceptance_modification()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            RAISE EXCEPTION 'legal_acceptances records are immutable';
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS no_acceptance_update
+        BEFORE UPDATE OR DELETE ON legal_acceptances
+        FOR EACH ROW EXECUTE FUNCTION prevent_acceptance_modification()
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS no_acceptance_update ON legal_acceptances")
+    op.execute("DROP FUNCTION IF EXISTS prevent_acceptance_modification()")

--- a/engine/db/migrations/versions/006_legal_acceptance_immutable.py
+++ b/engine/db/migrations/versions/006_legal_acceptance_immutable.py
@@ -9,8 +9,8 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "005_legal_acceptance_immutable"
-down_revision: str | Sequence[str] | None = "004_legal_documents"
+revision: str = "006_legal_acceptance_immutable"
+down_revision: str | Sequence[str] | None = "005_auth_rbac"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/engine/legal/service.py
+++ b/engine/legal/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid  # noqa: TC003
 from datetime import UTC
 from datetime import datetime as dt
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
@@ -10,6 +11,7 @@ from fastapi import HTTPException
 from packaging.version import Version
 from sqlalchemy import select
 
+from engine.config import settings
 from engine.db.models import (
     DataProviderAttribution,
     LegalAcceptance,
@@ -127,8 +129,19 @@ async def get_document_content(
         return None
     if version and version != doc.current_version:
         return None
+    resolved_path = Path(doc.file_path).resolve()
+    legal_root = Path(settings.legal_documents_dir).resolve()
+    if not resolved_path.is_relative_to(legal_root):
+        logger.error(
+            "legal.path_traversal_blocked",
+            path=doc.file_path,
+            resolved=str(resolved_path),
+            legal_root=str(legal_root),
+            slug=slug,
+        )
+        return None
     try:
-        with open(doc.file_path) as f:
+        with open(resolved_path) as f:
             markdown = f.read()
     except FileNotFoundError:
         logger.exception("legal.file_not_found", path=doc.file_path, slug=slug)

--- a/engine/legal/sync.py
+++ b/engine/legal/sync.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 
 from engine.config import settings
 from engine.db.models import LegalDocument
@@ -63,46 +63,32 @@ async def sync_legal_documents(db: AsyncSession) -> int:
             category = meta.get("category", "general")
             display_order = int(meta.get("display_order", "0"))
 
-            stmt = select(LegalDocument).where(LegalDocument.slug == slug)
-            result = await db.execute(stmt)
-            existing = result.scalar_one_or_none()
+            parsed_date = _parse_date(effective_date)
+            file_path = str(md_file)
 
-            if existing is None:
-                doc = LegalDocument(
-                    slug=slug,
-                    title=title,
-                    current_version=version,
-                    effective_date=_parse_date(effective_date),
-                    requires_acceptance=requires_acceptance,
-                    category=category,
-                    display_order=display_order,
-                    file_path=str(md_file),
-                )
-                db.add(doc)
-                logger.info("legal.document_registered", slug=slug, version=version)
-            elif existing.current_version != version:
-                old_version = existing.current_version
-                existing.current_version = version
-                existing.title = title
-                existing.effective_date = _parse_date(effective_date)
-                existing.requires_acceptance = requires_acceptance
-                existing.category = category
-                existing.display_order = display_order
-                existing.file_path = str(md_file)
-                logger.info(
-                    "legal.version_changed",
-                    slug=slug,
-                    old=old_version,
-                    new=version,
-                )
-            else:
-                existing.title = title
-                existing.effective_date = _parse_date(effective_date)
-                existing.requires_acceptance = requires_acceptance
-                existing.category = category
-                existing.display_order = display_order
-                existing.file_path = str(md_file)
-
+            stmt = insert(LegalDocument).values(
+                slug=slug,
+                title=title,
+                current_version=version,
+                effective_date=parsed_date,
+                requires_acceptance=requires_acceptance,
+                category=category,
+                display_order=display_order,
+                file_path=file_path,
+            )
+            upsert = stmt.on_conflict_do_update(
+                index_elements=["slug"],
+                set_={
+                    "title": title,
+                    "current_version": version,
+                    "effective_date": parsed_date,
+                    "requires_acceptance": requires_acceptance,
+                    "category": category,
+                    "display_order": display_order,
+                    "file_path": file_path,
+                },
+            )
+            await db.execute(upsert)
             synced += 1
         except Exception:
             logger.exception("legal.sync_file_error", file=str(md_file))

--- a/tests/test_security_sev507.py
+++ b/tests/test_security_sev507.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import asyncio
+import datetime
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from engine.api.routes.backtest import router as bt_router
+from engine.api.routes.legal import _apply_substitutions
+from engine.app import create_app
+from engine.db.models import LegalDocument
+from engine.deps import get_db
+from engine.legal import service as legal_service
+from engine.legal.dependencies import require_legal_acceptance
+from engine.legal.schemas import AcceptanceItem
+from engine.legal.sync import sync_legal_documents
+from tests.factories import make_user
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class TestC2ConsentWiring:
+    async def test_require_legal_acceptance_wired_on_backtest_routes(
+        self, db_session: AsyncSession
+    ):
+        app = FastAPI()
+
+        app.include_router(
+            bt_router,
+            prefix="/api/v1/backtest",
+            dependencies=[Depends(require_legal_acceptance)],
+        )
+
+        async def override_get_db():
+            yield db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/backtest/run",
+                json={
+                    "strategy_name": "mean_reversion_basic",
+                    "symbol": "AAPL",
+                    "start_date": "2024-01-01",
+                    "end_date": "2024-12-31",
+                },
+            )
+            assert response.status_code in (
+                HTTPStatus.OK,
+                HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS,
+            )
+
+    async def test_legal_routes_do_not_require_consent(self, db_session: AsyncSession):
+        app = create_app()
+
+        async def override_get_db():
+            yield db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/v1/legal/documents")
+            assert response.status_code == HTTPStatus.OK
+
+    async def test_health_routes_do_not_require_consent(self, db_session: AsyncSession):
+        app = create_app()
+
+        async def override_get_db():
+            yield db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/health")
+            assert response.status_code == HTTPStatus.OK
+
+
+class TestH3DbImmutability:
+    async def test_update_legal_acceptance_raises(self, db_session: AsyncSession):
+        await db_session.execute(
+            text(
+                "CREATE OR REPLACE FUNCTION prevent_acceptance_modification() "
+                "RETURNS TRIGGER AS $$ "
+                "BEGIN "
+                "  RAISE EXCEPTION 'legal_acceptances records are immutable'; "
+                "END; "
+                "$$ LANGUAGE plpgsql"
+            )
+        )
+        await db_session.execute(
+            text("DROP TRIGGER IF EXISTS no_acceptance_update ON legal_acceptances")
+        )
+        await db_session.execute(
+            text(
+                "CREATE TRIGGER no_acceptance_update "
+                "BEFORE UPDATE OR DELETE ON legal_acceptances "
+                "FOR EACH ROW EXECUTE FUNCTION prevent_acceptance_modification()"
+            )
+        )
+        await db_session.commit()
+
+        user = make_user(email="immutable@example.com")
+        db_session.add(user)
+        await db_session.flush()
+
+        doc = LegalDocument(
+            slug="immut-test",
+            title="Immut Test",
+            current_version="1.0.0",
+            effective_date=datetime.date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=0,
+            file_path="legal/terms-of-service.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="immut-test", document_version="1.0.0")],
+            "127.0.0.1",
+            "test",
+        )
+        await db_session.flush()
+
+        record = (
+            await db_session.execute(text("SELECT id FROM legal_acceptances LIMIT 1"))
+        ).scalar_one()
+
+        await db_session.execute(
+            text("UPDATE legal_acceptances SET document_version = '9.9.9' WHERE id = :id"),
+            {"id": str(record)},
+        )
+        with pytest.raises(Exception, match="immutable"):
+            await db_session.flush()
+
+    async def test_delete_legal_acceptance_raises(self, db_session: AsyncSession):
+        await db_session.execute(
+            text(
+                "CREATE OR REPLACE FUNCTION prevent_acceptance_modification() "
+                "RETURNS TRIGGER AS $$ "
+                "BEGIN "
+                "  RAISE EXCEPTION 'legal_acceptances records are immutable'; "
+                "END; "
+                "$$ LANGUAGE plpgsql"
+            )
+        )
+        await db_session.execute(
+            text("DROP TRIGGER IF EXISTS no_acceptance_update ON legal_acceptances")
+        )
+        await db_session.execute(
+            text(
+                "CREATE TRIGGER no_acceptance_update "
+                "BEFORE UPDATE OR DELETE ON legal_acceptances "
+                "FOR EACH ROW EXECUTE FUNCTION prevent_acceptance_modification()"
+            )
+        )
+        await db_session.commit()
+
+        user = make_user(email="immutable-del@example.com")
+        db_session.add(user)
+        await db_session.flush()
+
+        doc = LegalDocument(
+            slug="immut-del-test",
+            title="Immut Del Test",
+            current_version="1.0.0",
+            effective_date=datetime.date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=0,
+            file_path="legal/terms-of-service.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        await legal_service.record_acceptances(
+            db_session,
+            user.id,
+            [AcceptanceItem(document_slug="immut-del-test", document_version="1.0.0")],
+            "127.0.0.1",
+            "test",
+        )
+        await db_session.flush()
+
+        record = (
+            await db_session.execute(text("SELECT id FROM legal_acceptances LIMIT 1"))
+        ).scalar_one()
+
+        await db_session.execute(
+            text("DELETE FROM legal_acceptances WHERE id = :id"),
+            {"id": str(record)},
+        )
+        with pytest.raises(Exception, match="immutable"):
+            await db_session.flush()
+
+
+class TestM1MarkdownEscape:
+    async def test_substitutions_escape_markdown_special_chars(self):
+        with patch("engine.api.routes.legal.settings") as mock_settings:
+            mock_settings.operator_name = "Evil**Co__Corp~~\n#Heading"
+            mock_settings.operator_email = "test@test.com"
+            mock_settings.operator_url = "https://test.com"
+            mock_settings.jurisdiction = "US"
+            mock_settings.platform_fee_percent = 30
+
+            result = _apply_substitutions("{{OPERATOR_NAME}} rules")
+            assert "**" not in result
+            assert "##" not in result
+            assert result != "Evil**Co__Corp~~\n#Heading rules"
+
+
+class TestM2PathTraversal:
+    async def test_rejects_file_path_outside_legal_dir(self, db_session: AsyncSession):
+        doc = LegalDocument(
+            slug="traversal-test",
+            title="Traversal Test",
+            current_version="1.0.0",
+            effective_date=datetime.date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=0,
+            file_path="/etc/passwd",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        result = await legal_service.get_document_content(db_session, "traversal-test")
+        assert result is None
+
+    async def test_rejects_relative_traversal(self, db_session: AsyncSession):
+        doc = LegalDocument(
+            slug="relative-traversal",
+            title="Relative Traversal",
+            current_version="1.0.0",
+            effective_date=datetime.date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=0,
+            file_path="../../etc/passwd",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        result = await legal_service.get_document_content(db_session, "relative-traversal")
+        assert result is None
+
+    async def test_allows_valid_legal_dir_path(self, db_session: AsyncSession):
+        doc = LegalDocument(
+            slug="valid-path-test",
+            title="Valid Path",
+            current_version="1.0.0",
+            effective_date=datetime.date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=0,
+            file_path="legal/terms-of-service.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
+        result = await legal_service.get_document_content(db_session, "valid-path-test")
+        assert result is not None
+
+
+class TestL1SyncRaceCondition:
+    async def test_sync_is_idempotent_under_concurrency(self, db_session: AsyncSession):
+        with patch("engine.legal.sync.settings") as mock_settings:
+            mock_settings.legal_documents_dir = "legal"
+
+            results = await asyncio.gather(
+                sync_legal_documents(db_session),
+                sync_legal_documents(db_session),
+                return_exceptions=True,
+            )
+
+        for r in results:
+            if isinstance(r, Exception):
+                pytest.fail(f"Concurrent sync raised: {r}")
+            assert r >= 1
+
+
+class TestL2SlugValidation:
+    @pytest.fixture
+    async def legal_client_slug(self, db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+        app = create_app()
+
+        async def override_get_db():
+            yield db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+    async def test_rejects_slug_with_uppercase(self, legal_client_slug: AsyncClient):
+        response = await legal_client_slug.get("/api/v1/legal/documents/HelloWorld")
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    async def test_rejects_slug_with_dots(self, legal_client_slug: AsyncClient):
+        response = await legal_client_slug.get("/api/v1/legal/documents/hello.world")
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    async def test_rejects_slug_with_spaces(self, legal_client_slug: AsyncClient):
+        response = await legal_client_slug.get("/api/v1/legal/documents/hello%20world")
+        assert response.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.UNPROCESSABLE_ENTITY)
+
+    async def test_accepts_valid_slug(self, legal_client_slug: AsyncClient):
+        response = await legal_client_slug.get("/api/v1/legal/documents/risk-disclaimer")
+        assert response.status_code == HTTPStatus.OK

--- a/tests/test_security_sev507.py
+++ b/tests/test_security_sev507.py
@@ -139,12 +139,11 @@ class TestH3DbImmutability:
             await db_session.execute(text("SELECT id FROM legal_acceptances LIMIT 1"))
         ).scalar_one()
 
-        await db_session.execute(
-            text("UPDATE legal_acceptances SET document_version = '9.9.9' WHERE id = :id"),
-            {"id": str(record)},
-        )
         with pytest.raises(Exception, match="immutable"):
-            await db_session.flush()
+            await db_session.execute(
+                text("UPDATE legal_acceptances SET document_version = '9.9.9' WHERE id = :id"),
+                {"id": str(record)},
+            )
 
     async def test_delete_legal_acceptance_raises(self, db_session: AsyncSession):
         await db_session.execute(
@@ -199,12 +198,11 @@ class TestH3DbImmutability:
             await db_session.execute(text("SELECT id FROM legal_acceptances LIMIT 1"))
         ).scalar_one()
 
-        await db_session.execute(
-            text("DELETE FROM legal_acceptances WHERE id = :id"),
-            {"id": str(record)},
-        )
         with pytest.raises(Exception, match="immutable"):
-            await db_session.flush()
+            await db_session.execute(
+                text("DELETE FROM legal_acceptances WHERE id = :id"),
+                {"id": str(record)},
+            )
 
 
 class TestM1MarkdownEscape:
@@ -317,6 +315,21 @@ class TestL2SlugValidation:
         response = await legal_client_slug.get("/api/v1/legal/documents/hello%20world")
         assert response.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.UNPROCESSABLE_ENTITY)
 
-    async def test_accepts_valid_slug(self, legal_client_slug: AsyncClient):
+    async def test_accepts_valid_slug(
+        self, legal_client_slug: AsyncClient, db_session: AsyncSession
+    ):
+        doc = LegalDocument(
+            slug="risk-disclaimer",
+            title="Risk Disclaimer",
+            current_version="1.0.0",
+            effective_date=datetime.date(2026, 4, 20),
+            requires_acceptance=True,
+            category="general",
+            display_order=0,
+            file_path="legal/risk-disclaimer.md",
+        )
+        db_session.add(doc)
+        await db_session.flush()
+
         response = await legal_client_slug.get("/api/v1/legal/documents/risk-disclaimer")
         assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Summary

Fixes 6 security findings from the SEV-507 audit for the legal documents system.

- **C2 (CRITICAL)**: Wire `require_legal_acceptance` as `Depends()` on protected routes (backtest via api_router; strategies, portfolio, marketplace at router level). Legal and health routes excluded. No-op until auth lands.
- **H3 (HIGH)**: Add Alembic migration `005` creating `prevent_acceptance_modification()` trigger on `legal_acceptances` for DB-level immutability (GDPR Article 7).
- **M1 (MEDIUM)**: Escape markdown special characters in `_apply_substitutions()` before injecting operator config values.
- **M2 (MEDIUM)**: Validate `file_path` resolves within `settings.legal_documents_dir` in `get_document_content()` to prevent directory traversal.
- **L1 (LOW)**: Replace SELECT-then-INSERT/UPDATE with `INSERT ... ON CONFLICT DO UPDATE` in `sync_legal_documents()` for race-safe idempotent sync.
- **L2 (LOW)**: Add `Path(pattern=r"^[a-z0-9-]+$")` validation on slug parameter in document detail endpoint.

Closes [SEV-507](mention://issue/a7329be5-c977-4aaa-be37-011091f18885)