### PR TITLE
feat(reference): canonical symbol master + resolver (#131, PR1)

### DIFF
--- a/engine/reference/__init__.py
+++ b/engine/reference/__init__.py
@@ -1,0 +1,30 @@
+"""Reference data — canonical symbol master, identifier resolution,
+exchange metadata, sector classifications, and ingestion contract.
+
+This package gives every other engine subsystem a single source of truth
+for "what is this instrument" and "how do I look it up". Tickers go in,
+:class:`RefInstrument` records come out — keyed by stable internal UUIDs
+that survive symbol changes (e.g. FB → META) and cross-venue listings.
+"""
+
+from engine.reference.exceptions import AmbiguousSymbolError
+from engine.reference.model import (
+    Classification,
+    GICSNode,
+    InstrumentIds,
+    Listing,
+    RefInstrument,
+    Venue,
+)
+from engine.reference.resolver import Resolver
+
+__all__ = [
+    "AmbiguousSymbolError",
+    "Classification",
+    "GICSNode",
+    "InstrumentIds",
+    "Listing",
+    "RefInstrument",
+    "Resolver",
+    "Venue",
+]

--- a/engine/reference/classification.py
+++ b/engine/reference/classification.py
@@ -1,0 +1,129 @@
+"""Sector / industry / asset-class classification utilities.
+
+Includes:
+- A skeletal GICS hierarchy (subset — full table lands with the GICS
+  ingestion adapter) and ``is_valid_gics_path`` for cross-level checks.
+- Crypto taxonomy lookup (L1, L2, DeFi, stablecoin, meme, …).
+- Forex pair classification (major / minor / exotic).
+"""
+
+from __future__ import annotations
+
+# Representative GICS subset — enough for meaningful rejection. The
+# ingestion job will load the canonical table from MSCI's published
+# codebook in the follow-up issue.
+_GICS_HIERARCHY: dict[str, dict[str, dict[str, list[str]]]] = {
+    "Information Technology": {
+        "Software & Services": {
+            "Software": [
+                "Application Software",
+                "Systems Software",
+            ],
+            "IT Services": [
+                "IT Consulting & Other Services",
+                "Internet Services & Infrastructure",
+            ],
+        },
+        "Technology Hardware & Equipment": {
+            "Technology Hardware, Storage & Peripherals": [
+                "Technology Hardware, Storage & Peripherals",
+            ],
+            "Communications Equipment": ["Communications Equipment"],
+        },
+        "Semiconductors & Semiconductor Equipment": {
+            "Semiconductors & Semiconductor Equipment": [
+                "Semiconductors",
+                "Semiconductor Materials & Equipment",
+            ],
+        },
+    },
+    "Health Care": {
+        "Pharmaceuticals, Biotechnology & Life Sciences": {
+            "Pharmaceuticals": ["Pharmaceuticals"],
+            "Biotechnology": ["Biotechnology"],
+        },
+    },
+    "Financials": {
+        "Banks": {"Banks": ["Diversified Banks", "Regional Banks"]},
+    },
+}
+
+
+def is_valid_gics_path(
+    sector: str,
+    industry_group: str,
+    industry: str,
+    sub_industry: str,
+) -> bool:
+    """Return True iff the four-level GICS path rolls up cleanly."""
+    igs = _GICS_HIERARCHY.get(sector)
+    if igs is None:
+        return False
+    inds = igs.get(industry_group)
+    if inds is None:
+        return False
+    subs = inds.get(industry)
+    if subs is None:
+        return False
+    return sub_industry in subs
+
+
+_CRYPTO_TAXONOMY: dict[str, str] = {
+    "BTC": "l1",
+    "ETH": "l1",
+    "SOL": "l1",
+    "ADA": "l1",
+    "AVAX": "l1",
+    "DOT": "l1",
+    "ARB": "l2",
+    "OP": "l2",
+    "MATIC": "l2",
+    "BASE": "l2",
+    "USDT": "stablecoin",
+    "USDC": "stablecoin",
+    "DAI": "stablecoin",
+    "BUSD": "stablecoin",
+    "UNI": "defi",
+    "AAVE": "defi",
+    "MKR": "defi",
+    "DOGE": "meme",
+    "SHIB": "meme",
+    "PEPE": "meme",
+}
+
+
+def crypto_taxonomy(symbol: str) -> str:
+    """Return canonical crypto class for a base symbol (or 'unknown')."""
+    return _CRYPTO_TAXONOMY.get(symbol.upper(), "unknown")
+
+
+_FX_MAJORS = frozenset(
+    {
+        ("EUR", "USD"),
+        ("USD", "JPY"),
+        ("GBP", "USD"),
+        ("USD", "CHF"),
+        ("AUD", "USD"),
+        ("USD", "CAD"),
+        ("NZD", "USD"),
+    }
+)
+_FX_MINORS_BASES = frozenset({"EUR", "GBP", "JPY", "CHF", "AUD", "CAD", "NZD"})
+
+
+def forex_pair_class(base: str, quote: str) -> str:
+    """Classify a forex pair as 'major', 'minor', or 'exotic'."""
+    base_u = base.upper()
+    quote_u = quote.upper()
+    if (base_u, quote_u) in _FX_MAJORS or (quote_u, base_u) in _FX_MAJORS:
+        return "major"
+    if base_u in _FX_MINORS_BASES and quote_u in _FX_MINORS_BASES:
+        return "minor"
+    return "exotic"
+
+
+__all__ = [
+    "crypto_taxonomy",
+    "forex_pair_class",
+    "is_valid_gics_path",
+]

--- a/engine/reference/classification.py
+++ b/engine/reference/classification.py
@@ -78,7 +78,6 @@ _CRYPTO_TAXONOMY: dict[str, str] = {
     "ARB": "l2",
     "OP": "l2",
     "MATIC": "l2",
-    "BASE": "l2",
     "USDT": "stablecoin",
     "USDC": "stablecoin",
     "DAI": "stablecoin",

--- a/engine/reference/exceptions.py
+++ b/engine/reference/exceptions.py
@@ -1,0 +1,26 @@
+"""Reference-data exception hierarchy."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from engine.reference.model import RefInstrument
+
+
+class ReferenceError(Exception):  # noqa: A001 - domain name, not the builtin
+    """Base class for reference-data errors."""
+
+
+class AmbiguousSymbolError(ReferenceError):
+    """Raised when a query resolves to more than one instrument."""
+
+    def __init__(self, query: object, candidates: list[RefInstrument]) -> None:
+        self.query = query
+        self.candidates = candidates
+        super().__init__(
+            f"ambiguous symbol {query!r}: {len(candidates)} candidates"
+        )
+
+
+__all__ = ["AmbiguousSymbolError", "ReferenceError"]

--- a/engine/reference/ingestion/__init__.py
+++ b/engine/reference/ingestion/__init__.py
@@ -1,0 +1,11 @@
+"""Reference-data ingestion adapters.
+
+Base contract :class:`IngestionAdapter` is in :mod:`.base`. Concrete
+adapters (OpenFIGI, SEC EDGAR, MIC, Polygon, Alpaca, Binance) live in
+sibling modules. PR1 ships the contract and an OpenFIGI skeleton; HTTP
+implementations land in follow-up issues.
+"""
+
+from engine.reference.ingestion.base import IngestionAdapter, IngestionResult
+
+__all__ = ["IngestionAdapter", "IngestionResult"]

--- a/engine/reference/ingestion/base.py
+++ b/engine/reference/ingestion/base.py
@@ -14,13 +14,17 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class IngestionResult:
-    """Outcome of one sync run from a single adapter."""
+    """Outcome of one sync run from a single adapter.
+
+    ``errors`` is a tuple so the dataclass is genuinely immutable:
+    callers cannot append after construction.
+    """
 
     adapter: str
     fetched: int
     new: int
     updated: int
-    errors: list[str] = field(default_factory=list)
+    errors: tuple[str, ...] = field(default_factory=tuple)
 
 
 class IngestionAdapter(ABC):

--- a/engine/reference/ingestion/base.py
+++ b/engine/reference/ingestion/base.py
@@ -1,0 +1,40 @@
+"""Abstract ingestion contract for reference-data sources."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from engine.reference.model import RefInstrument
+
+
+@dataclass(frozen=True)
+class IngestionResult:
+    """Outcome of one sync run from a single adapter."""
+
+    adapter: str
+    fetched: int
+    new: int
+    updated: int
+    errors: list[str] = field(default_factory=list)
+
+
+class IngestionAdapter(ABC):
+    """Abstract contract every reference-data adapter implements."""
+
+    name: str
+
+    @abstractmethod
+    async def fetch(self) -> Iterable[RefInstrument]:
+        """Yield :class:`RefInstrument` records pulled from the source."""
+
+    @abstractmethod
+    async def health_check(self) -> bool:
+        """Return ``True`` when the upstream is reachable."""
+
+
+__all__ = ["IngestionAdapter", "IngestionResult"]

--- a/engine/reference/ingestion/openfigi.py
+++ b/engine/reference/ingestion/openfigi.py
@@ -26,6 +26,11 @@ class OpenFIGIAdapter(IngestionAdapter):
     def __init__(self, api_key: str | None = None) -> None:
         self.api_key = api_key
 
+    def __repr__(self) -> str:
+        # Always mask the key — debug logging or pickling must not leak it.
+        masked = "***" if self.api_key else "None"
+        return f"OpenFIGIAdapter(api_key={masked})"
+
     async def fetch(self) -> Iterable[RefInstrument]:  # pragma: no cover - skeleton
         return []
 

--- a/engine/reference/ingestion/openfigi.py
+++ b/engine/reference/ingestion/openfigi.py
@@ -1,0 +1,36 @@
+"""OpenFIGI ingestion adapter (skeleton).
+
+Full implementation hits ``https://api.openfigi.com/v3/mapping`` to
+batch-resolve identifiers. PR1 ships only the class structure so the
+ingestion contract can be exercised; live HTTP wiring lands in the
+follow-up issue.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from engine.reference.ingestion.base import IngestionAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from engine.reference.model import RefInstrument
+
+
+class OpenFIGIAdapter(IngestionAdapter):
+    """Stub adapter — emits no records; documents the planned shape."""
+
+    name = "openfigi"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key
+
+    async def fetch(self) -> Iterable[RefInstrument]:  # pragma: no cover - skeleton
+        return []
+
+    async def health_check(self) -> bool:  # pragma: no cover - skeleton
+        return self.api_key is not None
+
+
+__all__ = ["OpenFIGIAdapter"]

--- a/engine/reference/model.py
+++ b/engine/reference/model.py
@@ -43,6 +43,16 @@ _SEDOL = Annotated[str, StringConstraints(min_length=7, max_length=7)]
 _CIK = Annotated[str, StringConstraints(min_length=1, max_length=10, pattern=r"^[0-9]+$")]
 _MIC = Annotated[str, StringConstraints(min_length=4, max_length=4, pattern=r"^[A-Z0-9]{4}$")]
 _CCY = Annotated[str, StringConstraints(min_length=3, max_length=3, pattern=r"^[A-Z]{3}$")]
+# Ticker allowlist — covers all real-world formats (BRK.B, BTC-USD, ES_F,
+# AAPL.L, ALV1, AAPL:US) without admitting path-traversal or injection
+# characters. 1-32 chars. Slash is intentionally excluded so listing
+# tickers cannot smuggle `../../etc/passwd`-shaped strings into the
+# resolver indexes.
+_TICKER = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=32, pattern=r"^[A-Za-z0-9.\-_:]+$"),
+]
+_CLASSIFICATION_FIELD = Annotated[str, StringConstraints(max_length=128)]
 
 
 class InstrumentIds(BaseModel):
@@ -62,14 +72,14 @@ class Classification(BaseModel):
     their own taxonomies (see :mod:`engine.reference.classification`).
     """
 
-    gics_sector: str | None = None
-    gics_industry_group: str | None = None
-    gics_industry: str | None = None
-    gics_sub_industry: str | None = None
-    sic: str | None = None
-    naics: str | None = None
-    crypto_class: str | None = None
-    forex_class: str | None = None
+    gics_sector: _CLASSIFICATION_FIELD | None = None
+    gics_industry_group: _CLASSIFICATION_FIELD | None = None
+    gics_industry: _CLASSIFICATION_FIELD | None = None
+    gics_sub_industry: _CLASSIFICATION_FIELD | None = None
+    sic: _CLASSIFICATION_FIELD | None = None
+    naics: _CLASSIFICATION_FIELD | None = None
+    crypto_class: _CLASSIFICATION_FIELD | None = None
+    forex_class: _CLASSIFICATION_FIELD | None = None
 
 
 class Listing(BaseModel):
@@ -81,7 +91,7 @@ class Listing(BaseModel):
     """
 
     venue: _MIC
-    ticker: str = Field(..., min_length=1)
+    ticker: _TICKER
     currency: _CCY
     active_from: date
     active_to: date | None = None
@@ -115,7 +125,7 @@ class RefInstrument(BaseModel):
     model_config = {"validate_assignment": True}
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
-    primary_ticker: str = Field(..., min_length=1)
+    primary_ticker: _TICKER
     primary_venue: _MIC
     asset_class: AssetClassLiteral
     name: str = Field(..., min_length=1)

--- a/engine/reference/model.py
+++ b/engine/reference/model.py
@@ -1,0 +1,148 @@
+"""Reference-data domain model.
+
+Pure pydantic types — no DB session, no ORM coupling. The DB tables and
+ingestion adapters serialize *to* and *from* these models.
+
+Design notes:
+- ``RefInstrument.id`` is a UUID4 generated at construction time. Once
+  assigned, it is the **stable** internal handle that survives symbol
+  changes; downstream tables (positions, orders) should foreign-key on
+  this id, not on the ticker string.
+- Cross-listed equities are stored as separate ``RefInstrument`` rows
+  that share an ISIN. Use ``Resolver.resolve({"isin": ...})`` to fetch
+  any candidate, or filter by venue.
+- ``InstrumentIds`` validates the *shape* (ISIN 12 / CUSIP 9 / FIGI 12
+  chars, CIK numeric). Checksum validation is an ingestion concern.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date  # noqa: TC003 - pydantic needs runtime
+from decimal import Decimal
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, StringConstraints, field_validator
+
+AssetClassLiteral = Literal[
+    "equity",
+    "etf",
+    "crypto",
+    "crypto_perp",
+    "crypto_future",
+    "forex",
+    "option",
+    "future",
+]
+
+
+_ISIN = Annotated[str, StringConstraints(min_length=12, max_length=12, pattern=r"^[A-Z0-9]{12}$")]
+_CUSIP = Annotated[str, StringConstraints(min_length=9, max_length=9, pattern=r"^[A-Z0-9]{9}$")]
+_FIGI = Annotated[str, StringConstraints(min_length=12, max_length=12, pattern=r"^[A-Z0-9]{12}$")]
+_SEDOL = Annotated[str, StringConstraints(min_length=7, max_length=7)]
+_CIK = Annotated[str, StringConstraints(min_length=1, max_length=10, pattern=r"^[0-9]+$")]
+_MIC = Annotated[str, StringConstraints(min_length=4, max_length=4, pattern=r"^[A-Z0-9]{4}$")]
+_CCY = Annotated[str, StringConstraints(min_length=3, max_length=3, pattern=r"^[A-Z]{3}$")]
+
+
+class InstrumentIds(BaseModel):
+    """Cross-vendor identifier bundle for a single instrument."""
+
+    isin: _ISIN | None = None
+    cusip: _CUSIP | None = None
+    figi: _FIGI | None = None
+    sedol: _SEDOL | None = None
+    cik: _CIK | None = None
+
+
+class Classification(BaseModel):
+    """Sector / industry classification.
+
+    GICS for equities; SIC/NAICS for US filings; crypto and FX have
+    their own taxonomies (see :mod:`engine.reference.classification`).
+    """
+
+    gics_sector: str | None = None
+    gics_industry_group: str | None = None
+    gics_industry: str | None = None
+    gics_sub_industry: str | None = None
+    sic: str | None = None
+    naics: str | None = None
+    crypto_class: str | None = None
+    forex_class: str | None = None
+
+
+class Listing(BaseModel):
+    """A single venue listing for an instrument.
+
+    An instrument may have multiple listings over time (symbol changes,
+    cross-listing). The resolver searches across all listings to handle
+    historical ticker queries (FB → META).
+    """
+
+    venue: _MIC
+    ticker: str = Field(..., min_length=1)
+    currency: _CCY
+    active_from: date
+    active_to: date | None = None
+
+    @property
+    def is_active(self) -> bool:
+        return self.active_to is None
+
+
+class GICSNode(BaseModel):
+    """One node in the GICS taxonomy tree."""
+
+    code: str
+    name: str
+    level: Literal["sector", "industry_group", "industry", "sub_industry"]
+    parent_code: str | None = None
+
+
+class Venue(BaseModel):
+    """ISO 10383 MIC venue metadata."""
+
+    mic: _MIC
+    name: str
+    country: str = Field(..., min_length=2, max_length=2)
+    timezone: str = Field(..., min_length=1)
+
+
+class RefInstrument(BaseModel):
+    """Canonical reference record for any tradable instrument."""
+
+    model_config = {"validate_assignment": True}
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    primary_ticker: str = Field(..., min_length=1)
+    primary_venue: _MIC
+    asset_class: AssetClassLiteral
+    name: str = Field(..., min_length=1)
+    active: bool = True
+    lot_size: Decimal = Field(default=Decimal("1"))
+    tick_size: Decimal = Field(default=Decimal("0.01"))
+    currency: _CCY = "USD"
+    ids: InstrumentIds = Field(default_factory=InstrumentIds)
+    classification: Classification = Field(default_factory=Classification)
+    listings: list[Listing] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("primary_ticker")
+    @classmethod
+    def _ticker_no_whitespace(cls, v: str) -> str:
+        if not v.strip() or v.strip() != v:
+            msg = "primary_ticker must be non-empty and trimmed"
+            raise ValueError(msg)
+        return v
+
+
+__all__ = [
+    "AssetClassLiteral",
+    "Classification",
+    "GICSNode",
+    "InstrumentIds",
+    "Listing",
+    "RefInstrument",
+    "Venue",
+]

--- a/engine/reference/resolver.py
+++ b/engine/reference/resolver.py
@@ -1,0 +1,135 @@
+"""In-memory :class:`Resolver` — the canonical symbol → instrument lookup.
+
+Backs onto Python dicts so it is dependency-free and suitable for
+bootstrap, tests, and small caches. The DB-backed resolver implements
+the same surface against Postgres in a follow-up issue.
+
+Resolution order for a free-form string query:
+
+1. Empty / whitespace / suspicious garbage → ``None``
+2. ``TICKER.SUFFIX`` (e.g. ``AAPL.L``) → suffix mapped to MIC
+3. Exact ticker on a unique listing → that instrument
+4. Multiple matches → :class:`AmbiguousSymbolError`
+
+Dict-form queries (``{"ticker": ..., "venue": ...}`` or ``{"isin": ...}``)
+are deterministic — they either match exactly one or return ``None``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from engine.reference.exceptions import AmbiguousSymbolError
+
+if TYPE_CHECKING:
+    from engine.reference.model import RefInstrument
+
+
+_SUFFIX_TO_MIC: dict[str, str] = {
+    "L": "XLON",
+    "TO": "XTSE",
+    "PA": "XPAR",
+    "DE": "XETR",
+    "F": "XETR",
+    "MI": "XMIL",
+    "AS": "XAMS",
+    "T": "XTKS",
+    "HK": "XHKG",
+    "SS": "XSHG",
+    "SZ": "XSHE",
+    "SW": "XSWX",
+    "ST": "XSTO",
+    "OL": "XOSL",
+    "VI": "XWBO",
+    "MX": "XMEX",
+    "BR": "XBRU",
+    "JO": "XJSE",
+}
+
+_MAX_QUERY_LEN = 64
+_SUSPICIOUS = frozenset({"<", ">", "&", "\x00"})
+
+
+def _looks_garbage(raw: str) -> bool:
+    if not raw or not raw.strip():
+        return True
+    if len(raw) > _MAX_QUERY_LEN:
+        return True
+    return any(c in _SUSPICIOUS for c in raw)
+
+
+class Resolver:
+    """Symbol-master with multi-key lookup."""
+
+    def __init__(self) -> None:
+        self._by_id: dict[Any, RefInstrument] = {}
+        self._by_ticker_venue: dict[tuple[str, str], RefInstrument] = {}
+        self._by_ticker: dict[str, list[RefInstrument]] = defaultdict(list)
+        self._by_isin: dict[str, RefInstrument] = {}
+        self._by_cusip: dict[str, RefInstrument] = {}
+        self._by_figi: dict[str, RefInstrument] = {}
+        self._by_cik: dict[str, RefInstrument] = {}
+
+    def register(self, inst: RefInstrument) -> None:
+        """Add an instrument to the catalog and rebuild its indexes."""
+        self._by_id[inst.id] = inst
+        self._by_ticker[inst.primary_ticker.upper()].append(inst)
+        self._by_ticker_venue[(inst.primary_ticker.upper(), inst.primary_venue)] = inst
+        for listing in inst.listings:
+            self._by_ticker_venue[(listing.ticker.upper(), listing.venue)] = inst
+            self._by_ticker[listing.ticker.upper()].append(inst)
+        if inst.ids.isin:
+            self._by_isin[inst.ids.isin] = inst
+        if inst.ids.cusip:
+            self._by_cusip[inst.ids.cusip] = inst
+        if inst.ids.figi:
+            self._by_figi[inst.ids.figi] = inst
+        if inst.ids.cik:
+            self._by_cik[inst.ids.cik] = inst
+
+    def resolve(self, query: str | dict[str, Any]) -> RefInstrument | None:
+        """Look up an instrument by ticker, dotted suffix, or ID dict."""
+        if isinstance(query, dict):
+            return self._resolve_dict(query)
+        if not isinstance(query, str):
+            msg = f"resolve query must be str or dict, got {type(query).__name__}"
+            raise TypeError(msg)
+        if _looks_garbage(query):
+            return None
+        return self._resolve_string(query.strip())
+
+    def _resolve_dict(self, q: dict[str, Any]) -> RefInstrument | None:  # noqa: PLR0911 - one return per id type
+        if "isin" in q:
+            return self._by_isin.get(q["isin"])
+        if "cusip" in q:
+            return self._by_cusip.get(q["cusip"])
+        if "figi" in q:
+            return self._by_figi.get(q["figi"])
+        if "cik" in q:
+            return self._by_cik.get(q["cik"])
+        if "ticker" in q and "venue" in q:
+            return self._by_ticker_venue.get((str(q["ticker"]).upper(), q["venue"]))
+        if "ticker" in q:
+            return self._resolve_string(str(q["ticker"]))
+        return None
+
+    def _resolve_string(self, raw: str) -> RefInstrument | None:
+        if "." in raw:
+            ticker, _, suffix = raw.rpartition(".")
+            mic = _SUFFIX_TO_MIC.get(suffix.upper())
+            if mic and ticker:
+                hit = self._by_ticker_venue.get((ticker.upper(), mic))
+                if hit is not None:
+                    return hit
+        hits = self._by_ticker.get(raw.upper(), [])
+        unique_by_id: dict[Any, RefInstrument] = {h.id: h for h in hits}
+        candidates = list(unique_by_id.values())
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0]
+        raise AmbiguousSymbolError(query=raw, candidates=candidates)
+
+
+__all__ = ["Resolver"]

--- a/engine/reference/resolver.py
+++ b/engine/reference/resolver.py
@@ -17,6 +17,7 @@ are deterministic — they either match exactly one or return ``None``.
 
 from __future__ import annotations
 
+import unicodedata
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -48,7 +49,7 @@ _SUFFIX_TO_MIC: dict[str, str] = {
 }
 
 _MAX_QUERY_LEN = 64
-_SUSPICIOUS = frozenset({"<", ">", "&", "\x00"})
+_SUSPICIOUS = frozenset({"<", ">", "&", "'", '"', "`", ";", "\x00"})
 
 
 def _looks_garbage(raw: str) -> bool:
@@ -56,7 +57,17 @@ def _looks_garbage(raw: str) -> bool:
         return True
     if len(raw) > _MAX_QUERY_LEN:
         return True
-    return any(c in _SUSPICIOUS for c in raw)
+    if any(c in _SUSPICIOUS for c in raw):
+        return True
+    # Reject control / format / private-use code points (covers BIDI
+    # overrides and zero-width joiners that would let an attacker
+    # impersonate a legit ticker in logs / dashboards).
+    return any(unicodedata.category(c) in {"Cc", "Cf", "Co"} for c in raw)
+
+
+def _normalize(raw: str) -> str:
+    """NFKC-normalize the query so visually-equivalent unicode collapses."""
+    return unicodedata.normalize("NFKC", raw)
 
 
 class Resolver:
@@ -72,13 +83,30 @@ class Resolver:
         self._by_cik: dict[str, RefInstrument] = {}
 
     def register(self, inst: RefInstrument) -> None:
-        """Add an instrument to the catalog and rebuild its indexes."""
+        """Add an instrument to the catalog and rebuild its indexes.
+
+        Idempotent: re-registering the same ``id`` is a no-op. Two
+        different ``RefInstrument`` records with the same shared
+        identifier (e.g. ISIN for cross-listed equities) currently use
+        last-writer-wins semantics on the ID indexes — callers that
+        need disambiguation should query by ``{"ticker", "venue"}``.
+
+        Note: not asyncio-/thread-safe. Bootstrap registrations should
+        complete before concurrent ``resolve()`` traffic begins, or
+        wrap the catalog with an external lock.
+        """
+        if inst.id in self._by_id:
+            return  # idempotent — same record already registered
         self._by_id[inst.id] = inst
         self._by_ticker[inst.primary_ticker.upper()].append(inst)
         self._by_ticker_venue[(inst.primary_ticker.upper(), inst.primary_venue)] = inst
         for listing in inst.listings:
             self._by_ticker_venue[(listing.ticker.upper(), listing.venue)] = inst
-            self._by_ticker[listing.ticker.upper()].append(inst)
+            # Index plain listing ticker only when it differs from the
+            # primary ticker, so dotted-suffix forms like "AAPL.L" do not
+            # accidentally satisfy a raw-ticker fallback below.
+            if listing.ticker.upper() != inst.primary_ticker.upper():
+                self._by_ticker[listing.ticker.upper()].append(inst)
         if inst.ids.isin:
             self._by_isin[inst.ids.isin] = inst
         if inst.ids.cusip:
@@ -95,9 +123,10 @@ class Resolver:
         if not isinstance(query, str):
             msg = f"resolve query must be str or dict, got {type(query).__name__}"
             raise TypeError(msg)
-        if _looks_garbage(query):
+        normalized = _normalize(query)
+        if _looks_garbage(normalized):
             return None
-        return self._resolve_string(query.strip())
+        return self._resolve_string(normalized.strip())
 
     def _resolve_dict(self, q: dict[str, Any]) -> RefInstrument | None:  # noqa: PLR0911 - one return per id type
         if "isin" in q:
@@ -109,9 +138,12 @@ class Resolver:
         if "cik" in q:
             return self._by_cik.get(q["cik"])
         if "ticker" in q and "venue" in q:
-            return self._by_ticker_venue.get((str(q["ticker"]).upper(), q["venue"]))
+            ticker = _normalize(str(q["ticker"]))
+            if _looks_garbage(ticker):
+                return None
+            return self._by_ticker_venue.get((ticker.upper(), q["venue"]))
         if "ticker" in q:
-            return self._resolve_string(str(q["ticker"]))
+            return self.resolve(str(q["ticker"]))
         return None
 
     def _resolve_string(self, raw: str) -> RefInstrument | None:
@@ -122,6 +154,10 @@ class Resolver:
                 hit = self._by_ticker_venue.get((ticker.upper(), mic))
                 if hit is not None:
                     return hit
+                # Suffix mapped but no listing on that venue — return
+                # None rather than fall through to a raw-ticker lookup
+                # that would silently route to a different venue.
+                return None
         hits = self._by_ticker.get(raw.upper(), [])
         unique_by_id: dict[Any, RefInstrument] = {h.id: h for h in hits}
         candidates = list(unique_by_id.values())

--- a/engine/reference/search.py
+++ b/engine/reference/search.py
@@ -1,0 +1,60 @@
+"""In-memory typeahead :class:`SearchIndex`.
+
+Linear scan with substring matching plus an optional asset-class filter.
+Sufficient for the bootstrap path; the production index will sit behind
+Postgres ``pg_trgm`` in a follow-up issue.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from engine.reference.model import AssetClassLiteral, RefInstrument
+
+
+class SearchIndex:
+    """Append-only in-memory index over :class:`RefInstrument` records."""
+
+    def __init__(self) -> None:
+        self._records: list[RefInstrument] = []
+
+    def add(self, inst: RefInstrument) -> None:
+        self._records.append(inst)
+
+    def search(
+        self,
+        query: str,
+        *,
+        asset_class: AssetClassLiteral | None = None,
+        limit: int = 25,
+    ) -> list[RefInstrument]:
+        if not query or not query.strip():
+            return []
+        q = query.strip().lower()
+        out: list[tuple[int, RefInstrument]] = []
+        for rec in self._records:
+            if asset_class is not None and rec.asset_class != asset_class:
+                continue
+            score = self._score(rec, q)
+            if score > 0:
+                out.append((score, rec))
+        out.sort(key=lambda t: -t[0])
+        return [rec for _, rec in out[:limit]]
+
+    @staticmethod
+    def _score(rec: RefInstrument, q: str) -> int:
+        ticker = rec.primary_ticker.lower()
+        name = rec.name.lower()
+        if ticker == q:
+            return 100
+        if ticker.startswith(q):
+            return 75
+        if q in ticker:
+            return 50
+        if q in name:
+            return 25
+        return 0
+
+
+__all__ = ["SearchIndex"]

--- a/engine/reference/search.py
+++ b/engine/reference/search.py
@@ -22,6 +22,8 @@ class SearchIndex:
     def add(self, inst: RefInstrument) -> None:
         self._records.append(inst)
 
+    MAX_QUERY_LEN = 64
+
     def search(
         self,
         query: str,
@@ -31,16 +33,22 @@ class SearchIndex:
     ) -> list[RefInstrument]:
         if not query or not query.strip():
             return []
+        if len(query) > self.MAX_QUERY_LEN:
+            return []
         q = query.strip().lower()
-        out: list[tuple[int, RefInstrument]] = []
+        scored: list[tuple[int, RefInstrument]] = []
         for rec in self._records:
             if asset_class is not None and rec.asset_class != asset_class:
                 continue
             score = self._score(rec, q)
             if score > 0:
-                out.append((score, rec))
-        out.sort(key=lambda t: -t[0])
-        return [rec for _, rec in out[:limit]]
+                scored.append((score, rec))
+        # Use heap-based top-k so 100k records with many partial matches
+        # stay O(n log limit) rather than O(n log n).
+        import heapq  # noqa: PLC0415 - local import keeps cold-path stdlib out of hot path
+
+        top = heapq.nlargest(limit, scored, key=lambda t: t[0])
+        return [rec for _, rec in top]
 
     @staticmethod
     def _score(rec: RefInstrument, q: str) -> int:

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,0 +1,379 @@
+"""Tests for engine.reference — symbol master + identifier resolution."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from engine.reference import (
+    AmbiguousSymbolError,
+    Classification,
+    GICSNode,
+    InstrumentIds,
+    Listing,
+    RefInstrument,
+    Resolver,
+    Venue,
+)
+from engine.reference.classification import (
+    crypto_taxonomy,
+    forex_pair_class,
+    is_valid_gics_path,
+)
+from engine.reference.search import SearchIndex
+
+
+def _aapl() -> RefInstrument:
+    return RefInstrument(
+        primary_ticker="AAPL",
+        primary_venue="XNAS",
+        asset_class="equity",
+        name="Apple Inc.",
+        currency="USD",
+        ids=InstrumentIds(
+            isin="US0378331005",
+            cusip="037833100",
+            figi="BBG000B9XRY4",
+            cik="0000320193",
+        ),
+        classification=Classification(
+            gics_sector="Information Technology",
+            gics_industry_group="Technology Hardware & Equipment",
+            gics_industry="Technology Hardware, Storage & Peripherals",
+            gics_sub_industry="Technology Hardware, Storage & Peripherals",
+        ),
+        listings=[
+            Listing(
+                venue="XNAS",
+                ticker="AAPL",
+                currency="USD",
+                active_from=date(1980, 12, 12),
+            ),
+            Listing(
+                venue="XLON",
+                ticker="AAPL.L",
+                currency="GBP",
+                active_from=date(2003, 6, 1),
+            ),
+        ],
+    )
+
+
+def _aapl_lse() -> RefInstrument:
+    return RefInstrument(
+        primary_ticker="AAPL",
+        primary_venue="XLON",
+        asset_class="equity",
+        name="Apple Inc. (LSE)",
+        currency="GBP",
+        ids=InstrumentIds(isin="US0378331005"),
+        listings=[
+            Listing(
+                venue="XLON",
+                ticker="AAPL.L",
+                currency="GBP",
+                active_from=date(2003, 6, 1),
+            )
+        ],
+    )
+
+
+def _shop_nyse() -> RefInstrument:
+    return RefInstrument(
+        primary_ticker="SHOP",
+        primary_venue="XNYS",
+        asset_class="equity",
+        name="Shopify Inc.",
+        currency="USD",
+        ids=InstrumentIds(isin="CA82509L1076"),
+    )
+
+
+def _shop_lse() -> RefInstrument:
+    return RefInstrument(
+        primary_ticker="SHOP",
+        primary_venue="XLON",
+        asset_class="equity",
+        name="Shoprite Holdings",
+        currency="GBP",
+        ids=InstrumentIds(isin="ZAE000012084"),
+    )
+
+
+class TestRefInstrumentModel:
+    def test_construction_minimal(self):
+        inst = RefInstrument(
+            primary_ticker="MSFT",
+            primary_venue="XNAS",
+            asset_class="equity",
+            name="Microsoft Corp.",
+            currency="USD",
+        )
+        assert inst.id is not None
+        assert inst.active is True
+        assert inst.ids.isin is None
+
+    def test_each_constructed_instance_gets_fresh_id(self):
+        a = RefInstrument(
+            primary_ticker="X",
+            primary_venue="XNAS",
+            asset_class="equity",
+            name="X",
+        )
+        b = RefInstrument(
+            primary_ticker="X",
+            primary_venue="XNAS",
+            asset_class="equity",
+            name="X",
+        )
+        assert a.id != b.id
+
+    def test_validates_currency_iso_4217_length(self):
+        with pytest.raises((ValueError, TypeError)):
+            RefInstrument(
+                primary_ticker="X",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="X",
+                currency="DOLLAR",
+            )
+
+
+class TestInstrumentIdsValidation:
+    def test_isin_must_be_12_chars(self):
+        with pytest.raises((ValueError, TypeError)):
+            InstrumentIds(isin="US123")
+
+    def test_cusip_must_be_9_chars(self):
+        with pytest.raises((ValueError, TypeError)):
+            InstrumentIds(cusip="ABC")
+
+    def test_figi_must_be_12_chars(self):
+        with pytest.raises((ValueError, TypeError)):
+            InstrumentIds(figi="BBGAA")
+
+    def test_all_optional_passes(self):
+        ids = InstrumentIds()
+        assert ids.isin is None and ids.cusip is None and ids.figi is None
+
+
+class TestResolverByTicker:
+    def test_resolve_unique_ticker(self):
+        r = Resolver()
+        r.register(_aapl())
+        out = r.resolve("AAPL")
+        assert out is not None
+        assert out.primary_ticker == "AAPL"
+
+    def test_resolve_returns_none_for_unknown(self):
+        r = Resolver()
+        assert r.resolve("ZZZZZZ") is None
+
+    def test_ambiguous_ticker_raises(self):
+        r = Resolver()
+        r.register(_shop_nyse())
+        r.register(_shop_lse())
+        with pytest.raises(AmbiguousSymbolError) as exc:
+            r.resolve("SHOP")
+        assert len(exc.value.candidates) == 2
+
+    def test_disambiguate_with_venue(self):
+        r = Resolver()
+        r.register(_shop_nyse())
+        r.register(_shop_lse())
+        out = r.resolve({"ticker": "SHOP", "venue": "XNYS"})
+        assert out is not None
+        assert out.primary_venue == "XNYS"
+
+    def test_dot_suffix_routes_to_venue(self):
+        r = Resolver()
+        r.register(_aapl())
+        r.register(_aapl_lse())
+        out = r.resolve("AAPL.L")
+        assert out is not None
+        assert out.primary_venue == "XLON"
+
+
+class TestResolverByIdentifier:
+    def test_resolve_by_isin(self):
+        r = Resolver()
+        r.register(_aapl())
+        out = r.resolve({"isin": "US0378331005"})
+        assert out is not None and out.primary_ticker == "AAPL"
+
+    def test_resolve_by_cusip(self):
+        r = Resolver()
+        r.register(_aapl())
+        out = r.resolve({"cusip": "037833100"})
+        assert out is not None and out.primary_ticker == "AAPL"
+
+    def test_resolve_by_figi(self):
+        r = Resolver()
+        r.register(_aapl())
+        out = r.resolve({"figi": "BBG000B9XRY4"})
+        assert out is not None and out.primary_ticker == "AAPL"
+
+    def test_resolve_by_cik(self):
+        r = Resolver()
+        r.register(_aapl())
+        out = r.resolve({"cik": "0000320193"})
+        assert out is not None and out.primary_ticker == "AAPL"
+
+
+class TestResolverFuzz:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            " ",
+            "/",
+            "AAPL/",
+            ".",
+            "..L",
+            "VERY-LONG-" + "X" * 200,
+            "🚀",
+            "<script>",
+        ],
+    )
+    def test_garbage_returns_none_or_raises_value_error(self, raw):
+        r = Resolver()
+        r.register(_aapl())
+        try:
+            out = r.resolve(raw)
+            assert out is None or out.primary_ticker == "AAPL"
+        except ValueError:
+            pass
+
+
+class TestGICSValidation:
+    def test_valid_gics_path(self):
+        assert is_valid_gics_path(
+            "Information Technology",
+            "Software & Services",
+            "Software",
+            "Application Software",
+        )
+
+    def test_invalid_sector_rejected(self):
+        assert not is_valid_gics_path(
+            "Made Up Sector",
+            "Software & Services",
+            "Software",
+            "Application Software",
+        )
+
+    def test_partial_path_invalid(self):
+        assert not is_valid_gics_path(
+            "Health Care",
+            "Software & Services",
+            "Software",
+            "Application Software",
+        )
+
+
+class TestCryptoTaxonomy:
+    def test_known_l1(self):
+        assert crypto_taxonomy("BTC") == "l1"
+
+    def test_known_stablecoin(self):
+        assert crypto_taxonomy("USDC") == "stablecoin"
+
+    def test_unknown_falls_back(self):
+        assert crypto_taxonomy("XXXXX") == "unknown"
+
+
+class TestForexClassification:
+    def test_major(self):
+        assert forex_pair_class("EUR", "USD") == "major"
+
+    def test_minor(self):
+        assert forex_pair_class("EUR", "GBP") == "minor"
+
+    def test_exotic(self):
+        assert forex_pair_class("USD", "TRY") == "exotic"
+
+
+class TestSearchIndex:
+    def test_substring_match(self):
+        idx = SearchIndex()
+        idx.add(_aapl())
+        idx.add(_shop_nyse())
+        results = idx.search("apple")
+        tickers = [r.primary_ticker for r in results]
+        assert "AAPL" in tickers
+
+    def test_ticker_prefix_match(self):
+        idx = SearchIndex()
+        idx.add(_aapl())
+        idx.add(_shop_nyse())
+        results = idx.search("SHO")
+        tickers = [r.primary_ticker for r in results]
+        assert "SHOP" in tickers
+
+    def test_asset_class_filter(self):
+        idx = SearchIndex()
+        idx.add(_aapl())
+        results = idx.search("apple", asset_class="crypto")
+        assert results == []
+
+    def test_returns_top_n_only(self):
+        idx = SearchIndex()
+        for i in range(50):
+            idx.add(
+                RefInstrument(
+                    primary_ticker=f"TST{i}",
+                    primary_venue="XNAS",
+                    asset_class="equity",
+                    name=f"Test Co {i}",
+                )
+            )
+        results = idx.search("Test", limit=10)
+        assert len(results) == 10
+
+
+class TestGICSNode:
+    def test_construction(self):
+        node = GICSNode(code="45", name="Information Technology", level="sector")
+        assert node.code == "45"
+
+
+class TestVenue:
+    def test_mic_format(self):
+        v = Venue(mic="XNAS", name="Nasdaq", country="US", timezone="America/New_York")
+        assert v.mic == "XNAS"
+
+    def test_invalid_mic_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            Venue(mic="NAS", name="Nasdaq", country="US", timezone="America/New_York")
+
+
+class TestSymbolChange:
+    def test_old_ticker_still_resolves_via_listing_history(self):
+        r = Resolver()
+        meta = RefInstrument(
+            primary_ticker="META",
+            primary_venue="XNAS",
+            asset_class="equity",
+            name="Meta Platforms, Inc.",
+            listings=[
+                Listing(
+                    venue="XNAS",
+                    ticker="FB",
+                    currency="USD",
+                    active_from=date(2012, 5, 18),
+                    active_to=date(2022, 6, 8),
+                ),
+                Listing(
+                    venue="XNAS",
+                    ticker="META",
+                    currency="USD",
+                    active_from=date(2022, 6, 9),
+                ),
+            ],
+        )
+        r.register(meta)
+        old = r.resolve({"ticker": "FB", "venue": "XNAS"})
+        new = r.resolve({"ticker": "META", "venue": "XNAS"})
+        assert old is not None and new is not None
+        assert old.id == new.id

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -348,6 +348,118 @@ class TestVenue:
             Venue(mic="NAS", name="Nasdaq", country="US", timezone="America/New_York")
 
 
+class TestRegisterIdempotence:
+    def test_double_register_is_noop(self):
+        r = Resolver()
+        inst = _aapl()
+        r.register(inst)
+        r.register(inst)
+        # If non-idempotent, _by_ticker would have duplicates and the
+        # ambiguity branch could trip; this just verifies resolve still works.
+        out = r.resolve("AAPL")
+        assert out is not None and out.id == inst.id
+
+
+class TestDottedSuffixNoFallthrough:
+    def test_known_suffix_unknown_venue_returns_none(self):
+        r = Resolver()
+        # Apple registered with XNAS only — no XLON listing.
+        inst = RefInstrument(
+            primary_ticker="AAPL",
+            primary_venue="XNAS",
+            asset_class="equity",
+            name="Apple",
+        )
+        r.register(inst)
+        # `.L` maps to XLON; no listing exists. Must NOT silently route
+        # to the XNAS-primary record.
+        assert r.resolve("AAPL.L") is None
+
+
+class TestTickerAllowlist:
+    def test_injection_payload_in_ticker_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            RefInstrument(
+                primary_ticker="<script>alert(1)</script>",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="x",
+            )
+
+    def test_path_traversal_in_listing_ticker_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            Listing(
+                venue="XNAS",
+                ticker="../../etc/passwd",
+                currency="USD",
+                active_from=date(2020, 1, 1),
+            )
+
+    def test_legitimate_separators_accepted(self):
+        # Real-world ticker formats: BRK.B (NYSE share class),
+        # BTC-USD (crypto), ES_F (futures), AAPL.L (LSE), AAPL:US.
+        for tk in ("BRK.B", "BTC-USD", "ES_F", "AAPL.L", "AAPL:US"):
+            inst = RefInstrument(
+                primary_ticker=tk,
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="x",
+            )
+            assert inst.primary_ticker == tk
+
+
+class TestUnicodeGarbageGuard:
+    def test_bidi_override_in_query_returns_none(self):
+        r = Resolver()
+        r.register(_aapl())
+        rlo = chr(0x202E)  # RIGHT-TO-LEFT OVERRIDE
+        assert r.resolve(f"AAPL{rlo}") is None
+
+    def test_zero_width_space_in_query_returns_none(self):
+        r = Resolver()
+        r.register(_aapl())
+        zwsp = chr(0x200B)  # ZERO-WIDTH SPACE
+        assert r.resolve(f"A{zwsp}APL") is None
+
+    def test_dict_path_ticker_garbage_filtered(self):
+        r = Resolver()
+        r.register(_aapl())
+        assert r.resolve({"ticker": "<script>"}) is None
+
+
+class TestSearchQueryLengthCap:
+    def test_oversize_query_returns_empty(self):
+        idx = SearchIndex()
+        idx.add(_aapl())
+        results = idx.search("a" * 1000)
+        assert results == []
+
+
+class TestOpenFIGIRepr:
+    def test_repr_masks_api_key(self):
+        from engine.reference.ingestion.openfigi import OpenFIGIAdapter
+
+        adapter = OpenFIGIAdapter(api_key="sk-live-very-secret")
+        rendered = repr(adapter)
+        assert "sk-live-very-secret" not in rendered
+        assert "***" in rendered
+
+    def test_repr_with_no_key(self):
+        from engine.reference.ingestion.openfigi import OpenFIGIAdapter
+
+        adapter = OpenFIGIAdapter()
+        rendered = repr(adapter)
+        assert "None" in rendered
+
+
+class TestIngestionResultImmutability:
+    def test_errors_is_tuple(self):
+        from engine.reference.ingestion import IngestionResult
+
+        r = IngestionResult(adapter="x", fetched=0, new=0, updated=0)
+        assert isinstance(r.errors, tuple)
+
+
 class TestSymbolChange:
     def test_old_ticker_still_resolves_via_listing_history(self):
         r = Resolver()


### PR DESCRIPTION
## Summary

PR1 of issue #131 — pure-Python core for reference data: model + resolver + classification + search + ingestion contract. Closes the foundation gap that #112/#155/#156 will need; full DB/API/Celery/frontend wiring is a follow-up.

### What lands

- **\`engine/reference/model.py\`** — \`RefInstrument\`, \`InstrumentIds\` (ISIN/CUSIP/FIGI/SEDOL/CIK with regex shape validation), \`Listing\`, \`Classification\`, \`GICSNode\`, \`Venue\` (ISO 10383 MIC).
- **\`engine/reference/resolver.py\`** — in-memory \`Resolver\` with multi-key lookup (ticker, venue+ticker, ISIN/CUSIP/FIGI/CIK, dotted-suffix venue routing like \`AAPL.L\` → \`XLON\`). Garbage-input guard (empty / >64 chars / \`<\`, \`>\`, \`&\`, null) returns \`None\` rather than crashing. Multiple matches raise \`AmbiguousSymbolError\` with candidate list.
- **\`engine/reference/classification.py\`** — GICS hierarchy validator (subset), crypto taxonomy (l1/l2/defi/stablecoin/meme), forex pair class (major/minor/exotic).
- **\`engine/reference/search.py\`** — in-memory typeahead with substring + prefix scoring + asset-class filter + bounded limit.
- **\`engine/reference/ingestion/{__init__,base,openfigi}.py\`** — abstract \`IngestionAdapter\` contract + \`IngestionResult\` dataclass + skeleton OpenFIGI adapter. HTTP implementation is a follow-up.

### Out of scope (follow-up issues)

- [ ] DB models + Alembic migration for instruments / listings / classifications
- [ ] API routes (\`/api/v1/reference/{instrument,resolve,search,venues,sectors}\`)
- [ ] Celery beat sync job
- [ ] Frontend instrument picker
- [ ] MCP resource exposure
- [ ] Migrate existing modules from free-text tickers to \`instrument_id\`

### Acceptance criteria from #131

- [x] Normalized data model with ids, listings, classifications
- [ ] Multi-source ingestion with scheduled sync (skeleton only)
- [x] Resolver handles tickers, venues, ISIN, CUSIP, FIGI
- [x] GICS classification for equities (validator subset; full table is follow-up)
- [ ] API endpoints + typeahead search + MCP resource (follow-up)
- [ ] Frontend instrument picker (follow-up)
- [ ] Migration of existing ticker usages to \`instrument_id\` (follow-up)
- [x] Symbol-change events preserve stable internal id

### Test plan

- [x] \`pytest tests/test_reference_data.py\` — 42 passed
- [x] Full suite excluding pre-existing DB-required tests — 685 passed
- [x] \`ruff check\` clean
- [x] \`basedpyright\` clean
- [ ] Adversarial code-reviewer + security-reviewer (running next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)