### PR TITLE
feat(market-data): symbol bars/quote API + Market Watch chart screen (#227)

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -6,6 +6,7 @@ from engine.api.routes.auth import router as auth_router
 from engine.api.routes.backtest import router as backtest_router
 from engine.api.routes.health import router as health_router
 from engine.api.routes.legal import router as legal_router
+from engine.api.routes.market_data import router as market_data_router
 from engine.api.routes.marketplace import router as marketplace_router
 from engine.api.routes.portfolio import router as portfolio_router
 from engine.api.routes.scoring import router as scoring_router
@@ -29,5 +30,11 @@ api_router.include_router(
     scoring_router,
     prefix="/api/v1/scoring",
     tags=["scoring"],
+    dependencies=[Depends(require_legal_acceptance)],
+)
+api_router.include_router(
+    market_data_router,
+    prefix="/api/v1/market-data",
+    tags=["market-data"],
     dependencies=[Depends(require_legal_acceptance)],
 )

--- a/engine/api/routes/market_data.py
+++ b/engine/api/routes/market_data.py
@@ -12,6 +12,7 @@ to bypass registry routing — useful for parity testing across adapters.
 
 from __future__ import annotations
 
+import math
 import re
 from typing import TYPE_CHECKING
 
@@ -29,7 +30,10 @@ from engine.data.providers import (
     get_registry,
 )
 from engine.data.providers.base import SYMBOL_PATTERN
-from engine.data.providers.registry import CapabilityNotSupportedError
+from engine.data.providers.registry import (
+    CapabilityNotSupportedError,
+    DataProviderRegistry,
+)
 from engine.db.models import User
 
 if TYPE_CHECKING:
@@ -44,8 +48,12 @@ _SYMBOL_RE = re.compile(SYMBOL_PATTERN)
 # Heuristics for asset-class detection based on the symbol shape we see in
 # the wild. Order matters — first match wins.
 _FOREX_SUFFIX = re.compile(r"=X$", re.IGNORECASE)
-_FOREX_PAIR = re.compile(r"^[A-Z]{3}/[A-Z]{3}$")
-_CRYPTO_QUOTES = ("USD", "USDT", "USDC", "BUSD", "BTC", "ETH", "EUR", "GBP")
+# Conservative fiat allowlist for the slash-pair forex form. Anything outside
+# this set with a slash is treated as crypto when the quote currency matches
+# _CRYPTO_QUOTES — keeps `BTC/USD` and `ETH/USDT` out of the forex bucket.
+_FIAT_CCY = frozenset({"USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD", "NZD"})
+_CRYPTO_QUOTES = frozenset({"USD", "USDT", "USDC", "BUSD", "BTC", "ETH", "EUR", "GBP"})
+_CRYPTO_DASH_QUOTES = _CRYPTO_QUOTES  # dash form: BTC-USD, ETH-USDT
 
 
 def detect_asset_class(symbol: str) -> AssetClass:
@@ -53,38 +61,59 @@ def detect_asset_class(symbol: str) -> AssetClass:
 
     Used only when the caller hasn't pinned ``asset_class`` via query param.
     Conservative: equities are the default since they cover the long tail.
+    Crypto is checked before forex because the fiat/crypto quote sets
+    overlap (``BTC/USD`` would otherwise misclassify as forex).
     """
     upper = symbol.upper()
-    if _FOREX_SUFFIX.search(upper) or _FOREX_PAIR.match(upper):
+
+    # Yahoo-style forex first — unambiguous shape.
+    if _FOREX_SUFFIX.search(upper):
         return AssetClass.FOREX
-    if "-" in upper or "/" in upper:
-        # Treat hyphen/slash pairs as crypto when the quote currency looks
-        # like a crypto/stable. Otherwise leave as equity (e.g. BRK-B).
-        sep = "-" if "-" in upper else "/"
-        parts = upper.split(sep)
-        if len(parts) == 2 and parts[1] in _CRYPTO_QUOTES:
+
+    if "-" in upper:
+        parts = upper.split("-", 1)
+        if len(parts) == 2 and parts[1] in _CRYPTO_DASH_QUOTES:
             return AssetClass.CRYPTO
+        # Fall through to equity for things like BRK-B.
+        return AssetClass.EQUITY
+
+    if "/" in upper:
+        parts = upper.split("/", 1)
+        if len(parts) == 2:
+            base, quote = parts
+            if quote in _CRYPTO_QUOTES and base not in _FIAT_CCY:
+                return AssetClass.CRYPTO
+            if base in _FIAT_CCY and quote in _FIAT_CCY:
+                return AssetClass.FOREX
+
     return AssetClass.EQUITY
 
 
 def _validate_symbol(symbol: str) -> str:
-    if not _SYMBOL_RE.match(symbol):
+    """Normalise + validate a symbol from a path parameter.
+
+    Uses ``fullmatch`` (not ``match``) so trailing newlines or stray bytes
+    can't satisfy the trailing ``$`` anchor and slip an unsanitised value
+    into logs or response echoes. Mirrors the provider-layer ``..`` reject.
+    """
+    cleaned = symbol.strip()
+    if not cleaned or ".." in cleaned or not _SYMBOL_RE.fullmatch(cleaned):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid symbol format",
         )
-    return symbol
+    return cleaned
 
 
 def _resolve_asset_class(value: str | None, symbol: str) -> AssetClass:
     if not value:
         return detect_asset_class(symbol)
     try:
-        return AssetClass(value.lower())
+        return AssetClass(value.strip().lower())
     except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Unknown asset_class: {value}",
+            detail=f"Unknown asset_class: {value!r}",
         ) from None
 
 
@@ -113,24 +142,51 @@ class QuoteResponse(BaseModel):
     price: float
 
 
+def _safe_float(value: object) -> float:
+    """Coerce a provider value to a finite float or raise.
+
+    Real provider feeds emit NaN for low-volume bars or `null` for delisted
+    fields; serialising NaN produces invalid JSON, so callers skip rows
+    where any field can't be made finite.
+    """
+    if value is None:
+        raise ValueError("None is not a finite float")
+    f = float(value)
+    if not math.isfinite(f):
+        raise ValueError("non-finite float")
+    return f
+
+
 def _df_to_bars(df: pd.DataFrame) -> list[Bar]:
     if df is None or df.empty:
         return []
     out: list[Bar] = []
-    # Provider contract: index is ascending UTC DatetimeIndex with the
-    # canonical lowercase OHLCV columns.
     for ts, row in df.iterrows():
-        out.append(
-            Bar(
+        try:
+            bar = Bar(
                 timestamp=ts.isoformat(),
-                open=float(row["open"]),
-                high=float(row["high"]),
-                low=float(row["low"]),
-                close=float(row["close"]),
-                volume=float(row["volume"]),
+                open=_safe_float(row.get("open")),
+                high=_safe_float(row.get("high")),
+                low=_safe_float(row.get("low")),
+                close=_safe_float(row.get("close")),
+                volume=_safe_float(row.get("volume")),
             )
-        )
+        except (ValueError, TypeError, KeyError):
+            # Provider returned NaN/None or missing columns — drop the bar
+            # rather than serialise invalid JSON.
+            continue
+        out.append(bar)
     return out
+
+
+def _resolve_pinned_provider(name: str, registry: DataProviderRegistry):
+    adapter = registry.get(name)
+    if adapter is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Provider not registered: {name}",
+        )
+    return adapter
 
 
 @router.get("/{symbol}/bars", response_model=BarsResponse)
@@ -147,12 +203,7 @@ async def get_bars(
     registry = get_registry()
 
     if provider:
-        adapter = registry.get(provider)
-        if adapter is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Provider not registered: {provider}",
-            )
+        adapter = _resolve_pinned_provider(provider, registry)
         try:
             df = await adapter.get_ohlcv(symbol, period=period, interval=interval)
         except FatalProviderError as exc:
@@ -170,10 +221,10 @@ async def get_bars(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Upstream provider unavailable",
             ) from None
-        provider_name = provider
+        served_provider = provider
     else:
         try:
-            df = await registry.get_ohlcv(
+            df, served_provider = await registry.get_ohlcv_traced(
                 symbol,
                 period=period,
                 interval=interval,
@@ -188,17 +239,21 @@ async def get_bars(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
             ) from None
         except FatalProviderError as exc:
+            logger.warning(
+                "market_data.fatal_provider_error",
+                symbol=symbol,
+                error=type(exc).__name__,
+            )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from None
-        provider_name = _last_provider_for(registry, resolved_class)
 
     return BarsResponse(
         symbol=symbol,
         interval=interval,
         period=period,
         asset_class=resolved_class.value,
-        provider=provider_name,
+        provider=served_provider,
         bars=_df_to_bars(df),
     )
 
@@ -216,22 +271,55 @@ async def get_quote(
 
     price: float | None
     if provider:
-        adapter = registry.get(provider)
-        if adapter is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Provider not registered: {provider}",
-            )
+        adapter = _resolve_pinned_provider(provider, registry)
         try:
             price = await adapter.get_latest_price(symbol)
+        except FatalProviderError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from None
+        except (TransientProviderError, TimeoutError) as exc:
+            logger.warning(
+                "market_data.provider_transient",
+                provider=provider,
+                symbol=symbol,
+                error=type(exc).__name__,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Upstream provider unavailable",
+            ) from None
         except ProviderError as exc:
+            logger.warning(
+                "market_data.provider_error",
+                provider=provider,
+                symbol=symbol,
+                error=type(exc).__name__,
+            )
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)
             ) from None
-        provider_name = provider
+        served_provider = provider
     else:
-        price = await registry.get_latest_price(symbol, asset_class=resolved_class)
-        provider_name = _last_provider_for(registry, resolved_class)
+        try:
+            price, served_provider = await registry.get_latest_price_traced(
+                symbol, asset_class=resolved_class
+            )
+        except CapabilityNotSupportedError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(exc)
+            ) from None
+        except NoProviderAvailableError as exc:
+            # Distinguish "no providers configured" from "no price for symbol":
+            # NoProviderAvailableError raised here means every candidate
+            # adapter failed (or none registered); 503 is the honest signal.
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+            ) from None
+        except FatalProviderError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from None
 
     if price is None:
         raise HTTPException(
@@ -242,17 +330,6 @@ async def get_quote(
     return QuoteResponse(
         symbol=symbol,
         asset_class=resolved_class.value,
-        provider=provider_name,
-        price=float(price),
+        provider=served_provider,
+        price=_safe_float(price),
     )
-
-
-def _last_provider_for(registry, asset_class: AssetClass) -> str:
-    """Best-effort name of the registry's first candidate for an asset class.
-
-    The registry doesn't expose which provider actually served a request, but
-    surfacing the *intended* primary in the response header is still useful
-    for the client. If nothing matches, returns an empty string.
-    """
-    candidates = registry.candidates_for(asset_class)
-    return candidates[0].name if candidates else ""

--- a/engine/api/routes/market_data.py
+++ b/engine/api/routes/market_data.py
@@ -1,0 +1,258 @@
+"""Market data REST endpoints.
+
+Surface for the pluggable provider system (engine.data.providers): given a
+symbol the registry resolves an adapter (Yahoo, Polygon, Alpaca, Binance,
+CoinGecko, OANDA, ...), fetches OHLCV bars or a quote, and returns it
+normalised as JSON.
+
+The asset class is inferred from symbol shape and can be overridden via the
+``asset_class`` query param. The provider can also be pinned via ``provider``
+to bypass registry routing — useful for parity testing across adapters.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from engine.api.auth.dependency import get_current_user
+from engine.data.providers import (
+    AssetClass,
+    FatalProviderError,
+    NoProviderAvailableError,
+    ProviderError,
+    TransientProviderError,
+    get_registry,
+)
+from engine.data.providers.base import SYMBOL_PATTERN
+from engine.data.providers.registry import CapabilityNotSupportedError
+from engine.db.models import User
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+_SYMBOL_RE = re.compile(SYMBOL_PATTERN)
+
+# Heuristics for asset-class detection based on the symbol shape we see in
+# the wild. Order matters — first match wins.
+_FOREX_SUFFIX = re.compile(r"=X$", re.IGNORECASE)
+_FOREX_PAIR = re.compile(r"^[A-Z]{3}/[A-Z]{3}$")
+_CRYPTO_QUOTES = ("USD", "USDT", "USDC", "BUSD", "BTC", "ETH", "EUR", "GBP")
+
+
+def detect_asset_class(symbol: str) -> AssetClass:
+    """Best-effort asset class inference from the symbol string alone.
+
+    Used only when the caller hasn't pinned ``asset_class`` via query param.
+    Conservative: equities are the default since they cover the long tail.
+    """
+    upper = symbol.upper()
+    if _FOREX_SUFFIX.search(upper) or _FOREX_PAIR.match(upper):
+        return AssetClass.FOREX
+    if "-" in upper or "/" in upper:
+        # Treat hyphen/slash pairs as crypto when the quote currency looks
+        # like a crypto/stable. Otherwise leave as equity (e.g. BRK-B).
+        sep = "-" if "-" in upper else "/"
+        parts = upper.split(sep)
+        if len(parts) == 2 and parts[1] in _CRYPTO_QUOTES:
+            return AssetClass.CRYPTO
+    return AssetClass.EQUITY
+
+
+def _validate_symbol(symbol: str) -> str:
+    if not _SYMBOL_RE.match(symbol):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid symbol format",
+        )
+    return symbol
+
+
+def _resolve_asset_class(value: str | None, symbol: str) -> AssetClass:
+    if not value:
+        return detect_asset_class(symbol)
+    try:
+        return AssetClass(value.lower())
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown asset_class: {value}",
+        ) from None
+
+
+class Bar(BaseModel):
+    timestamp: str = Field(..., description="ISO-8601 UTC timestamp")
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class BarsResponse(BaseModel):
+    symbol: str
+    interval: str
+    period: str
+    asset_class: str
+    provider: str
+    bars: list[Bar]
+
+
+class QuoteResponse(BaseModel):
+    symbol: str
+    asset_class: str
+    provider: str
+    price: float
+
+
+def _df_to_bars(df: pd.DataFrame) -> list[Bar]:
+    if df is None or df.empty:
+        return []
+    out: list[Bar] = []
+    # Provider contract: index is ascending UTC DatetimeIndex with the
+    # canonical lowercase OHLCV columns.
+    for ts, row in df.iterrows():
+        out.append(
+            Bar(
+                timestamp=ts.isoformat(),
+                open=float(row["open"]),
+                high=float(row["high"]),
+                low=float(row["low"]),
+                close=float(row["close"]),
+                volume=float(row["volume"]),
+            )
+        )
+    return out
+
+
+@router.get("/{symbol}/bars", response_model=BarsResponse)
+async def get_bars(
+    symbol: str,
+    interval: str = Query("1d", min_length=1, max_length=8),
+    period: str = Query("1y", min_length=1, max_length=8),
+    provider: str | None = Query(None, max_length=32),
+    asset_class: str | None = Query(None, max_length=16),
+    _: User = Depends(get_current_user),
+) -> BarsResponse:
+    symbol = _validate_symbol(symbol)
+    resolved_class = _resolve_asset_class(asset_class, symbol)
+    registry = get_registry()
+
+    if provider:
+        adapter = registry.get(provider)
+        if adapter is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Provider not registered: {provider}",
+            )
+        try:
+            df = await adapter.get_ohlcv(symbol, period=period, interval=interval)
+        except FatalProviderError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from None
+        except (TransientProviderError, TimeoutError) as exc:
+            logger.warning(
+                "market_data.provider_transient",
+                provider=provider,
+                symbol=symbol,
+                error=type(exc).__name__,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Upstream provider unavailable",
+            ) from None
+        provider_name = provider
+    else:
+        try:
+            df = await registry.get_ohlcv(
+                symbol,
+                period=period,
+                interval=interval,
+                asset_class=resolved_class,
+            )
+        except CapabilityNotSupportedError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(exc)
+            ) from None
+        except NoProviderAvailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+            ) from None
+        except FatalProviderError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from None
+        provider_name = _last_provider_for(registry, resolved_class)
+
+    return BarsResponse(
+        symbol=symbol,
+        interval=interval,
+        period=period,
+        asset_class=resolved_class.value,
+        provider=provider_name,
+        bars=_df_to_bars(df),
+    )
+
+
+@router.get("/{symbol}/quote", response_model=QuoteResponse)
+async def get_quote(
+    symbol: str,
+    provider: str | None = Query(None, max_length=32),
+    asset_class: str | None = Query(None, max_length=16),
+    _: User = Depends(get_current_user),
+) -> QuoteResponse:
+    symbol = _validate_symbol(symbol)
+    resolved_class = _resolve_asset_class(asset_class, symbol)
+    registry = get_registry()
+
+    price: float | None
+    if provider:
+        adapter = registry.get(provider)
+        if adapter is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Provider not registered: {provider}",
+            )
+        try:
+            price = await adapter.get_latest_price(symbol)
+        except ProviderError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)
+            ) from None
+        provider_name = provider
+    else:
+        price = await registry.get_latest_price(symbol, asset_class=resolved_class)
+        provider_name = _last_provider_for(registry, resolved_class)
+
+    if price is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No price available for {symbol}",
+        )
+
+    return QuoteResponse(
+        symbol=symbol,
+        asset_class=resolved_class.value,
+        provider=provider_name,
+        price=float(price),
+    )
+
+
+def _last_provider_for(registry, asset_class: AssetClass) -> str:
+    """Best-effort name of the registry's first candidate for an asset class.
+
+    The registry doesn't expose which provider actually served a request, but
+    surfacing the *intended* primary in the response header is still useful
+    for the client. If nothing matches, returns an empty string.
+    """
+    candidates = registry.candidates_for(asset_class)
+    return candidates[0].name if candidates else ""

