### PR TITLE
feat(secrets): encrypted secret store with master-key rotation (gh#115)

### DIFF
--- a/engine/core/secrets.py
+++ b/engine/core/secrets.py
@@ -16,21 +16,51 @@ Two layers:
   sees plaintext.
 
 The service never logs plaintext or ciphertext, never includes secret
-values in raised exceptions, and rejects empty names or values at the
-boundary so callers cannot accidentally store sentinel-like data.
+values or names in raised exceptions on the rotation path, and rejects
+empty / whitespace-only names and empty values at the boundary so callers
+cannot accidentally store sentinel-like data.
 """
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import binascii
 import time
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from typing import Protocol
 
 from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
+_FERNET_KEY_BYTES = 32
+
 
 class SecretsError(Exception):
     """Raised on malformed input or decrypt failure."""
+
+
+def _validate_fernet_key(key: bytes) -> None:
+    """Reject anything that is not a url-safe-base64 32-byte Fernet key."""
+    if not key:
+        msg = "Fernet key must be non-empty"
+        raise SecretsError(msg)
+    try:
+        decoded = base64.urlsafe_b64decode(key)
+    except (binascii.Error, ValueError) as exc:
+        msg = "Fernet key must be url-safe base64"
+        raise SecretsError(msg) from exc
+    if len(decoded) != _FERNET_KEY_BYTES:
+        msg = f"Fernet key must decode to exactly {_FERNET_KEY_BYTES} bytes"
+        raise SecretsError(msg)
+
+
+def _normalize_name(name: str) -> str:
+    """Strip whitespace and reject empty or whitespace-only names."""
+    stripped = name.strip()
+    if not stripped:
+        msg = "secret name must be non-empty / non-whitespace"
+        raise SecretsError(msg)
+    return stripped
 
 
 def generate_master_key() -> bytes:
@@ -51,9 +81,9 @@ class MasterKey:
     previous: bytes | None = None
 
     def __post_init__(self) -> None:
-        if not self.current:
-            msg = "MasterKey.current must be non-empty"
-            raise SecretsError(msg)
+        _validate_fernet_key(self.current)
+        if self.previous is not None:
+            _validate_fernet_key(self.previous)
 
 
 @dataclass(frozen=True)
@@ -75,25 +105,31 @@ class SecretStore(Protocol):
 
 
 class InMemorySecretStore:
-    """Process-local store. Single-pod / tests."""
+    """Process-local store. Single-pod / tests. Concurrency-safe."""
 
     def __init__(self) -> None:
         self._records: dict[str, SecretRecord] = {}
+        self._lock = asyncio.Lock()
 
     async def put_record(self, record: SecretRecord) -> None:
-        self._records[record.name] = record
+        async with self._lock:
+            self._records[record.name] = record
 
     async def get_record(self, name: str) -> SecretRecord | None:
-        return self._records.get(name)
+        async with self._lock:
+            return self._records.get(name)
 
     async def delete_record(self, name: str) -> None:
-        self._records.pop(name, None)
+        async with self._lock:
+            self._records.pop(name, None)
 
     async def list_names(self) -> list[str]:
-        return sorted(self._records.keys())
+        async with self._lock:
+            return sorted(self._records.keys())
 
     async def all_records(self) -> list[SecretRecord]:
-        return list(self._records.values())
+        async with self._lock:
+            return list(self._records.values())
 
 
 def _build_fernet(master: MasterKey) -> MultiFernet:
@@ -109,29 +145,27 @@ class SecretsService:
     """High-level put / get / rotate on top of a :class:`SecretStore`."""
 
     store: SecretStore
-    master_key: MasterKey
-    _master_key: MasterKey = field(init=False)
+    master_key: InitVar[MasterKey]
+    _master_key: MasterKey = field(init=False, repr=False)
 
-    def __post_init__(self) -> None:
-        self._master_key = self.master_key
+    def __post_init__(self, master_key: MasterKey) -> None:
+        self._master_key = master_key
 
     def _fernet(self) -> MultiFernet:
         return _build_fernet(self._master_key)
 
     async def put(self, name: str, value: str) -> None:
-        if not name.strip():
-            msg = "secret name must be non-empty"
-            raise SecretsError(msg)
         if not value:
             msg = "secret value must be non-empty"
             raise SecretsError(msg)
+        canonical = _normalize_name(name)
         ct = self._fernet().encrypt(value.encode("utf-8"))
         now = time.time()
-        existing = await self.store.get_record(name)
+        existing = await self.store.get_record(canonical)
         created = existing.created_at_epoch if existing is not None else now
         await self.store.put_record(
             SecretRecord(
-                name=name,
+                name=canonical,
                 ciphertext=ct,
                 created_at_epoch=created,
                 updated_at_epoch=now,
@@ -139,71 +173,103 @@ class SecretsService:
         )
 
     async def get(self, name: str) -> str | None:
-        rec = await self.store.get_record(name)
+        canonical = _normalize_name(name)
+        rec = await self.store.get_record(canonical)
         if rec is None:
             return None
         try:
             pt = self._fernet().decrypt(rec.ciphertext)
         except InvalidToken as exc:
-            msg = f"failed to decrypt secret {name!r}: token invalid"
+            msg = f"failed to decrypt secret {canonical!r}: token invalid"
             raise SecretsError(msg) from exc
         return pt.decode("utf-8")
 
     async def delete(self, name: str) -> None:
-        await self.store.delete_record(name)
+        canonical = _normalize_name(name)
+        await self.store.delete_record(canonical)
 
     async def list_names(self) -> list[str]:
         return await self.store.list_names()
 
     def rotate_master_key(self, *, new_current: bytes) -> None:
-        """Promote current master to previous and install new_current.
+        """Promote current master to previous and install ``new_current``.
+
+        Refuses to overwrite an existing previous key; that situation
+        means a prior rotation never finished its :meth:`reencrypt_all`
+        and silently dropping the old previous would render any records
+        still encrypted under it permanently unreadable.
 
         After this call, run :meth:`reencrypt_all` to migrate stored
         ciphertext, then drop the previous key by constructing a fresh
-        :class:`MasterKey` without ``previous``.
+        :class:`MasterKey` without ``previous`` (or call
+        :meth:`drop_previous_key` once the migration verifies clean).
         """
-        if not new_current:
-            msg = "new_current must be non-empty"
+        _validate_fernet_key(new_current)
+        if self._master_key.previous is not None:
+            msg = (
+                "rotate_master_key called while a previous key is still "
+                "held; run reencrypt_all to drain the previous slot first"
+            )
             raise SecretsError(msg)
         self._master_key = MasterKey(
             current=new_current, previous=self._master_key.current
         )
 
+    def drop_previous_key(self) -> None:
+        """Forget the previous key. Call only after :meth:`reencrypt_all` succeeds."""
+        self._master_key = MasterKey(current=self._master_key.current)
+
     async def reencrypt_all(self) -> int:
         """Re-encrypt every stored secret under the current master key.
 
-        Returns the number of records migrated. Records that fail to
-        decrypt with either current or previous are left in place and
-        a :class:`SecretsError` is raised after the pass completes so
-        the operator can investigate.
+        Two-phase to bound partial-failure blast radius:
+
+        - Phase 1: decrypt every record into memory. If any record fails
+          to decrypt under either current or previous, abort with
+          :class:`SecretsError` *before any writes* — the store is left
+          untouched, the operator must keep the previous key installed,
+          and the count of failures is reported (names are not, to
+          avoid leaking sensitive identifiers).
+        - Phase 2: encrypt under current + write each record.
+
+        Phase 2 is not transactional: on a process crash mid-flush some
+        records will be on the new key and others on the old. The
+        previous key MUST remain installed until a full run completes
+        without raising; only then is :meth:`drop_previous_key` safe.
+
+        Returns the number of records migrated.
         """
         records = await self.store.all_records()
         f = self._fernet()
-        failures: list[str] = []
-        migrated = 0
+        plaintexts: list[tuple[SecretRecord, bytes]] = []
+        failure_count = 0
         for rec in records:
             try:
                 pt = f.decrypt(rec.ciphertext)
             except InvalidToken:
-                failures.append(rec.name)
+                failure_count += 1
                 continue
+            plaintexts.append((rec, pt))
+        if failure_count:
+            msg = (
+                f"reencrypt_all aborted: {failure_count} record(s) failed "
+                "to decrypt under either current or previous master key. "
+                "No records were modified. Keep the previous key installed "
+                "and investigate."
+            )
+            raise SecretsError(msg)
+        now = time.time()
+        for rec, pt in plaintexts:
             ct = f.encrypt(pt)
             await self.store.put_record(
                 SecretRecord(
                     name=rec.name,
                     ciphertext=ct,
                     created_at_epoch=rec.created_at_epoch,
-                    updated_at_epoch=time.time(),
+                    updated_at_epoch=now,
                 )
             )
-            migrated += 1
-        if failures:
-            msg = (
-                f"reencrypt_all completed with {len(failures)} undecryptable "
-                f"records: {sorted(failures)!r}"
-            )
-            raise SecretsError(msg)
-        return migrated
+        return len(plaintexts)
 
 
 __all__ = [

--- a/engine/core/secrets.py
+++ b/engine/core/secrets.py
@@ -1,0 +1,217 @@
+"""Encrypted secret store with master-key rotation.
+
+Values are encrypted at rest with Fernet (AES-128-CBC + HMAC-SHA-256,
+authenticated) using a process-held master key. Rotation is supported by
+holding both a current and an optional previous key in :class:`MasterKey`;
+on rotation the operator calls :meth:`SecretsService.rotate_master_key`
+and then :meth:`SecretsService.reencrypt_all` to migrate every stored
+ciphertext to the new key.
+
+Two layers:
+
+- :class:`SecretStore` Protocol — pluggable persistence (in-memory
+  ships here; DB / KMS-backed adapters arrive in follow-up issues).
+- :class:`SecretsService` — wraps a store with put / get / delete /
+  list / rotate / reencrypt semantics, and is the only layer that ever
+  sees plaintext.
+
+The service never logs plaintext or ciphertext, never includes secret
+values in raised exceptions, and rejects empty names or values at the
+boundary so callers cannot accidentally store sentinel-like data.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+
+
+class SecretsError(Exception):
+    """Raised on malformed input or decrypt failure."""
+
+
+def generate_master_key() -> bytes:
+    """Generate a fresh 32-byte url-safe-base64 Fernet key."""
+    return Fernet.generate_key()
+
+
+@dataclass(frozen=True)
+class MasterKey:
+    """Wraps a current Fernet key and an optional previous one.
+
+    The previous key allows decrypting records that were encrypted under
+    the prior master before :meth:`SecretsService.reencrypt_all` has
+    finished migrating them.
+    """
+
+    current: bytes
+    previous: bytes | None = None
+
+    def __post_init__(self) -> None:
+        if not self.current:
+            msg = "MasterKey.current must be non-empty"
+            raise SecretsError(msg)
+
+
+@dataclass(frozen=True)
+class SecretRecord:
+    """One stored secret. Plaintext is *never* held here."""
+
+    name: str
+    ciphertext: bytes
+    created_at_epoch: float
+    updated_at_epoch: float
+
+
+class SecretStore(Protocol):
+    async def put_record(self, record: SecretRecord) -> None: ...
+    async def get_record(self, name: str) -> SecretRecord | None: ...
+    async def delete_record(self, name: str) -> None: ...
+    async def list_names(self) -> list[str]: ...
+    async def all_records(self) -> list[SecretRecord]: ...
+
+
+class InMemorySecretStore:
+    """Process-local store. Single-pod / tests."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, SecretRecord] = {}
+
+    async def put_record(self, record: SecretRecord) -> None:
+        self._records[record.name] = record
+
+    async def get_record(self, name: str) -> SecretRecord | None:
+        return self._records.get(name)
+
+    async def delete_record(self, name: str) -> None:
+        self._records.pop(name, None)
+
+    async def list_names(self) -> list[str]:
+        return sorted(self._records.keys())
+
+    async def all_records(self) -> list[SecretRecord]:
+        return list(self._records.values())
+
+
+def _build_fernet(master: MasterKey) -> MultiFernet:
+    """Build a MultiFernet that encrypts with current and decrypts via either key."""
+    keys = [Fernet(master.current)]
+    if master.previous is not None:
+        keys.append(Fernet(master.previous))
+    return MultiFernet(keys)
+
+
+@dataclass
+class SecretsService:
+    """High-level put / get / rotate on top of a :class:`SecretStore`."""
+
+    store: SecretStore
+    master_key: MasterKey
+    _master_key: MasterKey = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._master_key = self.master_key
+
+    def _fernet(self) -> MultiFernet:
+        return _build_fernet(self._master_key)
+
+    async def put(self, name: str, value: str) -> None:
+        if not name.strip():
+            msg = "secret name must be non-empty"
+            raise SecretsError(msg)
+        if not value:
+            msg = "secret value must be non-empty"
+            raise SecretsError(msg)
+        ct = self._fernet().encrypt(value.encode("utf-8"))
+        now = time.time()
+        existing = await self.store.get_record(name)
+        created = existing.created_at_epoch if existing is not None else now
+        await self.store.put_record(
+            SecretRecord(
+                name=name,
+                ciphertext=ct,
+                created_at_epoch=created,
+                updated_at_epoch=now,
+            )
+        )
+
+    async def get(self, name: str) -> str | None:
+        rec = await self.store.get_record(name)
+        if rec is None:
+            return None
+        try:
+            pt = self._fernet().decrypt(rec.ciphertext)
+        except InvalidToken as exc:
+            msg = f"failed to decrypt secret {name!r}: token invalid"
+            raise SecretsError(msg) from exc
+        return pt.decode("utf-8")
+
+    async def delete(self, name: str) -> None:
+        await self.store.delete_record(name)
+
+    async def list_names(self) -> list[str]:
+        return await self.store.list_names()
+
+    def rotate_master_key(self, *, new_current: bytes) -> None:
+        """Promote current master to previous and install new_current.
+
+        After this call, run :meth:`reencrypt_all` to migrate stored
+        ciphertext, then drop the previous key by constructing a fresh
+        :class:`MasterKey` without ``previous``.
+        """
+        if not new_current:
+            msg = "new_current must be non-empty"
+            raise SecretsError(msg)
+        self._master_key = MasterKey(
+            current=new_current, previous=self._master_key.current
+        )
+
+    async def reencrypt_all(self) -> int:
+        """Re-encrypt every stored secret under the current master key.
+
+        Returns the number of records migrated. Records that fail to
+        decrypt with either current or previous are left in place and
+        a :class:`SecretsError` is raised after the pass completes so
+        the operator can investigate.
+        """
+        records = await self.store.all_records()
+        f = self._fernet()
+        failures: list[str] = []
+        migrated = 0
+        for rec in records:
+            try:
+                pt = f.decrypt(rec.ciphertext)
+            except InvalidToken:
+                failures.append(rec.name)
+                continue
+            ct = f.encrypt(pt)
+            await self.store.put_record(
+                SecretRecord(
+                    name=rec.name,
+                    ciphertext=ct,
+                    created_at_epoch=rec.created_at_epoch,
+                    updated_at_epoch=time.time(),
+                )
+            )
+            migrated += 1
+        if failures:
+            msg = (
+                f"reencrypt_all completed with {len(failures)} undecryptable "
+                f"records: {sorted(failures)!r}"
+            )
+            raise SecretsError(msg)
+        return migrated
+
+
+__all__ = [
+    "InMemorySecretStore",
+    "MasterKey",
+    "SecretRecord",
+    "SecretStore",
+    "SecretsError",
+    "SecretsService",
+    "generate_master_key",
+]

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -53,9 +53,53 @@ class TestPutGet:
             await service.put("", "v")
 
     @pytest.mark.asyncio
+    async def test_whitespace_only_name_rejected(
+        self, service: SecretsService
+    ) -> None:
+        with pytest.raises(SecretsError):
+            await service.put("   ", "v")
+
+    @pytest.mark.asyncio
     async def test_empty_value_rejected(self, service: SecretsService) -> None:
         with pytest.raises(SecretsError):
             await service.put("k", "")
+
+    @pytest.mark.asyncio
+    async def test_name_normalized_consistently(
+        self, service: SecretsService
+    ) -> None:
+        await service.put("  api_key  ", "v")
+        assert await service.get("api_key") == "v"
+        assert await service.get("  api_key  ") == "v"
+
+    @pytest.mark.asyncio
+    async def test_unicode_name_round_trip(self, service: SecretsService) -> None:
+        await service.put("密钥", "v")
+        assert await service.get("密钥") == "v"
+
+    @pytest.mark.asyncio
+    async def test_corrupted_ciphertext_raises(
+        self, service: SecretsService
+    ) -> None:
+        from engine.core.secrets import SecretRecord
+
+        await service.store.put_record(
+            SecretRecord(
+                name="garbage",
+                ciphertext=b"not-a-fernet-token",
+                created_at_epoch=0.0,
+                updated_at_epoch=0.0,
+            )
+        )
+        with pytest.raises(SecretsError):
+            await service.get("garbage")
+
+    @pytest.mark.asyncio
+    async def test_get_whitespace_only_name_rejected(
+        self, service: SecretsService
+    ) -> None:
+        with pytest.raises(SecretsError):
+            await service.get("   ")
 
 
 class TestDelete:
@@ -68,6 +112,13 @@ class TestDelete:
     @pytest.mark.asyncio
     async def test_delete_missing_is_noop(self, service: SecretsService) -> None:
         await service.delete("never-existed")
+
+    @pytest.mark.asyncio
+    async def test_delete_whitespace_only_name_rejected(
+        self, service: SecretsService
+    ) -> None:
+        with pytest.raises(SecretsError):
+            await service.delete("   ")
 
 
 class TestList:
@@ -106,14 +157,14 @@ class TestRotation:
         assert await service.get("k") == "v"
 
     @pytest.mark.asyncio
-    async def test_after_reencrypt_previous_key_unused(
+    async def test_drop_previous_key_after_reencrypt(
         self, service: SecretsService
     ) -> None:
         await service.put("k", "v")
         new_key = generate_master_key()
         service.rotate_master_key(new_current=new_key)
         await service.reencrypt_all()
-        service._master_key = MasterKey(current=new_key)
+        service.drop_previous_key()
         assert await service.get("k") == "v"
 
     @pytest.mark.asyncio
@@ -129,6 +180,63 @@ class TestRotation:
         with pytest.raises(SecretsError):
             await svc2.get("k")
 
+    @pytest.mark.asyncio
+    async def test_double_rotation_without_reencrypt_rejected(
+        self, service: SecretsService
+    ) -> None:
+        service.rotate_master_key(new_current=generate_master_key())
+        with pytest.raises(SecretsError, match="previous key is still held"):
+            service.rotate_master_key(new_current=generate_master_key())
+
+    @pytest.mark.asyncio
+    async def test_reencrypt_all_aborts_on_undecryptable_record(self) -> None:
+        from engine.core.secrets import SecretRecord
+
+        store = InMemorySecretStore()
+        svc = SecretsService(
+            store=store, master_key=MasterKey(current=generate_master_key())
+        )
+        await svc.put("good", "v")
+        # Insert a record that decrypts under neither key.
+        await store.put_record(
+            SecretRecord(
+                name="bad",
+                ciphertext=b"not-a-fernet-token",
+                created_at_epoch=0.0,
+                updated_at_epoch=0.0,
+            )
+        )
+        good_before = await store.get_record("good")
+        assert good_before is not None
+        new_key = generate_master_key()
+        svc.rotate_master_key(new_current=new_key)
+        with pytest.raises(SecretsError, match="No records were modified"):
+            await svc.reencrypt_all()
+        # Good record must be untouched (atomic abort).
+        good_after = await store.get_record("good")
+        assert good_after is not None
+        assert good_after.ciphertext == good_before.ciphertext
+
+    @pytest.mark.asyncio
+    async def test_reencrypt_error_does_not_leak_names(self) -> None:
+        from engine.core.secrets import SecretRecord
+
+        store = InMemorySecretStore()
+        svc = SecretsService(
+            store=store, master_key=MasterKey(current=generate_master_key())
+        )
+        await store.put_record(
+            SecretRecord(
+                name="prod_stripe_key",
+                ciphertext=b"not-a-fernet-token",
+                created_at_epoch=0.0,
+                updated_at_epoch=0.0,
+            )
+        )
+        with pytest.raises(SecretsError) as exc_info:
+            await svc.reencrypt_all()
+        assert "prod_stripe_key" not in str(exc_info.value)
+
 
 class TestMasterKey:
     def test_generate_master_key_returns_bytes(self) -> None:
@@ -142,3 +250,29 @@ class TestMasterKey:
     def test_master_key_rejects_empty_current(self) -> None:
         with pytest.raises(SecretsError):
             MasterKey(current=b"")
+
+    def test_master_key_rejects_short_key(self) -> None:
+        with pytest.raises(SecretsError, match="32 bytes"):
+            MasterKey(current=b"tooshort")
+
+    def test_master_key_rejects_non_base64_key(self) -> None:
+        # 32 random raw bytes — not url-safe-base64-encoded.
+        raw_bytes = bytes(range(32))
+        with pytest.raises(SecretsError):
+            MasterKey(current=raw_bytes)
+
+    def test_master_key_rejects_invalid_previous(self) -> None:
+        with pytest.raises(SecretsError):
+            MasterKey(current=generate_master_key(), previous=b"garbage")
+
+    def test_rotate_rejects_invalid_new_key(
+        self, service: SecretsService
+    ) -> None:
+        with pytest.raises(SecretsError):
+            service.rotate_master_key(new_current=b"")
+
+    def test_rotate_rejects_short_new_key(
+        self, service: SecretsService
+    ) -> None:
+        with pytest.raises(SecretsError, match="32 bytes"):
+            service.rotate_master_key(new_current=b"tooshort")

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,144 @@
+"""Tests for engine.core.secrets — encrypted secret storage with rotation."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.secrets import (
+    InMemorySecretStore,
+    MasterKey,
+    SecretsError,
+    SecretsService,
+    generate_master_key,
+)
+
+
+@pytest.fixture
+def master() -> MasterKey:
+    return MasterKey(current=generate_master_key())
+
+
+@pytest.fixture
+def service(master: MasterKey) -> SecretsService:
+    return SecretsService(store=InMemorySecretStore(), master_key=master)
+
+
+class TestPutGet:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, service: SecretsService) -> None:
+        await service.put("api_key", "s3cret-value")
+        out = await service.get("api_key")
+        assert out == "s3cret-value"
+
+    @pytest.mark.asyncio
+    async def test_overwrite_replaces_value(self, service: SecretsService) -> None:
+        await service.put("k", "v1")
+        await service.put("k", "v2")
+        assert await service.get("k") == "v2"
+
+    @pytest.mark.asyncio
+    async def test_missing_returns_none(self, service: SecretsService) -> None:
+        assert await service.get("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_ciphertext_is_not_plaintext(self, service: SecretsService) -> None:
+        await service.put("k", "plaintext-marker")
+        rec = await service.store.get_record("k")
+        assert rec is not None
+        assert b"plaintext-marker" not in rec.ciphertext
+
+    @pytest.mark.asyncio
+    async def test_empty_name_rejected(self, service: SecretsService) -> None:
+        with pytest.raises(SecretsError):
+            await service.put("", "v")
+
+    @pytest.mark.asyncio
+    async def test_empty_value_rejected(self, service: SecretsService) -> None:
+        with pytest.raises(SecretsError):
+            await service.put("k", "")
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_delete_removes_secret(self, service: SecretsService) -> None:
+        await service.put("k", "v")
+        await service.delete("k")
+        assert await service.get("k") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_is_noop(self, service: SecretsService) -> None:
+        await service.delete("never-existed")
+
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_list_returns_names_only(self, service: SecretsService) -> None:
+        await service.put("a", "x")
+        await service.put("b", "y")
+        names = await service.list_names()
+        assert set(names) == {"a", "b"}
+
+
+class TestRotation:
+    @pytest.mark.asyncio
+    async def test_old_secrets_decrypt_after_rotation_with_previous(
+        self, service: SecretsService
+    ) -> None:
+        await service.put("k", "v")
+        new_key = generate_master_key()
+        service.rotate_master_key(new_current=new_key)
+        assert await service.get("k") == "v"
+
+    @pytest.mark.asyncio
+    async def test_reencrypt_all_uses_new_key(
+        self, service: SecretsService
+    ) -> None:
+        await service.put("k", "v")
+        old_record = await service.store.get_record("k")
+        assert old_record is not None
+        old_ct = old_record.ciphertext
+        new_key = generate_master_key()
+        service.rotate_master_key(new_current=new_key)
+        await service.reencrypt_all()
+        new_record = await service.store.get_record("k")
+        assert new_record is not None
+        assert new_record.ciphertext != old_ct
+        assert await service.get("k") == "v"
+
+    @pytest.mark.asyncio
+    async def test_after_reencrypt_previous_key_unused(
+        self, service: SecretsService
+    ) -> None:
+        await service.put("k", "v")
+        new_key = generate_master_key()
+        service.rotate_master_key(new_current=new_key)
+        await service.reencrypt_all()
+        service._master_key = MasterKey(current=new_key)
+        assert await service.get("k") == "v"
+
+    @pytest.mark.asyncio
+    async def test_decrypt_fails_without_either_key(self) -> None:
+        store = InMemorySecretStore()
+        svc1 = SecretsService(
+            store=store, master_key=MasterKey(current=generate_master_key())
+        )
+        await svc1.put("k", "v")
+        svc2 = SecretsService(
+            store=store, master_key=MasterKey(current=generate_master_key())
+        )
+        with pytest.raises(SecretsError):
+            await svc2.get("k")
+
+
+class TestMasterKey:
+    def test_generate_master_key_returns_bytes(self) -> None:
+        k = generate_master_key()
+        assert isinstance(k, bytes)
+        assert len(k) > 0
+
+    def test_two_generated_keys_differ(self) -> None:
+        assert generate_master_key() != generate_master_key()
+
+    def test_master_key_rejects_empty_current(self) -> None:
+        with pytest.raises(SecretsError):
+            MasterKey(current=b"")


### PR DESCRIPTION
## Summary
- Adds `engine.core.secrets`: encrypted-at-rest secret storage with rotation
- Fernet (AES-128-CBC + HMAC-SHA-256) via MultiFernet so rotation can decrypt under either current or previous key
- `SecretStore` Protocol + `InMemorySecretStore`; DB / KMS adapters in follow-up
- `SecretsService.put / get / delete / list_names / rotate_master_key / reencrypt_all`

## Rotation flow
1. `rotate_master_key(new_current=...)` — promotes current to previous, installs new
2. `reencrypt_all()` — migrates every ciphertext under new current; raises `SecretsError` on any record that fails to decrypt under either key
3. Caller drops the previous key once migration verifies

## Security stance
- Plaintext never persisted, never logged, never in raised exceptions
- Empty names and values rejected at the boundary
- Decrypt failures surface as `SecretsError` with the secret name only — never the value

## Test plan
- [x] 16/16 unit tests pass
  - Put/get round-trip, overwrite, missing returns None
  - Ciphertext is not plaintext (negative containment check)
  - Empty name + empty value rejected
  - Delete + delete-missing-noop
  - List names returns only names
  - Rotation: secrets stored under old key decrypt via previous after rotate
  - `reencrypt_all` migrates ciphertext to current; post-migration drop of previous still decrypts
  - Decrypt fails when neither key matches
  - `MasterKey` rejects empty current
  - `generate_master_key` produces fresh distinct keys
- [x] `ruff check` clean
- [x] `basedpyright` 0 errors
- [ ] CI green

Closes #115 (PR1 — core module). KMS / DB-backed adapters in follow-up.