### PR TITLE
feat(core): portfolio optimization primitives (#123)

### DIFF
--- a/engine/core/portfolio_optimizer.py
+++ b/engine/core/portfolio_optimizer.py
@@ -1,0 +1,293 @@
+"""Portfolio optimization primitives.
+
+Pure-numpy implementations of four classic portfolio construction
+techniques:
+
+- :func:`mean_variance_optimization` — Markowitz min-variance / max-Sharpe
+  closed-form solution.
+- :func:`risk_parity` — equal-risk-contribution weights via fixed-point
+  iteration.
+- :func:`hierarchical_risk_parity` — Lopez de Prado's HRP (correlation
+  -> distance -> linkage tree -> recursive bisection inverse-variance).
+- :func:`black_litterman` — posterior return + covariance update from a
+  prior plus investor views.
+
+All functions operate on dense ``numpy.ndarray`` inputs. No bounds /
+turnover / sector constraints — those layer on top in a follow-up
+issue. Outputs are weight vectors that sum to 1; no leverage.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+FloatArray = npt.NDArray[np.float64]
+
+_NDIM_MATRIX = 2
+_PD_EIGVAL_FLOOR = 1e-12
+
+
+class OptimizerError(Exception):
+    """Raised when input matrices are malformed or numerically degenerate."""
+
+
+def _validate_cov(cov: FloatArray) -> FloatArray:
+    cov = np.asarray(cov, dtype=np.float64)
+    if cov.ndim != _NDIM_MATRIX or cov.shape[0] != cov.shape[1]:
+        msg = f"cov must be a square 2-D array; got shape {cov.shape}"
+        raise OptimizerError(msg)
+    if cov.shape[0] == 0:
+        msg = "cov must have at least one asset"
+        raise OptimizerError(msg)
+    return cov
+
+
+def _safe_inv(cov: FloatArray) -> FloatArray:
+    try:
+        return np.linalg.inv(cov).astype(np.float64, copy=False)
+    except np.linalg.LinAlgError as exc:
+        msg = f"cov is singular and cannot be inverted: {exc}"
+        raise OptimizerError(msg) from exc
+
+
+def mean_variance_optimization(
+    *,
+    cov: FloatArray,
+    expected_returns: FloatArray | None = None,
+) -> FloatArray:
+    """Markowitz mean-variance optimization (closed-form).
+
+    Without ``expected_returns``: solves ``min w' Σ w`` subject to
+    ``sum(w) = 1``. Closed form: ``w = Σ⁻¹ 1 / (1' Σ⁻¹ 1)``.
+
+    With ``expected_returns``: solves ``max w' μ - λ w' Σ w`` for the
+    tangency / max-Sharpe portfolio: ``w ∝ Σ⁻¹ μ`` rescaled to sum to 1.
+
+    No long-only constraint, no leverage cap. Both layer separately
+    in the constrained-optimization follow-up.
+    """
+    cov = _validate_cov(cov)
+    inv = _safe_inv(cov)
+    n = cov.shape[0]
+    if expected_returns is None:
+        ones = np.ones(n)
+        unscaled = inv @ ones
+    else:
+        mu = np.asarray(expected_returns, dtype=np.float64)
+        if mu.shape != (n,):
+            msg = (
+                f"expected_returns shape {mu.shape} does not match cov "
+                f"shape ({n},{n})"
+            )
+            raise OptimizerError(msg)
+        unscaled = inv @ mu
+    total = unscaled.sum()
+    if not np.isfinite(total) or total == 0.0:
+        msg = "MVO produced a degenerate weight vector (sum=0 or non-finite)"
+        raise OptimizerError(msg)
+    return unscaled / total
+
+
+def risk_parity(
+    *,
+    cov: FloatArray,
+    max_iter: int = 1000,
+    tol: float = 1e-8,
+) -> FloatArray:
+    """Equal-risk-contribution weights via Spinu fixed-point.
+
+    Each asset contributes the same share of total portfolio variance:
+    ``w_i * (Σw)_i`` is equal across all i. Multiplicative-update
+    fixed-point converges to the unique positive solution when Σ is
+    positive-definite.
+    """
+    cov = _validate_cov(cov)
+    n = cov.shape[0]
+    eigvals = np.linalg.eigvalsh(cov)
+    if eigvals.min() <= _PD_EIGVAL_FLOOR:
+        msg = "cov is not positive-definite; risk parity requires PD"
+        raise OptimizerError(msg)
+    w = np.full(n, 1.0 / n)
+    for _ in range(max_iter):
+        sigma_w = cov @ w
+        # Guard against pathological covariances where sigma_w * w can
+        # turn non-positive (PD cov with negative off-diagonals).
+        if (sigma_w <= 0).any():
+            msg = (
+                "risk parity iteration produced non-positive marginal "
+                "contributions; covariance is not diagonally dominant "
+                "enough for the Spinu fixed-point"
+            )
+            raise OptimizerError(msg)
+        # Spinu fixed-point: w_{k+1,i} = sqrt(w_{k,i} / (Σ w_k)_i),
+        # then renormalize. Converges to equal-risk-contribution for
+        # diagonally-dominant Σ.
+        new_w = np.sqrt(w / sigma_w)
+        new_w = new_w / new_w.sum()
+        if np.linalg.norm(new_w - w, ord=np.inf) < tol:
+            return new_w
+        w = new_w
+    return w
+
+
+def _correlation_from_cov(cov: FloatArray) -> FloatArray:
+    std = np.sqrt(np.diag(cov))
+    outer = np.outer(std, std)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        corr = np.where(outer > 0, cov / outer, 0.0)
+    return np.clip(corr, -1.0, 1.0)
+
+
+def _correlation_distance(corr: FloatArray) -> FloatArray:
+    return np.sqrt(np.clip((1.0 - corr) / 2.0, 0.0, 1.0))
+
+
+def _quasi_diag_order(cov: FloatArray) -> list[int]:
+    """Single-linkage hierarchical-clustering quasi-diagonal leaf order.
+
+    Simple agglomerative algorithm; no scipy dependency. Repeatedly
+    merges the two clusters whose minimum pairwise correlation-distance
+    is smallest, returning the resulting leaf ordering.
+    """
+    n = cov.shape[0]
+    if n <= 1:
+        return list(range(n))
+    corr = _correlation_from_cov(cov)
+    dist = _correlation_distance(corr)
+    clusters: list[list[int]] = [[i] for i in range(n)]
+    while len(clusters) > 1:
+        best = (np.inf, -1, -1)
+        for i in range(len(clusters)):
+            for j in range(i + 1, len(clusters)):
+                d_ij = min(
+                    dist[a, b] for a in clusters[i] for b in clusters[j]
+                )
+                if d_ij < best[0]:
+                    best = (d_ij, i, j)
+        _, i, j = best
+        merged = clusters[i] + clusters[j]
+        clusters.pop(j)
+        clusters.pop(i)
+        clusters.append(merged)
+    return clusters[0]
+
+
+def _ivp_weights(cov_block: FloatArray) -> FloatArray:
+    ivp = 1.0 / np.diag(cov_block)
+    return ivp / ivp.sum()
+
+
+def _cluster_var(cov: FloatArray, indices: list[int]) -> float:
+    block = cov[np.ix_(indices, indices)]
+    w = _ivp_weights(block)
+    return float(w @ block @ w)
+
+
+def _recursive_bisection(cov: FloatArray, order: list[int]) -> FloatArray:
+    n = cov.shape[0]
+    weights = np.ones(n)
+    stack: list[list[int]] = [order]
+    while stack:
+        cluster = stack.pop()
+        if len(cluster) <= 1:
+            continue
+        mid = len(cluster) // 2
+        left, right = cluster[:mid], cluster[mid:]
+        var_left = _cluster_var(cov, left)
+        var_right = _cluster_var(cov, right)
+        alpha = 1.0 - var_left / (var_left + var_right)
+        for idx in left:
+            weights[idx] *= alpha
+        for idx in right:
+            weights[idx] *= 1.0 - alpha
+        stack.extend([left, right])
+    return weights
+
+
+def hierarchical_risk_parity(*, cov: FloatArray) -> FloatArray:
+    """Lopez de Prado HRP weights.
+
+    Pipeline: (1) correlation-distance hierarchical clustering for a
+    quasi-diagonal asset ordering, (2) recursive bisection along that
+    ordering, (3) inverse-variance allocation within each split.
+
+    Robust to ill-conditioned Σ — never inverts the full matrix; only
+    diagonals of sub-blocks are touched.
+    """
+    cov = _validate_cov(cov)
+    order = _quasi_diag_order(cov)
+    weights = _recursive_bisection(cov, order)
+    total = weights.sum()
+    if not np.isfinite(total) or total <= 0:
+        msg = "HRP produced a degenerate weight vector"
+        raise OptimizerError(msg)
+    return weights / total
+
+
+def black_litterman(
+    *,
+    prior_returns: FloatArray,
+    prior_cov: FloatArray,
+    views_p: FloatArray,
+    views_q: FloatArray,
+    view_uncertainty: FloatArray,
+    tau: float = 0.05,
+) -> tuple[FloatArray, FloatArray]:
+    """Black-Litterman posterior returns + covariance.
+
+    Parameters
+    ----------
+    prior_returns
+        Equilibrium / market-implied excess returns ``π``, shape ``(n,)``.
+    prior_cov
+        Asset covariance ``Σ``, shape ``(n, n)``.
+    views_p
+        View pick matrix ``P``, shape ``(k, n)``.
+    views_q
+        View target returns ``Q``, shape ``(k,)``.
+    view_uncertainty
+        View-uncertainty matrix ``Ω``, shape ``(k, k)``.
+    tau
+        Scalar uncertainty in the prior. Standard practice: 0.025-0.10.
+
+    Returns
+    -------
+    (posterior_mu, posterior_cov)
+        Blended posterior expected returns and covariance.
+    """
+    cov = _validate_cov(prior_cov)
+    pi = np.asarray(prior_returns, dtype=np.float64)
+    if pi.shape != (cov.shape[0],):
+        msg = (
+            f"prior_returns shape {pi.shape} does not match prior_cov "
+            f"({cov.shape[0]},)"
+        )
+        raise OptimizerError(msg)
+    p = np.asarray(views_p, dtype=np.float64).reshape(-1, cov.shape[0])
+    q = np.asarray(views_q, dtype=np.float64).reshape(-1)
+    omega = np.asarray(view_uncertainty, dtype=np.float64)
+
+    if p.shape[0] == 0:
+        return pi.copy(), cov.copy()
+
+    omega = omega.reshape(p.shape[0], p.shape[0])
+    tau_cov = tau * cov
+    inv_tau_cov = _safe_inv(tau_cov)
+    inv_omega = _safe_inv(omega)
+    posterior_precision = inv_tau_cov + p.T @ inv_omega @ p
+    posterior_cov_overlay = _safe_inv(posterior_precision)
+    posterior_mu = posterior_cov_overlay @ (
+        inv_tau_cov @ pi + p.T @ inv_omega @ q
+    )
+    posterior_cov_full = cov + posterior_cov_overlay
+    return posterior_mu, posterior_cov_full
+
+
+__all__ = [
+    "OptimizerError",
+    "black_litterman",
+    "hierarchical_risk_parity",
+    "mean_variance_optimization",
+    "risk_parity",
+]

--- a/engine/core/portfolio_optimizer.py
+++ b/engine/core/portfolio_optimizer.py
@@ -40,6 +40,9 @@ def _validate_cov(cov: FloatArray) -> FloatArray:
     if cov.shape[0] == 0:
         msg = "cov must have at least one asset"
         raise OptimizerError(msg)
+    if not np.isfinite(cov).all():
+        msg = "cov contains non-finite entries (NaN / Inf)"
+        raise OptimizerError(msg)
     return cov
 
 
@@ -80,6 +83,9 @@ def mean_variance_optimization(
                 f"expected_returns shape {mu.shape} does not match cov "
                 f"shape ({n},{n})"
             )
+            raise OptimizerError(msg)
+        if not np.isfinite(mu).all():
+            msg = "expected_returns contains non-finite entries (NaN / Inf)"
             raise OptimizerError(msg)
         unscaled = inv @ mu
     total = unscaled.sum()
@@ -128,7 +134,11 @@ def risk_parity(
         if np.linalg.norm(new_w - w, ord=np.inf) < tol:
             return new_w
         w = new_w
-    return w
+    msg = (
+        f"risk parity did not converge in {max_iter} iterations "
+        f"(tol={tol})"
+    )
+    raise OptimizerError(msg)
 
 
 def _correlation_from_cov(cov: FloatArray) -> FloatArray:
@@ -256,6 +266,9 @@ def black_litterman(
     (posterior_mu, posterior_cov)
         Blended posterior expected returns and covariance.
     """
+    if tau <= 0:
+        msg = f"tau must be positive; got {tau}"
+        raise OptimizerError(msg)
     cov = _validate_cov(prior_cov)
     pi = np.asarray(prior_returns, dtype=np.float64)
     if pi.shape != (cov.shape[0],):

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -176,3 +176,44 @@ class TestNumericProperties:
         w1 = hierarchical_risk_parity(cov=cov)
         w2 = hierarchical_risk_parity(cov=cov)
         np.testing.assert_allclose(w1, w2)
+
+
+class TestInputValidation:
+    def test_mvo_rejects_nan_in_cov(self):
+        cov = np.array([[0.04, np.nan], [np.nan, 0.09]])
+        with pytest.raises(OptimizerError, match="non-finite"):
+            mean_variance_optimization(cov=cov)
+
+    def test_mvo_rejects_inf_in_returns(self):
+        cov = np.eye(2) * 0.04
+        with pytest.raises(OptimizerError, match="non-finite"):
+            mean_variance_optimization(
+                cov=cov, expected_returns=np.array([np.inf, 0.05])
+            )
+
+    def test_risk_parity_raises_on_non_convergence(self):
+        # max_iter=1 with the multi-asset convergent default cov should
+        # not converge — the iteration needs more steps.
+        cov = np.array(
+            [
+                [0.20, 0.02, 0.01, 0.01],
+                [0.02, 0.25, 0.02, 0.01],
+                [0.01, 0.02, 0.30, 0.02],
+                [0.01, 0.01, 0.02, 0.35],
+            ]
+        )
+        with pytest.raises(OptimizerError, match="not converge"):
+            risk_parity(cov=cov, max_iter=1, tol=1e-12)
+
+    def test_black_litterman_rejects_non_positive_tau(self):
+        prior = np.array([0.05, 0.05])
+        cov = np.eye(2) * 0.04
+        with pytest.raises(OptimizerError, match="tau"):
+            black_litterman(
+                prior_returns=prior,
+                prior_cov=cov,
+                views_p=np.zeros((0, 2)),
+                views_q=np.zeros(0),
+                view_uncertainty=np.zeros((0, 0)),
+                tau=0.0,
+            )

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -1,0 +1,178 @@
+"""Tests for engine.core.portfolio_optimizer — MVO, risk parity, HRP, BL."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from engine.core.portfolio_optimizer import (
+    OptimizerError,
+    black_litterman,
+    hierarchical_risk_parity,
+    mean_variance_optimization,
+    risk_parity,
+)
+
+
+class TestMVO:
+    def test_minimum_variance_diagonal_cov(self):
+        cov = np.diag([1.0, 4.0, 9.0])
+        w = mean_variance_optimization(cov=cov)
+        expected_unnorm = np.array([1.0, 0.25, 1.0 / 9.0])
+        expected = expected_unnorm / expected_unnorm.sum()
+        np.testing.assert_allclose(w, expected, atol=1e-8)
+
+    def test_min_variance_weights_sum_to_one(self):
+        cov = np.array([[0.04, 0.01], [0.01, 0.09]])
+        w = mean_variance_optimization(cov=cov)
+        assert pytest.approx(1.0, abs=1e-8) == w.sum()
+
+    def test_equal_variance_yields_equal_weights(self):
+        cov = np.eye(4) * 0.05
+        w = mean_variance_optimization(cov=cov)
+        np.testing.assert_allclose(w, np.full(4, 0.25), atol=1e-8)
+
+    def test_max_sharpe_tilts_toward_high_return(self):
+        cov = np.eye(2) * 0.04
+        mu = np.array([0.10, 0.05])
+        w = mean_variance_optimization(cov=cov, expected_returns=mu)
+        assert w[0] > w[1]
+        assert pytest.approx(1.0, abs=1e-8) == w.sum()
+
+    def test_rejects_non_square_cov(self):
+        with pytest.raises(OptimizerError):
+            mean_variance_optimization(cov=np.zeros((2, 3)))
+
+    def test_rejects_singular_cov(self):
+        with pytest.raises(OptimizerError):
+            mean_variance_optimization(cov=np.zeros((3, 3)))
+
+
+class TestRiskParity:
+    def test_diagonal_cov_yields_inverse_vol_weights(self):
+        cov = np.diag([0.04, 0.16])
+        w = risk_parity(cov=cov)
+        np.testing.assert_allclose(w, np.array([2.0 / 3.0, 1.0 / 3.0]), atol=1e-3)
+
+    def test_weights_sum_to_one(self):
+        # Diagonally-dominant cov — guarantees positive sigma_w for
+        # positive w during the Spinu iteration.
+        cov = np.array(
+            [
+                [0.20, 0.02, 0.01, 0.01],
+                [0.02, 0.25, 0.02, 0.01],
+                [0.01, 0.02, 0.30, 0.02],
+                [0.01, 0.01, 0.02, 0.35],
+            ]
+        )
+        w = risk_parity(cov=cov)
+        assert pytest.approx(1.0, abs=1e-6) == w.sum()
+        assert (w > 0).all()
+
+    def test_equal_risk_contribution_property(self):
+        cov = np.array(
+            [
+                [0.10, 0.02, 0.04],
+                [0.02, 0.20, 0.05],
+                [0.04, 0.05, 0.30],
+            ]
+        )
+        w = risk_parity(cov=cov)
+        rc = w * (cov @ w)
+        for i in range(1, len(rc)):
+            assert pytest.approx(rc[0], rel=1e-3) == rc[i]
+
+
+class TestHRP:
+    def test_hrp_diagonal_cov_inverse_vol(self):
+        cov = np.diag([0.01, 0.04, 0.09, 0.16])
+        w = hierarchical_risk_parity(cov=cov)
+        assert (w > 0).all()
+        np.testing.assert_allclose(w.sum(), 1.0, atol=1e-8)
+
+    def test_hrp_weights_positive_and_sum_to_one(self):
+        rng = np.random.default_rng(7)
+        a = rng.standard_normal((50, 5))
+        cov = a.T @ a / 49.0
+        w = hierarchical_risk_parity(cov=cov)
+        assert (w > 0).all()
+        np.testing.assert_allclose(w.sum(), 1.0, atol=1e-8)
+
+    def test_hrp_handles_two_assets(self):
+        cov = np.array([[0.04, 0.01], [0.01, 0.09]])
+        w = hierarchical_risk_parity(cov=cov)
+        assert (w > 0).all()
+        np.testing.assert_allclose(w.sum(), 1.0, atol=1e-8)
+
+
+class TestBlackLitterman:
+    def test_no_views_returns_prior(self):
+        prior = np.array([0.05, 0.07, 0.06])
+        cov = np.diag([0.04, 0.04, 0.04])
+        post_mu, _ = black_litterman(
+            prior_returns=prior,
+            prior_cov=cov,
+            views_p=np.zeros((0, 3)),
+            views_q=np.zeros(0),
+            view_uncertainty=np.zeros((0, 0)),
+            tau=0.05,
+        )
+        np.testing.assert_allclose(post_mu, prior, atol=1e-8)
+
+    def test_absolute_view_shifts_posterior_toward_view(self):
+        prior = np.array([0.05, 0.05])
+        cov = np.eye(2) * 0.04
+        p = np.array([[1.0, 0.0]])
+        q = np.array([0.10])
+        omega = np.array([[0.001]])
+        post_mu, _ = black_litterman(
+            prior_returns=prior,
+            prior_cov=cov,
+            views_p=p,
+            views_q=q,
+            view_uncertainty=omega,
+            tau=0.05,
+        )
+        assert 0.05 < post_mu[0] <= 0.10
+        assert pytest.approx(prior[1], abs=1e-3) == post_mu[1]
+
+
+class TestErrors:
+    def test_mvo_negative_returns_input_passes(self):
+        # Σ⁻¹μ-summing-to-zero degenerates the unconstrained tangency
+        # solution. Verify a non-pathological mixed-sign vector still
+        # produces a valid weight vector that sums to 1.
+        cov = np.eye(2) * 0.04
+        mu = np.array([-0.02, 0.05])
+        w = mean_variance_optimization(cov=cov, expected_returns=mu)
+        assert pytest.approx(1.0, abs=1e-8) == w.sum()
+
+    def test_mvo_zero_sum_tangency_raises(self):
+        # Anti-symmetric μ gives a zero-sum tangency solution (long
+        # one asset, short the other in equal magnitude). Without a
+        # long-only constraint the closed form is degenerate.
+        cov = np.eye(2) * 0.04
+        mu = np.array([-0.05, 0.05])
+        with pytest.raises(OptimizerError):
+            mean_variance_optimization(cov=cov, expected_returns=mu)
+
+    def test_risk_parity_singular_cov_raises(self):
+        with pytest.raises(OptimizerError):
+            risk_parity(cov=np.zeros((3, 3)))
+
+    def test_hrp_non_square_raises(self):
+        with pytest.raises(OptimizerError):
+            hierarchical_risk_parity(cov=np.zeros((2, 3)))
+
+
+class TestNumericProperties:
+    def test_mvo_weights_are_finite(self):
+        cov = np.eye(5) * 0.05
+        w = mean_variance_optimization(cov=cov)
+        assert np.isfinite(w).all()
+
+    def test_hrp_repeatable(self):
+        cov = np.array([[0.04, 0.02], [0.02, 0.09]])
+        w1 = hierarchical_risk_parity(cov=cov)
+        w2 = hierarchical_risk_parity(cov=cov)
+        np.testing.assert_allclose(w1, w2)


### PR DESCRIPTION
## Summary

Closes #123. Pure-numpy implementations of four classic portfolio construction techniques: Markowitz MVO, equal-risk-contribution (risk parity), Lopez de Prado HRP, Black-Litterman.

### What lands

| Function | Method |
|---|---|
| \`mean_variance_optimization\` | Min-variance / max-Sharpe closed-form |
| \`risk_parity\` | Spinu fixed-point — equal risk contribution |
| \`hierarchical_risk_parity\` | LdP HRP — clustering + recursive bisection + IVP |
| \`black_litterman\` | Posterior μ/Σ from prior + views |

No scipy / cvxpy dependency. \`OptimizerError\` for malformed input or singular Σ.

### Out of scope (follow-up)

- Long-only / leverage / turnover / sector constraints (need a QP solver — separate issue)
- Rolling-window covariance estimation (Ledoit-Wolf, OAS)
- API routes / strategy-builder integration

### Test plan

- [x] 20 unit tests against known closed-form cases
- [x] Full suite — 828 passed
- [x] \`ruff\` + \`basedpyright\` clean
- [ ] Adversarial review next

🤖 Generated with [Claude Code](https://claude.com/claude-code)