### PR TITLE
feat(core): market calendar (#113)

### DIFF
--- a/engine/core/market_calendar.py
+++ b/engine/core/market_calendar.py
@@ -1,0 +1,227 @@
+"""Market calendar: trading sessions, holidays, half-days per venue.
+
+Pure-stdlib (datetime + zoneinfo). No pandas-market-calendars dep.
+
+Per-venue calendar carries:
+- timezone (IANA zone name)
+- regular open + close (local time)
+- holiday set (full closures, by local date)
+- half-day map (early-close override, by local date)
+
+Public functions are stateless — they take a :class:`VenueCalendar`
+and a datetime/date and answer the schedule question. The
+:class:`MarketCalendar` service is a thin facade over the built-in
+catalog for callers that want a stable handle.
+
+Built-in calendars cover the major liquidity venues:
+- XNAS (NYSE / Nasdaq, America/New_York, 09:30-16:00)
+- XLON (London Stock Exchange, Europe/London, 08:00-16:30)
+- XHKG (Hong Kong, Asia/Hong_Kong, 09:30-16:00)
+- XTKS (Tokyo, Asia/Tokyo, 09:00-15:00)
+- XETR (Frankfurt Xetra, Europe/Berlin, 09:00-17:30)
+
+Holiday tables ship empty by default — operators load the venue's
+published schedule via the corporate-actions ingestion job (#112).
+"""
+
+from __future__ import annotations
+
+import zoneinfo
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from zoneinfo import ZoneInfo
+
+
+_MIC_LENGTH = 4
+_WEEKEND_START = 5  # Saturday
+_MAX_LOOKAHEAD_DAYS = 366
+
+
+class MarketCalendarError(Exception):
+    """Raised on malformed venue calendars or unknown MIC codes."""
+
+
+@dataclass(frozen=True)
+class VenueCalendar:
+    """Trading session schedule for a single venue."""
+
+    mic: str
+    timezone: str
+    regular_open: time
+    regular_close: time
+    holidays: frozenset[date] = field(default_factory=frozenset)
+    half_days: dict[date, time] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if len(self.mic) != _MIC_LENGTH or not self.mic.isalnum():
+            msg = f"mic must be 4 alphanumeric chars; got {self.mic!r}"
+            raise MarketCalendarError(msg)
+        if self.regular_open >= self.regular_close:
+            msg = (
+                f"regular_open {self.regular_open} must precede "
+                f"regular_close {self.regular_close}"
+            )
+            raise MarketCalendarError(msg)
+        try:
+            zoneinfo.ZoneInfo(self.timezone)
+        except (zoneinfo.ZoneInfoNotFoundError, ValueError) as exc:
+            msg = f"invalid timezone {self.timezone!r}: {exc}"
+            raise MarketCalendarError(msg) from exc
+
+    @property
+    def zone(self) -> ZoneInfo:
+        return zoneinfo.ZoneInfo(self.timezone)
+
+
+@dataclass(frozen=True)
+class SessionBounds:
+    """Open/close datetimes for a single trading day."""
+
+    open_dt: datetime
+    close_dt: datetime
+
+
+def _to_local(cal: VenueCalendar, dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        msg = "datetime must be timezone-aware"
+        raise MarketCalendarError(msg)
+    return dt.astimezone(cal.zone)
+
+
+def _is_trading_day(cal: VenueCalendar, day: date) -> bool:
+    if day.weekday() >= _WEEKEND_START:
+        return False
+    return day not in cal.holidays
+
+
+def _close_for_day(cal: VenueCalendar, day: date) -> time:
+    half = cal.half_days.get(day)
+    return half if half is not None else cal.regular_close
+
+
+def is_open(cal: VenueCalendar, dt: datetime) -> bool:
+    """Return True iff ``dt`` falls inside a regular or half-day session."""
+    local = _to_local(cal, dt)
+    if not _is_trading_day(cal, local.date()):
+        return False
+    close = _close_for_day(cal, local.date())
+    return cal.regular_open <= local.time() < close
+
+
+def session_bounds(
+    cal: VenueCalendar, day: date
+) -> SessionBounds | None:
+    """Return open/close datetimes for ``day``, or ``None`` if closed."""
+    if not _is_trading_day(cal, day):
+        return None
+    close = _close_for_day(cal, day)
+    open_dt = datetime.combine(day, cal.regular_open, tzinfo=cal.zone)
+    close_dt = datetime.combine(day, close, tzinfo=cal.zone)
+    return SessionBounds(open_dt=open_dt, close_dt=close_dt)
+
+
+def next_open(cal: VenueCalendar, dt: datetime) -> datetime:
+    """Return the next datetime at which the venue is open.
+
+    If ``dt`` already falls inside a session, returns ``dt`` itself.
+    Otherwise advances day-by-day until a trading day with a session
+    that hasn't yet closed is found.
+    """
+    local = _to_local(cal, dt)
+    cursor_date = local.date()
+    cursor_time = local.time()
+    for _ in range(_MAX_LOOKAHEAD_DAYS):
+        bounds = session_bounds(cal, cursor_date)
+        if bounds is not None:
+            local_open = bounds.open_dt.time()
+            local_close = bounds.close_dt.time()
+            if cursor_time < local_open:
+                return bounds.open_dt
+            if cursor_time < local_close:
+                return datetime.combine(
+                    cursor_date, cursor_time, tzinfo=cal.zone
+                )
+        cursor_date += timedelta(days=1)
+        cursor_time = time(0, 0)
+    msg = (
+        f"no open session found within {_MAX_LOOKAHEAD_DAYS} days of "
+        f"{dt!r} for venue {cal.mic}; check holiday table"
+    )
+    raise MarketCalendarError(msg)
+
+
+_BUILTIN: dict[str, VenueCalendar] = {
+    "XNAS": VenueCalendar(
+        mic="XNAS",
+        timezone="America/New_York",
+        regular_open=time(9, 30),
+        regular_close=time(16, 0),
+    ),
+    "XNYS": VenueCalendar(
+        mic="XNYS",
+        timezone="America/New_York",
+        regular_open=time(9, 30),
+        regular_close=time(16, 0),
+    ),
+    "XLON": VenueCalendar(
+        mic="XLON",
+        timezone="Europe/London",
+        regular_open=time(8, 0),
+        regular_close=time(16, 30),
+    ),
+    "XHKG": VenueCalendar(
+        mic="XHKG",
+        timezone="Asia/Hong_Kong",
+        regular_open=time(9, 30),
+        regular_close=time(16, 0),
+    ),
+    "XTKS": VenueCalendar(
+        mic="XTKS",
+        timezone="Asia/Tokyo",
+        regular_open=time(9, 0),
+        regular_close=time(15, 0),
+    ),
+    "XETR": VenueCalendar(
+        mic="XETR",
+        timezone="Europe/Berlin",
+        regular_open=time(9, 0),
+        regular_close=time(17, 30),
+    ),
+}
+
+
+def builtin_calendar(mic: str) -> VenueCalendar:
+    cal = _BUILTIN.get(mic)
+    if cal is None:
+        msg = f"no built-in calendar for MIC {mic!r}"
+        raise MarketCalendarError(msg)
+    return cal
+
+
+class MarketCalendar:
+    """Stable facade over the built-in catalog with override hook."""
+
+    def __init__(
+        self, *, overrides: dict[str, VenueCalendar] | None = None
+    ) -> None:
+        self._overrides = dict(overrides or {})
+
+    def for_venue(self, mic: str) -> VenueCalendar:
+        if mic in self._overrides:
+            return self._overrides[mic]
+        return builtin_calendar(mic)
+
+
+__all__ = [
+    "MarketCalendar",
+    "MarketCalendarError",
+    "SessionBounds",
+    "VenueCalendar",
+    "builtin_calendar",
+    "is_open",
+    "next_open",
+    "session_bounds",
+]

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -1,0 +1,189 @@
+"""Tests for engine.core.market_calendar — venue trading sessions."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from engine.core.market_calendar import (
+    MarketCalendar,
+    MarketCalendarError,
+    SessionBounds,
+    VenueCalendar,
+    builtin_calendar,
+    is_open,
+    next_open,
+    session_bounds,
+)
+
+_NYC = ZoneInfo("America/New_York")
+_UTC = ZoneInfo("UTC")
+
+
+def _xnas() -> VenueCalendar:
+    return builtin_calendar("XNAS")
+
+
+class TestBuiltinCalendars:
+    def test_xnas_known(self):
+        cal = builtin_calendar("XNAS")
+        assert cal.mic == "XNAS"
+        assert cal.timezone == "America/New_York"
+
+    def test_xlon_known(self):
+        cal = builtin_calendar("XLON")
+        assert cal.mic == "XLON"
+        assert cal.timezone == "Europe/London"
+
+    def test_unknown_mic_raises(self):
+        with pytest.raises(MarketCalendarError):
+            builtin_calendar("NOTAVENUE")
+
+
+class TestIsOpen:
+    def test_regular_weekday_at_noon_open(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 9, 12, 0, tzinfo=_NYC)
+        assert is_open(cal, dt) is True
+
+    def test_saturday_closed(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 6, 12, 0, tzinfo=_NYC)
+        assert is_open(cal, dt) is False
+
+    def test_sunday_closed(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 7, 12, 0, tzinfo=_NYC)
+        assert is_open(cal, dt) is False
+
+    def test_pre_market_closed(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 9, 8, 30, tzinfo=_NYC)
+        assert is_open(cal, dt) is False
+
+    def test_after_close_closed(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 9, 16, 30, tzinfo=_NYC)
+        assert is_open(cal, dt) is False
+
+    def test_holiday_closed(self):
+        cal = VenueCalendar(
+            mic="XCST",
+            timezone="UTC",
+            regular_open=time(9, 30),
+            regular_close=time(16, 0),
+            holidays=frozenset({date(2024, 12, 25)}),
+        )
+        dt = datetime(2024, 12, 25, 12, 0, tzinfo=_UTC)
+        assert is_open(cal, dt) is False
+
+    def test_half_day_uses_early_close(self):
+        cal = VenueCalendar(
+            mic="XCST",
+            timezone="UTC",
+            regular_open=time(9, 30),
+            regular_close=time(16, 0),
+            half_days={date(2024, 11, 29): time(13, 0)},
+        )
+        dt = datetime(2024, 11, 29, 14, 0, tzinfo=_UTC)
+        assert is_open(cal, dt) is False
+        dt = datetime(2024, 11, 29, 12, 0, tzinfo=_UTC)
+        assert is_open(cal, dt) is True
+
+
+class TestNextOpen:
+    def test_during_session_returns_now(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 9, 12, 0, tzinfo=_NYC)
+        out = next_open(cal, dt)
+        assert out == dt
+
+    def test_pre_market_returns_today_open(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 9, 8, 0, tzinfo=_NYC)
+        out = next_open(cal, dt)
+        assert out == datetime(2024, 1, 9, 9, 30, tzinfo=_NYC)
+
+    def test_after_close_returns_next_day_open(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 9, 17, 0, tzinfo=_NYC)
+        out = next_open(cal, dt)
+        assert out == datetime(2024, 1, 10, 9, 30, tzinfo=_NYC)
+
+    def test_friday_after_close_skips_to_monday(self):
+        cal = _xnas()
+        dt = datetime(2024, 1, 5, 17, 0, tzinfo=_NYC)
+        out = next_open(cal, dt)
+        assert out == datetime(2024, 1, 8, 9, 30, tzinfo=_NYC)
+
+
+class TestSessionBounds:
+    def test_regular_day_bounds(self):
+        cal = _xnas()
+        out = session_bounds(cal, date(2024, 1, 9))
+        assert isinstance(out, SessionBounds)
+        assert out.open_dt == datetime(2024, 1, 9, 9, 30, tzinfo=_NYC)
+        assert out.close_dt == datetime(2024, 1, 9, 16, 0, tzinfo=_NYC)
+
+    def test_weekend_bounds_none(self):
+        cal = _xnas()
+        out = session_bounds(cal, date(2024, 1, 6))
+        assert out is None
+
+    def test_half_day_bounds_use_early_close(self):
+        cal = VenueCalendar(
+            mic="XCST",
+            timezone="UTC",
+            regular_open=time(9, 30),
+            regular_close=time(16, 0),
+            half_days={date(2024, 11, 29): time(13, 0)},
+        )
+        out = session_bounds(cal, date(2024, 11, 29))
+        assert out is not None
+        assert out.close_dt.time() == time(13, 0)
+
+
+class TestServiceFacade:
+    def test_calendar_service_resolve(self):
+        svc = MarketCalendar()
+        cal = svc.for_venue("XNAS")
+        assert cal.mic == "XNAS"
+
+
+class TestValidation:
+    def test_open_must_precede_close(self):
+        with pytest.raises(MarketCalendarError):
+            VenueCalendar(
+                mic="XCST",
+                timezone="UTC",
+                regular_open=time(16, 0),
+                regular_close=time(9, 30),
+            )
+
+    def test_invalid_mic_format_rejected(self):
+        with pytest.raises(MarketCalendarError):
+            VenueCalendar(
+                mic="ABC",
+                timezone="UTC",
+                regular_open=time(9, 30),
+                regular_close=time(16, 0),
+            )
+
+    def test_invalid_timezone_rejected(self):
+        with pytest.raises(MarketCalendarError):
+            VenueCalendar(
+                mic="XCST",
+                timezone="Not/A/Real/Zone",
+                regular_open=time(9, 30),
+                regular_close=time(16, 0),
+            )
+
+
+class TestUtcArgsAccepted:
+    def test_is_open_with_utc_arg_converts_to_local(self):
+        cal = _xnas()
+        # 17:00 UTC = 12:00 EST on 2024-01-09.
+        dt = datetime(2024, 1, 9, 17, 0, tzinfo=_UTC)
+        assert is_open(cal, dt) is True


### PR DESCRIPTION
## Summary

Closes #113. Pure-stdlib (datetime + zoneinfo) market calendar — venue trading sessions, holidays, half-days. No pandas-market-calendars dep.

### Public surface

- \`VenueCalendar\` frozen dataclass: mic, timezone, regular_open, regular_close, holidays frozenset, half_days dict.
- \`SessionBounds\` (open_dt, close_dt) for a single trading day.
- \`is_open(cal, dt)\` / \`session_bounds(cal, date)\` / \`next_open(cal, dt)\` — stateless functions.
- \`builtin_calendar(mic)\` — fetch from built-in catalog.
- \`MarketCalendar\` facade with override hook.

### Built-in catalog

XNAS, XNYS, XLON, XHKG, XTKS, XETR — public open/close times. Holiday tables ship empty; operators load via #112 corporate-actions ingestion or constructor overrides.

### Out of scope (follow-up)

- Holiday-table ingestion job (#112)
- DST transition edge cases beyond zoneinfo's defaults
- Pre-market / after-hours session bounds (separate from regular session)

### Test plan

- [x] 22 unit tests cover catalog, weekday/weekend/holiday/half-day gating, next_open across day boundaries, UTC↔local conversion, validation
- [x] Full suite — 954 passed
- [x] \`ruff\` + \`basedpyright\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)