### PR TITLE
feat(core): walk-forward train/test split iterator (#119)

### DIFF
--- a/engine/core/walk_forward.py
+++ b/engine/core/walk_forward.py
@@ -1,0 +1,95 @@
+"""Walk-forward analysis: rolling / expanding train+test split iterator.
+
+Standard cross-validation pattern for time-series backtests: strict
+temporal ordering, no leakage. Two modes:
+
+- :class:`WindowMode.ROLLING` — fixed-size train window slides forward
+  by ``step`` each iteration; older history drops off.
+- :class:`WindowMode.EXPANDING` — train window starts at index 0 and
+  grows by ``step`` each iteration; older history is retained.
+
+In both modes the test window has constant size ``test_size`` and
+immediately follows the train window. Test indices are contiguous and
+disjoint from training data within that split.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+IntArray = npt.NDArray[np.int64]
+
+
+class WalkForwardError(Exception):
+    """Raised on malformed walk-forward configuration."""
+
+
+class WindowMode(StrEnum):
+    ROLLING = "rolling"
+    EXPANDING = "expanding"
+
+
+@dataclass(frozen=True)
+class WindowSplit:
+    """One train+test split."""
+
+    train_indices: IntArray
+    test_indices: IntArray
+
+
+def walk_forward_splits(
+    *,
+    n_obs: int,
+    train_size: int,
+    test_size: int,
+    step: int,
+    mode: WindowMode = WindowMode.ROLLING,
+) -> Iterator[WindowSplit]:
+    """Yield successive train+test splits.
+
+    First window starts at index 0; subsequent windows advance by
+    ``step``. Iteration stops when the next window would extend past
+    ``n_obs``.
+    """
+    if n_obs <= 0:
+        msg = f"n_obs must be > 0; got {n_obs}"
+        raise WalkForwardError(msg)
+    if train_size <= 0:
+        msg = f"train_size must be > 0; got {train_size}"
+        raise WalkForwardError(msg)
+    if test_size <= 0:
+        msg = f"test_size must be > 0; got {test_size}"
+        raise WalkForwardError(msg)
+    if step <= 0:
+        msg = f"step must be > 0; got {step}"
+        raise WalkForwardError(msg)
+
+    train_start = 0
+    while True:
+        train_end = train_start + train_size
+        test_end = train_end + test_size
+        if test_end > n_obs:
+            return
+        if mode == WindowMode.ROLLING:
+            train_idx = np.arange(train_start, train_end, dtype=np.int64)
+        else:
+            train_idx = np.arange(0, train_end, dtype=np.int64)
+        test_idx = np.arange(train_end, test_end, dtype=np.int64)
+        yield WindowSplit(train_indices=train_idx, test_indices=test_idx)
+        train_start += step
+
+
+__all__ = [
+    "WalkForwardError",
+    "WindowMode",
+    "WindowSplit",
+    "walk_forward_splits",
+]

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -1,0 +1,189 @@
+"""Tests for engine.core.walk_forward — train/test split iterator."""
+
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+import pytest
+
+from engine.core.walk_forward import (
+    WalkForwardError,
+    WindowMode,
+    WindowSplit,
+    walk_forward_splits,
+)
+
+
+class TestRollingWindow:
+    def test_basic_rolling_split(self):
+        n = 100
+        splits = list(
+            walk_forward_splits(
+                n_obs=n,
+                train_size=50,
+                test_size=10,
+                step=10,
+                mode=WindowMode.ROLLING,
+            )
+        )
+        assert len(splits) > 0
+        for s in splits:
+            assert isinstance(s, WindowSplit)
+            assert len(s.train_indices) == 50
+            assert len(s.test_indices) == 10
+
+    def test_rolling_window_slides_forward(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=100,
+                train_size=20,
+                test_size=10,
+                step=10,
+                mode=WindowMode.ROLLING,
+            )
+        )
+        for prev, nxt in itertools.pairwise(splits):
+            assert nxt.train_indices[0] == prev.train_indices[0] + 10
+
+    def test_train_then_test_no_overlap(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=50,
+                train_size=20,
+                test_size=10,
+                step=5,
+            )
+        )
+        for s in splits:
+            assert s.train_indices[-1] < s.test_indices[0]
+
+    def test_count_of_splits(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=100,
+                train_size=50,
+                test_size=10,
+                step=10,
+            )
+        )
+        assert len(splits) == 5
+
+
+class TestExpandingWindow:
+    def test_expanding_train_grows(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=80,
+                train_size=20,
+                test_size=10,
+                step=10,
+                mode=WindowMode.EXPANDING,
+            )
+        )
+        train_sizes = [len(s.train_indices) for s in splits]
+        for prev, nxt in itertools.pairwise(train_sizes):
+            assert nxt == prev + 10
+
+    def test_expanding_test_size_constant(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=80,
+                train_size=20,
+                test_size=10,
+                step=10,
+                mode=WindowMode.EXPANDING,
+            )
+        )
+        for s in splits:
+            assert len(s.test_indices) == 10
+
+    def test_expanding_starts_from_origin(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=80,
+                train_size=20,
+                test_size=10,
+                step=10,
+                mode=WindowMode.EXPANDING,
+            )
+        )
+        for s in splits:
+            assert s.train_indices[0] == 0
+
+
+class TestIndexing:
+    def test_indices_are_arrays(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=50, train_size=20, test_size=5, step=5
+            )
+        )
+        for s in splits:
+            assert isinstance(s.train_indices, np.ndarray)
+            assert isinstance(s.test_indices, np.ndarray)
+
+    def test_test_window_immediately_follows_train(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=50, train_size=20, test_size=5, step=5
+            )
+        )
+        for s in splits:
+            assert s.test_indices[0] == s.train_indices[-1] + 1
+
+
+class TestValidation:
+    def test_train_size_must_be_positive(self):
+        with pytest.raises(WalkForwardError):
+            list(
+                walk_forward_splits(
+                    n_obs=100, train_size=0, test_size=10, step=10
+                )
+            )
+
+    def test_test_size_must_be_positive(self):
+        with pytest.raises(WalkForwardError):
+            list(
+                walk_forward_splits(
+                    n_obs=100, train_size=10, test_size=0, step=10
+                )
+            )
+
+    def test_step_must_be_positive(self):
+        with pytest.raises(WalkForwardError):
+            list(
+                walk_forward_splits(
+                    n_obs=100, train_size=10, test_size=10, step=0
+                )
+            )
+
+    def test_train_plus_test_larger_than_n_returns_empty(self):
+        splits = list(
+            walk_forward_splits(
+                n_obs=20, train_size=15, test_size=10, step=5
+            )
+        )
+        assert splits == []
+
+    def test_n_obs_zero_raises(self):
+        with pytest.raises(WalkForwardError):
+            list(
+                walk_forward_splits(
+                    n_obs=0, train_size=10, test_size=10, step=5
+                )
+            )
+
+
+class TestDataclass:
+    def test_window_split_carries_arrays(self):
+        s = WindowSplit(
+            train_indices=np.array([0, 1, 2]),
+            test_indices=np.array([3, 4]),
+        )
+        assert s.train_indices.tolist() == [0, 1, 2]
+        assert s.test_indices.tolist() == [3, 4]
+
+    def test_window_mode_enum_values(self):
+        assert WindowMode.ROLLING.value == "rolling"
+        assert WindowMode.EXPANDING.value == "expanding"


### PR DESCRIPTION
## Summary

Closes #119. Pure-numpy walk-forward cross-validation iterator for time-series backtests. Two modes: rolling and expanding.

### Public API

- \`walk_forward_splits(*, n_obs, train_size, test_size, step, mode)\` — generator yielding \`WindowSplit\` records.
- \`WindowSplit\` — frozen dataclass with \`train_indices\` / \`test_indices\` (numpy int64).
- \`WindowMode\` StrEnum: \`ROLLING\` (default) / \`EXPANDING\`.
- \`WalkForwardError\` on malformed config.

### Behavior

- Test window immediately follows train; no leakage.
- Iteration stops cleanly when next window exceeds \`n_obs\` (no exception on under-sized inputs).
- \`train_size + test_size > n_obs\` returns empty iterator.

### Out of scope (follow-up)

- k-fold cross-validation (anachronistic for time series; not part of this issue)
- Anchored / unanchored variants beyond rolling/expanding
- Direct integration into \`BacktestRunner\` (consumer-side change)

### Test plan

- [x] 16 unit tests cover rolling slide, expanding growth, no-overlap invariant, count of splits, index types, validation paths, empty-on-too-small
- [x] Full suite — 917 passed
- [x] \`ruff\` + \`basedpyright\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)