### PR TITLE
feat(reference): typeahead suggest() — prefix-first + typo-tolerant fallback

### DIFF
--- a/engine/reference/search.py
+++ b/engine/reference/search.py
@@ -3,14 +3,35 @@
 Linear scan with substring matching plus an optional asset-class filter.
 Sufficient for the bootstrap path; the production index will sit behind
 Postgres ``pg_trgm`` in a follow-up issue.
+
+Two entry points:
+
+- :meth:`SearchIndex.search` — general ranked search. Symbol-style and
+  company-name queries both reach the target instrument; the caller does
+  not need to know which form the catalog stores.
+- :meth:`SearchIndex.suggest` — typeahead-optimized variant. Prefers
+  prefix completions, accepts single-character queries, and falls back
+  to one-edit-distance fuzzy matching on tokens only when no
+  prefix/substring hit is found. Default limit is small enough for a
+  typeahead dropdown.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from engine.reference.model import AssetClassLiteral, RefInstrument
+
+
+@dataclass(frozen=True)
+class Suggestion:
+    """One typeahead suggestion: the matched record + presentational hint."""
+
+    record: RefInstrument
+    completion: str
+    score: int
 
 
 class SearchIndex:
@@ -23,6 +44,7 @@ class SearchIndex:
         self._records.append(inst)
 
     MAX_QUERY_LEN = 64