--- a/engine/app.py
+++ b/engine/app.py
@@ -12,6 +12,13 @@ from engine.api.auth.local import LocalAuthProvider
 from engine.api.auth.registry import AuthProviderRegistry
 from engine.api.router import api_router
 from engine.config import settings
+from engine.data.providers import (
+    AssetClass,
+    ProviderRegistration,
+    YahooDataProvider,
+    configure_from_file,
+    get_registry,
+)
 from engine.db.session import dispose_engine, get_session_factory
 from engine.legal.sync import sync_legal_documents
 from engine.observability.logging import setup_logging
@@ -21,6 +28,47 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
 logger = structlog.get_logger()
+
+
+def _configure_data_providers() -> None:
+    """Wire data providers into the registry on app start.
+
+    Loads YAML at ``settings.data_providers_config`` if set; otherwise
+    registers a keyless Yahoo adapter so the API works in dev without any
+    further setup. Failures are logged but never abort startup — the API
+    will still serve a 503 from the provider routes.
+    """
+    registry = get_registry()
+    if registry.list_providers():
+        return  # already configured (e.g. by tests)
+
+    if settings.data_providers_config:
+        try:
+            configure_from_file(settings.data_providers_config, registry)
+        except Exception:
+            logger.exception(
+                "data_provider.bootstrap.failed", path=settings.data_providers_config
+            )
+        else:
+            logger.info(
+                "data_provider.bootstrap.from_file",
+                path=settings.data_providers_config,
+                count=len(registry.list_providers()),
+            )
+            return
+
+    try:
+        registry.register(
+            ProviderRegistration(
+                provider=YahooDataProvider(),
+                priority=99,
+                asset_classes=frozenset({AssetClass.EQUITY, AssetClass.ETF}),
+            )
+        )
+        logger.info("data_provider.bootstrap.default", provider="yahoo")
+    except ValueError:
+        # Already registered by a parallel bootstrap; ignore.
+        pass
 
 
 def _build_auth_registry() -> AuthProviderRegistry:
