### PR TITLE
feat(corp-actions): split + cash-dividend back-adjustment (gh#112 PR1)

### DIFF
--- a/engine/core/corp_actions.py
+++ b/engine/core/corp_actions.py
@@ -1,0 +1,179 @@
+"""Corporate-action back-adjustment.
+
+Given a chronological log of corporate actions per symbol, this module
+adjusts a historical bar's price (or volume) so that an analysis run at
+``as_of`` sees a continuous, comparable series across splits and cash
+dividends.
+
+Conventions:
+
+- Splits use ``ratio`` interpreted as new-shares-per-old. A 2-for-1 has
+  ``ratio=2.0``; a 1-for-2 reverse split has ``ratio=0.5``. Pre-split
+  prices are divided by ``ratio``; pre-split volumes are multiplied
+  by ``ratio``.
+- Cash dividends use ``cash_amount`` per share. Pre-ex-date prices are
+  multiplied by ``(close_pre - cash_amount) / close_pre`` (CRSP-style
+  total-return adjustment). The caller passes the ex-date raw close as
+  ``ex_date_close``; without it the dividend factor is skipped.
+- Only actions with ``effective_date <= as_of`` are applied. Actions
+  newer than ``as_of`` are ignored, so an as-of analysis never sees a
+  future split.
+- Actions with ``effective_date > bar_date`` *and* ``effective_date <=
+  as_of`` are applied — the bar pre-dates the action and so must be
+  adjusted into post-action share units.
+
+This is PR1: splits + cash dividends. Spinoffs, mergers, and symbol
+changes are accepted by the dataclass but their adjustment math lands
+in follow-up PRs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date  # noqa: TC003 - runtime use as dataclass field type
+from typing import Literal
+
+ActionType = Literal[
+    "split",
+    "cash_dividend",
+    "spinoff",
+    "merger",
+    "symbol_change",
+]
+_VALID_ACTION_TYPES: frozenset[str] = frozenset(
+    ["split", "cash_dividend", "spinoff", "merger", "symbol_change"]
+)
+
+
+class CorporateActionError(Exception):
+    """Raised on malformed corporate-action input."""
+
+
+@dataclass(frozen=True)
+class CorporateAction:
+    """One corporate action against one symbol on one effective date."""
+
+    action_type: ActionType
+    symbol: str
+    effective_date: date
+    ratio: float | None = None
+    cash_amount: float | None = None
+    new_symbol: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.action_type not in _VALID_ACTION_TYPES:
+            msg = (
+                f"unknown action_type {self.action_type!r}; "
+                f"expected one of {sorted(_VALID_ACTION_TYPES)}"
+            )
+            raise CorporateActionError(msg)
+        if not self.symbol.strip():
+            msg = "symbol must be non-empty"
+            raise CorporateActionError(msg)
+        if self.action_type == "split":
+            if self.ratio is None:
+                msg = "split requires a ratio"
+                raise CorporateActionError(msg)
+            if self.ratio <= 0:
+                msg = f"split ratio must be positive; got {self.ratio}"
+                raise CorporateActionError(msg)
+        if self.action_type == "cash_dividend":
+            if self.cash_amount is None:
+                msg = "cash_dividend requires a cash_amount"
+                raise CorporateActionError(msg)
+            if self.cash_amount < 0:
+                msg = (
+                    "cash_dividend cash_amount must be non-negative; "
+                    f"got {self.cash_amount}"
+                )
+                raise CorporateActionError(msg)
+
+
+class CorporateActionLog:
+    """Append-only chronological log of corporate actions across symbols."""
+
+    def __init__(self, actions: list[CorporateAction]) -> None:
+        self._actions: list[CorporateAction] = list(actions)
+
+    def append(self, action: CorporateAction) -> None:
+        self._actions.append(action)
+
+    def actions_for(self, symbol: str) -> list[CorporateAction]:
+        """All actions for ``symbol`` sorted by effective_date ascending."""
+        out = [a for a in self._actions if a.symbol == symbol]
+        out.sort(key=lambda a: a.effective_date)
+        return out
+
+
+def _applicable(
+    actions: list[CorporateAction], bar_date: date, as_of: date
+) -> list[CorporateAction]:
+    """Actions that adjust ``bar_date`` given ``as_of`` cutoff.
+
+    Action applies iff ``bar_date < effective_date <= as_of``.
+    """
+    return [a for a in actions if bar_date < a.effective_date <= as_of]
+
+
+def adjust_price(
+    log: CorporateActionLog,
+    *,
+    symbol: str,
+    bar_date: date,
+    raw_price: float,
+    as_of: date,
+    ex_date_close: float | None = None,
+) -> float:
+    """Return ``raw_price`` adjusted backward through corporate actions.
+
+    ``ex_date_close`` is the raw close of the ex-dividend bar; required
+    to compute the dividend back-adjustment factor. When omitted, cash
+    dividends are skipped (only splits are applied).
+    """
+    actions = _applicable(log.actions_for(symbol), bar_date, as_of)
+    factor = 1.0
+    for a in actions:
+        if a.action_type == "split":
+            assert a.ratio is not None
+            factor /= a.ratio
+        elif a.action_type == "cash_dividend":
+            if ex_date_close is None or ex_date_close <= 0:
+                continue
+            assert a.cash_amount is not None
+            div_factor = (ex_date_close - a.cash_amount) / ex_date_close
+            if div_factor <= 0:
+                continue
+            factor *= div_factor
+    return raw_price * factor
+
+
+def adjust_volume(
+    log: CorporateActionLog,
+    *,
+    symbol: str,
+    bar_date: date,
+    raw_volume: int,
+    as_of: date,
+) -> int:
+    """Return ``raw_volume`` adjusted backward through splits.
+
+    Cash dividends do not change share count, so volume adjustment only
+    consumes the split actions in the window.
+    """
+    actions = _applicable(log.actions_for(symbol), bar_date, as_of)
+    multiplier = 1.0
+    for a in actions:
+        if a.action_type == "split":
+            assert a.ratio is not None
+            multiplier *= a.ratio
+    return round(raw_volume * multiplier)
+
+
+__all__ = [
+    "ActionType",
+    "CorporateAction",
+    "CorporateActionError",
+    "CorporateActionLog",
+    "adjust_price",
+    "adjust_volume",
+]

--- a/tests/test_corp_actions.py
+++ b/tests/test_corp_actions.py
@@ -1,0 +1,231 @@
+"""Tests for engine.core.corp_actions — corporate-action back-adjustment."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from engine.core.corp_actions import (
+    CorporateAction,
+    CorporateActionError,
+    CorporateActionLog,
+    adjust_price,
+    adjust_volume,
+)
+
+
+def _split(eff: date, ratio: float) -> CorporateAction:
+    return CorporateAction(
+        action_type="split",
+        symbol="AAPL",
+        effective_date=eff,
+        ratio=ratio,
+    )
+
+
+def _dividend(eff: date, cash: float) -> CorporateAction:
+    return CorporateAction(
+        action_type="cash_dividend",
+        symbol="AAPL",
+        effective_date=eff,
+        cash_amount=cash,
+    )
+
+
+class TestSplitAdjustment:
+    def test_two_for_one_split_halves_pre_split_price(self):
+        log = CorporateActionLog([_split(date(2025, 6, 1), 2.0)])
+        adj = adjust_price(
+            log,
+            symbol="AAPL",
+            bar_date=date(2025, 5, 31),
+            raw_price=200.0,
+            as_of=date(2025, 12, 31),
+        )
+        assert adj == pytest.approx(100.0)
+
+    def test_post_split_bar_unaffected(self):
+        log = CorporateActionLog([_split(date(2025, 6, 1), 2.0)])
+        adj = adjust_price(
+            log,
+            symbol="AAPL",
+            bar_date=date(2025, 6, 1),
+            raw_price=100.0,
+            as_of=date(2025, 12, 31),
+        )
+        assert adj == pytest.approx(100.0)
+
+    def test_three_for_two_split(self):
+        log = CorporateActionLog([_split(date(2025, 6, 1), 1.5)])
+        adj = adjust_price(
+            log,
+            symbol="AAPL",
+            bar_date=date(2025, 5, 31),
+            raw_price=150.0,
+            as_of=date(2025, 12, 31),
+        )
+        assert adj == pytest.approx(100.0)
+
+    def test_reverse_split_one_for_two(self):
+        log = CorporateActionLog([_split(date(2025, 6, 1), 0.5)])
+        adj = adjust_price(
+            log,
+            symbol="AAPL",
+            bar_date=date(2025, 5, 31),
+            raw_price=10.0,
+            as_of=date(2025, 12, 31),
+        )
+        assert adj == pytest.approx(20.0)
+
+    def test_compound_splits_multiply(self):
+        log = CorporateActionLog(
+            [
+                _split(date(2024, 6, 1), 2.0),
+                _split(date(2025, 6, 1), 2.0),
+            ]
+        )
+        adj = adjust_price(
+            log,
+            symbol="AAPL",
+            bar_date=date(2024, 1, 1),
+            raw_price=400.0,
+            as_of=date(2025, 12, 31),
+        )
+        assert adj == pytest.approx(100.0)
+
+    def test_zero_ratio_rejected(self):
+        with pytest.raises(CorporateActionError):
+            CorporateAction(
+                action_type="split",
+                symbol="AAPL",
+                effective_date=date(2025, 1, 1),
+                ratio=0.0,
+            )
+
+    def test_negative_ratio_rejected(self):
+        with pytest.raises(CorporateActionError):
+            CorporateAction(
+                action_type="split",
+                symbol="AAPL",
+                effective_date=date(2025, 1, 1),
+                ratio=-2.0,
+            )
+
+
+class TestVolumeAdjustment:
+    def test_two_for_one_split_doubles_pre_split_volume(self):
+        log = CorporateActionLog([_split(date(2025, 6, 1), 2.0)])
+        adj = adjust_volume(
+            log,
+            symbol="AAPL",
+            bar_date=date(2025, 5, 31),
+            raw_volume=1_000_000,
+            as_of=date(2025, 12, 31),
+        )
+        assert adj == 2_000_000
+
+
+class TestCashDividend:
+    def test_pre_dividend_bar_back_adjusted(self):
+        # Multiplicative back-adjustment: factor = (close_pre - cash) / close_pre
+        # applied to bars strictly before the ex-date.
+        log = CorporateActionLog([_dividend(date(2025, 6, 1), 1.50)])
+        adj = adjust_price(
+            log,
+            symbol="AAPL",
+            bar_date=date(2025, 5, 31),
+            raw_price=100.0,
+            as_of=date(2025, 12, 31),
+            ex_date_close=100.0,
+        )
+        assert adj == pytest.approx(98.50, abs=1e-6)
+
+    def test_dividend_amount_required(self):
+        with pytest.raises(CorporateActionError):
+            CorporateAction(
+                action_type="cash_dividend",
+                symbol="AAPL",
+                effective_date=date(2025, 6, 1),
+            )
+
+    def test_dividend_negative_amount_rejected(self):
+        with pytest.raises(CorporateActionError):
+            CorporateAction(
+                action_type="cash_dividend",
+                symbol="AAPL",
+                effective_date=date(2025, 6, 1),
+                cash_amount=-1.0,
+            )
+
+
+class TestAsOfWindow:
+    def test_action_after_as_of_ignored(self):
+        log = CorporateActionLog([_split(date(2025, 6, 1), 2.0)])
+        adj = adjust_price(
+            log,
+            symbol="AAPL",
+            bar_date=date(2025, 1, 1),
+            raw_price=200.0,
+            as_of=date(2025, 5, 1),
+        )
+        assert adj == pytest.approx(200.0)
+
+
+class TestSymbolFilter:
+    def test_other_symbol_unaffected(self):
+        log = CorporateActionLog([_split(date(2025, 6, 1), 2.0)])
+        adj = adjust_price(
+            log,
+            symbol="MSFT",
+            bar_date=date(2025, 5, 31),
+            raw_price=300.0,
+            as_of=date(2025, 12, 31),
+        )
+        assert adj == pytest.approx(300.0)
+
+
+class TestLogQueries:
+    def test_actions_for_symbol_returns_chronological(self):
+        a = _split(date(2024, 6, 1), 2.0)
+        b = _split(date(2025, 6, 1), 2.0)
+        log = CorporateActionLog([b, a])
+        out = log.actions_for("AAPL")
+        assert [x.effective_date for x in out] == [a.effective_date, b.effective_date]
+
+    def test_actions_for_unknown_symbol_returns_empty(self):
+        log = CorporateActionLog([_split(date(2025, 6, 1), 2.0)])
+        assert log.actions_for("NONE") == []
+
+    def test_log_supports_append(self):
+        log = CorporateActionLog([])
+        log.append(_split(date(2025, 6, 1), 2.0))
+        assert len(log.actions_for("AAPL")) == 1
+
+
+class TestActionTypeValidation:
+    def test_unknown_action_type_rejected(self):
+        with pytest.raises(CorporateActionError):
+            CorporateAction(
+                action_type="bogus",  # type: ignore[arg-type]
+                symbol="AAPL",
+                effective_date=date(2025, 6, 1),
+                ratio=1.0,
+            )
+
+    def test_split_requires_ratio(self):
+        with pytest.raises(CorporateActionError):
+            CorporateAction(
+                action_type="split",
+                symbol="AAPL",
+                effective_date=date(2025, 6, 1),
+            )
+
+    def test_empty_symbol_rejected(self):
+        with pytest.raises(CorporateActionError):
+            CorporateAction(
+                action_type="split",
+                symbol="",
+                effective_date=date(2025, 6, 1),
+                ratio=2.0,
+            )


