### PR TITLE
feat(core): strategy versioning + rollback + immutable deployments (#125)

### DIFF
--- a/engine/core/strategy_versioning.py
+++ b/engine/core/strategy_versioning.py
@@ -40,9 +40,11 @@ from typing import Any, Protocol
 
 class VersionStatus(StrEnum):
     DRAFT = "draft"
-    STAGING = "staging"
     ACTIVE = "active"
     RETIRED = "retired"
+    # STAGING intentionally omitted — promotion gates land in #124. Add
+    # the enum value back when the staging transition is wired with
+    # explicit guards.
 
 
 @dataclass(frozen=True)
@@ -56,14 +58,26 @@ class StrategyVersion:
     config_hash: str
     status: VersionStatus
     created_at_epoch: float
+    # Wall-clock epoch of the last time this version was activated;
+    # `None` for versions that were never activated. Used as the
+    # tiebreaker for `rollback` so the previously-live version wins
+    # over a higher-numbered version that was deployed-then-retired
+    # without ever serving live traffic.
+    last_activated_at_epoch: float | None = None
 
 
 class VersionNotFoundError(Exception):
     """Raised when a version id or strategy id does not exist."""
 
 
-class VersionAlreadyExistsError(Exception):
-    """Raised when re-deploying with content that doesn't match recorded record."""
+class VersionInvalidConfigError(ValueError):
+    """Raised when ``deploy`` cannot serialize the supplied config."""
+
+
+# Hard cap on the size of a single code blob. Plugins should be small;
+# a 5 MB ceiling catches operator footguns (passing a tarball or a
+# bundled artifact) without restricting any realistic strategy.
+_MAX_CODE_SIZE_BYTES = 5 * 1024 * 1024
 
 
 class StrategyRegistry(Protocol):
@@ -114,11 +128,30 @@ def _sha256(blob: bytes) -> str:
 
 
 def _canonical_config_hash(config: dict[str, Any]) -> str:
-    """Hash a config dict over its canonical JSON encoding so semantically
-    identical configs (key order independent) hash identically."""
-    payload = json.dumps(
-        config, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    )
+    """Hash a config dict over its canonical JSON encoding.
+
+    `sort_keys=True` recursively canonicalizes dict key ordering. Lists
+    keep their insertion order — list-typed config values are treated
+    as ordered sequences (changing order produces a different hash).
+
+    `allow_nan=False` so NaN/Infinity float values raise
+    :class:`VersionInvalidConfigError` rather than embedding non-standard
+    JSON tokens that would silently hash inconsistently.
+    """
+    try:
+        payload = json.dumps(
+            config,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        msg = (
+            "config must be JSON-serializable with finite floats; "
+            f"got {type(config).__name__} with error: {exc}"
+        )
+        raise VersionInvalidConfigError(msg) from exc
     return _sha256(payload.encode("utf-8"))
 
 
@@ -138,8 +171,19 @@ class StrategyVersionService:
         if not code:
             msg = "code blob must not be empty"
             raise ValueError(msg)
+        if len(code) > _MAX_CODE_SIZE_BYTES:
+            msg = (
+                f"code blob exceeds {_MAX_CODE_SIZE_BYTES} bytes "
+                f"(got {len(code)})"
+            )
+            raise ValueError(msg)
         code_hash = _sha256(code)
         config_hash = _canonical_config_hash(config)
+        # NOTE: the in-memory registry serializes deploy via the per-
+        # strategy asyncio.Lock below. A DB-backed registry MUST use a
+        # strongly consistent read of `list_for_strategy` or a DB-level
+        # sequence to allocate `version_number`, otherwise two pods can
+        # independently compute the same number and double-write.
         async with self._lock(strategy_id):
             existing = await self.registry.find_by_hashes(
                 strategy_id, code_hash, config_hash
@@ -169,13 +213,19 @@ class StrategyVersionService:
         target = await self.registry.get(version_id)
         if target is None:
             raise VersionNotFoundError(version_id)
-        if target.status == VersionStatus.RETIRED:
-            msg = f"version {version_id} is retired and cannot be activated"
-            raise ValueError(msg)
         async with self._lock(target.strategy_id):
+            # Re-fetch + re-check inside the lock so a concurrent
+            # `retire` between the entry check and the save cannot be
+            # silently overwritten.
             current = await self.registry.get(version_id)
             if current is None:
                 raise VersionNotFoundError(version_id)
+            if current.status == VersionStatus.RETIRED:
+                msg = (
+                    f"version {version_id} is retired and cannot be "
+                    "activated"
+                )
+                raise ValueError(msg)
             for sibling in await self.registry.list_for_strategy(
                 current.strategy_id
             ):
@@ -186,38 +236,69 @@ class StrategyVersionService:
                     await self.registry.save(
                         replace(sibling, status=VersionStatus.RETIRED)
                     )
-            updated = replace(current, status=VersionStatus.ACTIVE)
+            updated = replace(
+                current,
+                status=VersionStatus.ACTIVE,
+                last_activated_at_epoch=time.time(),
+            )
             await self.registry.save(updated)
             return updated
 
     async def rollback(self, strategy_id: str) -> StrategyVersion:
-        """Flip to the most recent prior active version."""
+        """Flip to the most recently-active prior version.
+
+        The candidate is the previously-live version (largest
+        `last_activated_at_epoch` among RETIRED), not the highest-
+        numbered RETIRED version. A version that was deployed-then-
+        retired without ever serving live traffic is *not* a rollback
+        target.
+        """
         async with self._lock(strategy_id):
             siblings = await self.registry.list_for_strategy(strategy_id)
             current_active = next(
                 (v for v in siblings if v.status == VersionStatus.ACTIVE),
                 None,
             )
-            retired = [
+            previously_active = [
                 v
                 for v in siblings
                 if v.status == VersionStatus.RETIRED
+                and v.last_activated_at_epoch is not None
                 and (current_active is None or v.id != current_active.id)
             ]
-            if not retired:
+            if not previously_active:
                 raise VersionNotFoundError(
                     f"no rollback candidate for strategy {strategy_id}"
                 )
-            previous = max(retired, key=lambda v: v.version_number)
+            previous = max(
+                previously_active,
+                key=lambda v: v.last_activated_at_epoch or 0.0,
+            )
             if current_active is not None:
                 await self.registry.save(
                     replace(current_active, status=VersionStatus.RETIRED)
                 )
-            promoted = replace(previous, status=VersionStatus.ACTIVE)
+            promoted = replace(
+                previous,
+                status=VersionStatus.ACTIVE,
+                last_activated_at_epoch=time.time(),
+            )
             await self.registry.save(promoted)
             return promoted
 
-    async def retire(self, version_id: str) -> StrategyVersion:
+    async def retire(
+        self,
+        version_id: str,
+        *,
+        allow_retire_active: bool = False,
+    ) -> StrategyVersion:
+        """Retire a version.
+
+        Retiring the *currently ACTIVE* version leaves the strategy with
+        no live deployment. Callers that intentionally take a strategy
+        offline must pass ``allow_retire_active=True`` so the silent
+        stop is explicit at the call site.
+        """
         target = await self.registry.get(version_id)
         if target is None:
             raise VersionNotFoundError(version_id)
@@ -225,6 +306,16 @@ class StrategyVersionService:
             current = await self.registry.get(version_id)
             if current is None:
                 raise VersionNotFoundError(version_id)
+            if (
+                current.status == VersionStatus.ACTIVE
+                and not allow_retire_active
+            ):
+                msg = (
+                    f"version {version_id} is the active deployment; "
+                    "pass allow_retire_active=True to take the strategy "
+                    "offline, or activate a successor first"
+                )
+                raise ValueError(msg)
             updated = replace(current, status=VersionStatus.RETIRED)
             await self.registry.save(updated)
             return updated
@@ -255,7 +346,7 @@ __all__ = [
     "StrategyRegistry",
     "StrategyVersion",
     "StrategyVersionService",
-    "VersionAlreadyExistsError",
+    "VersionInvalidConfigError",
     "VersionNotFoundError",
     "VersionStatus",
 ]

--- a/engine/core/strategy_versioning.py
+++ b/engine/core/strategy_versioning.py
@@ -1,0 +1,261 @@
+"""Strategy versioning, rollback, and immutable deployments.
+
+A :class:`StrategyVersion` is a frozen, content-addressed record of one
+deploy: a SHA-256 hash of the strategy's code blob plus a hash of its
+canonical-JSON config. The same code+config never produces two version
+records — the registry deduplicates so re-deploys are idempotent.
+
+Lifecycle:
+- ``deploy``  — content-hash the blob, return existing record if seen,
+                else create a new ``DRAFT`` version with a monotonic
+                version number scoped per strategy.
+- ``activate`` — promote a version to ``ACTIVE``, demoting the prior
+                active version to ``RETIRED``. Exactly one active version
+                per strategy at any time.
+- ``rollback`` — flip back to the most recent prior active version,
+                retiring the current active.
+- ``retire``  — explicitly mark a version as ``RETIRED``.
+
+All mutations are serialized through an ``asyncio.Lock`` so concurrent
+``deploy``/``activate``/``rollback`` calls cannot corrupt the active-
+version pointer or duplicate version numbers.
+
+The store layer is a Protocol so the in-memory backend (single-pod,
+tests) and a DB-backed backend (multi-pod, follow-up) share the same
+surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from typing import Any, Protocol
+
+
+class VersionStatus(StrEnum):
+    DRAFT = "draft"
+    STAGING = "staging"
+    ACTIVE = "active"
+    RETIRED = "retired"
+
+
+@dataclass(frozen=True)
+class StrategyVersion:
+    """One immutable deployment record. Frozen — registry replaces on update."""
+
+    id: str
+    strategy_id: str
+    version_number: int
+    code_hash: str
+    config_hash: str
+    status: VersionStatus
+    created_at_epoch: float
+
+
+class VersionNotFoundError(Exception):
+    """Raised when a version id or strategy id does not exist."""
+
+
+class VersionAlreadyExistsError(Exception):
+    """Raised when re-deploying with content that doesn't match recorded record."""
+
+
+class StrategyRegistry(Protocol):
+    """Pluggable persistence for :class:`StrategyVersion` records."""
+
+    async def get(self, version_id: str) -> StrategyVersion | None: ...
+    async def save(self, version: StrategyVersion) -> None: ...
+    async def list_for_strategy(
+        self, strategy_id: str
+    ) -> list[StrategyVersion]: ...
+    async def find_by_hashes(
+        self, strategy_id: str, code_hash: str, config_hash: str
+    ) -> StrategyVersion | None: ...
+
+
+class InMemoryStrategyRegistry:
+    """Process-local registry. Single-pod / tests only."""
+
+    def __init__(self) -> None:
+        self._by_id: dict[str, StrategyVersion] = {}
+        self._by_strategy: dict[str, list[str]] = defaultdict(list)
+
+    async def get(self, version_id: str) -> StrategyVersion | None:
+        return self._by_id.get(version_id)
+
+    async def save(self, version: StrategyVersion) -> None:
+        if version.id not in self._by_id:
+            self._by_strategy[version.strategy_id].append(version.id)
+        self._by_id[version.id] = version
+
+    async def list_for_strategy(
+        self, strategy_id: str
+    ) -> list[StrategyVersion]:
+        ids = self._by_strategy.get(strategy_id, ())
+        return [self._by_id[i] for i in ids if i in self._by_id]
+
+    async def find_by_hashes(
+        self, strategy_id: str, code_hash: str, config_hash: str
+    ) -> StrategyVersion | None:
+        for v in await self.list_for_strategy(strategy_id):
+            if v.code_hash == code_hash and v.config_hash == config_hash:
+                return v
+        return None
+
+
+def _sha256(blob: bytes) -> str:
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _canonical_config_hash(config: dict[str, Any]) -> str:
+    """Hash a config dict over its canonical JSON encoding so semantically
+    identical configs (key order independent) hash identically."""
+    payload = json.dumps(
+        config, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return _sha256(payload.encode("utf-8"))
+
+
+class StrategyVersionService:
+    """Lifecycle operations on top of a :class:`StrategyRegistry`."""
+
+    def __init__(self, registry: StrategyRegistry) -> None:
+        self.registry = registry
+        self._strategy_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    def _lock(self, strategy_id: str) -> asyncio.Lock:
+        return self._strategy_locks[strategy_id]
+
+    async def deploy(
+        self, strategy_id: str, code: bytes, config: dict[str, Any]
+    ) -> StrategyVersion:
+        if not code:
+            msg = "code blob must not be empty"
+            raise ValueError(msg)
+        code_hash = _sha256(code)
+        config_hash = _canonical_config_hash(config)
+        async with self._lock(strategy_id):
+            existing = await self.registry.find_by_hashes(
+                strategy_id, code_hash, config_hash
+            )
+            if existing is not None:
+                return existing
+            siblings = await self.registry.list_for_strategy(strategy_id)
+            version_number = (
+                max((v.version_number for v in siblings), default=0) + 1
+            )
+            v = StrategyVersion(
+                id=str(uuid.uuid4()),
+                strategy_id=strategy_id,
+                version_number=version_number,
+                code_hash=code_hash,
+                config_hash=config_hash,
+                status=VersionStatus.DRAFT,
+                created_at_epoch=time.time(),
+            )
+            await self.registry.save(v)
+            return v
+
+    async def get(self, version_id: str) -> StrategyVersion | None:
+        return await self.registry.get(version_id)
+
+    async def activate(self, version_id: str) -> StrategyVersion:
+        target = await self.registry.get(version_id)
+        if target is None:
+            raise VersionNotFoundError(version_id)
+        if target.status == VersionStatus.RETIRED:
+            msg = f"version {version_id} is retired and cannot be activated"
+            raise ValueError(msg)
+        async with self._lock(target.strategy_id):
+            current = await self.registry.get(version_id)
+            if current is None:
+                raise VersionNotFoundError(version_id)
+            for sibling in await self.registry.list_for_strategy(
+                current.strategy_id
+            ):
+                if (
+                    sibling.id != current.id
+                    and sibling.status == VersionStatus.ACTIVE
+                ):
+                    await self.registry.save(
+                        replace(sibling, status=VersionStatus.RETIRED)
+                    )
+            updated = replace(current, status=VersionStatus.ACTIVE)
+            await self.registry.save(updated)
+            return updated
+
+    async def rollback(self, strategy_id: str) -> StrategyVersion:
+        """Flip to the most recent prior active version."""
+        async with self._lock(strategy_id):
+            siblings = await self.registry.list_for_strategy(strategy_id)
+            current_active = next(
+                (v for v in siblings if v.status == VersionStatus.ACTIVE),
+                None,
+            )
+            retired = [
+                v
+                for v in siblings
+                if v.status == VersionStatus.RETIRED
+                and (current_active is None or v.id != current_active.id)
+            ]
+            if not retired:
+                raise VersionNotFoundError(
+                    f"no rollback candidate for strategy {strategy_id}"
+                )
+            previous = max(retired, key=lambda v: v.version_number)
+            if current_active is not None:
+                await self.registry.save(
+                    replace(current_active, status=VersionStatus.RETIRED)
+                )
+            promoted = replace(previous, status=VersionStatus.ACTIVE)
+            await self.registry.save(promoted)
+            return promoted
+
+    async def retire(self, version_id: str) -> StrategyVersion:
+        target = await self.registry.get(version_id)
+        if target is None:
+            raise VersionNotFoundError(version_id)
+        async with self._lock(target.strategy_id):
+            current = await self.registry.get(version_id)
+            if current is None:
+                raise VersionNotFoundError(version_id)
+            updated = replace(current, status=VersionStatus.RETIRED)
+            await self.registry.save(updated)
+            return updated
+
+    async def list_for_strategy(
+        self,
+        strategy_id: str,
+        *,
+        status: VersionStatus | None = None,
+    ) -> list[StrategyVersion]:
+        out = await self.registry.list_for_strategy(strategy_id)
+        out.sort(key=lambda v: v.version_number)
+        if status is not None:
+            out = [v for v in out if v.status == status]
+        return out
+
+    async def get_active(
+        self, strategy_id: str
+    ) -> StrategyVersion | None:
+        for v in await self.registry.list_for_strategy(strategy_id):
+            if v.status == VersionStatus.ACTIVE:
+                return v
+        return None
+
+
+__all__ = [
+    "InMemoryStrategyRegistry",
+    "StrategyRegistry",
+    "StrategyVersion",
+    "StrategyVersionService",
+    "VersionAlreadyExistsError",
+    "VersionNotFoundError",
+    "VersionStatus",
+]

--- a/tests/test_strategy_versioning.py
+++ b/tests/test_strategy_versioning.py
@@ -10,7 +10,7 @@ from engine.core.strategy_versioning import (
     InMemoryStrategyRegistry,
     StrategyVersion,
     StrategyVersionService,
-    VersionAlreadyExistsError,
+    VersionInvalidConfigError,
     VersionNotFoundError,
     VersionStatus,
 )
@@ -131,11 +131,21 @@ class TestRetire:
             await service.activate(version_id=v.id)
 
     @pytest.mark.asyncio
-    async def test_retire_active_version_clears_active_pointer(self, service):
+    async def test_retire_active_requires_explicit_flag(self, service):
         sid = _strategy()
         v = await service.deploy(sid, CODE_A, {})
         await service.activate(version_id=v.id)
-        await service.retire(version_id=v.id)
+        with pytest.raises(ValueError, match="active deployment"):
+            await service.retire(version_id=v.id)
+
+    @pytest.mark.asyncio
+    async def test_retire_active_version_with_explicit_flag_clears_pointer(
+        self, service
+    ):
+        sid = _strategy()
+        v = await service.deploy(sid, CODE_A, {})
+        await service.activate(version_id=v.id)
+        await service.retire(version_id=v.id, allow_retire_active=True)
         active = await service.get_active(strategy_id=sid)
         assert active is None
 
@@ -210,5 +220,61 @@ class TestEntity:
         )
         assert v.strategy_id == sid
 
-    def test_already_exists_error_class(self):
-        assert issubclass(VersionAlreadyExistsError, Exception)
+    def test_invalid_config_error_class(self):
+        assert issubclass(VersionInvalidConfigError, ValueError)
+
+
+class TestConfigValidation:
+    @pytest.mark.asyncio
+    async def test_deploy_rejects_nan_floats(self, service):
+        sid = _strategy()
+        with pytest.raises(VersionInvalidConfigError):
+            await service.deploy(sid, CODE_A, {"threshold": float("nan")})
+
+    @pytest.mark.asyncio
+    async def test_deploy_rejects_non_serializable(self, service):
+        sid = _strategy()
+        with pytest.raises(VersionInvalidConfigError):
+            await service.deploy(sid, CODE_A, {"f": lambda: 1})
+
+    @pytest.mark.asyncio
+    async def test_deploy_rejects_oversize_code(self, service):
+        sid = _strategy()
+        with pytest.raises(ValueError, match="exceeds"):
+            await service.deploy(sid, b"x" * (10 * 1024 * 1024), {})
+
+
+class TestRollbackTarget:
+    @pytest.mark.asyncio
+    async def test_rollback_picks_previously_active_not_highest_retired(
+        self, service
+    ):
+        # Sequence: deploy v1, v2, v3; activate v1, then v3 (skipping
+        # v2). Rollback should restore v1 (the only previously-live
+        # version), not v2 (deployed but never activated).
+        sid = _strategy()
+        v1 = await service.deploy(sid, CODE_A, {})
+        v2 = await service.deploy(sid, CODE_B, {})
+        v3 = await service.deploy(sid, b"def evaluate(): return 3\n", {})
+        await service.activate(version_id=v1.id)
+        await service.activate(version_id=v3.id)
+        # Retire v2 deliberately so it sits in the retired pool with no
+        # last_activated_at — without the fix it would be the rollback
+        # target by version_number.
+        await service.retire(version_id=v2.id)
+        rolled = await service.rollback(strategy_id=sid)
+        assert rolled.id == v1.id
+
+
+class TestActivateConcurrencySafety:
+    @pytest.mark.asyncio
+    async def test_retired_check_inside_lock(self, service):
+        # Even though the test cannot reliably interleave a concurrent
+        # retire mid-activate, the contract change is that the retired
+        # check happens after the in-lock re-fetch. Smoke-test: a
+        # version retired between activate calls remains rejected.
+        sid = _strategy()
+        v = await service.deploy(sid, CODE_A, {})
+        await service.retire(version_id=v.id)
+        with pytest.raises(ValueError, match="retired"):
+            await service.activate(version_id=v.id)

--- a/tests/test_strategy_versioning.py
+++ b/tests/test_strategy_versioning.py
@@ -1,0 +1,214 @@
+"""Tests for engine.core.strategy_versioning — versioned strategy lifecycle."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from engine.core.strategy_versioning import (
+    InMemoryStrategyRegistry,
+    StrategyVersion,
+    StrategyVersionService,
+    VersionAlreadyExistsError,
+    VersionNotFoundError,
+    VersionStatus,
+)
+
+
+@pytest.fixture
+def registry():
+    return InMemoryStrategyRegistry()
+
+
+@pytest.fixture
+def service(registry):
+    return StrategyVersionService(registry=registry)
+
+
+def _strategy() -> str:
+    return f"strat-{uuid.uuid4().hex[:8]}"
+
+
+CODE_A = b"def evaluate(): return 1\n"
+CODE_B = b"def evaluate(): return 2\n"
+
+
+class TestDeploy:
+    @pytest.mark.asyncio
+    async def test_deploy_creates_draft_version(self, service):
+        sid = _strategy()
+        v = await service.deploy(strategy_id=sid, code=CODE_A, config={})
+        assert v.strategy_id == sid
+        assert v.status == VersionStatus.DRAFT
+        assert v.code_hash
+        assert len(v.code_hash) >= 32
+
+    @pytest.mark.asyncio
+    async def test_deploy_assigns_monotonic_versions(self, service):
+        sid = _strategy()
+        a = await service.deploy(strategy_id=sid, code=CODE_A, config={})
+        b = await service.deploy(strategy_id=sid, code=CODE_B, config={})
+        assert b.version_number > a.version_number
+
+    @pytest.mark.asyncio
+    async def test_deploy_with_identical_blob_returns_existing(self, service):
+        sid = _strategy()
+        a = await service.deploy(strategy_id=sid, code=CODE_A, config={})
+        b = await service.deploy(strategy_id=sid, code=CODE_A, config={})
+        assert a.id == b.id
+
+    @pytest.mark.asyncio
+    async def test_deploy_with_changed_config_creates_new_version(self, service):
+        sid = _strategy()
+        a = await service.deploy(strategy_id=sid, code=CODE_A, config={"x": 1})
+        b = await service.deploy(strategy_id=sid, code=CODE_A, config={"x": 2})
+        assert a.id != b.id
+
+
+class TestActivate:
+    @pytest.mark.asyncio
+    async def test_activate_promotes_version_to_active(self, service):
+        sid = _strategy()
+        v = await service.deploy(sid, CODE_A, {})
+        out = await service.activate(version_id=v.id)
+        assert out.status == VersionStatus.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_activate_demotes_prior_active(self, service):
+        sid = _strategy()
+        a = await service.deploy(sid, CODE_A, {})
+        b = await service.deploy(sid, CODE_B, {})
+        await service.activate(version_id=a.id)
+        await service.activate(version_id=b.id)
+        a_out = await service.get(a.id)
+        b_out = await service.get(b.id)
+        assert a_out.status == VersionStatus.RETIRED
+        assert b_out.status == VersionStatus.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_only_one_active_version_per_strategy(self, service):
+        sid = _strategy()
+        a = await service.deploy(sid, CODE_A, {})
+        b = await service.deploy(sid, CODE_B, {})
+        await service.activate(version_id=a.id)
+        await service.activate(version_id=b.id)
+        active = await service.get_active(strategy_id=sid)
+        assert active is not None
+        assert active.id == b.id
+
+
+class TestRollback:
+    @pytest.mark.asyncio
+    async def test_rollback_restores_previous_active(self, service):
+        sid = _strategy()
+        a = await service.deploy(sid, CODE_A, {})
+        b = await service.deploy(sid, CODE_B, {})
+        await service.activate(version_id=a.id)
+        await service.activate(version_id=b.id)
+        rolled = await service.rollback(strategy_id=sid)
+        assert rolled.id == a.id
+        assert rolled.status == VersionStatus.ACTIVE
+        b_out = await service.get(b.id)
+        assert b_out.status == VersionStatus.RETIRED
+
+    @pytest.mark.asyncio
+    async def test_rollback_fails_when_no_prior_version(self, service):
+        sid = _strategy()
+        a = await service.deploy(sid, CODE_A, {})
+        await service.activate(version_id=a.id)
+        with pytest.raises(VersionNotFoundError):
+            await service.rollback(strategy_id=sid)
+
+
+class TestRetire:
+    @pytest.mark.asyncio
+    async def test_retired_version_cannot_be_activated(self, service):
+        sid = _strategy()
+        v = await service.deploy(sid, CODE_A, {})
+        await service.retire(version_id=v.id)
+        with pytest.raises(ValueError, match="retired"):
+            await service.activate(version_id=v.id)
+
+    @pytest.mark.asyncio
+    async def test_retire_active_version_clears_active_pointer(self, service):
+        sid = _strategy()
+        v = await service.deploy(sid, CODE_A, {})
+        await service.activate(version_id=v.id)
+        await service.retire(version_id=v.id)
+        active = await service.get_active(strategy_id=sid)
+        assert active is None
+
+
+class TestImmutability:
+    @pytest.mark.asyncio
+    async def test_version_record_is_frozen(self, service):
+        sid = _strategy()
+        v = await service.deploy(sid, CODE_A, {})
+        with pytest.raises((AttributeError, TypeError)):
+            v.code_hash = "tampered"  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_version_id_is_uuid(self, service):
+        sid = _strategy()
+        v = await service.deploy(sid, CODE_A, {})
+        parsed = uuid.UUID(v.id)
+        assert parsed.version == 4
+
+
+class TestListing:
+    @pytest.mark.asyncio
+    async def test_list_versions_ordered_oldest_first(self, service):
+        sid = _strategy()
+        a = await service.deploy(sid, CODE_A, {})
+        b = await service.deploy(sid, CODE_B, {})
+        out = await service.list_for_strategy(strategy_id=sid)
+        assert [v.id for v in out] == [a.id, b.id]
+
+    @pytest.mark.asyncio
+    async def test_list_filters_by_status(self, service):
+        sid = _strategy()
+        a = await service.deploy(sid, CODE_A, {})
+        await service.deploy(sid, CODE_B, {})
+        await service.activate(version_id=a.id)
+        active_only = await service.list_for_strategy(
+            strategy_id=sid, status=VersionStatus.ACTIVE
+        )
+        assert len(active_only) == 1
+        assert active_only[0].id == a.id
+
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_get_unknown_returns_none(self, service):
+        out = await service.get("definitely-not-real")
+        assert out is None
+
+    @pytest.mark.asyncio
+    async def test_activate_unknown_raises(self, service):
+        with pytest.raises(VersionNotFoundError):
+            await service.activate(version_id="nope")
+
+    @pytest.mark.asyncio
+    async def test_deploy_rejects_empty_code(self, service):
+        sid = _strategy()
+        with pytest.raises(ValueError, match="code"):
+            await service.deploy(strategy_id=sid, code=b"", config={})
+
+
+class TestEntity:
+    def test_strategy_version_dataclass_shape(self):
+        sid = _strategy()
+        v = StrategyVersion(
+            id=str(uuid.uuid4()),
+            strategy_id=sid,
+            version_number=1,
+            code_hash="a" * 64,
+            config_hash="b" * 64,
+            status=VersionStatus.DRAFT,
+            created_at_epoch=1.0,
+        )
+        assert v.strategy_id == sid
+
+    def test_already_exists_error_class(self):
+        assert issubclass(VersionAlreadyExistsError, Exception)


### PR DESCRIPTION
## Summary

Closes #125. Pure-Python content-addressed strategy version registry with deploy / activate / rollback / retire lifecycle. Storage layer is a Protocol so the in-memory backend (single-pod / tests) and a DB-backed backend (multi-pod, follow-up) share the same surface.

### What lands

- **\`StrategyVersion\`** frozen dataclass — id, strategy_id, version_number, code_hash, config_hash, status, created_at_epoch.
- **\`VersionStatus\`** StrEnum: DRAFT / STAGING / ACTIVE / RETIRED.
- **\`StrategyRegistry\`** Protocol + **\`InMemoryStrategyRegistry\`**.
- **\`StrategyVersionService\`** — deploy (content-addressed dedup, monotonic version), activate (exactly-one-active per strategy), rollback (restore previous active), retire, list, get_active. Per-strategy asyncio.Lock for race safety.

### Out of scope (follow-up)

- DB-backed registry + Alembic migration
- Promotion gates (#124 — WFA, Monte Carlo, paper-window evidence)
- API routes / MCP resource exposure
- Strategy code-blob storage (S3 / object store)

### Test plan

- [x] 20 unit tests cover dedup, monotonic versioning, activate/demote, rollback, retire, listing+filters, error paths
- [x] Full suite — 780 passed
- [x] \`ruff\` + \`basedpyright\` clean
- [ ] Adversarial review next

🤖 Generated with [Claude Code](https://claude.com/claude-code)