### PR TITLE
feat(observability): data lineage DAG (#134)

### DIFF
--- a/engine/observability/lineage.py
+++ b/engine/observability/lineage.py
@@ -1,0 +1,221 @@
+"""Data lineage DAG.
+
+Tracks the chain of transformations from raw provider feeds through
+bars, signals, backtests, and into final reports. Each transformation
+is a directed edge between two :class:`LineageNode` records; the graph
+is enforced acyclic at insert time so traversal is always finite.
+
+Three abstractions:
+
+- :class:`NodeKind` — typed identity for the kind of artifact a node
+  represents (provider / bar / signal / backtest / report).
+- :class:`LineageStore` Protocol — pluggable persistence layer.
+- :class:`InMemoryLineageStore` — process-local backend; single-pod /
+  tests. DB-backed implementation lands in a follow-up.
+- :class:`LineageService` — register_node / link / ancestors /
+  descendants / list_by_kind / get.
+
+The service rejects cycles (self-loops + back-edges) at link time so
+``ancestors`` and ``descendants`` are guaranteed to terminate.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Protocol
+
+
+class NodeKind(StrEnum):
+    PROVIDER = "provider"
+    BAR = "bar"
+    SIGNAL = "signal"
+    BACKTEST = "backtest"
+    REPORT = "report"
+
+
+class LineageError(Exception):
+    """Raised on malformed lineage operations (bad ids, cycles, empty inputs)."""
+
+
+@dataclass(frozen=True)
+class LineageNode:
+    id: str
+    kind: NodeKind
+    name: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+    created_at_epoch: float = 0.0
+
+
+@dataclass(frozen=True)
+class LineageEdge:
+    parent_id: str
+    child_id: str
+    relation: str
+    created_at_epoch: float = 0.0
+
+
+class LineageStore(Protocol):
+    async def save_node(self, node: LineageNode) -> None: ...
+    async def get_node(self, node_id: str) -> LineageNode | None: ...
+    async def add_edge(self, edge: LineageEdge) -> None: ...
+    async def children_of(self, node_id: str) -> list[str]: ...
+    async def parents_of(self, node_id: str) -> list[str]: ...
+    async def list_by_kind(self, kind: NodeKind) -> list[LineageNode]: ...
+
+
+class InMemoryLineageStore:
+    """Process-local store. Single-pod / tests only."""
+
+    def __init__(self) -> None:
+        self._nodes: dict[str, LineageNode] = {}
+        self._children: dict[str, list[str]] = defaultdict(list)
+        self._parents: dict[str, list[str]] = defaultdict(list)
+
+    async def save_node(self, node: LineageNode) -> None:
+        self._nodes[node.id] = node
+
+    async def get_node(self, node_id: str) -> LineageNode | None:
+        return self._nodes.get(node_id)
+
+    async def add_edge(self, edge: LineageEdge) -> None:
+        self._children[edge.parent_id].append(edge.child_id)
+        self._parents[edge.child_id].append(edge.parent_id)
+
+    async def children_of(self, node_id: str) -> list[str]:
+        return list(self._children.get(node_id, ()))
+
+    async def parents_of(self, node_id: str) -> list[str]:
+        return list(self._parents.get(node_id, ()))
+
+    async def list_by_kind(self, kind: NodeKind) -> list[LineageNode]:
+        return [n for n in self._nodes.values() if n.kind == kind]
+
+
+class LineageService:
+    """High-level lineage operations on top of a :class:`LineageStore`."""
+
+    def __init__(self, store: LineageStore) -> None:
+        self.store = store
+
+    async def register_node(
+        self,
+        kind: NodeKind,
+        name: str,
+        attributes: dict[str, Any],
+    ) -> LineageNode:
+        if not name.strip():
+            msg = "name must be non-empty"
+            raise LineageError(msg)
+        node = LineageNode(
+            id=str(uuid.uuid4()),
+            kind=kind,
+            name=name,
+            attributes=dict(attributes),
+            created_at_epoch=time.time(),
+        )
+        await self.store.save_node(node)
+        return node
+
+    async def get(self, node_id: str) -> LineageNode | None:
+        return await self.store.get_node(node_id)
+
+    async def link(
+        self, *, parent_id: str, child_id: str, relation: str
+    ) -> LineageEdge:
+        if not relation.strip():
+            msg = "relation must be non-empty"
+            raise LineageError(msg)
+        if parent_id == child_id:
+            msg = f"link would create a self-loop cycle on {parent_id}"
+            raise LineageError(msg)
+        parent = await self.store.get_node(parent_id)
+        child = await self.store.get_node(child_id)
+        if parent is None:
+            msg = f"unknown parent_id {parent_id}"
+            raise LineageError(msg)
+        if child is None:
+            msg = f"unknown child_id {child_id}"
+            raise LineageError(msg)
+        if await self._is_reachable(start=child_id, target=parent_id):
+            msg = (
+                f"link {parent_id} -> {child_id} would create a cycle "
+                f"(parent already reachable from child)"
+            )
+            raise LineageError(msg)
+        edge = LineageEdge(
+            parent_id=parent_id,
+            child_id=child_id,
+            relation=relation,
+            created_at_epoch=time.time(),
+        )
+        await self.store.add_edge(edge)
+        return edge
+
+    async def _is_reachable(self, *, start: str, target: str) -> bool:
+        if start == target:
+            return True
+        seen: set[str] = {start}
+        frontier: list[str] = [start]
+        while frontier:
+            current = frontier.pop(0)
+            for child_id in await self.store.children_of(current):
+                if child_id == target:
+                    return True
+                if child_id not in seen:
+                    seen.add(child_id)
+                    frontier.append(child_id)
+        return False
+
+    async def ancestors(self, node_id: str) -> list[LineageNode]:
+        if await self.store.get_node(node_id) is None:
+            return []
+        seen: set[str] = set()
+        frontier: list[str] = [node_id]
+        while frontier:
+            current = frontier.pop(0)
+            for parent_id in await self.store.parents_of(current):
+                if parent_id not in seen:
+                    seen.add(parent_id)
+                    frontier.append(parent_id)
+        out: list[LineageNode] = []
+        for i in seen:
+            n = await self.store.get_node(i)
+            if n is not None:
+                out.append(n)
+        return out
+
+    async def descendants(self, node_id: str) -> list[LineageNode]:
+        if await self.store.get_node(node_id) is None:
+            return []
+        seen: set[str] = set()
+        frontier: list[str] = [node_id]
+        while frontier:
+            current = frontier.pop(0)
+            for child_id in await self.store.children_of(current):
+                if child_id not in seen:
+                    seen.add(child_id)
+                    frontier.append(child_id)
+        out: list[LineageNode] = []
+        for i in seen:
+            n = await self.store.get_node(i)
+            if n is not None:
+                out.append(n)
+        return out
+
+    async def list_by_kind(self, kind: NodeKind) -> list[LineageNode]:
+        return await self.store.list_by_kind(kind)
+
+
+__all__ = [
+    "InMemoryLineageStore",
+    "LineageEdge",
+    "LineageError",
+    "LineageNode",
+    "LineageService",
+    "LineageStore",
+    "NodeKind",
+]

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,0 +1,152 @@
+"""Tests for engine.observability.lineage — data lineage DAG."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.observability.lineage import (
+    InMemoryLineageStore,
+    LineageEdge,
+    LineageError,
+    LineageNode,
+    LineageService,
+    NodeKind,
+)
+
+
+@pytest.fixture
+def service():
+    return LineageService(store=InMemoryLineageStore())
+
+
+class TestNodeKind:
+    def test_node_kinds(self):
+        assert NodeKind.PROVIDER.value == "provider"
+        assert NodeKind.BAR.value == "bar"
+        assert NodeKind.BACKTEST.value == "backtest"
+        assert NodeKind.REPORT.value == "report"
+        assert NodeKind.SIGNAL.value == "signal"
+
+
+class TestNodeAndEdge:
+    @pytest.mark.asyncio
+    async def test_register_node(self, service):
+        n = await service.register_node(
+            kind=NodeKind.PROVIDER, name="yahoo", attributes={"asset": "equity"}
+        )
+        assert n.id
+        assert n.kind == NodeKind.PROVIDER
+
+    @pytest.mark.asyncio
+    async def test_link_creates_edge(self, service):
+        a = await service.register_node(NodeKind.PROVIDER, "yahoo", {})
+        b = await service.register_node(NodeKind.BAR, "AAPL_2024_01_02", {})
+        e = await service.link(parent_id=a.id, child_id=b.id, relation="produced")
+        assert isinstance(e, LineageEdge)
+        assert e.parent_id == a.id
+        assert e.child_id == b.id
+
+    @pytest.mark.asyncio
+    async def test_link_rejects_unknown_node(self, service):
+        a = await service.register_node(NodeKind.PROVIDER, "yahoo", {})
+        with pytest.raises(LineageError):
+            await service.link(parent_id=a.id, child_id="nope", relation="x")
+
+
+class TestTraversal:
+    @pytest.mark.asyncio
+    async def test_ancestors_of_report(self, service):
+        p = await service.register_node(NodeKind.PROVIDER, "yahoo", {})
+        bar = await service.register_node(NodeKind.BAR, "AAPL", {})
+        bt = await service.register_node(NodeKind.BACKTEST, "bt-1", {})
+        rpt = await service.register_node(NodeKind.REPORT, "r-1", {})
+        await service.link(parent_id=p.id, child_id=bar.id, relation="produced")
+        await service.link(parent_id=bar.id, child_id=bt.id, relation="consumed")
+        await service.link(parent_id=bt.id, child_id=rpt.id, relation="generated")
+        ancestors = await service.ancestors(rpt.id)
+        ids = {n.id for n in ancestors}
+        assert ids == {p.id, bar.id, bt.id}
+
+    @pytest.mark.asyncio
+    async def test_descendants_of_provider(self, service):
+        p = await service.register_node(NodeKind.PROVIDER, "yahoo", {})
+        bar = await service.register_node(NodeKind.BAR, "AAPL", {})
+        bt = await service.register_node(NodeKind.BACKTEST, "bt-1", {})
+        await service.link(parent_id=p.id, child_id=bar.id, relation="produced")
+        await service.link(parent_id=bar.id, child_id=bt.id, relation="consumed")
+        descendants = await service.descendants(p.id)
+        ids = {n.id for n in descendants}
+        assert ids == {bar.id, bt.id}
+
+    @pytest.mark.asyncio
+    async def test_ancestors_of_unknown_returns_empty(self, service):
+        out = await service.ancestors("does-not-exist")
+        assert out == []
+
+
+class TestCycleDetection:
+    @pytest.mark.asyncio
+    async def test_self_loop_rejected(self, service):
+        a = await service.register_node(NodeKind.BAR, "x", {})
+        with pytest.raises(LineageError, match="cycle"):
+            await service.link(parent_id=a.id, child_id=a.id, relation="x")
+
+    @pytest.mark.asyncio
+    async def test_back_edge_rejected(self, service):
+        a = await service.register_node(NodeKind.PROVIDER, "p", {})
+        b = await service.register_node(NodeKind.BAR, "b", {})
+        await service.link(parent_id=a.id, child_id=b.id, relation="x")
+        with pytest.raises(LineageError, match="cycle"):
+            await service.link(parent_id=b.id, child_id=a.id, relation="x")
+
+
+class TestQueries:
+    @pytest.mark.asyncio
+    async def test_list_nodes_by_kind(self, service):
+        await service.register_node(NodeKind.PROVIDER, "yahoo", {})
+        await service.register_node(NodeKind.PROVIDER, "polygon", {})
+        await service.register_node(NodeKind.BAR, "AAPL", {})
+        providers = await service.list_by_kind(NodeKind.PROVIDER)
+        assert len(providers) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_returns_node(self, service):
+        a = await service.register_node(NodeKind.BAR, "x", {"src": "test"})
+        out = await service.get(a.id)
+        assert out is not None
+        assert out.attributes["src"] == "test"
+
+
+class TestEntities:
+    def test_node_dataclass_fields(self):
+        n = LineageNode(
+            id="x",
+            kind=NodeKind.BAR,
+            name="AAPL",
+            attributes={"k": "v"},
+            created_at_epoch=1.0,
+        )
+        assert n.attributes["k"] == "v"
+
+    def test_edge_dataclass_fields(self):
+        e = LineageEdge(
+            parent_id="p",
+            child_id="c",
+            relation="produced",
+            created_at_epoch=1.0,
+        )
+        assert e.relation == "produced"
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_register_empty_name_rejected(self, service):
+        with pytest.raises(LineageError):
+            await service.register_node(NodeKind.BAR, "", {})
+
+    @pytest.mark.asyncio
+    async def test_link_empty_relation_rejected(self, service):
+        a = await service.register_node(NodeKind.BAR, "a", {})
+        b = await service.register_node(NodeKind.BAR, "b", {})
+        with pytest.raises(LineageError):
+            await service.link(parent_id=a.id, child_id=b.id, relation="")