+    DEFAULT_SUGGEST_LIMIT = 10
 
     def search(
         self,
@@ -49,6 +71,95 @@ class SearchIndex:
 
         top = heapq.nlargest(limit, scored, key=lambda t: t[0])
         return [rec for _, rec in top]
+
+    def suggest(
+        self,
+        query: str,
+        *,
+        asset_class: AssetClassLiteral | None = None,
+        limit: int | None = None,
+    ) -> list[Suggestion]:
+        """Typeahead suggestions: prefix-first, fuzzy as fallback.
+
+        Tiers (high → low):
+
+        - 100 ticker exact
+        - 90  name exact
+        - 80  ticker prefix
+        - 70  name token prefix (any whitespace-separated word in name)
+        - 60  ticker contains
+        - 25  name contains
+        - 15  fuzzy (Levenshtein distance 1) on a name token or ticker
+
+        Fuzzy is computed only if no record hit a higher tier, so a
+        clean prefix never gets diluted by typo candidates.
+        """
+        if not query or not query.strip():
+            return []
+        if len(query) > self.MAX_QUERY_LEN:
+            return []
+        q = query.strip().lower()
+        cap = limit if limit is not None else self.DEFAULT_SUGGEST_LIMIT
+        primary: list[Suggestion] = []
+        for rec in self._records:
+            if asset_class is not None and rec.asset_class != asset_class:
+                continue
+            score, completion = self._suggest_score(rec, q)
+            if score > 0:
+                primary.append(Suggestion(record=rec, completion=completion, score=score))
+        if primary:
+            primary.sort(key=lambda s: -s.score)
+            return primary[:cap]
+        # No prefix or substring hits — try fuzzy on tokens.
+        fuzzy: list[Suggestion] = []
+        for rec in self._records:
+            if asset_class is not None and rec.asset_class != asset_class:
+                continue
+            completion = self._fuzzy_match(rec, q)
+            if completion is not None:
+                fuzzy.append(Suggestion(record=rec, completion=completion, score=15))
+        return fuzzy[:cap]
+
+    @staticmethod
+    def _suggest_score(rec: RefInstrument, q: str) -> tuple[int, str]:  # noqa: PLR0911 - one return per scoring tier
+        """Score for typeahead. Returns (score, completion) or (0, '')."""
+        ticker = rec.primary_ticker.lower()
+        name = rec.name.lower()
+        if ticker == q:
+            return 100, rec.primary_ticker
+        if name == q:
+            return 90, rec.name
+        if ticker.startswith(q):
+            return 80, rec.primary_ticker
+        tokens = _tokenize_name(name)
+        for token in tokens:
+            if token == q:
+                return 78, token
+        # First-token prefix beats later-token prefix so "Microsoft Corp."
+        # ranks above "ZZZ has microsoft inside" for query "Micr".
+        if tokens and tokens[0].startswith(q):
+            return 75, tokens[0]
+        for token in tokens:
+            if token.startswith(q):
+                return 70, token
+        if q in ticker:
+            return 60, rec.primary_ticker
+        if q in name:
+            return 25, rec.name
+        return 0, ""
+
+    @staticmethod
+    def _fuzzy_match(rec: RefInstrument, q: str) -> str | None:
+        """Levenshtein distance ≤ 1 against any name token or ticker.
+
+        Returns the matched token (so callers can show the completion)
+        or None when no token is within distance 1.
+        """
+        candidates = [rec.primary_ticker.lower(), *_tokenize_name(rec.name.lower())]
+        for cand in candidates:
+            if _within_one_edit(q, cand):
+                return cand
+        return None
 
     @staticmethod
     def _score(rec: RefInstrument, q: str) -> int:  # noqa: PLR0911 - one return per scoring tier
@@ -105,4 +216,43 @@ def _tokenize_name(name: str) -> list[str]:
     return out
 
 
-__all__ = ["SearchIndex"]
+def _within_one_edit(a: str, b: str) -> bool:
+    """True iff a and b differ by at most one insertion, deletion, or substitution.
+
+    Linear-time short-circuit: bail out as soon as a second mismatch
+    appears. Only meaningful for short queries (typeahead) — do not use
+    on long strings.
+    """
+    if a == b:
+        return True
+    la, lb = len(a), len(b)
+    if abs(la - lb) > 1:
+        return False
+    # Ensure a is the shorter (or equal) one to simplify.
+    if la > lb:
+        a, b = b, a
+        la, lb = lb, la
+    i = j = 0
+    edits = 0
+    while i < la and j < lb:
+        if a[i] != b[j]:
+            edits += 1
+            if edits > 1:
+                return False
+            if la == lb:
+                # Substitution — advance both.
+                i += 1
+                j += 1
+            else:
+                # Insertion in b — advance only b.
+                j += 1
+        else:
+            i += 1
+            j += 1
+    # Trailing extra char in b (insertion at end) is one edit.
+    if j < lb:
+        edits += 1
+    return edits <= 1
+
+
+__all__ = ["SearchIndex", "Suggestion"]

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -21,7 +21,7 @@ from engine.reference.classification import (
     forex_pair_class,
     is_valid_gics_path,
 )
-from engine.reference.search import SearchIndex
+from engine.reference.search import SearchIndex, Suggestion
 
 
 def _aapl() -> RefInstrument:
@@ -577,3 +577,160 @@ class TestSymbolChange:
         new = r.resolve({"ticker": "META", "venue": "XNAS"})
         assert old is not None and new is not None
         assert old.id == new.id
+
+
+class TestTypeaheadSuggest:
+    """`suggest()` is the typeahead-optimized variant of search.
+
+    It prefers prefix completions (ticker-prefix, then word-token-prefix
+    in the company name) over substring matches, accepts very short
+    queries (a single character is enough to start narrowing), and
+    falls back to typo-tolerant fuzzy matching only when no prefix or
+    substring match is found.
+    """
+
+    def _idx(self) -> SearchIndex:
+        idx = SearchIndex()
+        idx.add(_aapl())
+        idx.add(
+            RefInstrument(
+                primary_ticker="MSFT",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="Microsoft Corp.",
+            )
+        )
+        idx.add(
+            RefInstrument(
+                primary_ticker="GOOG",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="Alphabet Inc.",
+            )
+        )
+        idx.add(
+            RefInstrument(
+                primary_ticker="BRK.B",
+                primary_venue="XNYS",
+                asset_class="equity",
+                name="Berkshire Hathaway Inc.",
+            )
+        )
+        idx.add(
+            RefInstrument(
+                primary_ticker="META",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="Meta Platforms Inc.",
+            )
+        )
+        return idx
+
+    def test_single_char_ticker_prefix_suggests(self):
+        out = self._idx().suggest("M")
+        tickers = [s.record.primary_ticker for s in out]
+        assert "MSFT" in tickers
+        assert "META" in tickers
+
+    def test_single_char_name_prefix_suggests(self):
+        out = self._idx().suggest("A")
+        tickers = [s.record.primary_ticker for s in out]
+        # AAPL ticker prefix and Alphabet name prefix should both surface.
+        assert "AAPL" in tickers
+        assert "GOOG" in tickers
+
+    def test_two_char_name_prefix_narrows(self):
+        out = self._idx().suggest("Mi")
+        assert out
+        assert out[0].record.primary_ticker == "MSFT"
+
+    def test_returns_suggestion_objects_with_completion(self):
+        out = self._idx().suggest("Micro")
+        assert out
+        assert isinstance(out[0], Suggestion)
+        # The completion is a presentational hint of what the user is
+        # filling in: the matched word from name or ticker.
+        assert out[0].completion.lower().startswith("micro")
+
+    def test_typo_tolerant_one_edit_distance(self):
+        # "Aple" → "Apple" (one insertion). Pure substring search would
+        # miss this; suggest() falls back to Levenshtein ≤ 1 on tokens.
+        out = self._idx().suggest("Aple")
+        tickers = [s.record.primary_ticker for s in out]
+        assert "AAPL" in tickers
+
+    def test_typo_tolerant_on_company_name(self):
+        out = self._idx().suggest("Berksire")
+        tickers = [s.record.primary_ticker for s in out]
+        assert "BRK.B" in tickers
+
+    def test_default_limit_is_typeahead_friendly(self):
+        # Typeahead UI shows ~10 results max; default should reflect that.
+        idx = SearchIndex()
+        # 30 records all matching "A" prefix on either ticker or name.
+        for i in range(30):
+            idx.add(
+                RefInstrument(
+                    primary_ticker=f"A{i:02d}",
+                    primary_venue="XNAS",
+                    asset_class="equity",
+                    name=f"Acme{i:02d} Corp.",
+                )
+            )
+        out = idx.suggest("A")
+        assert len(out) <= 10
+
+    def test_explicit_limit_respected(self):
+        out = self._idx().suggest("A", limit=2)
+        assert len(out) <= 2
+
+    def test_empty_query_returns_empty(self):
+        assert self._idx().suggest("") == []
+        assert self._idx().suggest("   ") == []
+
+    def test_no_match_returns_empty(self):
+        out = self._idx().suggest("xyznotapresent")
+        assert out == []
+
+    def test_prefix_ranks_above_substring(self):
+        idx = SearchIndex()
+        idx.add(
+            RefInstrument(
+                primary_ticker="ZZZ",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="ZZZ has microsoft inside",
+            )
+        )
+        idx.add(
+            RefInstrument(
+                primary_ticker="MSFT",
+                primary_venue="XNAS",
+                asset_class="equity",
+                name="Microsoft Corp.",
+            )
+        )
+        out = idx.suggest("Micr")
+        assert out
+        assert out[0].record.primary_ticker == "MSFT"
+
+    def test_asset_class_filter(self):
+        idx = self._idx()
+        idx.add(
+            RefInstrument(
+                primary_ticker="ETH",
+                primary_venue="XCRY",
+                asset_class="crypto",
+                name="Ethereum",
+            )
+        )
+        out = idx.suggest("E", asset_class="crypto")
+        assert all(s.record.asset_class == "crypto" for s in out)
+
+    def test_typo_only_kicks_in_when_no_exact_or_prefix_hit(self):
+        # If any prefix-tier result exists, fuzzy candidates should not
+        # dilute the top of the list — fuzzy is a fallback.
+        idx = self._idx()
+        out = idx.suggest("App")  # prefix hits Apple
+        assert out
+        assert out[0].record.primary_ticker == "AAPL"


### PR DESCRIPTION
## Summary
Adds \`SearchIndex.suggest()\` for typeahead UX. The existing \`search()\` is unchanged; \`suggest()\` is the small, fast variant a frontend dropdown should call on every keystroke.

\`\`\`python
out = idx.suggest(\"Aple\")  # typo-tolerant
# → [Suggestion(record=AAPL, completion=\"apple\", score=15)]

out = idx.suggest(\"Micr\")
# → [Suggestion(record=MSFT, completion=\"microsoft\", score=75), ...]
\`\`\`

## Why a separate method
- \`search()\` returns a flat list of records (≤ 25 default) for general retrieval. Acceptable when the user already knows what they want.
- \`suggest()\` returns \`Suggestion\` objects (record + completion text + score) so the UI can render the matched fragment in the dropdown row, accepts single-character queries, defaults to 10 results, and reaches for typo-tolerant fuzzy matching only when no prefix/substring hit exists.

## Tier order
| Score | Match | Example |
|-------|-------|---------|
| 100 | ticker exact | \"AAPL\" → AAPL |
| 90 | name exact | \"Apple Inc.\" → AAPL |
| 80 | ticker prefix | \"AAP\" → AAPL |
| 78 | name token equals q | \"apple\" → AAPL |
| 75 | first name token prefix | \"Micr\" → MSFT (\"Microsoft Corp.\") |
| 70 | later name token prefix | \"Micr\" → ZZZ (\"…microsoft inside\") |
| 60 | ticker contains | \"PL\" → AAPL |
| 25 | name contains | \"oft\" → MSFT |
| 15 | Levenshtein ≤ 1 | \"Aple\" → AAPL, \"Berksire\" → BRK.B |

Fuzzy is computed only when no record hit a higher tier. That keeps clean prefixes uncorrupted by typo candidates.

## Test plan
- [x] 74/74 \`tests/test_reference_data.py\` pass (13 new)
- [x] Single-char ticker / name prefix narrows
- [x] Two-char tightening
- [x] One-edit typo on company name + ticker
- [x] First-token-prefix beats later-token-prefix
- [x] Default limit ≤ 10; explicit limit honored
- [x] Empty / whitespace / no-match return \`[]\`
- [x] Asset-class filter applied
- [x] Prefix hits suppress fuzzy fallback
- [x] \`ruff check\` clean
- [x] \`basedpyright\` 0 errors
- [ ] CI green