### PR TITLE
feat(api): security response headers middleware (#128)

### DIFF
--- a/engine/api/security_headers.py
+++ b/engine/api/security_headers.py
@@ -38,13 +38,38 @@ _CSP_DIRECTIVE_ORDER = (
 )
 
 
+# Tokens that defeat the point of CSP when present in script-src.
+_FORBIDDEN_SCRIPT_SRC_TOKENS = frozenset({"*", "'unsafe-inline'", "'unsafe-eval'", "data:"})
+# Tokens that defeat the point of CSP when present in default-src.
+_FORBIDDEN_DEFAULT_SRC_TOKENS = frozenset({"*", "'unsafe-inline'", "'unsafe-eval'"})
+
+
+def _validate_directive(name: str, value: tuple[str, ...]) -> None:
+    """Raise ValueError when a directive carries a dangerous token.
+
+    Catches operator misconfiguration (env-var-driven CSP that reaches
+    `build_csp` with an attacker-influenced source list) at config
+    construction rather than silently downgrading the policy.
+    """
+    if name == "script_src":
+        bad = set(value) & _FORBIDDEN_SCRIPT_SRC_TOKENS
+        if bad:
+            msg = f"script_src must not include {sorted(bad)}"
+            raise ValueError(msg)
+    if name == "default_src":
+        bad = set(value) & _FORBIDDEN_DEFAULT_SRC_TOKENS
+        if bad:
+            msg = f"default_src must not include {sorted(bad)}"
+            raise ValueError(msg)
+
+
 def build_csp(
     *,
     default_src: tuple[str, ...] = ("'self'",),
     script_src: tuple[str, ...] = ("'self'",),
     style_src: tuple[str, ...] = ("'self'", "'unsafe-inline'"),
-    img_src: tuple[str, ...] = ("'self'", "data:", "https:"),
-    font_src: tuple[str, ...] = ("'self'", "https:", "data:"),
+    img_src: tuple[str, ...] = ("'self'", "data:"),
+    font_src: tuple[str, ...] = ("'self'", "data:"),
     connect_src: tuple[str, ...] = ("'self'",),
     frame_src: tuple[str, ...] = ("'none'",),
     object_src: tuple[str, ...] = ("'none'",),
@@ -54,13 +79,16 @@ def build_csp(
     media_src: tuple[str, ...] | None = None,
     worker_src: tuple[str, ...] | None = None,
     manifest_src: tuple[str, ...] | None = None,
+    upgrade_insecure_requests: bool = True,
+    report_uri: str | None = None,
 ) -> str:
     """Compose a CSP header value from per-directive source lists.
 
-    ``style_src`` defaults allow ``'unsafe-inline'`` because most
-    component libraries (FastAPI's Swagger UI included) ship inline
-    style attributes; ``script_src`` deliberately does NOT — JS should
-    run only from the same origin or a nonce-bound bundle.
+    ``style_src`` defaults allow ``'unsafe-inline'`` because component
+    libraries (Swagger UI etc.) ship inline style attributes; ``script_src``
+    deliberately does NOT — JS runs only from same-origin or a nonce-bound
+    bundle. ``script_src`` and ``default_src`` reject dangerous tokens at
+    construction time.
     """
     parts: list[str] = []
     locals_ = locals()
@@ -68,8 +96,13 @@ def build_csp(
         value = locals_.get(name)
         if value is None:
             continue
+        _validate_directive(name, value)
         directive = name.replace("_", "-")
         parts.append(f"{directive} {' '.join(value)}")
+    if upgrade_insecure_requests:
+        parts.append("upgrade-insecure-requests")
+    if report_uri:
+        parts.append(f"report-uri {report_uri}")
     return "; ".join(parts)
 
 
@@ -79,6 +112,10 @@ class SecurityHeadersConfig:
 
     Defaults are tightened for an API that serves only its own SPA and
     documentation; endpoints that need looser policies should override.
+
+    HSTS is emitted only on HTTPS responses (per RFC 6797 §8.1 browsers
+    ignore HSTS over plain HTTP, but plain-HTTP emission is treated as a
+    misconfiguration by audit tooling).
     """
 
     csp_enabled: bool = True
@@ -88,12 +125,16 @@ class SecurityHeadersConfig:
     hsts_include_subdomains: bool = True
     hsts_preload: bool = False
     x_content_type_options: str = "nosniff"
+    # X-Frame-Options retained for pre-CSP2 browsers; modern browsers
+    # honor `frame-ancestors 'none'` from the CSP. Defense-in-depth.
     x_frame_options: str = "DENY"
     referrer_policy: str = "strict-origin-when-cross-origin"
     permissions_policy: str = (
         "camera=(), microphone=(), geolocation=(), payment=(), usb=(), "
-        "interest-cohort=()"
+        "browsing-topics=(), interest-cohort=()"
     )
+    # Suppress runtime fingerprinting (uvicorn defaults to Server: uvicorn).
+    suppress_server_header: bool = True
 
     def hsts_value(self) -> str:
         parts = [f"max-age={self.hsts_max_age}"]
@@ -112,6 +153,17 @@ _STATIC_HEADERS: tuple[tuple[bytes, str], ...] = (
 )
 
 
+def _scheme_from_scope(scope: Any) -> str:
+    """Resolve the effective request scheme, honoring X-Forwarded-Proto."""
+    for raw_name, raw_value in scope.get("headers", []):
+        if raw_name == b"x-forwarded-proto":
+            try:
+                return raw_value.decode("latin-1").split(",")[0].strip().lower()
+            except UnicodeDecodeError:
+                return ""
+    return scope.get("scheme", "")
+
+
 class SecurityHeadersMiddleware:
     """ASGI middleware that injects security response headers."""
 
@@ -124,16 +176,20 @@ class SecurityHeadersMiddleware:
             await self.app(scope, receive, send)
             return
 
+        is_https = _scheme_from_scope(scope) == "https"
+
         async def send_wrapper(message: Any) -> None:
             if message["type"] == "http.response.start":
                 headers = list(message.get("headers", []))
-                self._inject(headers)
+                self._inject(headers, is_https=is_https)
                 message = {**message, "headers": headers}
             await send(message)
 
         await self.app(scope, receive, send_wrapper)
 
-    def _inject(self, headers: list[tuple[bytes, bytes]]) -> None:
+    def _inject(
+        self, headers: list[tuple[bytes, bytes]], *, is_https: bool
+    ) -> None:
         existing = {name.lower() for name, _ in headers}
 
         def add(name: bytes, value: str) -> None:
@@ -149,8 +205,16 @@ class SecurityHeadersMiddleware:
                 add(header, value)
         if cfg.csp_enabled and cfg.csp_value:
             add(b"content-security-policy", cfg.csp_value)
-        if cfg.hsts_enabled:
+        # Browsers ignore HSTS on plain HTTP; auditors flag emission as
+        # misconfiguration. Gate on the effective request scheme.
+        if cfg.hsts_enabled and is_https:
             add(b"strict-transport-security", cfg.hsts_value())
+        if cfg.suppress_server_header:
+            # Strip the upstream Server fingerprint if present.
+            for i, (name, _) in enumerate(headers):
+                if name.lower() == b"server":
+                    headers[i] = (b"server", b"")
+                    break
 
 
 __all__ = [

--- a/engine/api/security_headers.py
+++ b/engine/api/security_headers.py
@@ -1,0 +1,160 @@
+"""Security response headers middleware.
+
+Emits a defensive default for Content-Security-Policy plus the standard
+hardening headers (HSTS, X-Content-Type-Options, X-Frame-Options,
+Referrer-Policy, Permissions-Policy). Each header is opt-out via
+:class:`SecurityHeadersConfig` so endpoints that intentionally serve
+embeddable widgets / cross-origin assets can override.
+
+CSRF protection is not enforced here — auth/session layers handle that
+at the dependency level. This module is purely about response-header
+hardening.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp
+
+
+_CSP_DIRECTIVE_ORDER = (
+    "default_src",
+    "script_src",
+    "style_src",
+    "img_src",
+    "font_src",
+    "connect_src",
+    "frame_src",
+    "object_src",
+    "base_uri",
+    "form_action",
+    "frame_ancestors",
+    "media_src",
+    "worker_src",
+    "manifest_src",
+)
+
+
+def build_csp(
+    *,
+    default_src: tuple[str, ...] = ("'self'",),
+    script_src: tuple[str, ...] = ("'self'",),
+    style_src: tuple[str, ...] = ("'self'", "'unsafe-inline'"),
+    img_src: tuple[str, ...] = ("'self'", "data:", "https:"),
+    font_src: tuple[str, ...] = ("'self'", "https:", "data:"),
+    connect_src: tuple[str, ...] = ("'self'",),
+    frame_src: tuple[str, ...] = ("'none'",),
+    object_src: tuple[str, ...] = ("'none'",),
+    base_uri: tuple[str, ...] = ("'self'",),
+    form_action: tuple[str, ...] = ("'self'",),
+    frame_ancestors: tuple[str, ...] = ("'none'",),
+    media_src: tuple[str, ...] | None = None,
+    worker_src: tuple[str, ...] | None = None,
+    manifest_src: tuple[str, ...] | None = None,
+) -> str:
+    """Compose a CSP header value from per-directive source lists.
+
+    ``style_src`` defaults allow ``'unsafe-inline'`` because most
+    component libraries (FastAPI's Swagger UI included) ship inline
+    style attributes; ``script_src`` deliberately does NOT — JS should
+    run only from the same origin or a nonce-bound bundle.
+    """
+    parts: list[str] = []
+    locals_ = locals()
+    for name in _CSP_DIRECTIVE_ORDER:
+        value = locals_.get(name)
+        if value is None:
+            continue
+        directive = name.replace("_", "-")
+        parts.append(f"{directive} {' '.join(value)}")
+    return "; ".join(parts)
+
+
+@dataclass(frozen=True)
+class SecurityHeadersConfig:
+    """Toggle individual headers.
+
+    Defaults are tightened for an API that serves only its own SPA and
+    documentation; endpoints that need looser policies should override.
+    """
+
+    csp_enabled: bool = True
+    csp_value: str = field(default_factory=build_csp)
+    hsts_enabled: bool = True
+    hsts_max_age: int = 31_536_000  # 1 year
+    hsts_include_subdomains: bool = True
+    hsts_preload: bool = False
+    x_content_type_options: str = "nosniff"
+    x_frame_options: str = "DENY"
+    referrer_policy: str = "strict-origin-when-cross-origin"
+    permissions_policy: str = (
+        "camera=(), microphone=(), geolocation=(), payment=(), usb=(), "
+        "interest-cohort=()"
+    )
+
+    def hsts_value(self) -> str:
+        parts = [f"max-age={self.hsts_max_age}"]
+        if self.hsts_include_subdomains:
+            parts.append("includeSubDomains")
+        if self.hsts_preload:
+            parts.append("preload")
+        return "; ".join(parts)
+
+
+_STATIC_HEADERS: tuple[tuple[bytes, str], ...] = (
+    (b"x-content-type-options", "x_content_type_options"),
+    (b"x-frame-options", "x_frame_options"),
+    (b"referrer-policy", "referrer_policy"),
+    (b"permissions-policy", "permissions_policy"),
+)
+
+
+class SecurityHeadersMiddleware:
+    """ASGI middleware that injects security response headers."""
+
+    def __init__(self, app: ASGIApp, config: SecurityHeadersConfig) -> None:
+        self.app = app
+        self.config = config
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_wrapper(message: Any) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                self._inject(headers)
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+    def _inject(self, headers: list[tuple[bytes, bytes]]) -> None:
+        existing = {name.lower() for name, _ in headers}
+
+        def add(name: bytes, value: str) -> None:
+            if name in existing:
+                return
+            headers.append((name, value.encode("latin-1")))
+            existing.add(name)
+
+        cfg = self.config
+        for header, attr in _STATIC_HEADERS:
+            value = getattr(cfg, attr)
+            if value:
+                add(header, value)
+        if cfg.csp_enabled and cfg.csp_value:
+            add(b"content-security-policy", cfg.csp_value)
+        if cfg.hsts_enabled:
+            add(b"strict-transport-security", cfg.hsts_value())
+
+
+__all__ = [
+    "SecurityHeadersConfig",
+    "SecurityHeadersMiddleware",
+    "build_csp",
+]

--- a/engine/app.py
+++ b/engine/app.py
@@ -12,6 +12,10 @@ from engine.api.auth.local import LocalAuthProvider
 from engine.api.auth.registry import AuthProviderRegistry
 from engine.api.rate_limit import RateLimitConfig, RateLimitMiddleware
 from engine.api.router import api_router
+from engine.api.security_headers import (
+    SecurityHeadersConfig,
+    SecurityHeadersMiddleware,
+)
 from engine.config import settings
 from engine.data.providers import (
     AssetClass,
@@ -134,6 +138,10 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    app.add_middleware(
+        SecurityHeadersMiddleware,
+        config=SecurityHeadersConfig(),
+    )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_origins,

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,160 @@
+"""Tests for engine.api.security_headers — security response headers."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from engine.api.security_headers import (
+    SecurityHeadersConfig,
+    SecurityHeadersMiddleware,
+    build_csp,
+)
+
+
+def _build_app(config: SecurityHeadersConfig | None = None) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        SecurityHeadersMiddleware,
+        config=config or SecurityHeadersConfig(),
+    )
+
+    @app.get("/x")
+    async def x() -> dict:
+        return {"ok": True}
+
+    return app
+
+
+@pytest.fixture
+async def client():
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+class TestStaticHeaders:
+    @pytest.mark.asyncio
+    async def test_x_content_type_options_nosniff(self, client: AsyncClient):
+        r = await client.get("/x")
+        assert r.headers.get("X-Content-Type-Options") == "nosniff"
+
+    @pytest.mark.asyncio
+    async def test_x_frame_options_deny(self, client: AsyncClient):
+        r = await client.get("/x")
+        assert r.headers.get("X-Frame-Options") == "DENY"
+
+    @pytest.mark.asyncio
+    async def test_referrer_policy(self, client: AsyncClient):
+        r = await client.get("/x")
+        assert r.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+
+    @pytest.mark.asyncio
+    async def test_permissions_policy_locks_dangerous_apis(
+        self, client: AsyncClient
+    ):
+        r = await client.get("/x")
+        pp = r.headers.get("Permissions-Policy", "")
+        for token in ("camera=()", "microphone=()", "geolocation=()"):
+            assert token in pp
+
+
+class TestHSTS:
+    @pytest.mark.asyncio
+    async def test_hsts_present_when_enabled(self):
+        app = _build_app(SecurityHeadersConfig(hsts_enabled=True))
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            r = await ac.get("/x")
+        v = r.headers.get("Strict-Transport-Security", "")
+        assert "max-age=" in v
+        assert "includeSubDomains" in v
+
+    @pytest.mark.asyncio
+    async def test_hsts_omitted_when_disabled(self):
+        app = _build_app(SecurityHeadersConfig(hsts_enabled=False))
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            r = await ac.get("/x")
+        assert "Strict-Transport-Security" not in r.headers
+
+
+class TestCSP:
+    @pytest.mark.asyncio
+    async def test_csp_default_includes_self(self, client: AsyncClient):
+        r = await client.get("/x")
+        csp = r.headers.get("Content-Security-Policy", "")
+        assert "default-src 'self'" in csp
+
+    @pytest.mark.asyncio
+    async def test_csp_blocks_object_src(self, client: AsyncClient):
+        r = await client.get("/x")
+        csp = r.headers.get("Content-Security-Policy", "")
+        assert "object-src 'none'" in csp
+
+    @pytest.mark.asyncio
+    async def test_csp_blocks_frame_ancestors(self, client: AsyncClient):
+        r = await client.get("/x")
+        csp = r.headers.get("Content-Security-Policy", "")
+        assert "frame-ancestors 'none'" in csp
+
+    @pytest.mark.asyncio
+    async def test_csp_can_be_disabled(self):
+        app = _build_app(SecurityHeadersConfig(csp_enabled=False))
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            r = await ac.get("/x")
+        assert "Content-Security-Policy" not in r.headers
+
+
+class TestCSPBuilder:
+    def test_build_csp_basic(self):
+        csp = build_csp(default_src=("'self'",), img_src=("'self'", "data:"))
+        assert "default-src 'self'" in csp
+        assert "img-src 'self' data:" in csp
+
+    def test_build_csp_omits_unsafe_inline_for_script_by_default(self):
+        csp = build_csp()
+        script_segment = csp.split("script-src", 1)[-1].split(";", 1)[0]
+        assert "'unsafe-inline'" not in script_segment
+
+
+class TestExistingHeadersNotOverwritten:
+    @pytest.mark.asyncio
+    async def test_pre_set_csp_is_preserved(self):
+        from fastapi import Response
+
+        app = FastAPI()
+        app.add_middleware(
+            SecurityHeadersMiddleware, config=SecurityHeadersConfig()
+        )
+
+        @app.get("/y")
+        async def y() -> Response:
+            r = Response('{"ok":true}', media_type="application/json")
+            r.headers["Content-Security-Policy"] = "custom"
+            return r
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            r = await ac.get("/y")
+        assert r.headers.get("Content-Security-Policy") == "custom"
+
+
+class TestNoLeakOnNon200:
+    @pytest.mark.asyncio
+    async def test_404_still_carries_security_headers(self):
+        app = _build_app()
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            r = await ac.get("/missing")
+        assert r.status_code == 404
+        assert r.headers.get("X-Content-Type-Options") == "nosniff"

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -64,10 +64,12 @@ class TestStaticHeaders:
 
 class TestHSTS:
     @pytest.mark.asyncio
-    async def test_hsts_present_when_enabled(self):
+    async def test_hsts_present_when_enabled_over_https(self):
+        # Browsers ignore HSTS over HTTP; emit only when scheme is https
+        # (or X-Forwarded-Proto: https when behind a TLS-terminating proxy).
         app = _build_app(SecurityHeadersConfig(hsts_enabled=True))
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url="https://test"
         ) as ac:
             r = await ac.get("/x")
         v = r.headers.get("Strict-Transport-Security", "")
@@ -75,10 +77,30 @@ class TestHSTS:
         assert "includeSubDomains" in v
 
     @pytest.mark.asyncio
+    async def test_hsts_present_via_x_forwarded_proto(self):
+        # TLS-terminating proxy forwards plain HTTP to the app but flags
+        # the original scheme via X-Forwarded-Proto. HSTS must still emit.
+        app = _build_app(SecurityHeadersConfig(hsts_enabled=True))
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            r = await ac.get("/x", headers={"X-Forwarded-Proto": "https"})
+        assert "Strict-Transport-Security" in r.headers
+
+    @pytest.mark.asyncio
+    async def test_hsts_omitted_on_plain_http(self):
+        app = _build_app(SecurityHeadersConfig(hsts_enabled=True))
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            r = await ac.get("/x")
+        assert "Strict-Transport-Security" not in r.headers
+
+    @pytest.mark.asyncio
     async def test_hsts_omitted_when_disabled(self):
         app = _build_app(SecurityHeadersConfig(hsts_enabled=False))
         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
+            transport=ASGITransport(app=app), base_url="https://test"
         ) as ac:
             r = await ac.get("/x")
         assert "Strict-Transport-Security" not in r.headers
@@ -123,6 +145,61 @@ class TestCSPBuilder:
         csp = build_csp()
         script_segment = csp.split("script-src", 1)[-1].split(";", 1)[0]
         assert "'unsafe-inline'" not in script_segment
+
+    def test_build_csp_includes_upgrade_insecure_requests(self):
+        csp = build_csp()
+        assert "upgrade-insecure-requests" in csp
+
+    def test_build_csp_includes_report_uri_when_set(self):
+        csp = build_csp(report_uri="/csp-report")
+        assert "report-uri /csp-report" in csp
+
+    def test_build_csp_rejects_unsafe_inline_in_script_src(self):
+        with pytest.raises(ValueError, match="script_src"):
+            build_csp(script_src=("'self'", "'unsafe-inline'"))
+
+    def test_build_csp_rejects_unsafe_eval_in_script_src(self):
+        with pytest.raises(ValueError, match="script_src"):
+            build_csp(script_src=("'self'", "'unsafe-eval'"))
+
+    def test_build_csp_rejects_wildcard_in_script_src(self):
+        with pytest.raises(ValueError, match="script_src"):
+            build_csp(script_src=("*",))
+
+    def test_build_csp_rejects_wildcard_in_default_src(self):
+        with pytest.raises(ValueError, match="default_src"):
+            build_csp(default_src=("*",))
+
+
+class TestPermissionsPolicy:
+    @pytest.mark.asyncio
+    async def test_browsing_topics_disabled(self, client: AsyncClient):
+        # Topics API replaced FLoC; the new opt-out token must be present.
+        r = await client.get("/x")
+        assert "browsing-topics=()" in r.headers.get("Permissions-Policy", "")
+
+
+class TestServerHeaderSuppression:
+    @pytest.mark.asyncio
+    async def test_server_header_blanked(self):
+        # An upstream `Server: uvicorn` should not leak through.
+        from fastapi import Response
+
+        app = FastAPI()
+        app.add_middleware(SecurityHeadersMiddleware, config=SecurityHeadersConfig())
+
+        @app.get("/leaky")
+        async def leaky() -> Response:
+            r = Response('{"ok":true}', media_type="application/json")
+            r.headers["Server"] = "uvicorn/0.99"
+            return r
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/leaky")
+        # Either absent or empty — never carrying the runtime fingerprint.
+        assert resp.headers.get("Server", "") == ""
 
 
 class TestExistingHeadersNotOverwritten:


### PR DESCRIPTION
## Summary

Closes #128 (security headers part). Adds \`SecurityHeadersMiddleware\` that injects defensive defaults on every HTTP response.

### Headers emitted

| Header | Default |
|---|---|
| Content-Security-Policy | \`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https: data:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'\` |
| Strict-Transport-Security | \`max-age=31536000; includeSubDomains\` |
| X-Content-Type-Options | \`nosniff\` |
| X-Frame-Options | \`DENY\` |
| Referrer-Policy | \`strict-origin-when-cross-origin\` |
| Permissions-Policy | \`camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()\` |

\`script-src\` deliberately omits \`'unsafe-inline'\` — JS runs only from same-origin or nonce-bound bundles. \`style-src\` includes it because component libraries (Swagger UI etc.) ship inline style attributes.

### Out of scope

CORS is already configured via FastAPI \`CORSMiddleware\`. CSRF enforcement (double-submit / origin check) is auth-dependency territory, not response-header — handled separately in #127 session management work. This PR is purely response-header hardening.

### Test plan

- [x] 14 tests covering each header, HSTS toggle, CSP builder, header preservation, 404 propagation
- [x] Full suite — 727 passed
- [x] \`ruff\` + \`basedpyright\` clean
- [ ] Adversarial review next

🤖 Generated with [Claude Code](https://claude.com/claude-code)