@@ -62,6 +110,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.valkey = Valkey.from_url(settings.valkey_url)
     app.state.auth_registry = _build_auth_registry()
     logger.info("auth.providers_loaded", providers=list(app.state.auth_registry.providers.keys()))
+    _configure_data_providers()
     try:
         session_factory = get_session_factory()
         async with session_factory() as db:

--- a/engine/data/providers/registry.py
+++ b/engine/data/providers/registry.py
@@ -136,29 +136,58 @@ class DataProviderRegistry:
         interval: str = "1d",
         asset_class: AssetClass = AssetClass.EQUITY,
     ) -> pd.DataFrame:
+        df, _ = await self.get_ohlcv_traced(
+            symbol, period=period, interval=interval, asset_class=asset_class
+        )
+        return df
+
+    async def get_ohlcv_traced(
+        self,
+        symbol: str,
+        period: str = "1y",
+        interval: str = "1d",
+        asset_class: AssetClass = AssetClass.EQUITY,
+    ) -> tuple[pd.DataFrame, str]:
+        """Like :meth:`get_ohlcv` but also returns the provider that served the
+        result. The second element is the name of the provider that produced
+        the returned (possibly-empty) frame, useful for honest observability
+        instead of guessing the registry's intended primary."""
+
         async def call(p: IDataProvider) -> pd.DataFrame:
             return await p.get_ohlcv(symbol, period=period, interval=interval)
 
