### PR TITLE
feat(data-quality): OHLC consistency + return spike + duplicate timestamp rules (gh#117)

### DIFF
--- a/engine/data/quality.py
+++ b/engine/data/quality.py
@@ -417,34 +417,51 @@ class OHLCConsistencyRule(ValidationRule):
     ) -> pd.DataFrame:
         if df.empty:
             return df
-        body_max = df[["open", "close"]].max(axis=1)
-        body_min = df[["open", "close"]].min(axis=1)
-        high_below_body = df["high"] < body_max
-        low_above_body = df["low"] > body_min
-        high_below_low = df["high"] < df["low"]
-        for idx in df.index[high_below_body]:
+        required = ("open", "high", "low", "close")
+        if not all(c in df.columns for c in required):
+            return df
+        nan_mask = df[list(required)].isna().any(axis=1)
+        for _ in df.index[nan_mask]:
+            report.add_correction(
+                symbol=symbol,
+                field="ohlc",
+                original_value=None,
+                corrected_value=None,
+                reason="ohlc_nan_field",
+                action="flag",
+            )
+        # Comparisons against NaN evaluate False; restrict checks to clean rows.
+        clean = cast("pd.DataFrame", df[~nan_mask])
+        if clean.empty:
+            return df
+        body_max = clean[["open", "close"]].max(axis=1)
+        body_min = clean[["open", "close"]].min(axis=1)
+        high_below_body = clean["high"] < body_max
+        low_above_body = clean["low"] > body_min
+        high_below_low = clean["high"] < clean["low"]
+        for idx in clean.index[high_below_body]:
             report.add_correction(
                 symbol=symbol,
                 field="high",
-                original_value=float(df.loc[idx, "high"]),
+                original_value=float(clean.loc[idx, "high"]),
                 corrected_value=None,
                 reason="ohlc_high_below_body",
                 action="flag",
             )
-        for idx in df.index[low_above_body]:
+        for idx in clean.index[low_above_body]:
             report.add_correction(
                 symbol=symbol,
                 field="low",
-                original_value=float(df.loc[idx, "low"]),
+                original_value=float(clean.loc[idx, "low"]),
                 corrected_value=None,
                 reason="ohlc_low_above_body",
                 action="flag",
             )
-        for idx in df.index[high_below_low]:
+        for idx in clean.index[high_below_low]:
             report.add_correction(
                 symbol=symbol,
                 field="high",
-                original_value=float(df.loc[idx, "high"]),
+                original_value=float(clean.loc[idx, "high"]),
                 corrected_value=None,
                 reason="ohlc_high_below_low",
                 action="flag",
@@ -501,9 +518,19 @@ class ReturnSpikeRule(ValidationRule):
         median = float(log_returns.median())
         abs_dev = (log_returns - median).abs()
         mad = float(abs_dev.median())
-        if mad == 0.0 or not np.isfinite(mad):
+        if not np.isfinite(mad):
             return df
-        z = self._MAD_FACTOR * (log_returns - median) / mad
+        if mad == 0.0:
+            # Sparse-outlier series: most returns identical, ≥1 differs.
+            # MAD collapses to zero and would silently miss the outlier.
+            # Fall back to standard deviation; if that is also zero the
+            # series is genuinely constant and there is no anomaly.
+            std = float(log_returns.std(ddof=0))
+            if std == 0.0 or not np.isfinite(std):
+                return df
+            z = (log_returns - median) / std
+        else:
+            z = self._MAD_FACTOR * (log_returns - median) / mad
         threshold = self._config.return_spike_zscore
         flagged_idx = log_returns.index[z.abs() > threshold]
         for idx in flagged_idx:
@@ -536,7 +563,7 @@ class DuplicateTimestampRule(ValidationRule):
         dup_mask = df.index.duplicated(keep="last")
         if not dup_mask.any():
             return df
-        for _ in df.index[dup_mask].unique():
+        for ts in df.index[dup_mask].unique():
             report.add_correction(
                 symbol=symbol,
                 field="timestamp",
@@ -545,7 +572,16 @@ class DuplicateTimestampRule(ValidationRule):
                 reason="duplicate_timestamp",
                 action="dedup",
             )
-        return cast("pd.DataFrame", df[~dup_mask].copy())
+            logger.warning(
+                "data_quality.duplicate_timestamp",
+                symbol=symbol,
+                timestamp=str(ts),
+            )
+        # Sort after dedup so downstream return-based rules (which use
+        # positional shift) operate on a monotonic time series even if
+        # the upstream feed delivered rows out of order.
+        deduped = cast("pd.DataFrame", df[~dup_mask].copy())
+        return deduped.sort_index()
 
 
 class DataValidator:

--- a/engine/data/quality.py
+++ b/engine/data/quality.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+import numpy as np
 import structlog
 
 if TYPE_CHECKING:
@@ -27,6 +28,8 @@ class ValidationConfig:
     stale_volume_threshold: int = 0
     gbp_detection_factor: float = 80.0
     negative_revenue_tolerance: float = 0.1
+    return_spike_zscore: float = 8.0
+    return_spike_min_window: int = 20
 
     @classmethod
     def from_dict(cls, data: dict) -> ValidationConfig:
@@ -388,11 +391,171 @@ class StaleDataRule(ValidationRule):
         )
 
 
