### PR TITLE
feat(reference): symbol + company-name search both first-class

### DIFF
--- a/engine/reference/search.py
+++ b/engine/reference/search.py
@@ -51,18 +51,58 @@ class SearchIndex:
         return [rec for _, rec in top]
 
     @staticmethod
-    def _score(rec: RefInstrument, q: str) -> int:
+    def _score(rec: RefInstrument, q: str) -> int:  # noqa: PLR0911 - one return per scoring tier
+        """Rank both ticker and company-name matches.
+
+        Both symbol-style queries (e.g. ``AAPL``) and company-name
+        queries (e.g. ``Apple``) reach the target instrument; the
+        caller does not have to know which form the catalog stores.
+
+        Tiers (high -> low):
+
+        - 100: ticker exact match
+        - 90:  name exact match
+        - 80:  ticker prefix match
+        - 70:  name prefix match
+        - 60:  ticker contains q
+        - 50:  any name token starts with q (word-prefix)
+        - 25:  q anywhere inside name
+        """
         ticker = rec.primary_ticker.lower()
         name = rec.name.lower()
         if ticker == q:
             return 100
+        if name == q:
+            return 90
         if ticker.startswith(q):
-            return 75
+            return 80
+        if name.startswith(q):
+            return 70
         if q in ticker:
-            return 50
+            return 60
+        # Word-token prefix: catches "Berk" -> "Berkshire" inside
+        # "Berkshire Hathaway Inc." even when the ticker is BRK.B.
+        for token in _tokenize_name(name):
+            if token.startswith(q):
+                return 50
         if q in name:
             return 25
         return 0
+
+
+def _tokenize_name(name: str) -> list[str]:
+    """Split a name into lowercase alphanumeric word tokens."""
+    out: list[str] = []
+    current: list[str] = []
+    for ch in name:
+        if ch.isalnum():
+            current.append(ch)
+        elif current:
+            out.append("".join(current))
+            current = []
+    if current:
+        out.append("".join(current))
+    return out
 
 
 __all__ = ["SearchIndex"]

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -332,6 +332,94 @@ class TestSearchIndex:
         assert len(results) == 10
 
 
+class TestSymbolAndNameSearch:
+    """Both ticker and company-name queries are first-class entry points."""
+
+    def _idx(self) -> SearchIndex:
+        idx = SearchIndex()
+        idx.add(_aapl())
+        idx.add(
+            RefInstrument(
+                primary_ticker="MSFT",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="Microsoft Corp.",
+            )
+        )
+        idx.add(
+            RefInstrument(
+                primary_ticker="BRK.B",
+                primary_venue="XNYS",
+                asset_class="equity",
+                name="Berkshire Hathaway Inc.",
+            )
+        )
+        idx.add(
+            RefInstrument(
+                primary_ticker="WDFC",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="WD-40 Company",
+            )
+        )
+        return idx
+
+    def test_name_full_word_finds_ticker(self):
+        results = self._idx().search("Apple")
+        assert results
+        assert results[0].primary_ticker == "AAPL"
+
+    def test_name_prefix_finds_ticker(self):
+        results = self._idx().search("Micro")
+        assert results
+        assert results[0].primary_ticker == "MSFT"
+
+    def test_name_word_token_finds_ticker(self):
+        # Multi-word names: "Berk" matches the first word of
+        # "Berkshire Hathaway Inc." and ranks BRK.B above non-matches.
+        results = self._idx().search("Berk")
+        assert results
+        assert results[0].primary_ticker == "BRK.B"
+
+    def test_ticker_exact_still_wins_over_name_partial(self):
+        # If query matches one record's ticker exactly AND another
+        # record's name as a substring, the ticker-exact match comes
+        # first.
+        idx = SearchIndex()
+        idx.add(
+            RefInstrument(
+                primary_ticker="ABC",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="Some Company",
+            )
+        )
+        idx.add(
+            RefInstrument(
+                primary_ticker="ZZZ",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="ABC Industries",
+            )
+        )
+        results = idx.search("ABC")
+        assert results[0].primary_ticker == "ABC"
+
+    def test_name_search_is_case_insensitive(self):
+        results = self._idx().search("MICROSOFT")
+        assert results
+        assert results[0].primary_ticker == "MSFT"
+
+    def test_name_internal_substring_still_matches(self):
+        results = self._idx().search("soft")
+        tickers = [r.primary_ticker for r in results]
+        assert "MSFT" in tickers
+
+    def test_no_match_returns_empty(self):
+        results = self._idx().search("xyznotapresent")
+        assert results == []
+
+
 class TestGICSNode:
     def test_construction(self):
         node = GICSNode(code="45", name="Information Technology", level="sector")


### PR DESCRIPTION
## Summary

User asked for both ticker-symbol search ("AAPL") AND company-name search ("Apple") to be first-class entry points in \`SearchIndex\`. Reworks \`_score\` with a 7-tier scheme so neither form is privileged over the other beyond exact-match priority.

### Scoring tiers

| Score | Match |
|---|---|
| 100 | ticker exact |
| 90 | name exact |
| 80 | ticker prefix |
| 70 | name prefix |
| 60 | ticker contains q |
| 50 | any name token starts with q (word-prefix) |
| 25 | q anywhere in name (fallback) |

\`_tokenize_name\` splits the company name on non-alphanumeric boundaries so multi-word names ("Berkshire Hathaway Inc.") are searchable by any leading word.

### Behavior preserved

- Ticker exact still wins (100 > 90).
- Heap-based top-K and asset-class filter unchanged.
- Empty / oversize-query short-circuits unchanged.

### Test plan

- [x] 7 new \`TestSymbolAndNameSearch\` cases prove name-prefix, name-word-token, case-insensitivity, ticker-exact-still-wins, empty-result paths
- [x] 61 reference-data tests pass
- [x] \`ruff\` + \`basedpyright\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)