### PR TITLE
feat(api): session lifecycle + concurrent-session enforcement (#127)

### DIFF
--- a/engine/api/sessions.py
+++ b/engine/api/sessions.py
@@ -1,0 +1,197 @@
+"""Session lifecycle management.
+
+Models a user session as a typed entity with idle and absolute timeouts,
+concurrent-session caps with oldest-first eviction, and explicit revoke.
+The store layer is a Protocol so the in-memory backend (suitable for
+tests + single-pod) and a Valkey-backed backend (multi-pod, follow-up)
+share the same surface.
+
+Privacy:
+- ``ip`` and ``user_agent`` are hashed (HMAC-SHA-256 with a runtime
+  salt) before persistence so an exfiltrated session row cannot be
+  correlated back to a client without the salt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import uuid  # noqa: TC003 - referenced as uuid.UUID at runtime via dataclass
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def hash_ip(ip: str, *, salt: str) -> str:
+    """HMAC-SHA-256 of an IP under a server-side salt."""
+    return hmac.new(salt.encode("utf-8"), ip.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def hash_user_agent(ua: str, *, salt: str) -> str:
+    """HMAC-SHA-256 of a User-Agent string under a server-side salt."""
+    return hmac.new(salt.encode("utf-8"), ua.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+@dataclass(frozen=True)
+class Session:
+    """One session entity. Frozen — the store replaces records on update."""
+
+    id: str
+    user_id: uuid.UUID
+    device_label: str
+    ip_hash: str
+    ua_hash: str
+    created_at: datetime
+    last_active_at: datetime
+    revoked: bool = False
+
+
+@dataclass(frozen=True)
+class SessionConfig:
+    """Idle / absolute timeouts plus concurrent-session cap."""
+
+    idle_timeout_sec: int = 900  # 15 min
+    absolute_timeout_sec: int = 86_400  # 24 h
+    max_concurrent: int = 5
+    privacy_salt: str = field(default_factory=lambda: secrets.token_hex(16))
+
+
+class SessionExpiredError(Exception):
+    """Raised when a session has exceeded its idle or absolute timeout."""
+
+
+class SessionRevokedError(Exception):
+    """Raised when an operation targets a revoked session."""
+
+
+class SessionStore(Protocol):
+    """Pluggable persistence layer for sessions."""
+
+    async def get(self, session_id: str) -> Session | None: ...
+    async def save(self, session: Session) -> None: ...
+    async def list_for_user(self, user_id: uuid.UUID) -> list[Session]: ...
+
+
+class InMemorySessionStore:
+    """Process-local store. Not for multi-pod — use a Valkey backend."""
+
+    def __init__(self) -> None:
+        self._by_id: dict[str, Session] = {}
+
+    async def get(self, session_id: str) -> Session | None:
+        return self._by_id.get(session_id)
+
+    async def save(self, session: Session) -> None:
+        self._by_id[session.id] = session
+
+    async def list_for_user(self, user_id: uuid.UUID) -> list[Session]:
+        return [s for s in self._by_id.values() if s.user_id == user_id]
+
+
+class SessionService:
+    """Lifecycle operations on top of a SessionStore."""
+
+    def __init__(self, store: SessionStore, config: SessionConfig) -> None:
+        self.store = store
+        self.config = config
+
+    async def create(
+        self,
+        user_id: uuid.UUID,
+        device_label: str,
+        ip: str,
+        user_agent: str,
+    ) -> Session:
+        """Create a new session, enforcing the concurrent-session cap.
+
+        When the user already has ``max_concurrent`` active sessions, the
+        oldest one is revoked first.
+        """
+        await self._evict_to_make_room(user_id)
+        salt = self.config.privacy_salt
+        now = _now()
+        sess = Session(
+            id=secrets.token_urlsafe(32),
+            user_id=user_id,
+            device_label=device_label,
+            ip_hash=hash_ip(ip, salt=salt),
+            ua_hash=hash_user_agent(user_agent, salt=salt),
+            created_at=now,
+            last_active_at=now,
+            revoked=False,
+        )
+        await self.store.save(sess)
+        return sess
+
+    async def get(self, session_id: str) -> Session | None:
+        return await self.store.get(session_id)
+
+    async def touch(self, session_id: str) -> Session:
+        """Mark a session as recently active. Raises if expired or revoked."""
+        s = await self.store.get(session_id)
+        if s is None:
+            msg = f"unknown session {session_id}"
+            raise SessionRevokedError(msg)
+        if s.revoked:
+            raise SessionRevokedError(s.id)
+        now = _now()
+        if (now - s.last_active_at).total_seconds() > self.config.idle_timeout_sec:
+            raise SessionExpiredError(s.id)
+        if (now - s.created_at).total_seconds() > self.config.absolute_timeout_sec:
+            raise SessionExpiredError(s.id)
+        updated = replace(s, last_active_at=now)
+        await self.store.save(updated)
+        return updated
+
+    async def revoke(self, session_id: str) -> None:
+        s = await self.store.get(session_id)
+        if s is None:
+            return
+        await self.store.save(replace(s, revoked=True))
+
+    async def revoke_all_for_user(self, user_id: uuid.UUID) -> int:
+        sessions = await self.store.list_for_user(user_id)
+        count = 0
+        for s in sessions:
+            if not s.revoked:
+                await self.store.save(replace(s, revoked=True))
+                count += 1
+        return count
+
+    async def list_active_for_user(self, user_id: uuid.UUID) -> list[Session]:
+        all_for_user = await self.store.list_for_user(user_id)
+        return [s for s in all_for_user if not s.revoked]
+
+    async def _evict_to_make_room(self, user_id: uuid.UUID) -> None:
+        """If at the cap, revoke the oldest active session."""
+        active = await self.list_active_for_user(user_id)
+        if len(active) < self.config.max_concurrent:
+            return
+        oldest = min(active, key=lambda s: s.created_at)
+        await self.store.save(replace(oldest, revoked=True))
+
+
+__all__ = [
+    "InMemorySessionStore",
+    "Session",
+    "SessionConfig",
+    "SessionExpiredError",
+    "SessionRevokedError",
+    "SessionService",
+    "SessionStore",
+    "hash_ip",
+    "hash_user_agent",
+]
+
+
+def _iter_active(sessions: Iterable[Session]) -> Iterable[Session]:
+    """Helper retained as a future hook for the Valkey backend."""
+    return (s for s in sessions if not s.revoked)

--- a/engine/api/sessions.py
+++ b/engine/api/sessions.py
@@ -10,14 +10,30 @@ Privacy:
 - ``ip`` and ``user_agent`` are hashed (HMAC-SHA-256 with a runtime
   salt) before persistence so an exfiltrated session row cannot be
   correlated back to a client without the salt.
+- ``privacy_salt`` must be supplied explicitly in production via
+  configuration so all pods share the same salt and IP / UA hashes
+  remain comparable. ``SessionConfig`` only generates a random salt as
+  a development convenience.
+
+Concurrency:
+- ``SessionService`` serializes per-user mutations via an
+  ``asyncio.Lock`` so concurrent ``create``/``touch``/``revoke`` calls
+  never lose updates or bypass the concurrent-session cap.
+
+Caller responsibilities:
+- On privilege elevation (login, role change, MFA pass) the caller MUST
+  invoke ``revoke_all_for_user`` *before* ``create`` to defeat session
+  fixation. This module does not enforce that policy itself.
 """
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import secrets
 import uuid  # noqa: TC003 - referenced as uuid.UUID at runtime via dataclass
+from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol
@@ -54,13 +70,29 @@ class Session:
     revoked: bool = False
 
 
+_MAX_DEVICE_LABEL_LEN = 256
+_MAX_IP_LEN = 64  # IPv6 + brackets fit; longer strings are rejected
+_MAX_UA_LEN = 512
+
+
 @dataclass(frozen=True)
 class SessionConfig:
-    """Idle / absolute timeouts plus concurrent-session cap."""
+    """Idle / absolute timeouts plus concurrent-session cap.
+
+    ``privacy_salt`` defaults to a per-process random value for
+    development convenience. Production deployments must supply a
+    stable salt via configuration so IP / UA hashes are consistent
+    across pods.
+    """
 
     idle_timeout_sec: int = 900  # 15 min
     absolute_timeout_sec: int = 86_400  # 24 h
+    # 32 bytes = 256 bits of CSPRNG entropy in the encoded session id.
     max_concurrent: int = 5
+    # Total stored sessions per user (active + revoked). Prevents
+    # unbounded growth from long-lived users that accumulate revoked
+    # records over time.
+    max_total_per_user: int = 1_000
     privacy_salt: str = field(default_factory=lambda: secrets.token_hex(16))
 
 
@@ -70,6 +102,10 @@ class SessionExpiredError(Exception):
 
 class SessionRevokedError(Exception):
     """Raised when an operation targets a revoked session."""
+
+
+class SessionNotFoundError(Exception):
+    """Raised when a referenced session does not exist."""
 
 
 class SessionStore(Protocol):
@@ -83,25 +119,61 @@ class SessionStore(Protocol):
 class InMemorySessionStore:
     """Process-local store. Not for multi-pod — use a Valkey backend."""
 
-    def __init__(self) -> None:
+    def __init__(self, max_total_per_user: int = 1_000) -> None:
         self._by_id: dict[str, Session] = {}
+        # Secondary index so list_for_user is O(user-sessions) instead
+        # of O(global-sessions). Append-only oldest-first; eviction is
+        # the responsibility of the SessionService caller.
+        self._by_user: dict[uuid.UUID, list[str]] = defaultdict(list)
+        self._max_total_per_user = max_total_per_user
 
     async def get(self, session_id: str) -> Session | None:
         return self._by_id.get(session_id)
 
     async def save(self, session: Session) -> None:
+        if session.id not in self._by_id:
+            ids = self._by_user[session.user_id]
+            ids.append(session.id)
+            # Hard cap on total stored records per user to bound memory.
+            while len(ids) > self._max_total_per_user:
+                drop = ids.pop(0)
+                self._by_id.pop(drop, None)
         self._by_id[session.id] = session
 
     async def list_for_user(self, user_id: uuid.UUID) -> list[Session]:
-        return [s for s in self._by_id.values() if s.user_id == user_id]
+        ids = self._by_user.get(user_id, ())
+        return [self._by_id[i] for i in ids if i in self._by_id]
 
 
 class SessionService:
-    """Lifecycle operations on top of a SessionStore."""
+    """Lifecycle operations on top of a SessionStore.
+
+    Per-user mutations are serialized through an ``asyncio.Lock`` to
+    prevent the concurrent-create race that would otherwise let a user
+    exceed ``max_concurrent``, and the touch/revoke lost-update race
+    that would resurrect a revoked session.
+    """
 
     def __init__(self, store: SessionStore, config: SessionConfig) -> None:
         self.store = store
         self.config = config
+        self._user_locks: dict[uuid.UUID, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._global_lock = asyncio.Lock()
+
+    def _user_lock(self, user_id: uuid.UUID) -> asyncio.Lock:
+        return self._user_locks[user_id]
+
+    @staticmethod
+    def _validate_input(device_label: str, ip: str, user_agent: str) -> None:
+        if len(device_label) > _MAX_DEVICE_LABEL_LEN:
+            msg = f"device_label exceeds {_MAX_DEVICE_LABEL_LEN} chars"
+            raise ValueError(msg)
+        if len(ip) > _MAX_IP_LEN:
+            msg = f"ip exceeds {_MAX_IP_LEN} chars"
+            raise ValueError(msg)
+        if len(user_agent) > _MAX_UA_LEN:
+            msg = f"user_agent exceeds {_MAX_UA_LEN} chars"
+            raise ValueError(msg)
 
     async def create(
         self,
@@ -112,24 +184,27 @@ class SessionService:
     ) -> Session:
         """Create a new session, enforcing the concurrent-session cap.
 
-        When the user already has ``max_concurrent`` active sessions, the
-        oldest one is revoked first.
+        Caller must invoke ``revoke_all_for_user`` first when the user
+        is re-authenticating (password reset, MFA pass, etc.) to defeat
+        session-fixation attacks.
         """
-        await self._evict_to_make_room(user_id)
-        salt = self.config.privacy_salt
-        now = _now()
-        sess = Session(
-            id=secrets.token_urlsafe(32),
-            user_id=user_id,
-            device_label=device_label,
-            ip_hash=hash_ip(ip, salt=salt),
-            ua_hash=hash_user_agent(user_agent, salt=salt),
-            created_at=now,
-            last_active_at=now,
-            revoked=False,
-        )
-        await self.store.save(sess)
-        return sess
+        self._validate_input(device_label, ip, user_agent)
+        async with self._user_lock(user_id):
+            await self._evict_to_make_room_locked(user_id)
+            salt = self.config.privacy_salt
+            now = _now()
+            sess = Session(
+                id=secrets.token_urlsafe(32),
+                user_id=user_id,
+                device_label=device_label,
+                ip_hash=hash_ip(ip, salt=salt),
+                ua_hash=hash_user_agent(user_agent, salt=salt),
+                created_at=now,
+                last_active_at=now,
+                revoked=False,
+            )
+            await self.store.save(sess)
+            return sess
 
     async def get(self, session_id: str) -> Session | None:
         return await self.store.get(session_id)
@@ -138,40 +213,54 @@ class SessionService:
         """Mark a session as recently active. Raises if expired or revoked."""
         s = await self.store.get(session_id)
         if s is None:
-            msg = f"unknown session {session_id}"
-            raise SessionRevokedError(msg)
-        if s.revoked:
-            raise SessionRevokedError(s.id)
-        now = _now()
-        if (now - s.last_active_at).total_seconds() > self.config.idle_timeout_sec:
-            raise SessionExpiredError(s.id)
-        if (now - s.created_at).total_seconds() > self.config.absolute_timeout_sec:
-            raise SessionExpiredError(s.id)
-        updated = replace(s, last_active_at=now)
-        await self.store.save(updated)
-        return updated
+            raise SessionNotFoundError("session not found")
+        async with self._user_lock(s.user_id):
+            # Re-fetch under the lock so a concurrent revoke between
+            # the initial read and the save cannot be silently
+            # overwritten.
+            s = await self.store.get(session_id)
+            if s is None:
+                raise SessionNotFoundError("session not found")
+            if s.revoked:
+                raise SessionRevokedError("session is revoked")
+            now = _now()
+            if (now - s.last_active_at).total_seconds() > self.config.idle_timeout_sec:
+                raise SessionExpiredError("session has expired")
+            if (now - s.created_at).total_seconds() > self.config.absolute_timeout_sec:
+                raise SessionExpiredError("session has expired")
+            updated = replace(s, last_active_at=now)
+            await self.store.save(updated)
+            return updated
 
     async def revoke(self, session_id: str) -> None:
         s = await self.store.get(session_id)
         if s is None:
             return
-        await self.store.save(replace(s, revoked=True))
+        async with self._user_lock(s.user_id):
+            current = await self.store.get(session_id)
+            if current is None or current.revoked:
+                return
+            await self.store.save(replace(current, revoked=True))
 
     async def revoke_all_for_user(self, user_id: uuid.UUID) -> int:
-        sessions = await self.store.list_for_user(user_id)
-        count = 0
-        for s in sessions:
-            if not s.revoked:
-                await self.store.save(replace(s, revoked=True))
-                count += 1
-        return count
+        async with self._user_lock(user_id):
+            sessions = await self.store.list_for_user(user_id)
+            count = 0
+            for s in sessions:
+                if not s.revoked:
+                    await self.store.save(replace(s, revoked=True))
+                    count += 1
+            return count
 
     async def list_active_for_user(self, user_id: uuid.UUID) -> list[Session]:
         all_for_user = await self.store.list_for_user(user_id)
         return [s for s in all_for_user if not s.revoked]
 
-    async def _evict_to_make_room(self, user_id: uuid.UUID) -> None:
-        """If at the cap, revoke the oldest active session."""
+    async def _evict_to_make_room_locked(self, user_id: uuid.UUID) -> None:
+        """If at the cap, revoke the oldest active session.
+
+        Must be called while holding the per-user lock.
+        """
         active = await self.list_active_for_user(user_id)
         if len(active) < self.config.max_concurrent:
             return
@@ -184,6 +273,7 @@ __all__ = [
     "Session",
     "SessionConfig",
     "SessionExpiredError",
+    "SessionNotFoundError",
     "SessionRevokedError",
     "SessionService",
     "SessionStore",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -12,6 +12,7 @@ from engine.api.sessions import (
     Session,
     SessionConfig,
     SessionExpiredError,
+    SessionNotFoundError,
     SessionRevokedError,
     SessionService,
     hash_ip,
@@ -208,6 +209,102 @@ class TestPrivacyHashing:
         a = hash_ip("203.0.113.42", salt="s1")
         b = hash_ip("203.0.113.42", salt="s2")
         assert a != b
+
+
+class TestInputValidation:
+    @pytest.mark.asyncio
+    async def test_oversize_device_label_rejected(self, service: SessionService):
+        with pytest.raises(ValueError, match="device_label"):
+            await service.create(
+                _user(), "x" * 1000, "1.2.3.4", "ua"
+            )
+
+    @pytest.mark.asyncio
+    async def test_oversize_ip_rejected(self, service: SessionService):
+        with pytest.raises(ValueError, match="ip"):
+            await service.create(_user(), "d", "1." * 200, "ua")
+
+    @pytest.mark.asyncio
+    async def test_oversize_user_agent_rejected(self, service: SessionService):
+        with pytest.raises(ValueError, match="user_agent"):
+            await service.create(_user(), "d", "1.2.3.4", "ua" * 1000)
+
+
+class TestNotFoundDistinctFromRevoked:
+    @pytest.mark.asyncio
+    async def test_unknown_session_raises_not_found(
+        self, service: SessionService
+    ):
+        with pytest.raises(SessionNotFoundError):
+            await service.touch("definitely-not-real")
+
+    @pytest.mark.asyncio
+    async def test_error_messages_do_not_leak_token(
+        self, service: SessionService
+    ):
+        s = await service.create(_user(), "d", "1.2.3.4", "ua")
+        await service.revoke(s.id)
+        with pytest.raises(SessionRevokedError) as exc:
+            await service.touch(s.id)
+        assert s.id not in str(exc.value)
+
+
+class TestConcurrencySafety:
+    @pytest.mark.asyncio
+    async def test_concurrent_creates_respect_cap(self, store):
+        import asyncio
+
+        svc = SessionService(
+            store=store,
+            config=SessionConfig(
+                idle_timeout_sec=900,
+                absolute_timeout_sec=86_400,
+                max_concurrent=2,
+            ),
+        )
+        u = _user()
+        await asyncio.gather(
+            *(svc.create(u, f"d-{i}", "1.2.3.4", "ua") for i in range(10))
+        )
+        active = await svc.list_active_for_user(u)
+        assert len(active) <= 2
+
+    @pytest.mark.asyncio
+    async def test_revoke_during_touch_wins(self, service: SessionService):
+        import asyncio
+
+        s = await service.create(_user(), "d", "1.2.3.4", "ua")
+
+        async def touch_loop():
+            for _ in range(20):
+                try:
+                    await service.touch(s.id)
+                except SessionRevokedError:
+                    return
+
+        async def revoke_once():
+            await service.revoke(s.id)
+
+        await asyncio.gather(touch_loop(), revoke_once())
+        out = await service.get(s.id)
+        assert out is not None
+        # After revoke, no touch can resurrect the revoked flag.
+        assert out.revoked is True
+
+
+class TestStorePerUserBound:
+    @pytest.mark.asyncio
+    async def test_per_user_record_count_is_capped(self):
+        store = InMemorySessionStore(max_total_per_user=4)
+        svc = SessionService(
+            store=store,
+            config=SessionConfig(max_concurrent=4, max_total_per_user=4),
+        )
+        u = _user()
+        for i in range(10):
+            await svc.create(u, f"d-{i}", "1.2.3.4", "ua")
+        all_for_user = await store.list_for_user(u)
+        assert len(all_for_user) <= 4
 
 
 class TestSessionEntity:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,226 @@
+"""Tests for engine.api.sessions — session lifecycle + concurrent limits."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from engine.api.sessions import (
+    InMemorySessionStore,
+    Session,
+    SessionConfig,
+    SessionExpiredError,
+    SessionRevokedError,
+    SessionService,
+    hash_ip,
+    hash_user_agent,
+)
+
+
+def _user() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def store():
+    return InMemorySessionStore()
+
+
+@pytest.fixture
+def service(store):
+    return SessionService(
+        store=store,
+        config=SessionConfig(
+            idle_timeout_sec=900,
+            absolute_timeout_sec=86_400,
+            max_concurrent=3,
+        ),
+    )
+
+
+class TestCreateAndRetrieve:
+    @pytest.mark.asyncio
+    async def test_create_returns_session_with_id(self, service: SessionService):
+        s = await service.create(
+            user_id=_user(),
+            device_label="iPhone",
+            ip="1.2.3.4",
+            user_agent="Mozilla/5.0",
+        )
+        assert s.id
+        assert isinstance(s.id, str)
+        assert s.revoked is False
+
+    @pytest.mark.asyncio
+    async def test_get_returns_existing_session(self, service: SessionService):
+        s = await service.create(
+            user_id=_user(),
+            device_label="d",
+            ip="1.2.3.4",
+            user_agent="ua",
+        )
+        out = await service.get(s.id)
+        assert out is not None
+        assert out.id == s.id
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_for_unknown(self, service: SessionService):
+        assert await service.get("nope") is None
+
+
+class TestIdleTimeout:
+    @pytest.mark.asyncio
+    async def test_idle_timeout_expires_session(self, store):
+        svc = SessionService(
+            store=store,
+            config=SessionConfig(
+                idle_timeout_sec=10, absolute_timeout_sec=86_400
+            ),
+        )
+        s = await svc.create(_user(), "d", "1.2.3.4", "ua")
+        await store.save(
+            Session(
+                id=s.id,
+                user_id=s.user_id,
+                device_label=s.device_label,
+                ip_hash=s.ip_hash,
+                ua_hash=s.ua_hash,
+                created_at=s.created_at,
+                last_active_at=s.last_active_at - timedelta(seconds=11),
+                revoked=False,
+            )
+        )
+        with pytest.raises(SessionExpiredError):
+            await svc.touch(s.id)
+
+    @pytest.mark.asyncio
+    async def test_touch_extends_last_active(self, service: SessionService):
+        s = await service.create(_user(), "d", "1.2.3.4", "ua")
+        before = s.last_active_at
+        out = await service.touch(s.id)
+        assert out.last_active_at >= before
+
+
+class TestAbsoluteTimeout:
+    @pytest.mark.asyncio
+    async def test_absolute_timeout_kills_long_lived_session(self, store):
+        svc = SessionService(
+            store=store,
+            config=SessionConfig(
+                idle_timeout_sec=86_400, absolute_timeout_sec=10
+            ),
+        )
+        s = await svc.create(_user(), "d", "1.2.3.4", "ua")
+        await store.save(
+            Session(
+                id=s.id,
+                user_id=s.user_id,
+                device_label=s.device_label,
+                ip_hash=s.ip_hash,
+                ua_hash=s.ua_hash,
+                created_at=s.created_at - timedelta(seconds=11),
+                last_active_at=s.last_active_at,
+                revoked=False,
+            )
+        )
+        with pytest.raises(SessionExpiredError):
+            await svc.touch(s.id)
+
+
+class TestConcurrentLimit:
+    @pytest.mark.asyncio
+    async def test_creating_above_limit_revokes_oldest(self, store):
+        svc = SessionService(
+            store=store,
+            config=SessionConfig(
+                idle_timeout_sec=900,
+                absolute_timeout_sec=86_400,
+                max_concurrent=2,
+            ),
+        )
+        u = _user()
+        a = await svc.create(u, "phone", "1.2.3.4", "ua")
+        b = await svc.create(u, "laptop", "1.2.3.4", "ua")
+        c = await svc.create(u, "tablet", "1.2.3.4", "ua")
+        out_a = await store.get(a.id)
+        out_b = await store.get(b.id)
+        out_c = await store.get(c.id)
+        assert out_a is not None and out_a.revoked is True
+        assert out_b is not None and out_b.revoked is False
+        assert out_c is not None and out_c.revoked is False
+
+
+class TestRevocation:
+    @pytest.mark.asyncio
+    async def test_explicit_revoke_blocks_touch(self, service: SessionService):
+        s = await service.create(_user(), "d", "1.2.3.4", "ua")
+        await service.revoke(s.id)
+        with pytest.raises(SessionRevokedError):
+            await service.touch(s.id)
+
+    @pytest.mark.asyncio
+    async def test_revoke_all_for_user_kills_all_sessions(
+        self, service: SessionService, store
+    ):
+        u = _user()
+        a = await service.create(u, "a", "1.2.3.4", "ua")
+        b = await service.create(u, "b", "1.2.3.4", "ua")
+        n = await service.revoke_all_for_user(u)
+        assert n == 2
+        for sid in (a.id, b.id):
+            out = await store.get(sid)
+            assert out is not None and out.revoked is True
+
+
+class TestListing:
+    @pytest.mark.asyncio
+    async def test_list_for_user_excludes_revoked_by_default(
+        self, service: SessionService
+    ):
+        u = _user()
+        a = await service.create(u, "a", "1.2.3.4", "ua")
+        await service.create(u, "b", "1.2.3.4", "ua")
+        await service.revoke(a.id)
+        active = await service.list_active_for_user(u)
+        labels = [s.device_label for s in active]
+        assert "b" in labels
+        assert "a" not in labels
+
+
+class TestPrivacyHashing:
+    def test_ip_is_hashed_not_stored_plain(self):
+        h = hash_ip("203.0.113.42", salt="s1")
+        assert "203.0.113.42" not in h
+        assert len(h) >= 32
+
+    def test_user_agent_is_hashed(self):
+        h = hash_user_agent("Mozilla/5.0", salt="s1")
+        assert "Mozilla" not in h
+
+    def test_hashing_same_input_with_same_salt_is_stable(self):
+        a = hash_ip("203.0.113.42", salt="s1")
+        b = hash_ip("203.0.113.42", salt="s1")
+        assert a == b
+
+    def test_hashing_different_salts_differ(self):
+        a = hash_ip("203.0.113.42", salt="s1")
+        b = hash_ip("203.0.113.42", salt="s2")
+        assert a != b
+
+
+class TestSessionEntity:
+    def test_session_dataclass_fields(self):
+        s = Session(
+            id="x",
+            user_id=uuid.uuid4(),
+            device_label="d",
+            ip_hash="h1",
+            ua_hash="h2",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            revoked=False,
+        )
+        assert s.id == "x"
+        assert s.revoked is False


### PR DESCRIPTION
## Summary

Closes #127. Pure-Python session lifecycle layer: idle / absolute timeouts, concurrent-session cap with oldest-first eviction, explicit revoke, privacy-preserving IP / UA hashing. Storage layer is a Protocol so the in-memory backend (single-pod / tests) and a Valkey-backed backend (multi-pod, follow-up) share the same surface.

### What lands

- **\`Session\`** — frozen dataclass: id, user_id, device_label, ip_hash, ua_hash, created_at, last_active_at, revoked.
- **\`SessionConfig\`** — idle_timeout_sec=900, absolute_timeout_sec=86400, max_concurrent=5, privacy_salt (random per-process).
- **\`SessionStore\`** Protocol + **\`InMemorySessionStore\`**.
- **\`SessionService\`** — create / get / touch / revoke / revoke_all_for_user / list_active_for_user. \`create\` evicts oldest when at the cap. \`touch\` raises on expiry / revocation.
- **\`hash_ip\`** / **\`hash_user_agent\`** — HMAC-SHA-256 with a runtime salt.

### Out of scope (follow-up)

- Valkey-backed \`SessionStore\` for multi-pod deployments
- FastAPI dependency wiring + cookie/JWT integration
- Device-fingerprinting beyond UA hash
- Geo / risk-scoring on touch

### Test plan

- [x] 15 unit tests cover lifecycle, idle/absolute timeouts, concurrent cap eviction, revocation, listing, privacy hashing
- [x] Full suite — 752 passed
- [x] \`ruff\` + \`basedpyright\` clean
- [ ] Adversarial review next

🤖 Generated with [Claude Code](https://claude.com/claude-code)