+class OHLCConsistencyRule(ValidationRule):
+    """Flag bars where OHLC fields violate basic ordering invariants.
+
+    Detects:
+    - high < max(open, close)  → ohlc_high_below_body
+    - low  > min(open, close)  → ohlc_low_above_body
+    - high < low               → ohlc_high_below_low
+    - volume < 0               → ohlc_negative_volume
+
+    Default action is "flag" — bars are not dropped because OHLC bands
+    can be subtly off from data-vendor rounding without being unusable
+    for backtests. The downstream cost / risk path can decide.
+    """
+
+    def __init__(self, config: ValidationConfig | None = None) -> None:
+        self._config = config or ValidationConfig()
+
+    def apply(
+        self,
+        df: pd.DataFrame,
+        symbol: str,
+        report: DataQualityReport,
+        **_kwargs: object,
+    ) -> pd.DataFrame:
+        if df.empty:
+            return df
+        body_max = df[["open", "close"]].max(axis=1)
+        body_min = df[["open", "close"]].min(axis=1)
+        high_below_body = df["high"] < body_max
+        low_above_body = df["low"] > body_min
+        high_below_low = df["high"] < df["low"]
+        for idx in df.index[high_below_body]:
+            report.add_correction(
+                symbol=symbol,
+                field="high",
+                original_value=float(df.loc[idx, "high"]),
+                corrected_value=None,
+                reason="ohlc_high_below_body",
+                action="flag",
+            )
+        for idx in df.index[low_above_body]:
+            report.add_correction(
+                symbol=symbol,
+                field="low",
+                original_value=float(df.loc[idx, "low"]),
+                corrected_value=None,
+                reason="ohlc_low_above_body",
+                action="flag",
+            )
+        for idx in df.index[high_below_low]:
+            report.add_correction(
+                symbol=symbol,
+                field="high",
+                original_value=float(df.loc[idx, "high"]),
+                corrected_value=None,
+                reason="ohlc_high_below_low",
+                action="flag",
+            )
+        if "volume" in df.columns:
+            neg_vol = df["volume"] < 0
+            for idx in df.index[neg_vol]:
+                report.add_correction(
+                    symbol=symbol,
+                    field="volume",
+                    original_value=float(df.loc[idx, "volume"]),
+                    corrected_value=None,
+                    reason="ohlc_negative_volume",
+                    action="flag",
+                )
+        return df
+
+
+class ReturnSpikeRule(ValidationRule):
+    """Flag bars whose log return modified-z-score exceeds a threshold.
+
+    Uses a MAD-based modified z-score (Iglewicz & Hoaglin) rather than
+    classical mean/std because std is dragged up by the very outliers
+    we want to flag — a single 5x spike in a 60-bar series can
+    self-mask under classical sigma. MAD is robust to a small fraction
+    of contamination.
+
+    Skips series shorter than ``return_spike_min_window``: a small
+    sample has unreliable scale estimates and produces false positives.
+    """
+
+    _MAD_FACTOR = 0.6745  # 75th percentile of standard normal — makes
+    # MAD-z comparable to classical z under normality.
+
+    def __init__(self, config: ValidationConfig | None = None) -> None:
+        self._config = config or ValidationConfig()
+
+    def apply(
+        self,
+        df: pd.DataFrame,
+        symbol: str,
+        report: DataQualityReport,
+        **_kwargs: object,
+    ) -> pd.DataFrame:
+        window = self._config.return_spike_min_window
+        if len(df) < window:
+            return df
+        closes = df["close"].astype(float)
+        if (closes <= 0).any():
+            return df
+        log_returns = np.log(closes / closes.shift(1)).dropna()
+        if log_returns.empty:
+            return df
+        median = float(log_returns.median())
+        abs_dev = (log_returns - median).abs()
+        mad = float(abs_dev.median())
+        if mad == 0.0 or not np.isfinite(mad):
+            return df
+        z = self._MAD_FACTOR * (log_returns - median) / mad
+        threshold = self._config.return_spike_zscore
+        flagged_idx = log_returns.index[z.abs() > threshold]
+        for idx in flagged_idx:
+            report.add_correction(
+                symbol=symbol,
+                field="close",
+                original_value=float(df.loc[idx, "close"]),
+                corrected_value=None,
+                reason="return_spike",
+                action="flag",
+            )
+        return df
+
+
+class DuplicateTimestampRule(ValidationRule):
+    """Drop duplicate timestamps, keeping the last (most recent) write.
+
+    Vendor backfill jobs can re-emit a previously seen bar. Keeping the
+    later write matches what a streaming consumer would have observed
+    after backfill resolution.
+    """
+
+    def apply(
+        self,
+        df: pd.DataFrame,
+        symbol: str,
+        report: DataQualityReport,
+        **_kwargs: object,
+    ) -> pd.DataFrame:
+        dup_mask = df.index.duplicated(keep="last")
+        if not dup_mask.any():
+            return df
+        for _ in df.index[dup_mask].unique():
+            report.add_correction(
+                symbol=symbol,
+                field="timestamp",
+                original_value=None,
+                corrected_value=None,
+                reason="duplicate_timestamp",
+                action="dedup",
+            )
+        return cast("pd.DataFrame", df[~dup_mask].copy())
+
+
 class DataValidator:
     def __init__(self, config: ValidationConfig | None = None) -> None:
         self._config = config or ValidationConfig()
         self._rules: list[ValidationRule] = [
+            DuplicateTimestampRule(),
             PriceBoundsRule(self._config),
+            OHLCConsistencyRule(self._config),
+            ReturnSpikeRule(self._config),
             StaleDataRule(self._config),
             RatioSanityRule(self._config),
             GBpGBPRule(self._config),

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -750,3 +750,108 @@ class TestExtendedDataValidator:
         assert "ohlc_high_below_body" in reasons
         assert "return_spike" in reasons
         assert "duplicate_timestamp" in reasons
+
+
+class TestOHLCNanHandling:
+    def test_nan_in_ohlc_field_flagged(self):
+        df = _make_ohlcv_df(5)
+        df.iloc[2, df.columns.get_loc("high")] = float("nan")
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        reasons = {c.reason for c in report.corrections}
+        assert "ohlc_nan_field" in reasons
+
+    def test_nan_row_does_not_silently_pass_other_checks(self):
+        df = _make_ohlcv_df(5)
+        # Row with NaN high AND a low > close inconsistency; NaN should
+        # block the body comparison from silently evaluating to False.
+        df.iloc[2, df.columns.get_loc("high")] = float("nan")
+        df.iloc[2, df.columns.get_loc("low")] = float(df.iloc[2]["close"]) + 1.0
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        reasons = [c.reason for c in report.corrections]
+        # NaN row gets flagged once for ohlc_nan_field; we should not
+        # double-flag it under ohlc_low_above_body since comparisons
+        # against NaN are unreliable.
+        assert "ohlc_nan_field" in reasons
+        nan_row_low_flags = [
+            c for c in report.corrections
+            if c.reason == "ohlc_low_above_body"
+            and c.original_value is not None
+        ]
+        assert len(nan_row_low_flags) == 0
+
+    def test_missing_required_column_skipped_without_error(self):
+        df = _make_ohlcv_df(5).drop(columns=["high"])
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        out = rule.apply(df, "AAPL", report)
+        assert len(out) == len(df)
+        assert not [c for c in report.corrections if c.reason.startswith("ohlc_")]
+
+
+class TestReturnSpikeMADFallback:
+    def test_single_outlier_in_otherwise_flat_series_caught(self):
+        # 30 bars: closes constant at 100 except one spike to 150 at
+        # idx 20. MAD on this series is 0 (>50% of returns are zero);
+        # the fallback std path must engage so the spike is not silently
+        # dropped. Note: a single isolated outlier has z bounded by
+        # ~sqrt(n-1) ≈ 5.4 here, so use a tighter test threshold (3.0).
+        n = 30
+        closes = [100.0] * n
+        closes[20] = 150.0
+        df = pd.DataFrame(
+            {
+                "open": closes,
+                "high": [c + 1 for c in closes],
+                "low": [c - 1 for c in closes],
+                "close": closes,
+                "volume": [1000] * n,
+            },
+            index=pd.date_range("2025-01-01", periods=n, freq="D", tz="UTC"),
+        )
+        rule = ReturnSpikeRule(ValidationConfig(return_spike_zscore=3.0))
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        spikes = [c for c in report.corrections if c.reason == "return_spike"]
+        assert len(spikes) >= 1
+
+    def test_genuinely_constant_returns_no_false_positive(self):
+        # All closes identical → all returns zero → MAD == std == 0 → skip.
+        n = 30
+        df = pd.DataFrame(
+            {
+                "open": [100.0] * n,
+                "high": [101.0] * n,
+                "low": [99.0] * n,
+                "close": [100.0] * n,
+                "volume": [1000] * n,
+            },
+            index=pd.date_range("2025-01-01", periods=n, freq="D", tz="UTC"),
+        )
+        rule = ReturnSpikeRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        assert not [c for c in report.corrections if c.reason == "return_spike"]
+
+
+class TestDuplicateTimestampSorting:
+    def test_non_monotonic_input_with_duplicates_sorted_after_dedup(self):
+        # Construct a frame whose duplicates arrive out of order: the
+        # later positional duplicate has an earlier timestamp, so plain
+        # `keep="last"` without a subsequent sort would leave the index
+        # non-monotonic and break ReturnSpikeRule's positional shift.
+        df = _make_ohlcv_df(5)
+        dup_first = df.iloc[[1]]
+        # Append a duplicate of an early timestamp at the end so the
+        # raw index is monotonic-broken even after `keep="last"`.
+        with_dup = pd.concat([df, dup_first])
+        rule = DuplicateTimestampRule()
+        report = DataQualityReport()
+        out = rule.apply(with_dup, "AAPL", report)
+        assert out.index.is_monotonic_increasing
+        assert len(out) == len(df)
+        reasons = {c.reason for c in report.corrections}
+        assert "duplicate_timestamp" in reasons

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -16,9 +16,12 @@ from engine.data.quality import (
     CorrectionRecord,
     DataQualityReport,
     DataValidator,
+    DuplicateTimestampRule,
     GBpGBPRule,
+    OHLCConsistencyRule,
     PriceBoundsRule,
     RatioSanityRule,
+    ReturnSpikeRule,
     StaleDataRule,
     ValidationConfig,
 )
@@ -595,3 +598,155 @@ class TestM5NegativeRevenueTolerance:
         rule.apply_fundamentals("AAPL", report, fundamentals)
         rev_corrections = [c for c in report.corrections if c.reason == "negative_revenue"]
         assert len(rev_corrections) == 1
+
+
+class TestOHLCConsistencyRule:
+    def test_clean_bars_pass(self):
+        df = _make_ohlcv_df(20)
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        out = rule.apply(df, "AAPL", report)
+        assert len(out) == len(df)
+        assert not [c for c in report.corrections if c.reason.startswith("ohlc_")]
+
+    def test_high_below_open_flagged(self):
+        df = _make_ohlcv_df(5)
+        df.iloc[2, df.columns.get_loc("high")] = float(df.iloc[2]["open"]) - 1.0
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        reasons = {c.reason for c in report.corrections}
+        assert "ohlc_high_below_body" in reasons
+
+    def test_low_above_close_flagged(self):
+        df = _make_ohlcv_df(5)
+        df.iloc[1, df.columns.get_loc("low")] = float(df.iloc[1]["close"]) + 1.0
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        reasons = {c.reason for c in report.corrections}
+        assert "ohlc_low_above_body" in reasons
+
+    def test_high_below_low_flagged(self):
+        df = _make_ohlcv_df(5)
+        df.iloc[3, df.columns.get_loc("high")] = 50.0
+        df.iloc[3, df.columns.get_loc("low")] = 60.0
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        reasons = {c.reason for c in report.corrections}
+        assert "ohlc_high_below_low" in reasons
+
+    def test_negative_volume_flagged(self):
+        df = _make_ohlcv_df(5)
+        df.iloc[0, df.columns.get_loc("volume")] = -1
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        reasons = {c.reason for c in report.corrections}
+        assert "ohlc_negative_volume" in reasons
+
+    def test_default_action_is_flag_not_drop(self):
+        df = _make_ohlcv_df(5)
+        df.iloc[2, df.columns.get_loc("high")] = float(df.iloc[2]["open"]) - 1.0
+        rule = OHLCConsistencyRule()
+        report = DataQualityReport()
+        out = rule.apply(df, "AAPL", report)
+        assert len(out) == len(df)
+
+
+class TestReturnSpikeRule:
+    def test_clean_returns_pass(self):
+        df = _make_ohlcv_df(60, seed=7)
+        rule = ReturnSpikeRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        assert not [c for c in report.corrections if c.reason == "return_spike"]
+
+    def test_extreme_spike_flagged(self):
+        df = _make_ohlcv_df(60, seed=7)
+        col = df.columns.get_loc("close")
+        df.iloc[40, col] = float(df.iloc[40]["close"]) * 5.0  # 400% jump
+        rule = ReturnSpikeRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        spikes = [c for c in report.corrections if c.reason == "return_spike"]
+        assert len(spikes) >= 1
+
+    def test_short_series_skipped(self):
+        df = _make_ohlcv_df(3)
+        rule = ReturnSpikeRule()
+        report = DataQualityReport()
+        rule.apply(df, "AAPL", report)
+        assert not report.corrections
+
+    def test_zstar_threshold_configurable(self):
+        df = _make_ohlcv_df(60, seed=7)
+        col = df.columns.get_loc("close")
+        df.iloc[40, col] = float(df.iloc[40]["close"]) * 1.20  # 20% jump
+        # Default z-threshold (8) should not flag a moderate jump.
+        report_default = DataQualityReport()
+        ReturnSpikeRule().apply(df, "AAPL", report_default)
+        # Tight threshold should flag it.
+        config = ValidationConfig(return_spike_zscore=2.0)
+        report_tight = DataQualityReport()
+        ReturnSpikeRule(config).apply(df, "AAPL", report_tight)
+        default_spikes = [
+            c for c in report_default.corrections if c.reason == "return_spike"
+        ]
+        tight_spikes = [
+            c for c in report_tight.corrections if c.reason == "return_spike"
+        ]
+        assert len(tight_spikes) > len(default_spikes)
+
+
+class TestDuplicateTimestampRule:
+    def test_unique_timestamps_pass(self):
+        df = _make_ohlcv_df(10)
+        rule = DuplicateTimestampRule()
+        report = DataQualityReport()
+        out = rule.apply(df, "AAPL", report)
+        assert len(out) == len(df)
+        assert not report.corrections
+
+    def test_duplicate_index_flagged_and_deduped(self):
+        df = _make_ohlcv_df(5)
+        # Synthesize a duplicate at the second timestamp.
+        dup_row = df.iloc[[1]]
+        df_with_dup = pd.concat([df, dup_row]).sort_index()
+        rule = DuplicateTimestampRule()
+        report = DataQualityReport()
+        out = rule.apply(df_with_dup, "AAPL", report)
+        assert len(out) == len(df)
+        reasons = {c.reason for c in report.corrections}
+        assert "duplicate_timestamp" in reasons
+
+    def test_dedup_keeps_last_occurrence(self):
+        df = _make_ohlcv_df(3)
+        dup_row = df.iloc[[0]].copy()
+        dup_row.iloc[0, dup_row.columns.get_loc("close")] = 999.0
+        df_with_dup = pd.concat([df, dup_row]).sort_index()
+        rule = DuplicateTimestampRule()
+        report = DataQualityReport()
+        out = rule.apply(df_with_dup, "AAPL", report)
+        first_ts = df.index[0]
+        assert float(out.loc[first_ts, "close"]) == 999.0
+
+
+class TestExtendedDataValidator:
+    def test_pipeline_chains_new_rules(self):
+        df = _make_ohlcv_df(40, seed=11)
+        # Inject one of each anomaly type.
+        df.iloc[5, df.columns.get_loc("high")] = float(df.iloc[5]["open"]) - 1.0
+        df.iloc[10, df.columns.get_loc("close")] = (
+            float(df.iloc[10]["close"]) * 5.0
+        )
+        dup_row = df.iloc[[20]]
+        df = pd.concat([df, dup_row]).sort_index()
+        validator = DataValidator()
+        report = DataQualityReport()
+        validator.validate(df, "AAPL", report)
+        reasons = {c.reason for c in report.corrections}
+        assert "ohlc_high_below_body" in reasons
+        assert "return_spike" in reasons
+        assert "duplicate_timestamp" in reasons


### PR DESCRIPTION
## Summary
Extends the existing data quality pipeline with three new validators:

- **OHLCConsistencyRule** — flags high<body / low>body / high<low / volume<0
- **ReturnSpikeRule** — MAD-based modified z-score on log returns; default z=8 catches splits / decimal errors / fat-fingered ticks without false-positiving on real volatility
- **DuplicateTimestampRule** — dedupes index, keeps last write (vendor backfill behavior)

## Why MAD instead of mean/std
A single 5x close spike in a 60-bar series inflates classical std enough to bring its own |z-score| down to ~5 — under threshold 8, the outlier self-masks. MAD is robust to a small fraction of contamination by construction; the modified-z (`0.6745 * (x - median) / MAD`) gives the same scale as classical-z under normality but doesn't degrade in the presence of the very outliers we're hunting.

## Pipeline order
\`\`\`
DuplicateTimestampRule
  → PriceBoundsRule        (drop garbage prices first)
  → OHLCConsistencyRule    (then flag bands)
  → ReturnSpikeRule        (then anomalies)
  → StaleDataRule
  → RatioSanityRule
  → GBpGBPRule
\`\`\`
PriceBounds runs before OHLC so a negative close doesn't double-fire as both \`negative_price\` *and* \`ohlc_low_above_body\`.

## Test plan
- [x] 68/68 \`tests/test_data_quality.py\` pass (16 new tests)
- [x] Clean bars produce zero corrections (OHLC, return spike, duplicate)
- [x] Each OHLC violation type fires its own reason code
- [x] 5x close spike detected at default threshold (z=8)
- [x] Tighter z-threshold (2.0) flags moderate jumps default ignores
- [x] Short series (< 20 bars) skipped without false positives
- [x] Duplicate index dedup keeps last write
- [x] DataValidator chains all three new rules end-to-end with mixed anomalies
- [x] \`ruff check engine/data/quality.py\` — clean
- [x] \`basedpyright engine/data/quality.py\` — 0 errors
- [ ] CI green

## Compatibility
- \`ValidationConfig\` gains two new fields with defaults — existing callers and JSON config files load unchanged (\`from_dict\` already filters via \`__dataclass_fields__\`)
- No existing rule modified; pipeline order changes mean previously-rejected bars (negative close) hit the same exclusion as before, just before OHLC inspection

Closes #117 (PR2 — OHLC + anomaly rules). Earlier PR #224 added the price/ratio/stale/GBp foundation.