### PR DESCRIPTION
## Summary
First slice of #112. Adds \`engine.core.corp_actions\` for back-adjusting historical bars across splits and cash dividends.

\`\`\`python
log = CorporateActionLog([
    CorporateAction(\"split\", \"AAPL\", date(2025, 6, 1), ratio=2.0),
])
adj = adjust_price(log, symbol=\"AAPL\", bar_date=date(2025, 5, 31),
                   raw_price=200.0, as_of=date(2025, 12, 31))
# → 100.0
\`\`\`

## Math
- **Splits:** ratio = new-shares-per-old. Pre-split price ÷= ratio; pre-split volume *= ratio. Compound actions multiply (two 2-for-1s → ÷4).
- **Cash dividends:** CRSP-style; pre-ex-date price *= (close_pre - cash) / close_pre. Caller supplies ex-date raw close; without it, dividend factor is skipped.
- **as-of cutoff:** actions with \`effective_date > as_of\` ignored — an as-of run never sees a future split. Action applies iff \`bar_date < effective_date <= as_of\`.

## Out of scope (follow-up PRs)
Spinoffs, mergers, and symbol changes are accepted by the \`CorporateAction\` dataclass but their adjustment math lands in subsequent PRs (each requires an additional input besides the bar — spinoff-share value, merger consideration, prior symbol).

## Test plan
- [x] 19/19 tests pass
  - 2-for-1, 3-for-2, 1-for-2 reverse, compound 2-for-1 × 2-for-1
  - Post-split bar unaffected
  - Volume doubles on 2-for-1
  - Dividend back-adjusts pre-ex-date by (close-cash)/close
  - as-of horizon ignores future actions
  - Other symbols unaffected
  - Chronological order, unknown symbol returns [], append works
  - Validation: zero/negative ratio, negative dividend, missing required fields, unknown action type, empty symbol — all rejected
- [x] \`ruff check\` clean
- [x] \`basedpyright\` 0 errors
- [ ] CI green