-        return await self._run_with_failover(
+        return await self._run_with_failover_traced(
             asset_class, "get_ohlcv", call, symbol=symbol, retry_on_empty=True
         )
 
     async def get_latest_price(
         self, symbol: str, asset_class: AssetClass = AssetClass.EQUITY
     ) -> float | None:
+        try:
+            price, _ = await self.get_latest_price_traced(symbol, asset_class=asset_class)
+        except NoProviderAvailableError:
+            return None
+        return price
+
+    async def get_latest_price_traced(
+        self, symbol: str, asset_class: AssetClass = AssetClass.EQUITY
+    ) -> tuple[float | None, str]:
+        """Trace variant: returns ``(price, served_provider_name)``.
+
+        Raises :class:`NoProviderAvailableError` when no provider is configured
+        for the asset class so callers can distinguish "no providers" (503)
+        from "no price for this symbol" (404)."""
+
         async def call(p: IDataProvider) -> float | None:
             return await p.get_latest_price(symbol)
 
-        try:
-            return await self._run_with_failover(
-                asset_class,
-                "get_latest_price",
-                call,
-                symbol=symbol,
-                retry_on_empty=True,
-            )
-        except NoProviderAvailableError:
-            return None
+        return await self._run_with_failover_traced(
+            asset_class,
+            "get_latest_price",
+            call,
+            symbol=symbol,
+            retry_on_empty=True,
+        )
 
     async def get_multiple_prices(
         self, symbols: list[str], asset_class: AssetClass = AssetClass.EQUITY
@@ -245,6 +274,26 @@ class DataProviderRegistry:
         capability: CapabilityPredicate | None = None,
         retry_on_empty: bool = False,
     ) -> T:
+        result, _ = await self._run_with_failover_traced(
+            asset_class,
+            method,
+            call,
+            symbol=symbol,
+            capability=capability,
+            retry_on_empty=retry_on_empty,
+        )
+        return result
+
+    async def _run_with_failover_traced(
+        self,
+        asset_class: AssetClass,
+        method: str,
+        call: Callable[[IDataProvider], Awaitable[T]],
+        *,
+        symbol: str = "",
+        capability: CapabilityPredicate | None = None,
+        retry_on_empty: bool = False,
+    ) -> tuple[T, str]:
         candidates = self.candidates_for(asset_class, capability=capability)
         if not candidates:
             if capability is not None:
@@ -258,6 +307,8 @@ class DataProviderRegistry:
 
         last_exc: BaseException | None = None
         last_empty: T | None = None
+        last_empty_name: str = ""
+        saw_empty = False
         for reg in candidates:
             try:
                 result = await call(reg.provider)
@@ -288,6 +339,8 @@ class DataProviderRegistry:
                 or (isinstance(result, dict) and not result)
             ):
                 last_empty = result
+                last_empty_name = reg.name
+                saw_empty = True
                 logger.info(
                     "data_provider.registry.empty_result",
                     provider=reg.name,
@@ -296,10 +349,14 @@ class DataProviderRegistry:
                 )
                 continue
 
-            return result
+            return result, reg.name
 
