### PR TITLE
feat(core): Monte Carlo robustness testing (#121)

### DIFF
--- a/engine/core/monte_carlo.py
+++ b/engine/core/monte_carlo.py
@@ -1,0 +1,154 @@
+"""Monte Carlo robustness testing for backtest results.
+
+Resamples a return series with replacement to build a distribution of
+possible alternate-history outcomes.
+
+Two flavors:
+- :func:`bootstrap_returns` — i.i.d. bootstrap (Efron). Samples
+  independently and uniformly from the empirical distribution.
+- :func:`block_bootstrap` — moving-block bootstrap (Künsch). Samples
+  contiguous blocks so simulated paths preserve short-run autocorrelation.
+
+Pure-numpy. Deterministic given a ``seed``. Inputs validated to reject
+empty / non-finite series and impossible block sizes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+FloatArray = npt.NDArray[np.float64]
+
+
+class MonteCarloError(Exception):
+    """Raised on malformed inputs to a Monte Carlo simulation."""
+
+
+@dataclass(frozen=True)
+class SimulationStats:
+    """Distribution summary across N simulated paths."""
+
+    n_simulations: int
+    mean_total_return: float
+    median_total_return: float
+    p5_total_return: float
+    p95_total_return: float
+    mean_max_drawdown: float
+    p95_max_drawdown: float
+
+
+def max_drawdown(equity_curve: FloatArray) -> float:
+    """Worst peak-to-trough drop as a positive fraction in [0, 1]."""
+    eq = np.asarray(equity_curve, dtype=np.float64)
+    if eq.size == 0:
+        return 0.0
+    running_peak = np.maximum.accumulate(eq)
+    drawdowns = (running_peak - eq) / running_peak
+    drawdowns = np.where(running_peak > 0, drawdowns, 0.0)
+    return float(np.max(drawdowns))
+
+
+def _validate_returns(returns: FloatArray) -> FloatArray:
+    arr = np.asarray(returns, dtype=np.float64)
+    if arr.size == 0:
+        msg = "returns must be non-empty"
+        raise MonteCarloError(msg)
+    if not np.isfinite(arr).all():
+        msg = "returns must be finite (no NaN / Inf)"
+        raise MonteCarloError(msg)
+    return arr
+
+
+def _validate_n_simulations(n: int) -> None:
+    if n < 1:
+        msg = f"n_simulations must be >= 1; got {n}"
+        raise MonteCarloError(msg)
+
+
+def _summarize(
+    n_simulations: int,
+    total_returns: FloatArray,
+    max_drawdowns: FloatArray,
+) -> SimulationStats:
+    return SimulationStats(
+        n_simulations=n_simulations,
+        mean_total_return=float(np.mean(total_returns)),
+        median_total_return=float(np.median(total_returns)),
+        p5_total_return=float(np.percentile(total_returns, 5)),
+        p95_total_return=float(np.percentile(total_returns, 95)),
+        mean_max_drawdown=float(np.mean(max_drawdowns)),
+        p95_max_drawdown=float(np.percentile(max_drawdowns, 95)),
+    )
+
+
+def bootstrap_returns(
+    returns: FloatArray,
+    *,
+    n_simulations: int,
+    seed: int | None = None,
+) -> SimulationStats:
+    """i.i.d. bootstrap of a return series."""
+    arr = _validate_returns(returns)
+    _validate_n_simulations(n_simulations)
+    rng = np.random.default_rng(seed)
+    n_obs = arr.size
+    indices = rng.integers(0, n_obs, size=(n_simulations, n_obs))
+    sampled = arr[indices]
+    equity = np.cumprod(1.0 + sampled, axis=1).astype(np.float64, copy=False)
+    total_returns = (equity[:, -1] - 1.0).astype(np.float64, copy=False)
+    running_peak = np.maximum.accumulate(equity, axis=1)
+    drawdowns = ((running_peak - equity) / running_peak).astype(np.float64, copy=False)
+    max_dds = np.max(drawdowns, axis=1).astype(np.float64, copy=False)
+    return _summarize(n_simulations, total_returns, max_dds)
+
+
+def block_bootstrap(
+    returns: FloatArray,
+    *,
+    n_simulations: int,
+    block_size: int,
+    seed: int | None = None,
+) -> SimulationStats:
+    """Moving-block bootstrap (Künsch).
+
+    Samples contiguous blocks of length ``block_size`` to preserve
+    short-run autocorrelation. Each path concatenates
+    ``ceil(n_obs / block_size)`` blocks and truncates to ``n_obs``.
+    """
+    arr = _validate_returns(returns)
+    _validate_n_simulations(n_simulations)
+    n_obs = arr.size
+    if block_size < 1:
+        msg = f"block_size must be >= 1; got {block_size}"
+        raise MonteCarloError(msg)
+    if block_size >= n_obs:
+        msg = f"block_size {block_size} must be < returns length {n_obs}"
+        raise MonteCarloError(msg)
+
+    rng = np.random.default_rng(seed)
+    n_blocks = -(-n_obs // block_size)
+    n_starts = n_obs - block_size + 1
+
+    starts = rng.integers(0, n_starts, size=(n_simulations, n_blocks))
+    block_offsets = np.arange(block_size)
+    indices = starts[:, :, None] + block_offsets[None, None, :]
+    indices = indices.reshape(n_simulations, -1)[:, :n_obs]
+    sampled = arr[indices]
+    equity = np.cumprod(1.0 + sampled, axis=1).astype(np.float64, copy=False)
+    total_returns = (equity[:, -1] - 1.0).astype(np.float64, copy=False)
+    running_peak = np.maximum.accumulate(equity, axis=1)
+    drawdowns = ((running_peak - equity) / running_peak).astype(np.float64, copy=False)
+    max_dds = np.max(drawdowns, axis=1).astype(np.float64, copy=False)
+    return _summarize(n_simulations, total_returns, max_dds)
+
+
+__all__ = [
+    "MonteCarloError",
+    "SimulationStats",
+    "block_bootstrap",
+    "bootstrap_returns",
+    "max_drawdown",
+]

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -1,0 +1,126 @@
+"""Tests for engine.core.monte_carlo — bootstrap robustness analysis."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from engine.core.monte_carlo import (
+    MonteCarloError,
+    SimulationStats,
+    block_bootstrap,
+    bootstrap_returns,
+    max_drawdown,
+)
+
+
+class TestMaxDrawdown:
+    def test_monotonic_up_zero_drawdown(self):
+        eq = np.array([1.0, 1.1, 1.2, 1.3])
+        assert max_drawdown(eq) == pytest.approx(0.0)
+
+    def test_50pct_drop(self):
+        eq = np.array([1.0, 2.0, 1.0])
+        assert max_drawdown(eq) == pytest.approx(0.5)
+
+    def test_recovery_remembers_worst_drop(self):
+        eq = np.array([1.0, 2.0, 1.5, 2.5])
+        assert max_drawdown(eq) == pytest.approx(0.25)
+
+    def test_empty_array_returns_zero(self):
+        assert max_drawdown(np.array([])) == pytest.approx(0.0)
+
+
+class TestBootstrap:
+    def test_returns_simulation_stats(self):
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.001, 0.01, size=200)
+        out = bootstrap_returns(returns, n_simulations=500, seed=7)
+        assert isinstance(out, SimulationStats)
+
+    def test_seeded_deterministic(self):
+        returns = np.array([0.01, -0.005, 0.002, 0.015, -0.01])
+        a = bootstrap_returns(returns, n_simulations=100, seed=42)
+        b = bootstrap_returns(returns, n_simulations=100, seed=42)
+        assert a.mean_total_return == b.mean_total_return
+        assert a.p5_total_return == b.p5_total_return
+
+    def test_different_seeds_differ(self):
+        returns = np.array([0.01, -0.005, 0.002, 0.015, -0.01])
+        a = bootstrap_returns(returns, n_simulations=100, seed=1)
+        b = bootstrap_returns(returns, n_simulations=100, seed=2)
+        assert a.mean_total_return != b.mean_total_return
+
+    def test_p5_le_median_le_p95(self):
+        rng = np.random.default_rng(0)
+        returns = rng.normal(0.0005, 0.02, size=500)
+        out = bootstrap_returns(returns, n_simulations=1000, seed=11)
+        assert out.p5_total_return <= out.median_total_return
+        assert out.median_total_return <= out.p95_total_return
+
+    def test_bootstrap_mean_close_to_sample_compound(self):
+        rng = np.random.default_rng(0)
+        returns = rng.normal(0.001, 0.001, size=100)
+        out = bootstrap_returns(returns, n_simulations=2000, seed=13)
+        sample_compound = float(np.prod(1.0 + returns) - 1.0)
+        assert out.mean_total_return == pytest.approx(
+            sample_compound, abs=0.05
+        )
+
+
+class TestBlockBootstrap:
+    def test_block_bootstrap_runs(self):
+        rng = np.random.default_rng(0)
+        returns = rng.normal(0.0, 0.01, size=200)
+        out = block_bootstrap(
+            returns, n_simulations=200, block_size=10, seed=42
+        )
+        assert isinstance(out, SimulationStats)
+
+    def test_block_bootstrap_seeded_deterministic(self):
+        returns = np.array([0.01, -0.005, 0.002, 0.015, -0.01, 0.003] * 10)
+        a = block_bootstrap(returns, n_simulations=100, block_size=5, seed=99)
+        b = block_bootstrap(returns, n_simulations=100, block_size=5, seed=99)
+        assert a.mean_total_return == b.mean_total_return
+
+
+class TestValidation:
+    def test_empty_returns_raises(self):
+        with pytest.raises(MonteCarloError):
+            bootstrap_returns(np.array([]), n_simulations=100, seed=0)
+
+    def test_zero_simulations_raises(self):
+        returns = np.array([0.01, 0.02])
+        with pytest.raises(MonteCarloError):
+            bootstrap_returns(returns, n_simulations=0, seed=0)
+
+    def test_block_size_larger_than_returns_raises(self):
+        returns = np.array([0.01, 0.02])
+        with pytest.raises(MonteCarloError):
+            block_bootstrap(returns, n_simulations=10, block_size=10, seed=0)
+
+    def test_block_size_zero_raises(self):
+        returns = np.array([0.01, 0.02])
+        with pytest.raises(MonteCarloError):
+            block_bootstrap(returns, n_simulations=10, block_size=0, seed=0)
+
+    def test_non_finite_returns_rejected(self):
+        with pytest.raises(MonteCarloError):
+            bootstrap_returns(
+                np.array([0.01, np.nan]), n_simulations=10, seed=0
+            )
+
+
+class TestSimulationStats:
+    def test_dataclass_fields(self):
+        s = SimulationStats(
+            n_simulations=100,
+            mean_total_return=0.05,
+            median_total_return=0.04,
+            p5_total_return=-0.02,
+            p95_total_return=0.12,
+            mean_max_drawdown=0.10,
+            p95_max_drawdown=0.20,
+        )
+        assert s.n_simulations == 100
+        assert s.p5_total_return < s.median_total_return < s.p95_total_return


### PR DESCRIPTION
## Summary

Closes #121. Pure-numpy bootstrap analysis for backtest return series: i.i.d. (Efron) and moving-block (Künsch) variants.

### What lands

- \`bootstrap_returns(returns, *, n_simulations, seed)\` — i.i.d. resampling with replacement.
- \`block_bootstrap(returns, *, n_simulations, block_size, seed)\` — preserves short-run autocorrelation.
- \`max_drawdown(equity_curve)\` — peak-to-trough drop helper.
- \`SimulationStats\` — mean / median / p5 / p95 of compound total return; mean / p95 of max drawdown.
- \`MonteCarloError\` for malformed inputs (empty / NaN / zero-sims / oversize-block).

Vectorized index construction — single \`rng.integers\` call draws all simulated paths at once. Deterministic with explicit \`seed\`.

### Out of scope (follow-up)

- Stationary bootstrap (Politis-Romano) random block lengths
- Persistence: store sim runs in a backtest-results table
- API endpoint exposing distribution percentiles to the dashboard

### Test plan

- [x] 17 unit tests cover max-drawdown helper, bootstrap determinism, block bootstrap, percentile ordering, validation paths
- [x] Full suite — 868 passed
- [x] \`ruff\` + \`basedpyright\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)