### PR DESCRIPTION
## Summary

Closes #134. Pure-Python data-lineage DAG: tracks provider → bar → signal → backtest → report chains as directed acyclic edges between typed nodes.

### Public surface

- \`NodeKind\` StrEnum: provider / bar / signal / backtest / report.
- \`LineageNode\` / \`LineageEdge\` frozen dataclasses.
- \`LineageStore\` Protocol + \`InMemoryLineageStore\`.
- \`LineageService\` — register_node, link, get, ancestors, descendants, list_by_kind.

### Cycle defense

- Self-loops rejected.
- Back-edges rejected via BFS reachability check: before inserting \`parent → child\`, BFS forward from \`child\` checks whether \`parent\` is already downstream; if so the edge would close a cycle and is refused.
- Result: \`ancestors\` and \`descendants\` are guaranteed to terminate.

### Out of scope (follow-up)

- DB-backed \`LineageStore\` + Alembic migration
- API routes / Grafana lineage panel
- Auto-instrumentation hooks in \`BacktestRunner\` / data providers

### Test plan

- [x] 15 unit tests cover register/link, BFS over a 4-node chain, cycle detection (self-loop + back-edge), validation, dataclass shape
- [x] Full suite — 932 passed
- [x] \`ruff\` + \`basedpyright\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)