-        if last_empty is not None:
-            return last_empty
+        if saw_empty:
+            # A provider answered with an empty/None result — symbol is
+            # unknown to the configured providers, not that providers were
+            # missing. Surface the empty result so callers can map to 404
+            # instead of 503.
+            return last_empty, last_empty_name  # type: ignore[return-value]
 
         raise NoProviderAvailableError(
             f"All providers failed for asset_class={asset_class.value} "

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import OAuthCallback from "./pages/OAuthCallback";
 import Dashboard from "./screens/Dashboard";
+import MarketWatch from "./screens/MarketWatch";
 import Strategies from "./screens/Strategies";
 import Backtest from "./screens/Backtest";
 import Marketplace from "./screens/Marketplace";
@@ -59,6 +60,7 @@ export default function App() {
               }
             >
               <Route path="/" element={<Dashboard />} />
+              <Route path="/market-watch" element={<MarketWatch />} />
               <Route path="/strategies" element={<Strategies />} />
               <Route path="/backtest" element={<Backtest />} />
               <Route path="/marketplace" element={<Marketplace />} />

--- a/frontend/src/api/marketData.js
+++ b/frontend/src/api/marketData.js
@@ -1,0 +1,46 @@
+import { getAccessToken } from "./auth";
+
+const API = import.meta.env.VITE_API_URL || "http://localhost:8000";
+
+async function request(path) {
+  const headers = { "Content-Type": "application/json" };
+  const token = getAccessToken();
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const res = await fetch(`${API}${path}`, { headers });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const message = body.detail || body.message || `Request failed (${res.status})`;
+    const err = new Error(message);
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return res.json();
+}
+
+function buildQuery({ provider, assetClass, period, interval } = {}) {
+  const params = new URLSearchParams();
+  if (period) params.set("period", period);
+  if (interval) params.set("interval", interval);
+  if (provider) params.set("provider", provider);
+  if (assetClass) params.set("asset_class", assetClass);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export async function getBars(symbol, opts = {}) {
+  const trimmed = String(symbol || "").trim();
+  if (!trimmed) throw new Error("Symbol is required");
+  return request(
+    `/api/v1/market-data/${encodeURIComponent(trimmed)}/bars${buildQuery(opts)}`,
+  );
+}
+
+export async function getQuote(symbol, opts = {}) {
+  const trimmed = String(symbol || "").trim();
+  if (!trimmed) throw new Error("Symbol is required");
+  return request(
+    `/api/v1/market-data/${encodeURIComponent(trimmed)}/quote${buildQuery(opts)}`,
+  );
+}

--- a/frontend/src/components/data/PriceChart.jsx
+++ b/frontend/src/components/data/PriceChart.jsx
@@ -1,0 +1,204 @@
+import React from "react";
+import {
+  Bar,
+  Cell,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+const UP_COLOR = "var(--success, #16a34a)";
+const DOWN_COLOR = "var(--accent, #ef4444)";
+const LINE_COLOR = "var(--text-display, #e5e7eb)";
+
+function Candle(props) {
+  // Recharts gives us pixel-space x/y/width/height for the rendered Bar.
+  // The Bar's dataKey returns [low, high] so y is the pixel of `high` and
+  // height spans the wick. Use the original OHLC values from payload to
+  // place the body correctly within those bounds.
+  const { x, y, width, height, payload } = props;
+  if (!payload) return null;
+  const { open, close, high, low } = payload;
+  if (open == null || close == null || high == null || low == null) return null;
+
+  const priceRange = high - low;
+  if (priceRange <= 0) {
+    // Doji-only bar — render a thin tick.
+    const cx = x + width / 2;
+    return (
+      <line
+        x1={cx - width / 2}
+        y1={y}
+        x2={cx + width / 2}
+        y2={y}
+        stroke={LINE_COLOR}
+        strokeWidth={1}
+      />
+    );
+  }
+
+  const pxPerPrice = height / priceRange;
+  const cx = x + width / 2;
+  const isUp = close >= open;
+  const color = isUp ? UP_COLOR : DOWN_COLOR;
+
+  const bodyTopPrice = Math.max(open, close);
+  const bodyBottomPrice = Math.min(open, close);
+  const bodyTopPx = y + (high - bodyTopPrice) * pxPerPrice;
+  const bodyBottomPx = y + (high - bodyBottomPrice) * pxPerPrice;
+  const bodyHeight = Math.max(1, bodyBottomPx - bodyTopPx);
+
+  // Wick: vertical line spanning low→high (i.e. the full bar y range).
+  return (
+    <g>
+      <line
+        x1={cx}
+        y1={y}
+        x2={cx}
+        y2={y + height}
+        stroke={color}
+        strokeWidth={1}
+      />
+      <rect
+        x={x}
+        y={bodyTopPx}
+        width={width}
+        height={bodyHeight}
+        fill={color}
+      />
+    </g>
+  );
+}
+
+function formatTimestamp(value) {
+  if (!value) return "";
+  try {
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return value;
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return value;
+  }
+}
+
+function ChartTooltip({ active, payload }) {
+  if (!active || !payload || payload.length === 0) return null;
+  const row = payload[0]?.payload;
+  if (!row) return null;
+  return (
+    <div className="bg-nx-surface border border-nx-border rounded-md p-sm text-caption font-mono text-nx-text-primary">
+      <div className="text-nx-text-secondary mb-xs">{formatTimestamp(row.timestamp)}</div>
+      <div className="grid grid-cols-2 gap-x-md gap-y-xs tabular-nums">
+        <span className="text-nx-text-disabled">O</span>
+        <span>{Number(row.open).toFixed(2)}</span>
+        <span className="text-nx-text-disabled">H</span>
+        <span>{Number(row.high).toFixed(2)}</span>
+        <span className="text-nx-text-disabled">L</span>
+        <span>{Number(row.low).toFixed(2)}</span>
+        <span className="text-nx-text-disabled">C</span>
+        <span>{Number(row.close).toFixed(2)}</span>
+        <span className="text-nx-text-disabled">V</span>
+        <span>{Number(row.volume).toLocaleString()}</span>
+      </div>
+    </div>
+  );
+}
+
+export function PriceChart({ bars, mode = "line", height = 380 }) {
+  // Recharts' Bar with dataKey returning [low, high] makes the rendered Bar
+  // span the full vertical price range — that's the wick. The custom shape
+  // then paints the OHLC body on top. Memoise the row mapping so toggling
+  // line/candle doesn't churn references in tooltips.
+  const data = React.useMemo(() => bars || [], [bars]);
+
+  if (!data.length) {
+    return (
+      <div
+        className="flex items-center justify-center text-nx-text-disabled font-mono text-label uppercase border border-nx-border rounded-2xl"
+        style={{ height }}
+      >
+        No data
+      </div>
+    );
+  }
+
+  const wickRange = (d) => [d.low, d.high];
+
+  return (
+    <div style={{ width: "100%" }}>
+      <div style={{ height }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart
+            data={data}
+            margin={{ top: 16, right: 24, left: 0, bottom: 8 }}
+          >
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              stroke="var(--text-disabled, #6b7280)"
+              fontSize={11}
+              tickLine={false}
+              axisLine={false}
+              minTickGap={48}
+            />
+            <YAxis
+              domain={["dataMin", "dataMax"]}
+              stroke="var(--text-disabled, #6b7280)"
+              fontSize={11}
+              tickLine={false}
+              axisLine={false}
+              orientation="right"
+              width={64}
+              tickFormatter={(v) => Number(v).toFixed(2)}
+            />
+            <Tooltip content={<ChartTooltip />} cursor={{ stroke: "var(--border, #374151)" }} />
+            {mode === "line" ? (
+              <Line
+                type="monotone"
+                dataKey="close"
+                stroke={LINE_COLOR}
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ) : (
+              <Bar dataKey={wickRange} shape={<Candle />} isAnimationActive={false} />
+            )}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+      <div style={{ height: 80 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart
+            data={data}
+            margin={{ top: 4, right: 24, left: 0, bottom: 8 }}
+          >
+            <XAxis dataKey="timestamp" hide />
+            <YAxis hide domain={[0, "dataMax"]} />
+            <Tooltip content={<ChartTooltip />} cursor={false} />
+            <Bar dataKey="volume" isAnimationActive={false}>
+              {data.map((row, i) => {
+                const prev = i > 0 ? data[i - 1] : row;
+                const up = row.close >= prev.close;
+                return (
+                  <Cell
+                    key={`v-${row.timestamp}`}
+                    fill={up ? UP_COLOR : DOWN_COLOR}
+                    fillOpacity={0.55}
+                  />
+                );
+              })}
+            </Bar>
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Shell.jsx
+++ b/frontend/src/components/layout/Shell.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
-import { LayoutDashboard, Zap, Rewind, Store, BarChart3, Shield, Terminal, DollarSign, LogOut, Settings as SettingsIcon } from "lucide-react";
+import { LayoutDashboard, Zap, Rewind, Store, BarChart3, Shield, Terminal, DollarSign, LogOut, Settings as SettingsIcon, CandlestickChart } from "lucide-react";
 import clsx from "clsx";
 import { useTheme } from "../../hooks/useTheme";
 import { useAuth } from "../../auth/useAuth";
@@ -8,6 +8,7 @@ import { Footer } from "./Footer";
 
 const navItems = [
   { to: "/", label: "DASHBOARD", icon: LayoutDashboard },
+  { to: "/market-watch", label: "MARKET WATCH", icon: CandlestickChart },
   { to: "/strategies", label: "STRATEGIES", icon: Zap },
   { to: "/backtest", label: "BACKTEST", icon: Rewind },
   { to: "/marketplace", label: "MARKETPLACE", icon: Store },

--- a/frontend/src/screens/MarketWatch.jsx
+++ b/frontend/src/screens/MarketWatch.jsx
@@ -1,0 +1,269 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { CandlestickChart, LineChart, RefreshCw } from "lucide-react";
+import clsx from "clsx";
+import { getBars, getQuote } from "../api/marketData";
+import { PriceChart } from "../components/data/PriceChart";
+import { StatusBadge } from "../components/primitives/StatusBadge";
+import { LoadingSpinner } from "../components/feedback/LoadingSpinner";
+import { EmptyState } from "../components/feedback/EmptyState";
+
+const PERIODS = [
+  { id: "5d", label: "5D", interval: "1d" },
+  { id: "1mo", label: "1M", interval: "1d" },
+  { id: "3mo", label: "3M", interval: "1d" },
+  { id: "1y", label: "1Y", interval: "1d" },
+  { id: "5y", label: "5Y", interval: "1wk" },
+  { id: "max", label: "MAX", interval: "1mo" },
+];
+
+const PROVIDERS = [
+  { id: "", label: "AUTO" },
+  { id: "yahoo", label: "YAHOO" },
+  { id: "polygon", label: "POLYGON" },
+  { id: "alpaca", label: "ALPACA" },
+  { id: "binance", label: "BINANCE" },
+  { id: "coingecko", label: "COINGECKO" },
+  { id: "oanda", label: "OANDA" },
+];
+
+function PeriodPicker({ value, onChange }) {
+  return (
+    <div className="inline-flex items-center gap-xs bg-nx-surface border border-nx-border rounded-md p-xs">
+      {PERIODS.map((p) => {
+        const isActive = p.id === value;
+        return (
+          <button
+            type="button"
+            key={p.id}
+            onClick={() => onChange(p)}
+            className={clsx(
+              "px-sm py-xs text-label font-mono uppercase rounded transition-colors",
+              isActive
+                ? "bg-nx-accent-subtle text-nx-text-display"
+                : "text-nx-text-secondary hover:text-nx-text-primary",
+            )}
+          >
+            {p.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ChartModePicker({ value, onChange }) {
+  return (
+    <div className="inline-flex items-center gap-xs bg-nx-surface border border-nx-border rounded-md p-xs">
+      <button
+        type="button"
+        onClick={() => onChange("line")}
+        title="Line"
+        className={clsx(
+          "px-sm py-xs rounded flex items-center gap-xs text-label font-mono uppercase transition-colors",
+          value === "line"
+            ? "bg-nx-accent-subtle text-nx-text-display"
+            : "text-nx-text-secondary hover:text-nx-text-primary",
+        )}
+      >
+        <LineChart size={14} strokeWidth={1.5} />
+        LINE
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("candle")}
+        title="Candle"
+        className={clsx(
+          "px-sm py-xs rounded flex items-center gap-xs text-label font-mono uppercase transition-colors",
+          value === "candle"
+            ? "bg-nx-accent-subtle text-nx-text-display"
+            : "text-nx-text-secondary hover:text-nx-text-primary",
+        )}
+      >
+        <CandlestickChart size={14} strokeWidth={1.5} />
+        CANDLE
+      </button>
+    </div>
+  );
+}
+
+function formatPrice(value) {
+  if (value == null) return "—";
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "—";
+  return n.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatPct(value) {
+  if (!Number.isFinite(value)) return "—";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function deriveSummary(bars, quote) {
+  if (!bars || bars.length === 0) return null;
+  const last = bars[bars.length - 1];
+  const first = bars[0];
+  const lastPrice = quote?.price ?? Number(last.close);
+  const change = lastPrice - Number(first.close);
+  const changePct = (change / Number(first.close)) * 100;
+  return {
+    lastPrice,
+    change,
+    changePct,
+    asOf: last.timestamp,
+  };
+}
+
+export default function MarketWatch() {
+  const [draft, setDraft] = React.useState("AAPL");
+  const [symbol, setSymbol] = React.useState("AAPL");
+  const [period, setPeriod] = React.useState(PERIODS[3]); // 1y default
+  const [provider, setProvider] = React.useState("");
+  const [mode, setMode] = React.useState("line");
+
+  const queryKey = React.useMemo(
+    () => ["market-data", "bars", symbol, period.id, period.interval, provider || "auto"],
+    [symbol, period, provider],
+  );
+
+  const barsQuery = useQuery({
+    queryKey,
+    queryFn: () =>
+      getBars(symbol, {
+        period: period.id,
+        interval: period.interval,
+        provider: provider || undefined,
+      }),
+    enabled: Boolean(symbol),
+    staleTime: 60_000,
+  });
+
+  const quoteQuery = useQuery({
+    queryKey: ["market-data", "quote", symbol, provider || "auto"],
+    queryFn: () => getQuote(symbol, { provider: provider || undefined }),
+    enabled: Boolean(symbol),
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    const next = draft.trim().toUpperCase();
+    if (!next) return;
+    setSymbol(next);
+  }
+
+  const summary = deriveSummary(barsQuery.data?.bars, quoteQuery.data);
+  const changeIsPositive = summary ? summary.change >= 0 : true;
+  const providerLabel =
+    barsQuery.data?.provider || quoteQuery.data?.provider || "—";
+  const assetClass = barsQuery.data?.asset_class || "—";
+
+  return (
+    <div className="text-nx-text-primary p-xl">
+      <div className="max-w-7xl mx-auto">
+        <header className="mb-xl">
+          <span className="text-label font-mono uppercase text-nx-text-secondary block mb-sm">
+            MARKET WATCH
+          </span>
+          <span className="text-display-xl font-display text-nx-text-display tabular-nums block">
+            {symbol}
+          </span>
+          {summary && (
+            <div className="flex items-baseline gap-md mt-md">
+              <span className="text-heading font-display text-nx-text-display tabular-nums">
+                {formatPrice(summary.lastPrice)}
+              </span>
+              <span
+                className={clsx(
+                  "text-body font-mono tabular-nums",
+                  changeIsPositive ? "text-nx-success" : "text-nx-accent",
+                )}
+              >
+                {summary.change >= 0 ? "+" : ""}
+                {formatPrice(summary.change)} ({formatPct(summary.changePct)})
+              </span>
+              <StatusBadge status="ok">{providerLabel.toUpperCase()}</StatusBadge>
+              <span className="text-label font-mono uppercase text-nx-text-disabled">
+                {assetClass}
+              </span>
+            </div>
+          )}
+        </header>
+
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-wrap items-center gap-md mb-lg"
+        >
+          <label className="flex items-center gap-sm">
+            <span className="text-label font-mono uppercase text-nx-text-secondary">
+              SYMBOL
+            </span>
+            <input
+              type="text"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="AAPL, BTC-USD, EURUSD=X"
+              maxLength={32}
+              className="bg-nx-surface border border-nx-border rounded-md px-md py-sm font-mono uppercase tracking-wide text-nx-text-display placeholder:text-nx-text-disabled focus:outline-none focus:border-nx-accent"
+              aria-label="Symbol"
+            />
+          </label>
+          <label className="flex items-center gap-sm">
+            <span className="text-label font-mono uppercase text-nx-text-secondary">
+              PROVIDER
+            </span>
+            <select
+              value={provider}
+              onChange={(e) => setProvider(e.target.value)}
+              className="bg-nx-surface border border-nx-border rounded-md px-sm py-sm font-mono uppercase text-nx-text-primary focus:outline-none focus:border-nx-accent"
+              aria-label="Provider"
+            >
+              {PROVIDERS.map((p) => (
+                <option key={p.id || "auto"} value={p.id}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="submit"
+            className="bg-nx-accent-subtle text-nx-text-display border border-nx-border rounded-md px-md py-sm font-mono uppercase text-label hover:bg-nx-accent hover:text-white transition-colors flex items-center gap-xs"
+          >
+            <RefreshCw size={12} strokeWidth={1.5} />
+            LOAD
+          </button>
+        </form>
+
+        <div className="flex flex-wrap items-center justify-between gap-md mb-md">
+          <PeriodPicker value={period.id} onChange={setPeriod} />
+          <ChartModePicker value={mode} onChange={setMode} />
+        </div>
+
+        <section className="bg-nx-surface border border-nx-border rounded-2xl p-md">
+          {barsQuery.isPending ? (
+            <div className="flex items-center justify-center" style={{ height: 380 }}>
+              <LoadingSpinner />
+            </div>
+          ) : barsQuery.isError ? (
+            <EmptyState
+              title="Could not load bars"
+              description={barsQuery.error?.message || "Provider request failed."}
+            />
+          ) : barsQuery.data?.bars?.length === 0 ? (
+            <EmptyState
+              title="No bars available"
+              description={`No data for ${symbol} on the selected period.`}
+            />
+          ) : (
+            <PriceChart bars={barsQuery.data?.bars} mode={mode} height={380} />
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/tests/test_api_market_data.py
+++ b/tests/test_api_market_data.py
@@ -1,0 +1,344 @@
+"""Tests for /api/v1/market-data routes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+from engine.api.routes.market_data import detect_asset_class
+from engine.data.providers import (
+    AssetClass,
+    DataProviderCapability,
+    HealthCheckResult,
+    HealthStatus,
+    IDataProvider,
+    NoProviderAvailableError,
+    ProviderRegistration,
+    get_registry,
+    reset_registry_for_tests,
+)
+
+
+def _make_df() -> pd.DataFrame:
+    """Two-bar OHLCV frame with a tz-aware UTC index."""
+    idx = pd.to_datetime(
+        ["2026-01-02T00:00:00Z", "2026-01-03T00:00:00Z"], utc=True
+    )
+    return pd.DataFrame(
+        {
+            "open": [100.0, 102.0],
+            "high": [105.0, 106.0],
+            "low": [99.0, 101.0],
+            "close": [104.0, 105.5],
+            "volume": [1_000_000.0, 1_200_000.0],
+        },
+        index=idx,
+    )
+
+
+class _FakeProvider(IDataProvider):
+    """Minimal in-memory provider used to exercise the route end-to-end.
+
+    Has knobs to drive each branch — empty result, raise on price, raise an
+    error class — without touching the network.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        asset_classes: frozenset[AssetClass],
+        *,
+        df: pd.DataFrame | None = None,
+        latest_price: float | None = 105.5,
+    ) -> None:
+        self.capability = DataProviderCapability(
+            name=name, asset_classes=asset_classes
+        )
+        self._df = df if df is not None else _make_df()
+        self._latest = latest_price
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def get_ohlcv(
+        self, symbol: str, period: str = "1y", interval: str = "1d"
+    ) -> pd.DataFrame:
+        self.calls.append((symbol, period, interval))
+        return self._df
+
+    async def get_latest_price(self, symbol: str) -> float | None:
+        return self._latest
+
+    async def get_multiple_prices(self, symbols: list[str]) -> dict[str, float]:
+        return {s: self._latest for s in symbols if self._latest is not None}
+
+    async def get_options_chain(
+        self, symbol: str, expiry: str | None = None
+    ) -> pd.DataFrame:
+        return pd.DataFrame()
+
+    async def get_orderbook(self, symbol: str, depth: int = 20) -> pd.DataFrame:
+        return pd.DataFrame()
+
+    def stream_prices(self, symbols: list[str]) -> AsyncIterator[dict[str, float]]:
+        raise NotImplementedError
+
+    async def health_check(self) -> HealthCheckResult:
+        return HealthCheckResult(name=self.capability.name, status=HealthStatus.UP)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    """Each test gets a fresh process-wide registry singleton."""
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+
+
+def _register(provider: _FakeProvider, *, priority: int = 1) -> None:
+    get_registry().register(
+        ProviderRegistration(
+            provider=provider,
+            priority=priority,
+            asset_classes=provider.capability.asset_classes,
+        )
+    )
+
+
+# ---------- detect_asset_class ----------
+
+
+class TestDetectAssetClass:
+    def test_equity_default(self):
+        assert detect_asset_class("AAPL") == AssetClass.EQUITY
+
+    def test_equity_with_dot(self):
+        assert detect_asset_class("BRK.B") == AssetClass.EQUITY
+
+    def test_equity_dash_non_crypto_quote(self):
+        # Dash with non-crypto suffix stays equity (e.g. Berkshire Hathaway B class)
+        assert detect_asset_class("BRK-B") == AssetClass.EQUITY
+
+    def test_crypto_dash_pair(self):
+        assert detect_asset_class("BTC-USD") == AssetClass.CRYPTO
+
+    def test_crypto_slash_pair(self):
+        assert detect_asset_class("ETH/USDT") == AssetClass.CRYPTO
+
+    def test_forex_yahoo_suffix(self):
+        assert detect_asset_class("EURUSD=X") == AssetClass.FOREX
+
+    def test_forex_slash_pair(self):
+        assert detect_asset_class("EUR/USD") == AssetClass.FOREX
+
+
+# ---------- /bars endpoint ----------
+
+
+class TestBarsEndpoint:
+    @pytest.mark.asyncio
+    async def test_happy_path_equity(self, client):
+        provider = _FakeProvider(
+            "fake-equity", frozenset({AssetClass.EQUITY})
+        )
+        _register(provider)
+
+        res = await client.get("/api/v1/market-data/AAPL/bars")
+        assert res.status_code == 200, res.text
+
+        body = res.json()
+        assert body["symbol"] == "AAPL"
+        assert body["asset_class"] == "equity"
+        assert body["provider"] == "fake-equity"
+        assert body["interval"] == "1d"
+        assert body["period"] == "1y"
+        assert len(body["bars"]) == 2
+        first = body["bars"][0]
+        assert first["open"] == 100.0
+        assert first["high"] == 105.0
+        assert first["close"] == 104.0
+        assert first["timestamp"].startswith("2026-01-02")
+
+    @pytest.mark.asyncio
+    async def test_passes_period_and_interval_to_provider(self, client):
+        provider = _FakeProvider(
+            "fake-equity", frozenset({AssetClass.EQUITY})
+        )
+        _register(provider)
+
+        res = await client.get(
+            "/api/v1/market-data/AAPL/bars",
+            params={"period": "5y", "interval": "1wk"},
+        )
+        assert res.status_code == 200
+        assert provider.calls == [("AAPL", "5y", "1wk")]
+
+    @pytest.mark.asyncio
+    async def test_routes_crypto_pair_by_asset_class(self, client):
+        equity = _FakeProvider("fake-equity", frozenset({AssetClass.EQUITY}))
+        crypto = _FakeProvider("fake-crypto", frozenset({AssetClass.CRYPTO}))
+        _register(equity)
+        _register(crypto)
+
+        res = await client.get("/api/v1/market-data/BTC-USD/bars")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["asset_class"] == "crypto"
+        assert body["provider"] == "fake-crypto"
+        # Equity provider must not have been called.
+        assert equity.calls == []
+        assert crypto.calls and crypto.calls[0][0] == "BTC-USD"
+
+    @pytest.mark.asyncio
+    async def test_provider_override_pins_adapter(self, client):
+        primary = _FakeProvider(
+            "primary", frozenset({AssetClass.EQUITY})
+        )
+        secondary = _FakeProvider(
+            "secondary", frozenset({AssetClass.EQUITY})
+        )
+        _register(primary, priority=1)
+        _register(secondary, priority=2)
+
+        res = await client.get(
+            "/api/v1/market-data/AAPL/bars", params={"provider": "secondary"}
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["provider"] == "secondary"
+        assert primary.calls == []
+        assert secondary.calls and secondary.calls[0][0] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_provider_override_unknown_returns_404(self, client):
+        _register(
+            _FakeProvider("primary", frozenset({AssetClass.EQUITY}))
+        )
+        res = await client.get(
+            "/api/v1/market-data/AAPL/bars", params={"provider": "nope"}
+        )
+        assert res.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_no_provider_for_asset_class_returns_503(self, client):
+        # Only a forex provider registered; equity lookup must 503.
+        _register(_FakeProvider("fx", frozenset({AssetClass.FOREX})))
+        res = await client.get("/api/v1/market-data/AAPL/bars")
+        assert res.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_invalid_symbol_returns_400(self, client):
+        _register(_FakeProvider("fx", frozenset({AssetClass.EQUITY})))
+        # Space is outside the SYMBOL_PATTERN allowlist.
+        res = await client.get("/api/v1/market-data/AA%20PL/bars")
+        assert res.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_asset_class_param_returns_400(self, client):
+        _register(_FakeProvider("eq", frozenset({AssetClass.EQUITY})))
+        res = await client.get(
+            "/api/v1/market-data/AAPL/bars",
+            params={"asset_class": "totally-fake"},
+        )
+        assert res.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_explicit_asset_class_overrides_detection(self, client):
+        # BTC-USD would auto-detect as crypto, but caller forces forex.
+        _register(_FakeProvider("fx", frozenset({AssetClass.FOREX})))
+        res = await client.get(
+            "/api/v1/market-data/BTC-USD/bars",
+            params={"asset_class": "forex"},
+        )
+        assert res.status_code == 200
+        assert res.json()["asset_class"] == "forex"
+
+    @pytest.mark.asyncio
+    async def test_empty_dataframe_returns_empty_list(self, client):
+        provider = _FakeProvider(
+            "fake-equity",
+            frozenset({AssetClass.EQUITY}),
+            df=pd.DataFrame(),
+        )
+        _register(provider)
+        res = await client.get("/api/v1/market-data/ZZZZ/bars")
+        # Registry returns empty df from last candidate; route returns 200 + [].
+        assert res.status_code == 200
+        assert res.json()["bars"] == []
+
+
+# ---------- /quote endpoint ----------
+
+
+class TestQuoteEndpoint:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, client):
+        _register(
+            _FakeProvider(
+                "fake-equity",
+                frozenset({AssetClass.EQUITY}),
+                latest_price=187.42,
+            )
+        )
+        res = await client.get("/api/v1/market-data/AAPL/quote")
+        assert res.status_code == 200
+        body = res.json()
+        assert body == {
+            "symbol": "AAPL",
+            "asset_class": "equity",
+            "provider": "fake-equity",
+            "price": 187.42,
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_price_returns_404(self, client):
+        _register(
+            _FakeProvider(
+                "fake-equity",
+                frozenset({AssetClass.EQUITY}),
+                latest_price=None,
+            )
+        )
+        res = await client.get("/api/v1/market-data/UNLISTED/quote")
+        assert res.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_provider_override(self, client):
+        _register(
+            _FakeProvider("primary", frozenset({AssetClass.EQUITY}), latest_price=1.0),
+            priority=1,
+        )
+        _register(
+            _FakeProvider(
+                "secondary", frozenset({AssetClass.EQUITY}), latest_price=2.0
+            ),
+            priority=2,
+        )
+        res = await client.get(
+            "/api/v1/market-data/AAPL/quote", params={"provider": "secondary"}
+        )
+        assert res.status_code == 200
+        assert res.json()["provider"] == "secondary"
+        assert res.json()["price"] == 2.0
+
+    @pytest.mark.asyncio
+    async def test_unknown_provider_returns_404(self, client):
+        _register(_FakeProvider("primary", frozenset({AssetClass.EQUITY})))
+        res = await client.get(
+            "/api/v1/market-data/AAPL/quote", params={"provider": "ghost"}
+        )
+        assert res.status_code == 404
+
+
+class TestRegistryNotConfigured:
+    @pytest.mark.asyncio
+    async def test_bars_503_when_no_providers(self, client):
+        # No providers registered for any asset class.
+        with pytest.raises(NoProviderAvailableError):
+            # sanity: registry truly is empty
+            await get_registry().get_ohlcv("AAPL")
+        res = await client.get("/api/v1/market-data/AAPL/bars")
+        assert res.status_code == 503


### PR DESCRIPTION
Closes #227

## Summary
End-to-end consumer of the data provider adapter system (#78): pick a symbol, see a live price chart.

### Backend
`engine/api/routes/market_data.py` at `/api/v1/market-data`:
- GET `{symbol}/bars?interval=1d&period=1y&provider=&asset_class=` → OHLCV bars
- GET `{symbol}/quote?provider=` → quote payload
- Auth + legal posture match other /api/v1 routes
- Errors: NoProviderAvailable → 503, CapabilityNotSupported → 501, unknown / empty → 404

### Frontend
`frontend/src/screens/MarketWatch.jsx` — symbol input, provider override, period buttons, line/candle toggle, quote card, TanStack Query, loading/empty/error states. Sidebar route `/market-watch`.

### Registry trace
- Added `get_ohlcv_traced` / `get_latest_price_traced` returning `(data, provider_name)`
- Fixed empty-result accounting in _run_with_failover_traced so a None price returns the empty tuple (→ 404) instead of raising NoProviderAvailable (→ 503)

## Test plan
- [x] `pytest tests/test_api_market_data.py tests/test_data_providers.py` — 91 passed
- [x] Lint clean
- [ ] CI Engine Tests + Frontend Lint