### PR TITLE
feat(observability): structured logging with correlation IDs (#145)

### DIFF
--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -1,0 +1,127 @@
+# Structured logging & correlation IDs
+
+This page is the contract for log records emitted by every Nexus service.
+It covers the wire format, the correlation chain, the level policy, the
+redaction list, sampling, and sink selection.
+
+> **Code:** `engine/observability/{logging,context,processors,redact,middleware,taskiq_middleware,http_client}.py`
+> **Issue:** [#145](https://github.com/SevFle/nexus-trade-engine/issues/145)
+
+## Wire format
+
+Every record is one JSON object per line, UTF-8, written to stdout (default)
+or a file. Required fields:
+
+| Field            | Origin                                       | Notes                              |
+| ---------------- | -------------------------------------------- | ---------------------------------- |
+| `timestamp`      | `structlog.processors.TimeStamper`           | ISO 8601, UTC                      |
+| `level`          | `structlog.stdlib.add_log_level`             | `debug`/`info`/`warning`/`error`/`critical` |
+| `logger`         | `structlog.stdlib.add_logger_name`           | Dotted module path                 |
+| `event`          | First positional arg of `log.<level>(...)`   | Stable event name, snake_case      |
+| `service`        | `add_service_metadata`                       | `settings.app_name`                |
+| `env`            | `add_service_metadata`                       | `settings.app_env`                 |
+| `version`        | `add_service_metadata`                       | `settings.app_version`             |
+
+Context fields, attached when bound:
+
+| Field            | Bound by                                     |
+| ---------------- | -------------------------------------------- |
+| `correlation_id` | HTTP middleware / taskiq middleware / `ensure_correlation_id` |
+| `request_id`     | HTTP middleware (per request)                |
+| `span_id`        | HTTP middleware / taskiq middleware (per task) |
+| `user_id`, `role` | `ctx.bind_user_context(...)`                |
+| `portfolio_id`, `strategy_id`, `broker`, `order_id`, `tool` | `ctx.bind_domain_context(...)` |
+
+## Correlation chain
+
+```
+HTTP client                           HTTP server                              Worker / outbound
+─────────────                         ──────────────────────                   ─────────────────────────
+X-Correlation-Id: c1   ─────────►    CorrelationIdMiddleware       ─────►     CorrelationMiddleware
+                                     binds ctx.correlation_id=c1               (taskiq) reads label,
+                                                                               binds ctx.correlation_id=c1
+                                     log records get correlation_id            log records share c1
+
+                                     correlated_async_client       ─────►     downstream service
+                                     forwards X-Correlation-Id: c1
+```
+
+Where it gets bound:
+
+- **HTTP entry** — `engine/observability/middleware.py::CorrelationIdMiddleware` reads `X-Correlation-Id` or generates a UUID4 per request, then binds `correlation_id`, `request_id`, `span_id`. Cleared after the response.
+- **taskiq workers** — `engine/observability/taskiq_middleware.py::CorrelationMiddleware` copies the bound id into `message.labels` on `pre_send`, restores it from labels on `pre_execute`, clears on `post_execute`.
+- **Outbound HTTP** — use `correlated_async_client(...)` from `engine/observability/http_client.py`. It registers a request hook that injects `X-Correlation-Id` from `ctx.get_correlation_id()` if the header is unset.
+
+## Level policy
+
+| Level      | Use for                                                  |
+| ---------- | -------------------------------------------------------- |
+| `debug`    | Verbose traces, intermediate values. Off in prod.        |
+| `info`     | Lifecycle: session start/stop, order submitted, strategy activated. |
+| `warning`  | Recoverable: retry triggered, provider fallback, degraded mode. |
+| `error`    | User-facing failure: exception bubbled to API, failed order. |
+| `critical` | On-call wake-up: kill-switch fired, auth totally failing, data corruption detected. |
+
+## Redaction
+
+The `redact_processor` strips secrets before any record leaves the process.
+Banned keys (case-insensitive, dashes normalized to underscores):
+
+```
+password, passwd, token, secret, api_key, authorization, credit_card,
+card_number, ssn, access_token, refresh_token, client_secret,
+private_key, session_token, cookie, set_cookie
+```
+
+Banned **value** patterns:
+
+- `Bearer <anything>` — bearer tokens
+- 3-segment dot-separated base64-ish strings ≥ 8 chars per segment — JWTs
+- 13–19 digit blocks (with optional spaces / dashes) — card numbers
+- Prefixed secrets: `sk*`, `xoxb*`, `xoxp*`, `ghp*`, `ghs*`, `AKIA*`
+
+CI gate: `tests/observability/test_log_redaction_e2e.py` drives structlog
+through the full processor chain and asserts no banned values reach the
+wire. Add new patterns by editing `engine/observability/redact.py` and
+extending the test fixtures.
+
+## Sampling
+
+| Level                        | Rate setting                  | Default |
+| ---------------------------- | ----------------------------- | ------- |
+| `warning`/`error`/`critical` | always 100%                   | —       |
+| `info`                       | `settings.log_sampling_info`  | `1.0`   |
+| `debug`                      | `settings.log_sampling_debug` | `0.01`  |
+
+Set via env: `NEXUS_LOG_SAMPLING_INFO=0.1` etc. Implemented in
+`processors.sampling_filter` using `structlog.DropEvent`.
+
+## Sinks
+
+`NEXUS_LOG_SINK` selects the backend:
+
+- `stdout` (default) — `logging.StreamHandler(sys.stdout)`
+- `file` — `WatchedFileHandler` at `NEXUS_LOG_FILE_PATH` (default `logs/engine.log`)
+- `otlp` — currently falls back to stdout until the OTel logs SDK is wired in.
+
+## How to find logs
+
+1. Identify the `correlation_id` in the user-visible error or HTTP response (`X-Correlation-Id` header).
+2. Query the log sink for that id — every related record across HTTP, worker, and downstream calls carries it.
+3. Cross-reference with `request_id` to scope to the specific HTTP request.
+
+## Adding context to your code
+
+```python
+import structlog
+from engine.observability import context as ctx
+
+logger = structlog.get_logger(__name__)
+
+async def place_order(portfolio_id: str, strategy_id: str, ...):
+    ctx.bind_domain_context(portfolio_id=portfolio_id, strategy_id=strategy_id)
+    logger.info("order.submitted", broker="alpaca", quantity=10)
+```
+
+The fields bound via `bind_domain_context` attach to every subsequent log
+record in this asyncio task — no need to repeat them on each call.

--- a/engine/app.py
+++ b/engine/app.py
@@ -22,6 +22,7 @@ from engine.data.providers import (
 from engine.db.session import dispose_engine, get_session_factory
 from engine.legal.sync import sync_legal_documents
 from engine.observability.logging import setup_logging
+from engine.observability.middleware import CorrelationIdMiddleware
 from engine.observability.tracing import setup_tracing
 
 if TYPE_CHECKING:
@@ -139,6 +140,7 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    app.add_middleware(CorrelationIdMiddleware)
 
     app.include_router(api_router)
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -28,6 +28,11 @@ class Settings(BaseSettings):
     log_format: str = "console"
     otlp_endpoint: str = ""
     sentry_dsn: str = ""
+    app_version: str = "0.1.0"
+    log_sampling_info: float = 1.0
+    log_sampling_debug: float = 0.01
+    log_sink: str = "stdout"  # stdout | file | otlp
+    log_file_path: str = "logs/engine.log"
 
     # Worker
     worker_concurrency: int = 4

--- a/engine/observability/context.py
+++ b/engine/observability/context.py
@@ -1,0 +1,140 @@
+"""Per-request and per-task observability context.
+
+Built on :mod:`contextvars` so each asyncio Task gets isolated state. The
+HTTP middleware, taskiq broker middleware, and outbound HTTP client all
+read from this module to thread `correlation_id` end-to-end.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+_FIELDS: tuple[str, ...] = (
+    "correlation_id",
+    "request_id",
+    "span_id",
+    "user_id",
+    "role",
+    "portfolio_id",
+    "strategy_id",
+    "broker",
+    "order_id",
+    "tool",
+)
+
+_VARS: dict[str, ContextVar[str | None]] = {
+    name: ContextVar(f"obs_{name}", default=None) for name in _FIELDS
+}
+
+
+def _set(field: str, value: str | None) -> None:
+    _VARS[field].set(value)
+
+
+def _get(field: str) -> str | None:
+    return _VARS[field].get()
+
+
+def bind_correlation_id(value: str) -> None:
+    _set("correlation_id", value)
+
+
+def get_correlation_id() -> str | None:
+    return _get("correlation_id")
+
+
+def ensure_correlation_id() -> str:
+    """Return existing correlation id or generate and bind a new UUID4."""
+    existing = get_correlation_id()
+    if existing:
+        return existing
+    new = str(uuid.uuid4())
+    bind_correlation_id(new)
+    return new
+
+
+def bind_request_id(value: str) -> None:
+    _set("request_id", value)
+
+
+def get_request_id() -> str | None:
+    return _get("request_id")
+
+
+def new_span_id(value: str | None = None) -> str:
+    sid = value if value is not None else uuid.uuid4().hex[:16]
+    _set("span_id", sid)
+    return sid
+
+
+def get_span_id() -> str | None:
+    return _get("span_id")
+
+
+def bind_user_context(*, user_id: str | None = None, role: str | None = None) -> None:
+    if user_id is not None:
+        _set("user_id", user_id)
+    if role is not None:
+        _set("role", role)
+
+
+def bind_domain_context(
+    *,
+    portfolio_id: str | None = None,
+    strategy_id: str | None = None,
+    broker: str | None = None,
+    order_id: str | None = None,
+    tool: str | None = None,
+) -> None:
+    for k, v in (
+        ("portfolio_id", portfolio_id),
+        ("strategy_id", strategy_id),
+        ("broker", broker),
+        ("order_id", order_id),
+        ("tool", tool),
+    ):
+        if v is not None:
+            _set(k, v)
+
+
+def snapshot() -> dict[str, Any]:
+    """Return a dict of all bound, non-None context fields."""
+    return {name: v for name in _FIELDS if (v := _VARS[name].get()) is not None}
+
+
+def clear_context() -> None:
+    for var in _VARS.values():
+        var.set(None)
+
+
+@asynccontextmanager
+async def use_correlation_id(value: str) -> AsyncIterator[None]:
+    """Override the correlation id within an async block, restoring on exit."""
+    token = _VARS["correlation_id"].set(value)
+    try:
+        yield
+    finally:
+        _VARS["correlation_id"].reset(token)
+
+
+__all__ = [
+    "bind_correlation_id",
+    "bind_domain_context",
+    "bind_request_id",
+    "bind_user_context",
+    "clear_context",
+    "ensure_correlation_id",
+    "get_correlation_id",
+    "get_request_id",
+    "get_span_id",
+    "new_span_id",
+    "snapshot",
+    "use_correlation_id",
+]

--- a/engine/observability/context.py
+++ b/engine/observability/context.py
@@ -42,6 +42,29 @@ def _get(field: str) -> str | None:
     return _VARS[field].get()
 
 
+def bind_request_scope(
+    *, correlation_id: str, request_id: str, span_id: str
+) -> list[Any]:
+    """Bind the per-request triple and return tokens for later
+    :func:`reset_tokens`. Use this when you must restore the prior context
+    (e.g., from raw ASGI middleware running inside an inlined caller)."""
+    return [
+        _VARS["correlation_id"].set(correlation_id),
+        _VARS["request_id"].set(request_id),
+        _VARS["span_id"].set(span_id),
+    ]
+
+
+def reset_tokens(tokens: list[Any]) -> None:
+    """Reset previously captured contextvars tokens in reverse order."""
+    for tok in reversed(tokens):
+        try:
+            tok.var.reset(tok)
+        except (LookupError, ValueError):
+            # token may already have been reset, e.g., test teardown
+            continue
+
+
 def bind_correlation_id(value: str) -> None:
     _set("correlation_id", value)
 
@@ -128,6 +151,7 @@ __all__ = [
     "bind_correlation_id",
     "bind_domain_context",
     "bind_request_id",
+    "bind_request_scope",
     "bind_user_context",
     "clear_context",
     "ensure_correlation_id",
@@ -135,6 +159,7 @@ __all__ = [
     "get_request_id",
     "get_span_id",
     "new_span_id",
+    "reset_tokens",
     "snapshot",
     "use_correlation_id",
 ]

--- a/engine/observability/http_client.py
+++ b/engine/observability/http_client.py
@@ -1,0 +1,41 @@
+"""httpx integration that propagates correlation id on every outbound call.
+
+Use :func:`correlated_async_client` instead of constructing
+``httpx.AsyncClient`` directly so that any tail-end service receives the
+``X-Correlation-Id`` header that ties its logs back to the originating
+request.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from engine.observability import context as ctx
+from engine.observability.middleware import CORRELATION_HEADER
+
+
+def correlation_id_request_hook(request: httpx.Request) -> None:
+    """Mutating event hook: attach the bound correlation id if missing."""
+    if request.headers.get(CORRELATION_HEADER):
+        return
+    cid = ctx.get_correlation_id()
+    if cid:
+        request.headers[CORRELATION_HEADER] = cid
+
+
+async def _async_request_hook(request: httpx.Request) -> None:
+    correlation_id_request_hook(request)
+
+
+def correlated_async_client(**kwargs: Any) -> httpx.AsyncClient:
+    """Build an ``httpx.AsyncClient`` with the correlation hook attached."""
+    event_hooks: dict[str, list] = dict(kwargs.pop("event_hooks", {}))
+    request_hooks = list(event_hooks.get("request", []))
+    request_hooks.append(_async_request_hook)
+    event_hooks["request"] = request_hooks
+    return httpx.AsyncClient(event_hooks=event_hooks, **kwargs)
+
+
+__all__ = ["correlated_async_client", "correlation_id_request_hook"]

--- a/engine/observability/http_client.py
+++ b/engine/observability/http_client.py
@@ -4,11 +4,17 @@ Use :func:`correlated_async_client` instead of constructing
 ``httpx.AsyncClient`` directly so that any tail-end service receives the
 ``X-Correlation-Id`` header that ties its logs back to the originating
 request.
+
+By default the header is injected on every request. Pass
+``trusted_hosts={"internal-svc-a", "internal-svc-b"}`` to restrict
+injection to known internal destinations and avoid leaking internal ids
+to third-party vendors / brokers.
 """
 
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -16,26 +22,53 @@ from engine.observability import context as ctx
 from engine.observability.middleware import CORRELATION_HEADER
 
 
-def correlation_id_request_hook(request: httpx.Request) -> None:
-    """Mutating event hook: attach the bound correlation id if missing."""
+def correlation_id_request_hook(
+    request: httpx.Request, trusted_hosts: frozenset[str] | None = None
+) -> None:
+    """Attach the bound correlation id if missing and the host is trusted."""
     if request.headers.get(CORRELATION_HEADER):
         return
+    if trusted_hosts is not None:
+        host = request.url.host
+        if host not in trusted_hosts:
+            return
     cid = ctx.get_correlation_id()
     if cid:
         request.headers[CORRELATION_HEADER] = cid
 
 
-async def _async_request_hook(request: httpx.Request) -> None:
-    correlation_id_request_hook(request)
+def correlated_async_client(
+    *, trusted_hosts: set[str] | frozenset[str] | None = None, **kwargs: Any
+) -> httpx.AsyncClient:
+    """Build an ``httpx.AsyncClient`` with the correlation hook attached.
 
+    ``trusted_hosts`` — when provided, only requests targeting these hosts
+    receive the ``X-Correlation-Id`` header. Recommended for any client
+    that may call external services. Pass ``None`` (default) to inject on
+    every request.
+    """
+    frozen: frozenset[str] | None = (
+        frozenset(trusted_hosts) if trusted_hosts is not None else None
+    )
 
-def correlated_async_client(**kwargs: Any) -> httpx.AsyncClient:
-    """Build an ``httpx.AsyncClient`` with the correlation hook attached."""
+    async def _hook(request: httpx.Request) -> None:
+        correlation_id_request_hook(request, trusted_hosts=frozen)
+
     event_hooks: dict[str, list] = dict(kwargs.pop("event_hooks", {}))
     request_hooks = list(event_hooks.get("request", []))
-    request_hooks.append(_async_request_hook)
+    request_hooks.append(_hook)
     event_hooks["request"] = request_hooks
     return httpx.AsyncClient(event_hooks=event_hooks, **kwargs)
 
 
-__all__ = ["correlated_async_client", "correlation_id_request_hook"]
+def is_internal_host(url: str, internal_suffixes: tuple[str, ...]) -> bool:
+    """Helper for callers — match URL host against trusted internal suffixes."""
+    host = urlparse(url).hostname or ""
+    return any(host.endswith(s) for s in internal_suffixes)
+
+
+__all__ = [
+    "correlated_async_client",
+    "correlation_id_request_hook",
+    "is_internal_host",
+]

--- a/engine/observability/logging.py
+++ b/engine/observability/logging.py
@@ -16,10 +16,28 @@ from engine.observability.processors import (
 from engine.observability.redact import redact_processor
 
 
+def _resolve_log_path(raw: str) -> Path:
+    """Resolve and validate `log_file_path`.
+
+    The path must resolve under the current working directory or under an
+    explicit log dir (`logs/`) to prevent attacker-influenced env vars
+    from writing to system locations like `/etc/cron.d/...`.
+    """
+    cwd = Path.cwd().resolve()
+    candidate = (cwd / raw).resolve() if not Path(raw).is_absolute() else Path(raw).resolve()
+    if cwd not in candidate.parents and candidate != cwd:
+        msg = (
+            f"NEXUS_LOG_FILE_PATH must resolve under the working directory; "
+            f"got {candidate} (cwd={cwd})"
+        )
+        raise ValueError(msg)
+    return candidate
+
+
 def _build_handler() -> logging.Handler:
     sink = settings.log_sink.lower()
     if sink == "file":
-        path = Path(settings.log_file_path)
+        path = _resolve_log_path(settings.log_file_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         return logging.handlers.WatchedFileHandler(path, encoding="utf-8")
     # otlp routing happens via the OTel logs SDK; until that's wired in,
@@ -53,7 +71,7 @@ def setup_logging() -> None:
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=False,
+        cache_logger_on_first_use=True,
     )
 
     formatter = structlog.stdlib.ProcessorFormatter(

--- a/engine/observability/logging.py
+++ b/engine/observability/logging.py
@@ -1,11 +1,30 @@
 from __future__ import annotations
 
 import logging
+import logging.handlers
 import sys
+from pathlib import Path
 
 import structlog
 
 from engine.config import settings
+from engine.observability.processors import (
+    add_correlation_context,
+    add_service_metadata,
+    sampling_filter,
+)
+from engine.observability.redact import redact_processor
+
+
+def _build_handler() -> logging.Handler:
+    sink = settings.log_sink.lower()
+    if sink == "file":
+        path = Path(settings.log_file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return logging.handlers.WatchedFileHandler(path, encoding="utf-8")
+    # otlp routing happens via the OTel logs SDK; until that's wired in,
+    # otlp falls back to stdout so logs are never silently dropped.
+    return logging.StreamHandler(sys.stdout)
 
 
 def setup_logging() -> None:
@@ -13,9 +32,13 @@ def setup_logging() -> None:
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
-        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.TimeStamper(fmt="iso", utc=True, key="timestamp"),
+        sampling_filter,
+        add_service_metadata,
+        add_correlation_context,
         structlog.processors.StackInfoRenderer(),
         structlog.processors.UnicodeDecoder(),
+        redact_processor,
     ]
 
     if settings.log_format == "json" or settings.is_production:
@@ -30,7 +53,7 @@ def setup_logging() -> None:
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
+        cache_logger_on_first_use=False,
     )
 
     formatter = structlog.stdlib.ProcessorFormatter(
@@ -40,7 +63,7 @@ def setup_logging() -> None:
         ],
     )
 
-    handler = logging.StreamHandler(sys.stdout)
+    handler = _build_handler()
     handler.setFormatter(formatter)
 
     root_logger = logging.getLogger()

--- a/engine/observability/middleware.py
+++ b/engine/observability/middleware.py
@@ -4,55 +4,86 @@ Reads ``X-Correlation-Id`` from the incoming request or generates a fresh
 UUID4. The outbound response carries the same header. Each request gets a
 distinct ``request_id`` so a single causal chain (one correlation id) can
 span multiple HTTP requests while still being individually identifiable.
+
+This is a raw ASGI middleware (not a Starlette ``BaseHTTPMiddleware``) so
+that streaming responses and ``BackgroundTasks`` continue to see the
+bound correlation id while their generators / callbacks run.
 """
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import TYPE_CHECKING
-
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from engine.observability import context as ctx
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
-    from starlette.requests import Request
-    from starlette.responses import Response
-    from starlette.types import ASGIApp
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 CORRELATION_HEADER = "X-Correlation-Id"
+MAX_CORRELATION_ID_LENGTH = 128
+# Visible ASCII only — blocks CR/LF (response splitting), control chars
+# (terminal-control corruption), non-ASCII (header smuggling).
+_VALID_CORRELATION_ID = re.compile(r"^[\x21-\x7e]{1,128}$")
 
 
-class CorrelationIdMiddleware(BaseHTTPMiddleware):
-    """Bind correlation/request ids to contextvars for the lifetime of a
-    request, then echo the correlation header on the response."""
+def _safe_correlation_id(raw: str | None) -> str:
+    """Return a safe correlation id: the raw value if it passes validation,
+    otherwise a fresh UUID4. Never returns an attacker-controlled string."""
+    if raw and _VALID_CORRELATION_ID.match(raw):
+        return raw
+    return str(uuid.uuid4())
+
+
+class CorrelationIdMiddleware:
+    """Raw ASGI middleware. Each request runs in its own asyncio task and
+    therefore its own contextvars copy — there is no need to clear the
+    bound values; they go out of scope when the task finishes."""
 
     def __init__(self, app: ASGIApp, header_name: str = CORRELATION_HEADER) -> None:
-        super().__init__(app)
+        self.app = app
         self.header_name = header_name
+        self._header_name_bytes = header_name.lower().encode("latin-1")
 
-    async def dispatch(
-        self,
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        incoming = request.headers.get(self.header_name)
-        cid = incoming if incoming else str(uuid.uuid4())
-        rid = uuid.uuid4().hex
-        sid = uuid.uuid4().hex[:16]
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
 
-        ctx.bind_correlation_id(cid)
-        ctx.bind_request_id(rid)
-        ctx.new_span_id(sid)
+        incoming: str | None = None
+        for raw_name, raw_value in scope.get("headers", []):
+            if raw_name == self._header_name_bytes:
+                try:
+                    incoming = raw_value.decode("latin-1")
+                except UnicodeDecodeError:
+                    incoming = None
+                break
+
+        cid = _safe_correlation_id(incoming)
+        tokens = ctx.bind_request_scope(
+            correlation_id=cid,
+            request_id=uuid.uuid4().hex,
+            span_id=uuid.uuid4().hex[:16],
+        )
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                headers.append(
+                    (self._header_name_bytes, cid.encode("latin-1"))
+                )
+                message = {**message, "headers": headers}
+            await send(message)
+
         try:
-            response = await call_next(request)
+            await self.app(scope, receive, send_wrapper)
         finally:
-            ctx.clear_context()
-        response.headers[self.header_name] = cid
-        return response
+            # By the time `await self.app(...)` returns, all body chunks
+            # have been sent — including streaming responses. Reset is
+            # therefore safe and prevents leakage in inlined-caller tests.
+            ctx.reset_tokens(tokens)
 
 
-__all__ = ["CORRELATION_HEADER", "CorrelationIdMiddleware"]
+__all__ = ["CORRELATION_HEADER", "CorrelationIdMiddleware", "_safe_correlation_id"]

--- a/engine/observability/middleware.py
+++ b/engine/observability/middleware.py
@@ -1,0 +1,58 @@
+"""ASGI middleware that binds a per-request correlation id + request id.
+
+Reads ``X-Correlation-Id`` from the incoming request or generates a fresh
+UUID4. The outbound response carries the same header. Each request gets a
+distinct ``request_id`` so a single causal chain (one correlation id) can
+span multiple HTTP requests while still being individually identifiable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from engine.observability import context as ctx
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from starlette.requests import Request
+    from starlette.responses import Response
+    from starlette.types import ASGIApp
+
+
+CORRELATION_HEADER = "X-Correlation-Id"
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Bind correlation/request ids to contextvars for the lifetime of a
+    request, then echo the correlation header on the response."""
+
+    def __init__(self, app: ASGIApp, header_name: str = CORRELATION_HEADER) -> None:
+        super().__init__(app)
+        self.header_name = header_name
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        incoming = request.headers.get(self.header_name)
+        cid = incoming if incoming else str(uuid.uuid4())
+        rid = uuid.uuid4().hex
+        sid = uuid.uuid4().hex[:16]
+
+        ctx.bind_correlation_id(cid)
+        ctx.bind_request_id(rid)
+        ctx.new_span_id(sid)
+        try:
+            response = await call_next(request)
+        finally:
+            ctx.clear_context()
+        response.headers[self.header_name] = cid
+        return response
+
+
+__all__ = ["CORRELATION_HEADER", "CorrelationIdMiddleware"]

--- a/engine/observability/processors.py
+++ b/engine/observability/processors.py
@@ -13,7 +13,10 @@ from engine.observability import context as ctx
 if TYPE_CHECKING:
     from structlog.typing import EventDict, WrappedLogger
 
-_ALWAYS_KEEP = frozenset({"warning", "warn", "error", "critical", "exception"})
+# structlog normalizes `logger.exception(...)` to method_name="error",
+# so "exception" never reaches the filter — keep just the actual names
+# that arrive.
+_ALWAYS_KEEP = frozenset({"warning", "warn", "error", "critical"})
 
 
 def add_service_metadata(

--- a/engine/observability/processors.py
+++ b/engine/observability/processors.py
@@ -1,0 +1,71 @@
+"""structlog processors: service metadata, correlation merge, sampling."""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING, Any
+
+from structlog import DropEvent
+
+from engine.config import settings
+from engine.observability import context as ctx
+
+if TYPE_CHECKING:
+    from structlog.typing import EventDict, WrappedLogger
+
+_ALWAYS_KEEP = frozenset({"warning", "warn", "error", "critical", "exception"})
+
+
+def add_service_metadata(
+    _logger: WrappedLogger, _name: str, event_dict: EventDict
+) -> EventDict:
+    """Attach service / env / version to every record without overwriting."""
+    event_dict.setdefault("service", settings.app_name)
+    event_dict.setdefault("env", settings.app_env)
+    event_dict.setdefault("version", settings.app_version)
+    return event_dict
+
+
+def add_correlation_context(
+    _logger: WrappedLogger, _name: str, event_dict: EventDict
+) -> EventDict:
+    """Merge correlation/request/span/user/domain ids into the record."""
+    snap = ctx.snapshot()
+    for key, value in snap.items():
+        event_dict.setdefault(key, value)
+    return event_dict
+
+
+def sampling_filter(
+    _logger: WrappedLogger, method_name: str, event_dict: EventDict
+) -> EventDict:
+    """Drop a configurable fraction of info/debug records.
+
+    warn/error/critical always pass. info/debug pass according to
+    `settings.log_sampling_info` and `settings.log_sampling_debug`.
+    1.0 = keep all, 0.0 = drop all.
+    """
+    level = method_name.lower()
+    if level in _ALWAYS_KEEP:
+        return event_dict
+    if level == "info":
+        rate = settings.log_sampling_info
+    elif level == "debug":
+        rate = settings.log_sampling_debug
+    else:
+        return event_dict
+    if rate >= 1.0:
+        return event_dict
+    if rate <= 0.0 or random.random() >= rate:  # noqa: S311 - non-crypto sampling
+        raise DropEvent
+    return event_dict
+
+
+# Hint to type-checkers in callers that imports work without runtime deps.
+_ = Any
+
+__all__ = [
+    "add_correlation_context",
+    "add_service_metadata",
+    "sampling_filter",
+]

--- a/engine/observability/redact.py
+++ b/engine/observability/redact.py
@@ -1,0 +1,87 @@
+"""Redaction processor: scrubs sensitive keys and value patterns from log
+records before they leave the process.
+
+Idempotent. Safe to run after every other context-merger in the structlog
+chain, but always run *before* the renderer.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from structlog.typing import EventDict, WrappedLogger
+
+REDACTED = "***REDACTED***"
+
+_BANNED_KEYS_LOWER = frozenset(
+    {
+        "password",
+        "passwd",
+        "token",
+        "secret",
+        "api_key",
+        "apikey",
+        "authorization",
+        "credit_card",
+        "creditcard",
+        "card_number",
+        "cardnumber",
+        "ssn",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+        "private_key",
+        "session_token",
+        "cookie",
+        "set_cookie",
+    }
+)
+
+
+def _is_banned(key: str) -> bool:
+    return key.lower().replace("-", "_") in _BANNED_KEYS_LOWER
+
+
+_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?i)\bBearer\s+[\w\-._~+/=]+"),
+    re.compile(r"\b[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\b"),
+    re.compile(r"\b(?:\d[ \-]?){13,19}\b"),
+    re.compile(r"\b(?:sk|xoxb|xoxp|ghp|ghs|AKIA)[A-Za-z0-9_\-]{16,}\b"),
+)
+
+
+def _scrub_value(value: Any) -> Any:
+    if isinstance(value, str):
+        out = value
+        for pat in _VALUE_PATTERNS:
+            out = pat.sub(REDACTED, out)
+        return out
+    if isinstance(value, dict):
+        return _scrub_dict(value)
+    if isinstance(value, list):
+        return [_scrub_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub_value(item) for item in value)
+    return value
+
+
+def _scrub_dict(d: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in d.items():
+        if isinstance(k, str) and _is_banned(k):
+            out[k] = REDACTED
+        else:
+            out[k] = _scrub_value(v)
+    return out
+
+
+def redact_processor(
+    _logger: WrappedLogger, _name: str, event_dict: EventDict
+) -> EventDict:
+    """structlog processor entry point. Returns a new dict; input is not mutated."""
+    return _scrub_dict(dict(event_dict))
+
+
+__all__ = ["REDACTED", "redact_processor"]

--- a/engine/observability/redact.py
+++ b/engine/observability/redact.py
@@ -17,47 +17,85 @@ REDACTED = "***REDACTED***"
 
 _BANNED_KEYS_LOWER = frozenset(
     {
+        # explicit secrets
         "password",
         "passwd",
+        "pw",
+        "pass",
         "token",
+        "auth_token",
+        "access_token",
+        "refresh_token",
+        "session_token",
+        "id_token",
         "secret",
+        "client_secret",
+        "private_key",
+        "ssh_key",
         "api_key",
         "apikey",
+        "x_api_key",
+        "x_auth_token",
+        # auth payloads
         "authorization",
+        "auth",
+        "bearer",
+        "cookie",
+        "set_cookie",
+        # PII / cards
         "credit_card",
         "creditcard",
         "card_number",
         "cardnumber",
+        "cvv",
         "ssn",
-        "access_token",
-        "refresh_token",
-        "client_secret",
-        "private_key",
-        "session_token",
-        "cookie",
-        "set_cookie",
     }
 )
 
 
-def _is_banned(key: str) -> bool:
-    return key.lower().replace("-", "_") in _BANNED_KEYS_LOWER
+def _is_banned(key: object) -> bool:
+    if isinstance(key, str):
+        return key.lower().replace("-", "_") in _BANNED_KEYS_LOWER
+    # non-string keys (Enum, int, …) — coerce and test
+    try:
+        return str(key).lower().replace("-", "_") in _BANNED_KEYS_LOWER
+    except Exception:
+        return False
 
 
 _VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Bearer / authorization tokens
     re.compile(r"(?i)\bBearer\s+[\w\-._~+/=]+"),
-    re.compile(r"\b[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\b"),
+    # JWT-shaped: 3 dot-separated base64url segments, each ≥16 chars to
+    # avoid matching dotted module paths or version strings
+    re.compile(r"\b[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}\b"),
+    # 13-19 digit blocks with optional separators (PAN-shaped). Anchored
+    # to non-word boundaries so it survives most word-boundary edge cases.
     re.compile(r"\b(?:\d[ \-]?){13,19}\b"),
+    # Prefixed secrets (Slack, Stripe, GitHub, AWS access keys)
     re.compile(r"\b(?:sk|xoxb|xoxp|ghp|ghs|AKIA)[A-Za-z0-9_\-]{16,}\b"),
+    # PEM blocks (multi-line). Use [\s\S] so it crosses newlines without
+    # needing re.DOTALL on the engine.
+    re.compile(r"-----BEGIN [A-Z0-9 ]+-----[\s\S]+?-----END [A-Z0-9 ]+-----"),
 )
 
 
-def _scrub_value(value: Any) -> Any:
+def _scrub_string(s: str) -> str:
+    out = s
+    for pat in _VALUE_PATTERNS:
+        out = pat.sub(REDACTED, out)
+    return out
+
+
+def _scrub_value(value: Any) -> Any:  # noqa: PLR0911 - clear branch per type
     if isinstance(value, str):
-        out = value
-        for pat in _VALUE_PATTERNS:
-            out = pat.sub(REDACTED, out)
-        return out
+        return _scrub_string(value)
+    if isinstance(value, bytes):
+        try:
+            decoded = value.decode("utf-8", errors="replace")
+        except Exception:
+            return REDACTED
+        return _scrub_string(decoded)
     if isinstance(value, dict):
         return _scrub_dict(value)
     if isinstance(value, list):
@@ -67,10 +105,10 @@ def _scrub_value(value: Any) -> Any:
     return value
 
 
-def _scrub_dict(d: dict[str, Any]) -> dict[str, Any]:
-    out: dict[str, Any] = {}
+def _scrub_dict(d: dict[Any, Any]) -> dict[Any, Any]:
+    out: dict[Any, Any] = {}
     for k, v in d.items():
-        if isinstance(k, str) and _is_banned(k):
+        if _is_banned(k):
             out[k] = REDACTED
         else:
             out[k] = _scrub_value(v)

--- a/engine/observability/taskiq_middleware.py
+++ b/engine/observability/taskiq_middleware.py
@@ -9,14 +9,24 @@ from typing import TYPE_CHECKING
 from taskiq import TaskiqMiddleware
 
 from engine.observability import context as ctx
+from engine.observability.middleware import _safe_correlation_id
 
 if TYPE_CHECKING:
-    from taskiq import TaskiqMessage, TaskiqResult
+    from taskiq import TaskiqMessage
+
+_MAX_REQUEST_ID_LEN = 64
 
 
 class CorrelationMiddleware(TaskiqMiddleware):
     """Send: copy bound correlation id into message labels.
-    Receive: bind labels back into context for the worker's task scope."""
+    Receive: bind labels back into context for the worker's task scope.
+
+    No `post_execute` clear — taskiq runs each task in its own asyncio
+    Task, so contextvars are isolated and clean up when the task ends.
+    Calling `clear_context()` in `post_execute` would clobber a sibling
+    task's context if the broker shares an event loop without
+    `asyncio.create_task` boundaries.
+    """
 
     async def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
         cid = ctx.get_correlation_id()
@@ -28,20 +38,15 @@ class CorrelationMiddleware(TaskiqMiddleware):
         return message
 
     async def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
-        cid = message.labels.get("correlation_id") or str(uuid.uuid4())
-        ctx.bind_correlation_id(cid)
-        rid = message.labels.get("request_id")
-        if rid:
-            ctx.bind_request_id(rid)
-        ctx.new_span_id()
+        # Labels arrive from Redis and may have been crafted by a malicious
+        # producer; validate before binding into our log records.
+        raw_cid = message.labels.get("correlation_id")
+        ctx.bind_correlation_id(_safe_correlation_id(raw_cid))
+        raw_rid = message.labels.get("request_id")
+        if raw_rid and len(raw_rid) <= _MAX_REQUEST_ID_LEN:
+            ctx.bind_request_id(raw_rid)
+        ctx.new_span_id(uuid.uuid4().hex[:16])
         return message
-
-    async def post_execute(
-        self,
-        message: TaskiqMessage,  # noqa: ARG002 - taskiq protocol
-        result: TaskiqResult,  # noqa: ARG002 - taskiq protocol
-    ) -> None:
-        ctx.clear_context()
 
 
 __all__ = ["CorrelationMiddleware"]

--- a/engine/observability/taskiq_middleware.py
+++ b/engine/observability/taskiq_middleware.py
@@ -1,0 +1,47 @@
+"""taskiq broker middleware that propagates correlation context across
+the producer/consumer boundary using message labels."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from taskiq import TaskiqMiddleware
+
+from engine.observability import context as ctx
+
+if TYPE_CHECKING:
+    from taskiq import TaskiqMessage, TaskiqResult
+
+
+class CorrelationMiddleware(TaskiqMiddleware):
+    """Send: copy bound correlation id into message labels.
+    Receive: bind labels back into context for the worker's task scope."""
+
+    async def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
+        cid = ctx.get_correlation_id()
+        if cid:
+            message.labels["correlation_id"] = cid
+        rid = ctx.get_request_id()
+        if rid:
+            message.labels["request_id"] = rid
+        return message
+
+    async def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
+        cid = message.labels.get("correlation_id") or str(uuid.uuid4())
+        ctx.bind_correlation_id(cid)
+        rid = message.labels.get("request_id")
+        if rid:
+            ctx.bind_request_id(rid)
+        ctx.new_span_id()
+        return message
+
+    async def post_execute(
+        self,
+        message: TaskiqMessage,  # noqa: ARG002 - taskiq protocol
+        result: TaskiqResult,  # noqa: ARG002 - taskiq protocol
+    ) -> None:
+        ctx.clear_context()
+
+
+__all__ = ["CorrelationMiddleware"]

--- a/engine/tasks/worker.py
+++ b/engine/tasks/worker.py
@@ -8,14 +8,17 @@ from taskiq import TaskiqScheduler
 from taskiq_redis import ListQueueBroker, RedisAsyncResultBackend
 
 from engine.config import settings
+from engine.observability.taskiq_middleware import CorrelationMiddleware
 
 logger = structlog.get_logger()
 
 _parsed = urlparse(settings.valkey_url)
 _broker_url = urlunparse(_parsed._replace(scheme="redis"))
 
-broker = ListQueueBroker(url=_broker_url).with_result_backend(
-    RedisAsyncResultBackend(redis_url=_broker_url)
+broker = (
+    ListQueueBroker(url=_broker_url)
+    .with_result_backend(RedisAsyncResultBackend(redis_url=_broker_url))
+    .with_middlewares(CorrelationMiddleware())
 )
 
 scheduler = TaskiqScheduler(broker=broker, sources=[])

--- a/tests/observability/test_context.py
+++ b/tests/observability/test_context.py
@@ -1,0 +1,118 @@
+"""Tests for the correlation/request/span context plumbing."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+
+from engine.observability import context as ctx
+
+
+@pytest.fixture(autouse=True)
+def _clear_context():
+    ctx.clear_context()
+    yield
+    ctx.clear_context()
+
+
+class TestCorrelationIdLifecycle:
+    def test_get_correlation_id_returns_none_when_unset(self):
+        assert ctx.get_correlation_id() is None
+
+    def test_bind_correlation_id_persists_within_scope(self):
+        cid = "test-correlation-id"
+        ctx.bind_correlation_id(cid)
+        assert ctx.get_correlation_id() == cid
+
+    def test_clear_context_removes_correlation_id(self):
+        ctx.bind_correlation_id("x")
+        ctx.clear_context()
+        assert ctx.get_correlation_id() is None
+
+    def test_ensure_correlation_id_generates_uuid_when_missing(self):
+        cid = ctx.ensure_correlation_id()
+        assert ctx.get_correlation_id() == cid
+        parsed = uuid.UUID(cid)
+        assert parsed.version == 4
+
+    def test_ensure_correlation_id_preserves_existing(self):
+        ctx.bind_correlation_id("preexisting")
+        cid = ctx.ensure_correlation_id()
+        assert cid == "preexisting"
+
+
+class TestRequestAndSpanIds:
+    def test_bind_request_id(self):
+        ctx.bind_request_id("req-123")
+        assert ctx.get_request_id() == "req-123"
+
+    def test_new_span_id_generates_when_called_without_arg(self):
+        sid = ctx.new_span_id()
+        assert ctx.get_span_id() == sid
+        assert len(sid) > 0
+
+    def test_new_span_id_accepts_explicit_value(self):
+        sid = ctx.new_span_id("explicit-span")
+        assert sid == "explicit-span"
+        assert ctx.get_span_id() == "explicit-span"
+
+    def test_request_and_correlation_ids_are_independent(self):
+        ctx.bind_correlation_id("corr-1")
+        ctx.bind_request_id("req-1")
+        assert ctx.get_correlation_id() == "corr-1"
+        assert ctx.get_request_id() == "req-1"
+
+
+class TestUserAndDomainContext:
+    def test_bind_user_context_round_trip(self):
+        ctx.bind_user_context(user_id="u-1", role="admin")
+        snap = ctx.snapshot()
+        assert snap["user_id"] == "u-1"
+        assert snap["role"] == "admin"
+
+    def test_bind_domain_context_round_trip(self):
+        ctx.bind_domain_context(
+            portfolio_id="p-1",
+            strategy_id="s-1",
+            broker="alpaca",
+            order_id="o-1",
+        )
+        snap = ctx.snapshot()
+        assert snap["portfolio_id"] == "p-1"
+        assert snap["strategy_id"] == "s-1"
+        assert snap["broker"] == "alpaca"
+        assert snap["order_id"] == "o-1"
+
+    def test_snapshot_excludes_unset_values(self):
+        ctx.bind_correlation_id("c-1")
+        snap = ctx.snapshot()
+        assert "correlation_id" in snap
+        assert "request_id" not in snap
+
+
+class TestAsyncIsolation:
+    @pytest.mark.asyncio
+    async def test_correlation_id_isolated_between_tasks(self):
+        seen: dict[str, str | None] = {}
+
+        async def worker(name: str, cid: str):
+            ctx.bind_correlation_id(cid)
+            await asyncio.sleep(0.01)
+            seen[name] = ctx.get_correlation_id()
+
+        await asyncio.gather(
+            worker("a", "id-a"),
+            worker("b", "id-b"),
+        )
+
+        assert seen["a"] == "id-a"
+        assert seen["b"] == "id-b"
+
+    @pytest.mark.asyncio
+    async def test_use_correlation_context_manager(self):
+        ctx.bind_correlation_id("outer")
+        async with ctx.use_correlation_id("inner"):
+            assert ctx.get_correlation_id() == "inner"
+        assert ctx.get_correlation_id() == "outer"

--- a/tests/observability/test_http_client.py
+++ b/tests/observability/test_http_client.py
@@ -1,0 +1,58 @@
+"""Tests for the outbound httpx hook that injects X-Correlation-Id."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from engine.observability import context as ctx
+from engine.observability.http_client import (
+    correlated_async_client,
+    correlation_id_request_hook,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    ctx.clear_context()
+    yield
+    ctx.clear_context()
+
+
+class TestRequestHook:
+    def test_hook_injects_header_from_context(self):
+        ctx.bind_correlation_id("c-out")
+        req = httpx.Request("GET", "http://example.com")
+        correlation_id_request_hook(req)
+        assert req.headers["X-Correlation-Id"] == "c-out"
+
+    def test_hook_skips_when_unbound(self):
+        req = httpx.Request("GET", "http://example.com")
+        correlation_id_request_hook(req)
+        assert "X-Correlation-Id" not in req.headers
+
+    def test_hook_does_not_overwrite_existing(self):
+        ctx.bind_correlation_id("from-context")
+        req = httpx.Request(
+            "GET",
+            "http://example.com",
+            headers={"X-Correlation-Id": "explicit"},
+        )
+        correlation_id_request_hook(req)
+        assert req.headers["X-Correlation-Id"] == "explicit"
+
+
+def _echo(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"x-correlation-id": request.headers.get("X-Correlation-Id")},
+    )
+
+
+class TestCorrelatedClient:
+    @pytest.mark.asyncio
+    async def test_correlated_async_client_attaches_hook(self):
+        ctx.bind_correlation_id("c-client")
+        async with correlated_async_client(transport=httpx.MockTransport(_echo)) as c:
+            resp = await c.get("http://example.com/")
+        assert resp.json()["x-correlation-id"] == "c-client"

--- a/tests/observability/test_log_redaction_e2e.py
+++ b/tests/observability/test_log_redaction_e2e.py
@@ -1,0 +1,64 @@
+"""CI gate test: drive structlog with the full chain, then ensure no banned
+patterns appear in raw JSON output."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import re
+
+import pytest
+import structlog
+
+from engine.observability.logging import setup_logging
+
+
+@pytest.fixture
+def stream_buf(monkeypatch) -> io.StringIO:
+    from engine.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "log_format", "json")
+    setup_logging()
+    buf = io.StringIO()
+    root = logging.getLogger()
+    if root.handlers:
+        root.handlers[0].stream = buf  # type: ignore[attr-defined]
+    return buf
+
+
+class TestRedactionAtWire:
+    def test_password_is_not_in_wire_output(self, stream_buf: io.StringIO):
+        log = structlog.get_logger("redaction-test")
+        log.info("login_attempted", user="u-1", password="hunter2")
+
+        wire = stream_buf.getvalue()
+        assert "hunter2" not in wire
+        assert "REDACTED" in wire
+
+    def test_token_is_not_in_wire_output(self, stream_buf: io.StringIO):
+        log = structlog.get_logger("redaction-test")
+        log.info("api_call", token="sk-very-secret-1234567890abcdef")
+        wire = stream_buf.getvalue()
+        assert "sk-very-secret-1234567890abcdef" not in wire
+
+    def test_authorization_header_is_redacted(self, stream_buf: io.StringIO):
+        log = structlog.get_logger("redaction-test")
+        log.info("call", authorization="Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig")
+        wire = stream_buf.getvalue()
+        assert "eyJhbGciOiJIUzI1NiJ9" not in wire
+
+    def test_required_fields_present_in_json_record(self, stream_buf: io.StringIO):
+        log = structlog.get_logger("redaction-test")
+        log.info("hello", user_id="u-1")
+        lines = [ln for ln in stream_buf.getvalue().splitlines() if ln.strip()]
+        rec = json.loads(lines[-1])
+        for f in ("timestamp", "level", "service", "env", "version"):
+            assert f in rec, f"missing field {f} in {rec}"
+
+    def test_no_double_redaction_artifact(self, stream_buf: io.StringIO):
+        log = structlog.get_logger("redaction-test")
+        log.info("hi", user_id="u-1")
+        wire = stream_buf.getvalue()
+        assert "u-1" in wire
+        assert not re.search(r'"password"\s*:\s*"[^*]', wire)

--- a/tests/observability/test_middleware.py
+++ b/tests/observability/test_middleware.py
@@ -72,5 +72,52 @@ class TestRequestId:
 class TestContextLeak:
     @pytest.mark.asyncio
     async def test_context_cleared_after_response(self, client: AsyncClient):
-        await client.get("/echo", headers={"X-Correlation-Id": "leak-check"})
-        assert ctx.get_correlation_id() != "leak-check"
+        await client.get(
+            "/echo", headers={"X-Correlation-Id": "leak-check-abc-123"}
+        )
+        # Each ASGI request runs in its own task; outer test scope must
+        # never inherit the request-scoped correlation id.
+        assert ctx.get_correlation_id() is None
+
+
+class TestConcurrentRequests:
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_keep_isolated_ids(
+        self, client: AsyncClient
+    ):
+        import asyncio
+
+        async def fire(cid: str) -> str:
+            resp = await client.get("/echo", headers={"X-Correlation-Id": cid})
+            return resp.json()["correlation_id"]
+
+        ids = ("alpha-correlation-id", "beta-correlation-id")
+        results = await asyncio.gather(*(fire(c) for c in ids))
+        assert tuple(results) == ids
+
+
+class TestHeaderInjectionDefense:
+    @pytest.mark.asyncio
+    async def test_crlf_in_header_is_rejected(self, client: AsyncClient):
+        # httpx blocks CRLF in raw headers, so we drive a manually
+        # constructed value through the validator instead.
+        from engine.observability.middleware import _safe_correlation_id
+
+        out = _safe_correlation_id("legit\r\nSet-Cookie: pwn=1")
+        assert "\r" not in out
+        assert "\n" not in out
+        assert "Set-Cookie" not in out
+
+    @pytest.mark.asyncio
+    async def test_oversized_header_is_replaced(self, client: AsyncClient):
+        from engine.observability.middleware import _safe_correlation_id
+
+        out = _safe_correlation_id("x" * 10_000)
+        assert len(out) <= 128
+
+    @pytest.mark.asyncio
+    async def test_control_chars_rejected(self, client: AsyncClient):
+        from engine.observability.middleware import _safe_correlation_id
+
+        out = _safe_correlation_id("\x1b[31mred")
+        assert "\x1b" not in out

--- a/tests/observability/test_middleware.py
+++ b/tests/observability/test_middleware.py
@@ -1,0 +1,76 @@
+"""Tests for the FastAPI correlation middleware."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from engine.observability import context as ctx
+from engine.observability.middleware import CorrelationIdMiddleware
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CorrelationIdMiddleware)
+
+    @app.get("/echo")
+    async def echo() -> dict:
+        return {
+            "correlation_id": ctx.get_correlation_id(),
+            "request_id": ctx.get_request_id(),
+        }
+
+    return app
+
+
+@pytest.fixture
+async def client():
+    app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestIncomingHeader:
+    @pytest.mark.asyncio
+    async def test_header_propagates_into_context(self, client: AsyncClient):
+        cid = "abc-123-from-client"
+        resp = await client.get("/echo", headers={"X-Correlation-Id": cid})
+        assert resp.status_code == 200
+        assert resp.json()["correlation_id"] == cid
+
+    @pytest.mark.asyncio
+    async def test_response_echoes_header(self, client: AsyncClient):
+        cid = "abc-123"
+        resp = await client.get("/echo", headers={"X-Correlation-Id": cid})
+        assert resp.headers["X-Correlation-Id"] == cid
+
+
+class TestGenerateWhenMissing:
+    @pytest.mark.asyncio
+    async def test_generates_uuid_when_header_missing(self, client: AsyncClient):
+        resp = await client.get("/echo")
+        body_cid = resp.json()["correlation_id"]
+        assert body_cid is not None
+        uuid.UUID(body_cid)
+        assert resp.headers["X-Correlation-Id"] == body_cid
+
+
+class TestRequestId:
+    @pytest.mark.asyncio
+    async def test_each_request_gets_distinct_request_id(self, client: AsyncClient):
+        a = (await client.get("/echo")).json()["request_id"]
+        b = (await client.get("/echo")).json()["request_id"]
+        assert a is not None
+        assert b is not None
+        assert a != b
+
+
+class TestContextLeak:
+    @pytest.mark.asyncio
+    async def test_context_cleared_after_response(self, client: AsyncClient):
+        await client.get("/echo", headers={"X-Correlation-Id": "leak-check"})
+        assert ctx.get_correlation_id() != "leak-check"

--- a/tests/observability/test_processors.py
+++ b/tests/observability/test_processors.py
@@ -1,0 +1,98 @@
+"""Tests for service/env/version + correlation merge + sampling processors."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from engine.observability import context as ctx
+from engine.observability.processors import (
+    add_correlation_context,
+    add_service_metadata,
+    sampling_filter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_context():
+    ctx.clear_context()
+    yield
+    ctx.clear_context()
+
+
+class TestAddServiceMetadata:
+    @patch("engine.observability.processors.settings")
+    def test_adds_required_static_fields(self, mock_settings):
+        mock_settings.app_name = "engine"
+        mock_settings.app_env = "test"
+        mock_settings.app_version = "1.2.3"
+
+        out = add_service_metadata(None, "info", {"event": "hello"})
+
+        assert out["service"] == "engine"
+        assert out["env"] == "test"
+        assert out["version"] == "1.2.3"
+
+    @patch("engine.observability.processors.settings")
+    def test_does_not_overwrite_explicit_value(self, mock_settings):
+        mock_settings.app_name = "engine"
+        mock_settings.app_env = "test"
+        mock_settings.app_version = "1.0.0"
+
+        out = add_service_metadata(None, "info", {"event": "x", "service": "worker"})
+        assert out["service"] == "worker"
+
+
+class TestAddCorrelationContext:
+    def test_adds_correlation_id_when_present(self):
+        ctx.bind_correlation_id("c-1")
+        out = add_correlation_context(None, "info", {"event": "x"})
+        assert out["correlation_id"] == "c-1"
+
+    def test_omits_correlation_id_when_absent(self):
+        out = add_correlation_context(None, "info", {"event": "x"})
+        assert "correlation_id" not in out
+
+    def test_includes_request_and_span_ids(self):
+        ctx.bind_correlation_id("c-1")
+        ctx.bind_request_id("r-1")
+        ctx.new_span_id("s-1")
+        out = add_correlation_context(None, "info", {"event": "x"})
+        assert out["correlation_id"] == "c-1"
+        assert out["request_id"] == "r-1"
+        assert out["span_id"] == "s-1"
+
+
+class TestSamplingFilter:
+    @patch("engine.observability.processors.settings")
+    def test_warn_and_error_always_pass(self, mock_settings):
+        mock_settings.log_sampling_info = 0.0
+        mock_settings.log_sampling_debug = 0.0
+        for level in ("warning", "warn", "error", "critical"):
+            assert sampling_filter(None, level, {"event": "x"}) is not None
+
+    @patch("engine.observability.processors.settings")
+    def test_info_dropped_when_sampling_zero(self, mock_settings):
+        from structlog import DropEvent
+
+        mock_settings.log_sampling_info = 0.0
+        mock_settings.log_sampling_debug = 0.0
+        with pytest.raises(DropEvent):
+            sampling_filter(None, "info", {"event": "x"})
+
+    @patch("engine.observability.processors.settings")
+    def test_info_passes_when_sampling_one(self, mock_settings):
+        mock_settings.log_sampling_info = 1.0
+        mock_settings.log_sampling_debug = 1.0
+        out = sampling_filter(None, "info", {"event": "x"})
+        assert out["event"] == "x"
+
+    @patch("engine.observability.processors.settings")
+    def test_debug_dropped_when_sampling_zero(self, mock_settings):
+        from structlog import DropEvent
+
+        mock_settings.log_sampling_info = 1.0
+        mock_settings.log_sampling_debug = 0.0
+        with pytest.raises(DropEvent):
+            sampling_filter(None, "debug", {"event": "x"})

--- a/tests/observability/test_redact.py
+++ b/tests/observability/test_redact.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from engine.observability.redact import REDACTED, redact_processor
+from engine.observability.redact import (
+    _BANNED_KEYS_LOWER,
+    REDACTED,
+    redact_processor,
+)
 
 
 def _emit(event_dict: dict) -> dict:
@@ -43,10 +47,20 @@ class TestExactKeyRedaction:
 
 
 class TestNestedRedaction:
-    def test_nested_dict_redacted(self):
+    def test_outer_banned_key_replaces_whole_value(self):
+        # `auth` is itself a banned key; the entire payload it holds is
+        # treated as sensitive and replaced wholesale.
         out = _emit({"event": "x", "auth": {"token": "leak", "user": "ok"}})
-        assert out["auth"]["token"] == REDACTED
-        assert out["auth"]["user"] == "ok"
+        assert out["auth"] == REDACTED
+
+    def test_nested_dict_redacts_inner_banned_key(self):
+        # When the outer key is *not* banned, recursion redacts the
+        # banned inner key while preserving siblings.
+        out = _emit(
+            {"event": "x", "payload": {"token": "leak", "user": "ok"}}
+        )
+        assert out["payload"]["token"] == REDACTED
+        assert out["payload"]["user"] == "ok"
 
     def test_list_of_dicts_redacted(self):
         out = _emit({"event": "x", "items": [{"password": "p"}, {"name": "n"}]})
@@ -60,7 +74,13 @@ class TestPatternRedaction:
         assert "eyJhbGciOi" not in str(out["header"])
 
     def test_jwt_like_string_value_redacted(self):
-        jwt_like = "aaaaaaaaaa.bbbbbbbbbb.cccccccccc-dddddd_eeee"
+        # Real JWT segments are 16+ chars; the regex requires that to
+        # avoid matching dotted module paths.
+        jwt_like = (
+            "aaaaaaaaaaaaaaaaaaaa."
+            "bbbbbbbbbbbbbbbbbbbb."
+            "cccccccccccccccc-dddd"
+        )
         out = _emit({"event": "x", "note": f"token={jwt_like}"})
         assert jwt_like not in str(out["note"])
 
@@ -76,3 +96,50 @@ class TestPreservesShape:
         assert isinstance(result, dict)
         assert "event" in result
         assert "password" in result
+
+
+class TestBannedKeyAllCovered:
+    """Auto-covers every banned key without needing manual updates."""
+
+    @pytest.mark.parametrize("key", sorted(_BANNED_KEYS_LOWER))
+    def test_each_banned_key_redacted(self, key: str):
+        out = _emit({"event": "x", key: "leak-me"})
+        assert out[key] == REDACTED
+
+
+class TestBytesValue:
+    def test_bytes_secret_is_scrubbed(self):
+        pem = (
+            b"-----BEGIN RSA PRIVATE KEY-----\n"
+            b"MIIEowIBAAKCAQEAxxxxxxx\n"
+            b"-----END RSA PRIVATE KEY-----"
+        )
+        out = _emit({"event": "x", "blob": pem})
+        assert b"BEGIN RSA PRIVATE KEY" not in str(out["blob"]).encode()
+        assert "BEGIN RSA PRIVATE KEY" not in str(out["blob"])
+
+
+class TestPemBlock:
+    def test_pem_block_in_string_value_is_redacted(self):
+        s = (
+            "header\n-----BEGIN RSA PRIVATE KEY-----\n"
+            "MIIE...secret\n"
+            "-----END RSA PRIVATE KEY-----\nfooter"
+        )
+        out = _emit({"event": "x", "data": s})
+        assert "BEGIN RSA PRIVATE KEY" not in out["data"]
+        assert "MIIE...secret" not in out["data"]
+        assert "header" in out["data"]
+        assert "footer" in out["data"]
+
+
+class TestNonStringKey:
+    def test_non_string_banned_key_still_redacts(self):
+        # Edge case: structlog may receive an Enum key from upstream code
+        from enum import Enum
+
+        class K(Enum):
+            TOKEN = "token"
+
+        out = _emit({"event": "x", K.TOKEN.value: "leak"})
+        assert out["token"] == REDACTED

--- a/tests/observability/test_redact.py
+++ b/tests/observability/test_redact.py
@@ -1,0 +1,78 @@
+"""Tests for the redaction processor — strips secrets from log records."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.observability.redact import REDACTED, redact_processor
+
+
+def _emit(event_dict: dict) -> dict:
+    return redact_processor(None, "info", dict(event_dict))
+
+
+class TestExactKeyRedaction:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "password",
+            "Password",
+            "PASSWORD",
+            "token",
+            "api_key",
+            "apiKey",
+            "secret",
+            "authorization",
+            "credit_card",
+            "creditCard",
+            "ssn",
+            "access_token",
+            "refresh_token",
+            "client_secret",
+        ],
+    )
+    def test_banned_key_replaced_with_redacted(self, key: str):
+        out = _emit({"event": "login", key: "leak-me"})
+        assert out[key] == REDACTED
+        assert out["event"] == "login"
+
+    def test_non_sensitive_key_preserved(self):
+        out = _emit({"event": "login", "user_id": "u-1", "ip": "1.2.3.4"})
+        assert out["user_id"] == "u-1"
+        assert out["ip"] == "1.2.3.4"
+
+
+class TestNestedRedaction:
+    def test_nested_dict_redacted(self):
+        out = _emit({"event": "x", "auth": {"token": "leak", "user": "ok"}})
+        assert out["auth"]["token"] == REDACTED
+        assert out["auth"]["user"] == "ok"
+
+    def test_list_of_dicts_redacted(self):
+        out = _emit({"event": "x", "items": [{"password": "p"}, {"name": "n"}]})
+        assert out["items"][0]["password"] == REDACTED
+        assert out["items"][1]["name"] == "n"
+
+
+class TestPatternRedaction:
+    def test_authorization_bearer_in_value_is_redacted(self):
+        out = _emit({"event": "x", "header": "Bearer eyJhbGciOi..."})
+        assert "eyJhbGciOi" not in str(out["header"])
+
+    def test_jwt_like_string_value_redacted(self):
+        jwt_like = "aaaaaaaaaa.bbbbbbbbbb.cccccccccc-dddddd_eeee"
+        out = _emit({"event": "x", "note": f"token={jwt_like}"})
+        assert jwt_like not in str(out["note"])
+
+    def test_credit_card_number_redacted_in_value(self):
+        out = _emit({"event": "x", "note": "card 4242 4242 4242 4242 declined"})
+        assert "4242 4242 4242 4242" not in str(out["note"])
+
+
+class TestPreservesShape:
+    def test_processor_returns_dict(self):
+        original = {"event": "x", "password": "secret"}
+        result = redact_processor(None, "info", original)
+        assert isinstance(result, dict)
+        assert "event" in result
+        assert "password" in result

--- a/tests/observability/test_taskiq_middleware.py
+++ b/tests/observability/test_taskiq_middleware.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from taskiq import TaskiqMessage, TaskiqResult
+from taskiq import TaskiqMessage
 
 from engine.observability import context as ctx
 from engine.observability.taskiq_middleware import CorrelationMiddleware
@@ -62,15 +62,22 @@ class TestReceiveSide:
         assert len(cid) >= 16
 
     @pytest.mark.asyncio
-    async def test_post_execute_clears_context(self):
+    async def test_pre_execute_rejects_invalid_label(self):
+        # Header-injection-style label must not be bound verbatim; a
+        # fresh UUID is generated instead.
         m = CorrelationMiddleware()
-        msg = _make_message(labels={"correlation_id": "c-clean"})
+        msg = _make_message(labels={"correlation_id": "evil\r\nLog-Inject: 1"})
         await m.pre_execute(msg)
-        result = TaskiqResult(
-            is_err=False,
-            return_value=None,
-            execution_time=0.0,
-            log=None,
-        )
-        await m.post_execute(msg, result)
-        assert ctx.get_correlation_id() is None
+        cid = ctx.get_correlation_id()
+        assert cid is not None
+        assert "\r" not in cid
+        assert "\n" not in cid
+
+    @pytest.mark.asyncio
+    async def test_pre_execute_rejects_oversize_label(self):
+        m = CorrelationMiddleware()
+        msg = _make_message(labels={"correlation_id": "x" * 10_000})
+        await m.pre_execute(msg)
+        cid = ctx.get_correlation_id()
+        assert cid is not None
+        assert len(cid) <= 128

--- a/tests/observability/test_taskiq_middleware.py
+++ b/tests/observability/test_taskiq_middleware.py
@@ -1,0 +1,76 @@
+"""Tests for taskiq broker middleware that propagates correlation ids."""
+
+from __future__ import annotations
+
+import pytest
+from taskiq import TaskiqMessage, TaskiqResult
+
+from engine.observability import context as ctx
+from engine.observability.taskiq_middleware import CorrelationMiddleware
+
+
+@pytest.fixture(autouse=True)
+def _clear_context():
+    ctx.clear_context()
+    yield
+    ctx.clear_context()
+
+
+def _make_message(labels: dict | None = None) -> TaskiqMessage:
+    return TaskiqMessage(
+        task_id="t-1",
+        task_name="some.task",
+        labels=labels or {},
+        labels_types=None,
+        args=[],
+        kwargs={},
+    )
+
+
+class TestSendSide:
+    @pytest.mark.asyncio
+    async def test_pre_send_attaches_correlation_id_label(self):
+        ctx.bind_correlation_id("c-1")
+        m = CorrelationMiddleware()
+        msg = _make_message()
+        out = await m.pre_send(msg)
+        assert out.labels.get("correlation_id") == "c-1"
+
+    @pytest.mark.asyncio
+    async def test_pre_send_noop_when_unbound(self):
+        m = CorrelationMiddleware()
+        msg = _make_message()
+        out = await m.pre_send(msg)
+        assert "correlation_id" not in out.labels
+
+
+class TestReceiveSide:
+    @pytest.mark.asyncio
+    async def test_pre_execute_binds_label_to_context(self):
+        m = CorrelationMiddleware()
+        msg = _make_message(labels={"correlation_id": "c-from-label"})
+        await m.pre_execute(msg)
+        assert ctx.get_correlation_id() == "c-from-label"
+
+    @pytest.mark.asyncio
+    async def test_pre_execute_generates_id_when_missing(self):
+        m = CorrelationMiddleware()
+        msg = _make_message()
+        await m.pre_execute(msg)
+        cid = ctx.get_correlation_id()
+        assert cid is not None
+        assert len(cid) >= 16
+
+    @pytest.mark.asyncio
+    async def test_post_execute_clears_context(self):
+        m = CorrelationMiddleware()
+        msg = _make_message(labels={"correlation_id": "c-clean"})
+        await m.pre_execute(msg)
+        result = TaskiqResult(
+            is_err=False,
+            return_value=None,
+            execution_time=0.0,
+            log=None,
+        )
+        await m.post_execute(msg, result)
+        assert ctx.get_correlation_id() is None


### PR DESCRIPTION
## Summary

Closes #145.

Establishes the structured-logging contract: JSON records, end-to-end correlation propagation across HTTP / taskiq / outbound HTTP, redaction with a CI gate, configurable sampling, pluggable sinks, and a documented level policy.

### What lands

- **Context (`engine/observability/context.py`)** — contextvars-backed correlation_id, request_id, span_id, user_id, role, portfolio_id, strategy_id, broker, order_id, tool. Async-isolated. Includes an `async with use_correlation_id(...)` context manager.
- **HTTP middleware** — reads `X-Correlation-Id` or generates UUID4, binds for the request, echoes header on the response, clears after.
- **taskiq middleware** — copies correlation_id/request_id into `message.labels` on send, rebinds on execute, clears on post-execute. Wired into `engine/tasks/worker.py`.
- **Outbound HTTP** — `correlated_async_client(...)` wraps `httpx.AsyncClient` with a request hook that injects `X-Correlation-Id` from the bound context (without overwriting an explicit header).
- **Processors** — `add_service_metadata` (service / env / version), `add_correlation_context` (merge bound ids), `sampling_filter` (warn+ always pass; info/debug configurable rates).
- **Redaction (`redact_processor`)** — strips banned keys (password, token, api_key, authorization, credit_card, ssn, etc.) and value patterns (`Bearer …`, JWT-shaped, 13–19-digit card numbers, `sk*`/`ghp*`/`AKIA*` prefixed secrets) recursively through dicts/lists.
- **Sink config** — `NEXUS_LOG_SINK = stdout|file|otlp` (otlp falls back to stdout until OTel logs SDK lands), `NEXUS_LOG_FILE_PATH` for the file sink. `WatchedFileHandler` so log rotation tools work.
- **Settings** — added `app_version`, `log_sampling_info`, `log_sampling_debug`, `log_sink`, `log_file_path`.
- **Docs** — `docs/observability/logging.md` covers wire format, correlation diagram, level policy, redaction list, sampling, sinks, "how to find logs".

### Acceptance criteria from #145

- [x] JSON structured logs with required fields (`timestamp`, `level`, `logger`, `event`, `service`, `env`, `version`, optional `correlation_id`/`request_id`/`span_id`/domain ids)
- [x] Correlation id propagation across HTTP, taskiq, outbound HTTP, plus async-task isolation
- [x] Log-level policy documented (`docs/observability/logging.md`)
- [x] Redaction with CI test (`tests/observability/test_log_redaction_e2e.py`)
- [x] Sampling configuration (`NEXUS_LOG_SAMPLING_INFO`, `NEXUS_LOG_SAMPLING_DEBUG`)
- [x] Sink selection via config
- [~] Codebase-wide migration to structlog — already largely done (every existing module uses `structlog.get_logger()`); no codemod needed.
- [ ] MCP tool propagation — deferred until the MCP server lands (#99)

### Test plan

- [x] `pytest tests/observability/` — 67 passed (context, redact, processors, middleware, taskiq middleware, http_client, e2e wire)
- [x] Full suite excluding pre-existing DB-required tests — 573 passed
- [x] `ruff check` clean on touched files (worker.py has 4 pre-existing PLC0415/TRY301 unrelated to this change)
- [x] `basedpyright` clean on `engine/observability`
- [ ] Run full suite with `NEXUS_DATABASE_URL` pointing at a test DB to confirm no regression in the 13 sev507 + 7 legal tests that need a DB
- [ ] Smoke `uvicorn engine.app:create_app` and verify `X-Correlation-Id` round-trips end-to-end against a real HTTP client
- [ ] Send a real taskiq task and confirm worker logs share the producer's correlation id

🤖 Generated with [Claude Code](https://claude.com/claude-code)