### PR TITLE
feat(core): post-trade TCA (#122)

### DIFF
--- a/engine/core/tca.py
+++ b/engine/core/tca.py
@@ -1,0 +1,213 @@
+"""Post-trade Transaction Cost Analysis.
+
+Computes implementation shortfall (IS) and arrival slippage per fill,
+plus aggregations over an arbitrary list of fills with rollups by
+broker and by symbol.
+
+Definitions
+-----------
+- *Decision price*: the price at the moment the strategy decided to
+  trade. The signal's reference quote.
+- *Arrival price*: the price at the moment the parent order arrived
+  at the venue. Captures pre-trade market drift and queue position.
+- *Fill price*: the actual execution price.
+
+For a BUY:
+    implementation_shortfall = (fill_price - decision_price) * quantity + fees
+    slippage_vs_arrival     = (fill_price - arrival_price)  * quantity
+
+For a SELL the price differences flip sign so a positive number always
+means "we paid more than expected" / "we sold for less than expected".
+Both quantities are reported as positive cost in dollars and as basis
+points of the fill notional.
+
+Pure-Python over plain dataclasses; no pandas/numpy dependency.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+class Side(StrEnum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+@dataclass(frozen=True)
+class Fill:
+    """One executed trade record."""
+
+    symbol: str
+    side: Side
+    quantity: int
+    fill_price: float
+    decision_price: float
+    arrival_price: float
+    fees: float
+    broker: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("fill_price", self.fill_price),
+            ("decision_price", self.decision_price),
+            ("arrival_price", self.arrival_price),
+            ("fees", self.fees),
+        ):
+            if not math.isfinite(value):
+                msg = f"{name} must be finite; got {value}"
+                raise ValueError(msg)
+        if self.quantity <= 0:
+            msg = f"quantity must be positive; got {self.quantity}"
+            raise ValueError(msg)
+        if self.fill_price <= 0:
+            msg = f"fill_price must be positive; got {self.fill_price}"
+            raise ValueError(msg)
+        if self.decision_price <= 0 or self.arrival_price <= 0:
+            msg = "decision_price and arrival_price must be positive"
+            raise ValueError(msg)
+        if self.fees < 0:
+            msg = f"fees must be non-negative; got {self.fees}"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class FillMetrics:
+    """Per-fill TCA outputs."""
+
+    implementation_shortfall: float
+    slippage_vs_arrival: float
+    fees: float
+    notional: float
+    implementation_shortfall_bps: float
+    slippage_vs_arrival_bps: float
+
+
+def _signed_cost(side: Side, fill_price: float, ref_price: float) -> float:
+    """Cost in price terms — always positive when fill is unfavorable."""
+    if side == Side.BUY:
+        return fill_price - ref_price
+    return ref_price - fill_price
+
+
+def fill_metrics(fill: Fill) -> FillMetrics:
+    notional = fill.quantity * fill.fill_price
+    is_per_share = _signed_cost(fill.side, fill.fill_price, fill.decision_price)
+    slip_per_share = _signed_cost(
+        fill.side, fill.fill_price, fill.arrival_price
+    )
+    is_total = is_per_share * fill.quantity + fill.fees
+    slip_total = slip_per_share * fill.quantity
+    if notional > 0:
+        is_bps = is_total / notional * 10_000.0
+        slip_bps = slip_total / notional * 10_000.0
+    else:
+        is_bps = 0.0
+        slip_bps = 0.0
+    return FillMetrics(
+        implementation_shortfall=is_total,
+        slippage_vs_arrival=slip_total,
+        fees=fill.fees,
+        notional=notional,
+        implementation_shortfall_bps=is_bps,
+        slippage_vs_arrival_bps=slip_bps,
+    )
+
+
+@dataclass(frozen=True)
+class TCAReport:
+    """Aggregate TCA report over a list of fills."""
+
+    total_implementation_shortfall: float = 0.0
+    total_slippage_vs_arrival: float = 0.0
+    total_fees: float = 0.0
+    total_notional: float = 0.0
+    fill_count: int = 0
+    weighted_average_is_bps: float = 0.0
+    weighted_average_slippage_bps: float = 0.0
+    by_broker: dict[str, TCAReport] = field(default_factory=dict)
+    by_symbol: dict[str, TCAReport] = field(default_factory=dict)
+
+
+def _empty_report() -> TCAReport:
+    return TCAReport()
+
+
+def _aggregate_no_rollups(fills: list[Fill]) -> TCAReport:
+    """Aggregate without per-broker / per-symbol rollups (used for nested)."""
+    if not fills:
+        return _empty_report()
+    is_total = 0.0
+    slip_total = 0.0
+    fee_total = 0.0
+    notional_total = 0.0
+    for f in fills:
+        m = fill_metrics(f)
+        is_total += m.implementation_shortfall
+        slip_total += m.slippage_vs_arrival
+        fee_total += m.fees
+        notional_total += m.notional
+    if notional_total > 0:
+        wa_is = is_total / notional_total * 10_000.0
+        wa_slip = slip_total / notional_total * 10_000.0
+    else:
+        wa_is = 0.0
+        wa_slip = 0.0
+    return TCAReport(
+        total_implementation_shortfall=is_total,
+        total_slippage_vs_arrival=slip_total,
+        total_fees=fee_total,
+        total_notional=notional_total,
+        fill_count=len(fills),
+        weighted_average_is_bps=wa_is,
+        weighted_average_slippage_bps=wa_slip,
+    )
+
+
+def aggregate_tca(fills: Iterable[Fill]) -> TCAReport:
+    """Compute the full TCA report including per-broker + per-symbol rollups."""
+    fills_list = list(fills)
+    if not fills_list:
+        return _empty_report()
+    base = _aggregate_no_rollups(fills_list)
+    by_broker_groups: dict[str, list[Fill]] = defaultdict(list)
+    by_symbol_groups: dict[str, list[Fill]] = defaultdict(list)
+    for f in fills_list:
+        by_broker_groups[f.broker].append(f)
+        by_symbol_groups[f.symbol].append(f)
+    by_broker = {
+        broker: _aggregate_no_rollups(group)
+        for broker, group in by_broker_groups.items()
+    }
+    by_symbol = {
+        symbol: _aggregate_no_rollups(group)
+        for symbol, group in by_symbol_groups.items()
+    }
+    return TCAReport(
+        total_implementation_shortfall=base.total_implementation_shortfall,
+        total_slippage_vs_arrival=base.total_slippage_vs_arrival,
+        total_fees=base.total_fees,
+        total_notional=base.total_notional,
+        fill_count=base.fill_count,
+        weighted_average_is_bps=base.weighted_average_is_bps,
+        weighted_average_slippage_bps=base.weighted_average_slippage_bps,
+        by_broker=by_broker,
+        by_symbol=by_symbol,
+    )
+
+
+__all__ = [
+    "Fill",
+    "FillMetrics",
+    "Side",
+    "TCAReport",
+    "aggregate_tca",
+    "fill_metrics",
+]

--- a/tests/test_tca.py
+++ b/tests/test_tca.py
@@ -1,0 +1,195 @@
+"""Tests for engine.core.tca — post-trade Transaction Cost Analysis."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.tca import (
+    Fill,
+    Side,
+    TCAReport,
+    aggregate_tca,
+    fill_metrics,
+)
+
+
+def _buy_fill(**kw) -> Fill:
+    base = {
+        "symbol": "AAPL",
+        "side": Side.BUY,
+        "quantity": 100,
+        "fill_price": 100.0,
+        "decision_price": 99.0,
+        "arrival_price": 99.5,
+        "fees": 1.0,
+        "broker": "alpaca",
+    }
+    base.update(kw)
+    return Fill(**base)
+
+
+def _sell_fill(**kw) -> Fill:
+    base = {
+        "symbol": "AAPL",
+        "side": Side.SELL,
+        "quantity": 100,
+        "fill_price": 100.0,
+        "decision_price": 101.0,
+        "arrival_price": 100.5,
+        "fees": 1.0,
+        "broker": "alpaca",
+    }
+    base.update(kw)
+    return Fill(**base)
+
+
+class TestSinglefillMetrics:
+    def test_buy_implementation_shortfall(self):
+        f = _buy_fill()
+        m = fill_metrics(f)
+        assert m.implementation_shortfall == pytest.approx(101.0)
+
+    def test_buy_slippage_vs_arrival(self):
+        f = _buy_fill()
+        m = fill_metrics(f)
+        assert m.slippage_vs_arrival == pytest.approx(50.0)
+
+    def test_sell_implementation_shortfall(self):
+        f = _sell_fill()
+        m = fill_metrics(f)
+        assert m.implementation_shortfall == pytest.approx(101.0)
+
+    def test_sell_slippage_vs_arrival(self):
+        f = _sell_fill()
+        m = fill_metrics(f)
+        assert m.slippage_vs_arrival == pytest.approx(50.0)
+
+    def test_metrics_in_bps(self):
+        f = _buy_fill()
+        m = fill_metrics(f)
+        assert m.implementation_shortfall_bps == pytest.approx(101.0)
+
+    def test_zero_fee_zero_slippage_zero_metrics(self):
+        f = _buy_fill(fill_price=99.0, arrival_price=99.0, fees=0.0)
+        m = fill_metrics(f)
+        assert m.implementation_shortfall == pytest.approx(0.0)
+        assert m.slippage_vs_arrival == pytest.approx(0.0)
+
+
+class TestSideEnum:
+    def test_side_values(self):
+        assert Side.BUY.value == "buy"
+        assert Side.SELL.value == "sell"
+
+
+class TestAggregation:
+    def test_empty_fills_zero_report(self):
+        report = aggregate_tca([])
+        assert isinstance(report, TCAReport)
+        assert report.total_implementation_shortfall == 0.0
+        assert report.total_fees == 0.0
+        assert report.fill_count == 0
+
+    def test_total_is_sum_of_fills(self):
+        f1 = _buy_fill()
+        f2 = _buy_fill(quantity=50, fill_price=100.0, decision_price=99.5)
+        report = aggregate_tca([f1, f2])
+        assert report.total_implementation_shortfall == pytest.approx(127.0)
+        assert report.fill_count == 2
+
+    def test_total_fees_aggregated(self):
+        f1 = _buy_fill(fees=1.0)
+        f2 = _buy_fill(fees=2.5)
+        report = aggregate_tca([f1, f2])
+        assert report.total_fees == pytest.approx(3.5)
+
+    def test_per_broker_rollup(self):
+        a = _buy_fill(broker="alpaca", fees=1.0)
+        b = _buy_fill(broker="ibkr", fees=2.0)
+        report = aggregate_tca([a, b])
+        assert "alpaca" in report.by_broker
+        assert "ibkr" in report.by_broker
+        assert report.by_broker["alpaca"].total_fees == pytest.approx(1.0)
+        assert report.by_broker["ibkr"].total_fees == pytest.approx(2.0)
+
+    def test_per_symbol_rollup(self):
+        a = _buy_fill(symbol="AAPL")
+        b = _buy_fill(symbol="MSFT")
+        c = _buy_fill(symbol="AAPL")
+        report = aggregate_tca([a, b, c])
+        assert report.by_symbol["AAPL"].fill_count == 2
+        assert report.by_symbol["MSFT"].fill_count == 1
+
+    def test_buy_and_sell_offset(self):
+        b = _buy_fill(arrival_price=99.5)
+        s = _sell_fill(arrival_price=100.5)
+        report = aggregate_tca([b, s])
+        assert report.total_slippage_vs_arrival == pytest.approx(100.0)
+
+
+class TestNotional:
+    def test_notional_is_quantity_times_fill_price(self):
+        f = _buy_fill()
+        m = fill_metrics(f)
+        assert m.notional == pytest.approx(10_000.0)
+
+
+class TestValidation:
+    def test_negative_quantity_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            Fill(
+                symbol="AAPL",
+                side=Side.BUY,
+                quantity=-10,
+                fill_price=100.0,
+                decision_price=99.0,
+                arrival_price=99.5,
+                fees=0.0,
+                broker="x",
+            )
+
+    def test_zero_fill_price_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            Fill(
+                symbol="AAPL",
+                side=Side.BUY,
+                quantity=10,
+                fill_price=0.0,
+                decision_price=99.0,
+                arrival_price=99.5,
+                fees=0.0,
+                broker="x",
+            )
+
+    def test_nan_price_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            Fill(
+                symbol="AAPL",
+                side=Side.BUY,
+                quantity=10,
+                fill_price=float("nan"),
+                decision_price=99.0,
+                arrival_price=99.5,
+                fees=0.0,
+                broker="x",
+            )
+
+    def test_inf_fees_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            Fill(
+                symbol="AAPL",
+                side=Side.BUY,
+                quantity=10,
+                fill_price=100.0,
+                decision_price=99.0,
+                arrival_price=99.5,
+                fees=float("inf"),
+                broker="x",
+            )
+
+
+class TestReportShape:
+    def test_report_has_average_bps(self):
+        f = _buy_fill()
+        report = aggregate_tca([f])
+        assert report.weighted_average_is_bps == pytest.approx(101.0)


### PR DESCRIPTION
## Summary

Closes #122. Pure-Python TCA: implementation shortfall, arrival slippage, and per-broker / per-symbol aggregation.

### Metrics

Per fill:
- \`implementation_shortfall = (fill - decision) * qty + fees\` (BUY; flipped for SELL).
- \`slippage_vs_arrival = (fill - arrival) * qty\` (BUY; flipped for SELL).
- bps conversions against notional.

Aggregate \`TCAReport\`:
- totals (IS / slippage / fees / notional)
- notional-weighted average bps
- \`by_broker\` and \`by_symbol\` flat rollups (each is a \`TCAReport\` over the filtered subset)

Validation at \`Fill.__post_init__\`: positive qty / prices, non-negative fees, all numeric fields finite (no NaN / Inf).

### Out of scope (follow-up)

- Persistence: store fills + reports in a tca-events table
- API route + dashboard rollups
- Volume-weighted impact decomposition (temporary vs permanent)

### Test plan

- [x] 19 unit tests cover IS, slippage, bps, BUY+SELL signs, empty list, aggregation, broker/symbol rollups, validation paths
- [x] Full suite — 849 passed
- [x] \`ruff\` + \`basedpyright\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)