### PR TITLE
feat(auth): TOTP MFA (#126, PR1)

### DIFF
--- a/engine/api/auth/mfa.py
+++ b/engine/api/auth/mfa.py
@@ -1,0 +1,151 @@
+"""Multi-factor authentication primitives.
+
+Pure-stdlib RFC 6238 (TOTP) / RFC 4226 (HOTP) implementation. No
+external pyotp dependency.
+
+PR1 ships TOTP enrollment + verification. WebAuthn / FIDO2 lands in a
+follow-up that pulls in a webauthn library at the API layer.
+
+Threat model:
+- Constant-time comparison on the verification path so timing leaks
+  cannot reveal partial code matches.
+- Codes outside [0, 10^digits) are rejected before any HMAC work.
+- ``window`` permits clock-drift tolerance symmetrically (±N steps);
+  caller must persist the last-accepted counter to defeat replay.
+
+Caller responsibilities:
+- Persist the base32 secret encrypted at rest.
+- Track last-accepted counter alongside the secret to reject replays.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+import struct
+import time
+from urllib.parse import quote, urlencode
+
+
+class MFAError(Exception):
+    """Raised on malformed inputs to MFA primitives."""
+
+
+_DEFAULT_DIGITS = 6
+_DEFAULT_STEP_SEC = 30
+_MIN_SECRET_BYTES = 16
+_MIN_DIGITS = 6
+_MAX_DIGITS = 10
+
+
+def generate_totp_secret(*, n_bytes: int = 20) -> str:
+    """Return a fresh base32-encoded TOTP secret (>=128 bits by default)."""
+    if n_bytes < _MIN_SECRET_BYTES:
+        msg = f"n_bytes must be >= {_MIN_SECRET_BYTES}; got {n_bytes}"
+        raise MFAError(msg)
+    raw = secrets.token_bytes(n_bytes)
+    return base64.b32encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_secret(secret_b32: str) -> bytes:
+    padding = (-len(secret_b32)) % 8
+    try:
+        return base64.b32decode(
+            secret_b32.upper() + "=" * padding, casefold=False
+        )
+    except (ValueError, TypeError) as exc:
+        msg = f"secret is not valid base32: {exc}"
+        raise MFAError(msg) from exc
+
+
+def _hotp(
+    secret_b32: str, counter: int, *, digits: int = _DEFAULT_DIGITS
+) -> str:
+    """RFC 4226 HMAC-One-Time-Password."""
+    if digits < _MIN_DIGITS or digits > _MAX_DIGITS:
+        msg = f"digits must be in [{_MIN_DIGITS}, {_MAX_DIGITS}]; got {digits}"
+        raise MFAError(msg)
+    if counter < 0:
+        msg = f"counter must be non-negative; got {counter}"
+        raise MFAError(msg)
+    key = _decode_secret(secret_b32)
+    counter_bytes = struct.pack(">Q", counter)
+    digest = hmac.new(key, counter_bytes, hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    truncated = (
+        ((digest[offset] & 0x7F) << 24)
+        | ((digest[offset + 1] & 0xFF) << 16)
+        | ((digest[offset + 2] & 0xFF) << 8)
+        | (digest[offset + 3] & 0xFF)
+    )
+    code = truncated % (10**digits)
+    return f"{code:0{digits}d}"
+
+
+def verify_totp(
+    secret_b32: str,
+    code: str,
+    *,
+    now: float | None = None,
+    step: int = _DEFAULT_STEP_SEC,
+    window: int = 1,
+    digits: int = _DEFAULT_DIGITS,
+) -> bool:
+    """Verify a TOTP ``code`` against ``secret_b32``.
+
+    ``window`` permits +/- N step accept-windows for clock drift.
+    ``now`` defaults to the current Unix epoch (seconds).
+    """
+    if step <= 0:
+        msg = f"step must be > 0; got {step}"
+        raise MFAError(msg)
+    if window < 0:
+        msg = f"window must be >= 0; got {window}"
+        raise MFAError(msg)
+    if not code or not code.isdigit() or len(code) != digits:
+        return False
+    _decode_secret(secret_b32)  # surface bad-secret errors before time math
+    t = time.time() if now is None else now
+    counter = int(t // step)
+    for offset in range(-window, window + 1):
+        candidate = _hotp(secret_b32, counter + offset, digits=digits)
+        if hmac.compare_digest(candidate, code):
+            return True
+    return False
+
+
+def totp_uri(
+    *,
+    secret: str,
+    account: str,
+    issuer: str,
+    digits: int = _DEFAULT_DIGITS,
+    step: int = _DEFAULT_STEP_SEC,
+    algorithm: str = "SHA1",
+) -> str:
+    """Build an ``otpauth://`` URI for QR-code enrollment."""
+    if not account.strip():
+        msg = "account must be non-empty"
+        raise MFAError(msg)
+    if not issuer.strip():
+        msg = "issuer must be non-empty"
+        raise MFAError(msg)
+    label = f"{quote(issuer, safe='')}:{quote(account, safe='@')}"
+    params = {
+        "secret": secret,
+        "issuer": issuer,
+        "algorithm": algorithm,
+        "digits": str(digits),
+        "period": str(step),
+    }
+    return f"otpauth://totp/{label}?{urlencode(params)}"
+
+
+__all__ = [
+    "MFAError",
+    "generate_totp_secret",
+    "totp_uri",
+    "verify_totp",
+]

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -1,0 +1,130 @@
+"""Tests for engine.api.auth.mfa — TOTP enrollment + verification."""
+
+from __future__ import annotations
+
+import base64
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from engine.api.auth.mfa import (
+    MFAError,
+    _hotp,
+    generate_totp_secret,
+    totp_uri,
+    verify_totp,
+)
+
+_RFC_SECRET_B32 = base64.b32encode(b"12345678901234567890").decode("ascii")
+
+
+class TestSecretGeneration:
+    def test_generated_secret_is_base32(self):
+        s = generate_totp_secret()
+        decoded = base64.b32decode(s, casefold=False)
+        assert len(decoded) >= 16
+
+    def test_each_call_unique(self):
+        a = generate_totp_secret()
+        b = generate_totp_secret()
+        assert a != b
+
+
+class TestHOTP:
+    def test_rfc_4226_vectors(self):
+        # RFC 4226 Appendix D published HOTP values for secret
+        # "12345678901234567890". Counters 0..9 -> these 6-digit codes.
+        expected = [
+            "755224",
+            "287082",
+            "359152",
+            "969429",
+            "338314",
+            "254676",
+            "287922",
+            "162583",
+            "399871",
+            "520489",
+        ]
+        for counter, code in enumerate(expected):
+            assert _hotp(_RFC_SECRET_B32, counter, digits=6) == code
+
+
+class TestVerifyTOTP:
+    def test_correct_code_within_window(self):
+        secret = _RFC_SECRET_B32
+        ok = verify_totp(secret, "287082", now=59, step=30, window=0)
+        assert ok is True
+
+    def test_wrong_code_rejected(self):
+        secret = _RFC_SECRET_B32
+        ok = verify_totp(secret, "000000", now=59, step=30, window=0)
+        assert ok is False
+
+    def test_window_accepts_previous_code(self):
+        secret = _RFC_SECRET_B32
+        ok = verify_totp(secret, "287082", now=89, step=30, window=1)
+        assert ok is True
+
+    def test_window_zero_strict(self):
+        secret = _RFC_SECRET_B32
+        ok = verify_totp(secret, "287082", now=89, step=30, window=0)
+        assert ok is False
+
+    def test_non_digit_code_rejected(self):
+        secret = _RFC_SECRET_B32
+        ok = verify_totp(secret, "abcdef", now=59, step=30, window=1)
+        assert ok is False
+
+    def test_wrong_length_code_rejected(self):
+        secret = _RFC_SECRET_B32
+        ok = verify_totp(secret, "12345", now=59, step=30, window=1)
+        assert ok is False
+        ok = verify_totp(secret, "1234567", now=59, step=30, window=1)
+        assert ok is False
+
+
+class TestURI:
+    def test_uri_has_otpauth_scheme(self):
+        uri = totp_uri(
+            secret="JBSWY3DPEHPK3PXP",
+            account="alice@example.com",
+            issuer="Nexus",
+        )
+        assert uri.startswith("otpauth://totp/")
+
+    def test_uri_includes_issuer_and_account(self):
+        uri = totp_uri(
+            secret="JBSWY3DPEHPK3PXP",
+            account="alice@example.com",
+            issuer="Nexus",
+        )
+        parsed = urlparse(uri)
+        assert "Nexus" in parsed.path
+        assert (
+            "alice%40example.com" in parsed.path
+            or "alice@example.com" in parsed.path
+        )
+        params = parse_qs(parsed.query)
+        assert params["secret"] == ["JBSWY3DPEHPK3PXP"]
+        assert params["issuer"] == ["Nexus"]
+
+
+class TestValidation:
+    def test_invalid_secret_b32_rejected(self):
+        with pytest.raises(MFAError):
+            verify_totp("not-base32!!!", "123456", now=0, step=30, window=0)
+
+    def test_negative_window_rejected(self):
+        with pytest.raises(MFAError):
+            verify_totp(
+                _RFC_SECRET_B32, "123456", now=0, step=30, window=-1
+            )
+
+    def test_zero_step_rejected(self):
+        with pytest.raises(MFAError):
+            verify_totp(_RFC_SECRET_B32, "123456", now=0, step=0, window=1)
+
+    def test_uri_rejects_empty_account(self):
+        with pytest.raises(MFAError):
+            totp_uri(secret="JBSWY3DPEHPK3PXP", account="", issuer="Nexus")


### PR DESCRIPTION
## Summary

Refs #126 (PR1). Pure-stdlib RFC 6238 (TOTP) / RFC 4226 (HOTP) implementation with no external pyotp dependency.

### Public surface

- \`generate_totp_secret(*, n_bytes=20)\` — ≥128-bit base32 secret.
- \`verify_totp(secret_b32, code, *, now=None, step=30, window=1, digits=6)\` — constant-time compare, drift window, rejects bad shapes before HMAC.
- \`totp_uri(*, secret, account, issuer, ...)\` — \`otpauth://\` URI for QR enrollment.
- \`_hotp(secret_b32, counter, *, digits=6)\` — RFC 4226 HMAC-OTP (validated against Appendix D vectors for counters 0–9).
- \`MFAError\` on malformed inputs.

### Out of scope (PR2)

- WebAuthn / FIDO2 (will pull in a webauthn library at the API layer)
- Recovery codes
- Per-user MFA enforcement policy

### Test plan

- [x] RFC 4226 Appendix D vectors for counters 0–9
- [x] TOTP correct/wrong codes within and outside window
- [x] Window=0 strict; window>0 absorbs ±N step drift
- [x] Code shape rejection (non-digit, wrong length)
- [x] Secret generation: ≥128 bits, unique per call
- [x] otpauth URI scheme + label + query params
- [x] Validation: invalid base32, negative window, zero step, empty account
- [x] 15 tests pass; 901 across the wider suite
- [x] \`ruff\` + \`basedpyright\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)