### PR TITLE
feat(core): immutable hash-chained audit log (#114)

### DIFF
--- a/engine/core/audit_log.py
+++ b/engine/core/audit_log.py
@@ -1,0 +1,224 @@
+"""Immutable hash-chained audit log.
+
+Every state change worth auditing (login, order submit, risk override,
+kill-switch trip, …) appends one :class:`AuditEvent`. Each event
+carries the SHA-256 hash of its own canonical payload plus the hash
+of the previous event, forming a tamper-evident chain — any later
+mutation to a payload, sequence number, or prev_hash invalidates the
+entire downstream chain.
+
+Two layers:
+
+- :class:`AuditLog` Protocol — pluggable persistence (in-memory ships
+  here; DB-backed in a follow-up).
+- :class:`AuditService` — wraps a log with append + verify_chain
+  semantics. Runs every payload through the redaction processor at
+  :func:`engine.observability.redact.redact_processor` so secrets in
+  caller payloads never reach disk.
+
+Genesis prev_hash is the all-zero 64-char sha256 sentinel.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from engine.observability.redact import redact_processor
+
+_GENESIS_PREV_HASH = "0" * 64
+
+
+class AuditLogError(Exception):
+    """Raised on malformed audit input or chain integrity failure."""
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    """One immutable audit record."""
+
+    id: str
+    sequence: int
+    event_type: str
+    actor_id: str
+    payload: dict[str, Any]
+    prev_hash: str
+    hash: str
+    created_at_epoch: float = 0.0
+
+
+class AuditLog(Protocol):
+    async def append(self, event: AuditEvent) -> None: ...
+    async def list(
+        self, *, actor_id: str | None = None
+    ) -> list[AuditEvent]: ...
+    async def get_by_sequence(self, sequence: int) -> AuditEvent | None: ...
+    async def last(self) -> AuditEvent | None: ...
+    async def all(self) -> list[AuditEvent]: ...
+
+
+class InMemoryAuditLog:
+    """Process-local log. Single-pod / tests."""
+
+    def __init__(self) -> None:
+        self._events: list[AuditEvent] = []
+
+    async def append(self, event: AuditEvent) -> None:
+        self._events.append(event)
+
+    async def list(
+        self, *, actor_id: str | None = None
+    ) -> list[AuditEvent]:
+        if actor_id is None:
+            return list(self._events)
+        return [e for e in self._events if e.actor_id == actor_id]
+
+    async def get_by_sequence(self, sequence: int) -> AuditEvent | None:
+        for e in self._events:
+            if e.sequence == sequence:
+                return e
+        return None
+
+    async def last(self) -> AuditEvent | None:
+        return self._events[-1] if self._events else None
+
+    async def all(self) -> list[AuditEvent]:
+        return list(self._events)
+
+
+def _canonical_bytes(
+    *,
+    sequence: int,
+    event_type: str,
+    actor_id: str,
+    payload: dict[str, Any],
+    prev_hash: str,
+    created_at_epoch: float,
+) -> bytes:
+    body = {
+        "sequence": sequence,
+        "event_type": event_type,
+        "actor_id": actor_id,
+        "payload": payload,
+        "prev_hash": prev_hash,
+        "created_at_epoch": created_at_epoch,
+    }
+    return json.dumps(
+        body, sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8")
+
+
+def _hash_event(
+    *,
+    sequence: int,
+    event_type: str,
+    actor_id: str,
+    payload: dict[str, Any],
+    prev_hash: str,
+    created_at_epoch: float,
+) -> str:
+    return hashlib.sha256(
+        _canonical_bytes(
+            sequence=sequence,
+            event_type=event_type,
+            actor_id=actor_id,
+            payload=payload,
+            prev_hash=prev_hash,
+            created_at_epoch=created_at_epoch,
+        )
+    ).hexdigest()
+
+
+@dataclass
+class AuditService:
+    """High-level append + verify on top of an :class:`AuditLog`."""
+
+    log: AuditLog
+    _log: AuditLog = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._log = self.log
+
+    async def append(
+        self,
+        event_type: str,
+        actor_id: str,
+        payload: dict[str, Any],
+    ) -> AuditEvent:
+        if not event_type.strip():
+            msg = "event_type must be non-empty"
+            raise AuditLogError(msg)
+        if not actor_id.strip():
+            msg = "actor_id must be non-empty"
+            raise AuditLogError(msg)
+        redacted: dict[str, Any] = dict(
+            redact_processor(None, "audit", dict(payload))
+        )
+        last = await self._log.last()
+        sequence = (last.sequence + 1) if last is not None else 1
+        prev_hash = last.hash if last is not None else _GENESIS_PREV_HASH
+        created_at_epoch = time.time()
+        digest = _hash_event(
+            sequence=sequence,
+            event_type=event_type,
+            actor_id=actor_id,
+            payload=redacted,
+            prev_hash=prev_hash,
+            created_at_epoch=created_at_epoch,
+        )
+        event = AuditEvent(
+            id=str(uuid.uuid4()),
+            sequence=sequence,
+            event_type=event_type,
+            actor_id=actor_id,
+            payload=redacted,
+            prev_hash=prev_hash,
+            hash=digest,
+            created_at_epoch=created_at_epoch,
+        )
+        await self._log.append(event)
+        return event
+
+    async def verify_chain(self) -> bool:
+        events = await self._log.all()
+        expected_prev = _GENESIS_PREV_HASH
+        expected_seq = 1
+        for ev in events:
+            if ev.sequence != expected_seq:
+                return False
+            if ev.prev_hash != expected_prev:
+                return False
+            expected = _hash_event(
+                sequence=ev.sequence,
+                event_type=ev.event_type,
+                actor_id=ev.actor_id,
+                payload=ev.payload,
+                prev_hash=ev.prev_hash,
+                created_at_epoch=ev.created_at_epoch,
+            )
+            if expected != ev.hash:
+                return False
+            expected_prev = ev.hash
+            expected_seq += 1
+        return True
+
+    async def list_events(
+        self, *, actor_id: str | None = None
+    ) -> list[AuditEvent]:
+        return await self._log.list(actor_id=actor_id)
+
+    async def get_by_sequence(self, sequence: int) -> AuditEvent | None:
+        return await self._log.get_by_sequence(sequence)
+
+
+__all__ = [
+    "AuditEvent",
+    "AuditLog",
+    "AuditLogError",
+    "AuditService",
+    "InMemoryAuditLog",
+]

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,143 @@
+"""Tests for engine.core.audit_log — hash-chained immutable audit trail."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from engine.core.audit_log import (
+    AuditEvent,
+    AuditLogError,
+    AuditService,
+    InMemoryAuditLog,
+)
+
+
+@pytest.fixture
+def service():
+    return AuditService(log=InMemoryAuditLog())
+
+
+class TestAppend:
+    @pytest.mark.asyncio
+    async def test_first_event_links_genesis(self, service):
+        ev = await service.append(
+            event_type="login",
+            actor_id="u-1",
+            payload={"ip": "1.2.3.4"},
+        )
+        assert ev.sequence == 1
+        assert ev.prev_hash == "0" * 64
+        assert len(ev.hash) == 64
+
+    @pytest.mark.asyncio
+    async def test_sequential_chain(self, service):
+        a = await service.append("login", "u-1", {})
+        b = await service.append("trade", "u-1", {"symbol": "AAPL"})
+        assert b.sequence == a.sequence + 1
+        assert b.prev_hash == a.hash
+
+    @pytest.mark.asyncio
+    async def test_hash_depends_on_payload(self, service):
+        a = await service.append("login", "u-1", {"ip": "1.1.1.1"})
+        b = await service.append("login", "u-1", {"ip": "2.2.2.2"})
+        assert a.hash != b.hash
+
+
+class TestVerifyChain:
+    @pytest.mark.asyncio
+    async def test_unmodified_chain_verifies(self, service):
+        await service.append("login", "u-1", {})
+        await service.append("trade", "u-1", {})
+        await service.append("logout", "u-1", {})
+        assert await service.verify_chain() is True
+
+    @pytest.mark.asyncio
+    async def test_empty_chain_verifies(self, service):
+        assert await service.verify_chain() is True
+
+    @pytest.mark.asyncio
+    async def test_tampered_payload_detected(self, service):
+        await service.append("login", "u-1", {"ip": "1.1.1.1"})
+        b = await service.append("trade", "u-1", {"symbol": "AAPL"})
+        log = service._log
+        tampered = replace(b, payload={"symbol": "MSFT"})
+        log._events[b.sequence - 1] = tampered
+        assert await service.verify_chain() is False
+
+    @pytest.mark.asyncio
+    async def test_broken_link_detected(self, service):
+        await service.append("login", "u-1", {})
+        b = await service.append("trade", "u-1", {})
+        log = service._log
+        bad = replace(b, prev_hash="0" * 64)
+        log._events[b.sequence - 1] = bad
+        assert await service.verify_chain() is False
+
+
+class TestQueries:
+    @pytest.mark.asyncio
+    async def test_list_returns_in_order(self, service):
+        a = await service.append("login", "u-1", {})
+        b = await service.append("trade", "u-1", {})
+        c = await service.append("logout", "u-1", {})
+        out = await service.list_events()
+        assert [e.sequence for e in out] == [a.sequence, b.sequence, c.sequence]
+
+    @pytest.mark.asyncio
+    async def test_filter_by_actor(self, service):
+        await service.append("login", "u-1", {})
+        await service.append("login", "u-2", {})
+        await service.append("trade", "u-1", {})
+        out = await service.list_events(actor_id="u-1")
+        assert {e.actor_id for e in out} == {"u-1"}
+        assert len(out) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_by_sequence(self, service):
+        a = await service.append("login", "u-1", {})
+        out = await service.get_by_sequence(a.sequence)
+        assert out is not None and out.id == a.id
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self, service):
+        assert await service.get_by_sequence(999) is None
+
+
+class TestRedaction:
+    @pytest.mark.asyncio
+    async def test_password_payload_redacted_at_append(self, service):
+        ev = await service.append(
+            "login",
+            "u-1",
+            {"username": "alice", "password": "hunter2"},
+        )
+        assert ev.payload["password"] != "hunter2"
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_empty_event_type_rejected(self, service):
+        with pytest.raises(AuditLogError):
+            await service.append("", "u-1", {})
+
+    @pytest.mark.asyncio
+    async def test_empty_actor_rejected(self, service):
+        with pytest.raises(AuditLogError):
+            await service.append("login", "", {})
+
+
+class TestEntity:
+    def test_audit_event_dataclass(self):
+        e = AuditEvent(
+            id="e1",
+            sequence=1,
+            event_type="login",
+            actor_id="u-1",
+            payload={},
+            prev_hash="0" * 64,
+            hash="a" * 64,
+            created_at_epoch=1.0,
+        )
+        assert e.sequence == 1


### PR DESCRIPTION
## Summary

Closes #114. Tamper-evident audit trail. Every event carries SHA-256 of its own canonical payload + the previous event's hash. Genesis prev_hash is the all-zero sha256 sentinel.

### Public surface

- \`AuditEvent\` frozen dataclass.
- \`AuditLog\` Protocol + \`InMemoryAuditLog\`.
- \`AuditService\` — append, verify_chain, list_events (filter by actor), get_by_sequence.

Append runs every payload through \`engine.observability.redact.redact_processor\` so secrets in caller payloads never reach disk.

### Out of scope (follow-up)

- DB-backed \`AuditLog\` + Alembic migration
- API route for replay / export
- External timestamping for non-repudiation

### Test plan

- [x] 15 unit tests cover append/chain linkage, tampered-payload + broken-link detection, queries, redaction, validation
- [x] Full suite — 969 passed
- [x] \`ruff\` + \`basedpyright\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)