### PR TITLE
feat(api): wire SearchIndex.suggest() to GET /api/v1/reference/suggest

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -9,6 +9,7 @@ from engine.api.routes.legal import router as legal_router
 from engine.api.routes.market_data import router as market_data_router
 from engine.api.routes.marketplace import router as marketplace_router
 from engine.api.routes.portfolio import router as portfolio_router
+from engine.api.routes.reference import router as reference_router
 from engine.api.routes.scoring import router as scoring_router
 from engine.api.routes.strategies import router as strategies_router
 from engine.legal.dependencies import require_legal_acceptance
@@ -26,6 +27,7 @@ api_router.include_router(legal_router, tags=["legal"])
 api_router.include_router(portfolio_router, prefix="/api/v1/portfolio", tags=["portfolio"])
 api_router.include_router(strategies_router, prefix="/api/v1/strategies", tags=["strategies"])
 api_router.include_router(marketplace_router, prefix="/api/v1/marketplace", tags=["marketplace"])
+api_router.include_router(reference_router, prefix="/api/v1/reference", tags=["reference"])
 api_router.include_router(
     scoring_router,
     prefix="/api/v1/scoring",

--- a/engine/api/routes/reference.py
+++ b/engine/api/routes/reference.py
@@ -1,0 +1,112 @@
+"""Reference data search + typeahead endpoints.
+
+Public surface:
+
+- ``GET /reference/suggest?q=<query>&limit=<n>&asset_class=<cls>``
+  Typeahead-friendly: prefix-first ranking, single-character queries
+  accepted, default limit 10, Levenshtein-1 fuzzy fallback when no
+  prefix match exists. Returns a list of ``Suggestion`` objects, each
+  with ``completion`` (the matched fragment, suitable for highlighting
+  in a dropdown), ``score`` (the underlying tier weight), and
+  ``record`` (the full :class:`RefInstrument`).
+
+The :class:`SearchIndex` instance is a process-singleton injected via
+:func:`get_search_index`. Production wires it once at app startup;
+tests inject a seeded fixture via FastAPI's dependency overrides.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from engine.reference.model import AssetClassLiteral
+from engine.reference.search import SearchIndex
+
+if TYPE_CHECKING:
+    from engine.reference.search import Suggestion
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 50
+_MAX_QUERY_LEN = SearchIndex.MAX_QUERY_LEN
+
+_INDEX: SearchIndex | None = None
+
+
+def get_search_index() -> SearchIndex:
+    """Return the process-singleton :class:`SearchIndex`.
+
+    Production wires the singleton once at startup. Tests override this
+    dependency via ``app.dependency_overrides[get_search_index]`` to
+    inject a seeded fixture.
+    """
+    global _INDEX  # noqa: PLW0603 - process-wide singleton initialized lazily
+    if _INDEX is None:
+        _INDEX = SearchIndex()
+    return _INDEX
+
+
+def _serialize(suggestion: Suggestion) -> dict[str, object]:
+    """Surface symbol + company name at the top of the suggestion.
+
+    The frontend dropdown row needs both the ticker (e.g. ``AAPL``) and
+    the company name (``Apple Inc.``) regardless of which one matched
+    the user's query — a typeahead row that says only ``Apple`` without
+    showing ``AAPL`` is unusable for placing a trade. ``display`` is a
+    pre-formatted ``SYMBOL — Name`` string so the frontend does not
+    have to assemble it.
+    """
+    rec = suggestion.record
+    return {
+        "symbol": rec.primary_ticker,
+        "name": rec.name,
+        "display": f"{rec.primary_ticker} — {rec.name}",
+        "completion": suggestion.completion,
+        "score": suggestion.score,
+        "record": {
+            "id": str(rec.id),
+            "primary_ticker": rec.primary_ticker,
+            "primary_venue": rec.primary_venue,
+            "asset_class": rec.asset_class,
+            "name": rec.name,
+            "currency": rec.currency,
+        },
+    }
+
+
+@router.get("/suggest")
+async def suggest(
+    q: str = Query(..., description="User-typed query (ticker or name fragment)"),
+    limit: int = Query(_DEFAULT_LIMIT, ge=1, description="Maximum results"),
+    asset_class: AssetClassLiteral | None = Query(
+        None, description="Optional asset-class filter"
+    ),
+    index: SearchIndex = Depends(get_search_index),
+) -> dict[str, list[dict[str, object]]]:
+    """Typeahead suggestions for ticker / company-name queries.
+
+    Empty / whitespace-only / over-long queries return 400 so a misuse
+    surfaces during integration rather than as silent zero results.
+    """
+    if not q or not q.strip():
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="query must be non-empty",
+        )
+    if len(q) > _MAX_QUERY_LEN:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"query exceeds {_MAX_QUERY_LEN} chars",
+        )
+    capped_limit = min(limit, _MAX_LIMIT)
+    out = index.suggest(q, asset_class=asset_class, limit=capped_limit)
+    return {"suggestions": [_serialize(s) for s in out]}
+
+
+__all__ = ["get_search_index", "router"]

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -1,0 +1,189 @@
+"""Tests for the /api/v1/reference search + suggest endpoints."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from engine.api.routes.reference import (
+    get_search_index,
+)
+from engine.api.routes.reference import (
+    router as reference_router,
+)
+from engine.reference.model import RefInstrument
+from engine.reference.search import SearchIndex
+
+
+def _seeded_index() -> SearchIndex:
+    idx = SearchIndex()
+    idx.add(
+        RefInstrument(
+            primary_ticker="AAPL",
+            primary_venue="XNAS",
+            asset_class="equity",
+            name="Apple Inc.",
+        )
+    )
+    idx.add(
+        RefInstrument(
+            primary_ticker="MSFT",
+            primary_venue="XNAS",
+            asset_class="equity",
+            name="Microsoft Corp.",
+        )
+    )
+    idx.add(
+        RefInstrument(
+            primary_ticker="BRK.B",
+            primary_venue="XNYS",
+            asset_class="equity",
+            name="Berkshire Hathaway Inc.",
+        )
+    )
+    idx.add(
+        RefInstrument(
+            primary_ticker="ETH",
+            primary_venue="XCRY",
+            asset_class="crypto",
+            name="Ethereum",
+        )
+    )
+    return idx
+
+
+@pytest.fixture
+async def reference_client():
+    app = FastAPI()
+    app.include_router(reference_router, prefix="/api/v1/reference")
+    app.dependency_overrides[get_search_index] = _seeded_index
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestSuggestEndpoint:
+    async def test_ticker_prefix_suggests(self, reference_client: AsyncClient):
+        r = await reference_client.get("/api/v1/reference/suggest", params={"q": "AA"})
+        assert r.status_code == HTTPStatus.OK
+        body = r.json()
+        tickers = [s["record"]["primary_ticker"] for s in body["suggestions"]]
+        assert "AAPL" in tickers
+
+    async def test_name_prefix_suggests(self, reference_client: AsyncClient):
+        r = await reference_client.get("/api/v1/reference/suggest", params={"q": "Micro"})
+        assert r.status_code == HTTPStatus.OK
+        body = r.json()
+        assert body["suggestions"]
+        assert body["suggestions"][0]["record"]["primary_ticker"] == "MSFT"
+
+    async def test_typo_tolerant(self, reference_client: AsyncClient):
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "Aple"}
+        )
+        assert r.status_code == HTTPStatus.OK
+        body = r.json()
+        tickers = [s["record"]["primary_ticker"] for s in body["suggestions"]]
+        assert "AAPL" in tickers
+
+    async def test_empty_query_returns_400(self, reference_client: AsyncClient):
+        r = await reference_client.get("/api/v1/reference/suggest", params={"q": ""})
+        assert r.status_code == HTTPStatus.BAD_REQUEST
+
+    async def test_query_too_long_returns_400(self, reference_client: AsyncClient):
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "x" * 200}
+        )
+        assert r.status_code == HTTPStatus.BAD_REQUEST
+
+    async def test_default_limit(self, reference_client: AsyncClient):
+        r = await reference_client.get("/api/v1/reference/suggest", params={"q": "A"})
+        assert r.status_code == HTTPStatus.OK
+        body = r.json()
+        assert len(body["suggestions"]) <= 10
+
+    async def test_explicit_limit_respected(self, reference_client: AsyncClient):
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "A", "limit": 1}
+        )
+        assert r.status_code == HTTPStatus.OK
+        body = r.json()
+        assert len(body["suggestions"]) <= 1
+
+    async def test_limit_clamped(self, reference_client: AsyncClient):
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "A", "limit": 9999}
+        )
+        assert r.status_code == HTTPStatus.OK
+
+    async def test_asset_class_filter(self, reference_client: AsyncClient):
+        r = await reference_client.get(
+            "/api/v1/reference/suggest",
+            params={"q": "E", "asset_class": "crypto"},
+        )
+        assert r.status_code == HTTPStatus.OK
+        body = r.json()
+        for s in body["suggestions"]:
+            assert s["record"]["asset_class"] == "crypto"
+
+    async def test_no_match_returns_empty_list(self, reference_client: AsyncClient):
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "xyznotapresent"}
+        )
+        assert r.status_code == HTTPStatus.OK
+        assert r.json()["suggestions"] == []
+
+    async def test_response_schema_has_completion_and_score(
+        self, reference_client: AsyncClient
+    ):
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "Micro"}
+        )
+        body = r.json()
+        first = body["suggestions"][0]
+        assert "completion" in first
+        assert "score" in first
+        assert "record" in first
+
+    async def test_response_surfaces_symbol_and_name_top_level(
+        self, reference_client: AsyncClient
+    ):
+        # Frontend dropdown needs both ticker and company name visible
+        # on every row regardless of which one matched the query.
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "Micro"}
+        )
+        body = r.json()
+        first = body["suggestions"][0]
+        assert first["symbol"] == "MSFT"
+        assert first["name"] == "Microsoft Corp."
+
+    async def test_display_combines_symbol_and_name(
+        self, reference_client: AsyncClient
+    ):
+        # When the query matches only the ticker, the dropdown row must
+        # still show the company name so the user can confirm.
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "AAPL"}
+        )
+        body = r.json()
+        first = body["suggestions"][0]
+        assert "AAPL" in first["display"]
+        assert "Apple" in first["display"]
+
+    async def test_name_match_still_shows_symbol(
+        self, reference_client: AsyncClient
+    ):
+        # Reverse: query matched the company name; the symbol still has
+        # to be visible on the row.
+        r = await reference_client.get(
+            "/api/v1/reference/suggest", params={"q": "Berkshire"}
+        )
+        body = r.json()
+        first = body["suggestions"][0]
+        assert first["symbol"] == "BRK.B"
+        assert "BRK.B" in first["display"]
+        assert "Berkshire" in first["display"]


### PR DESCRIPTION
## Summary
Wires the existing \`SearchIndex.suggest()\` (shipped in #252) to a public REST endpoint so the frontend can do typeahead.

\`\`\`
GET /api/v1/reference/suggest?q=Apple&limit=10
\`\`\`
\`\`\`json
{
  \"suggestions\": [
    {
      \"symbol\": \"AAPL\",
      \"name\": \"Apple Inc.\",
      \"display\": \"AAPL — Apple Inc.\",
      \"completion\": \"apple\",
      \"score\": 75,
      \"record\": { \"id\": \"...\", \"primary_ticker\": \"AAPL\", \"primary_venue\": \"XNAS\", \"asset_class\": \"equity\", \"name\": \"Apple Inc.\", \"currency\": \"USD\" }
    }
  ]
}
\`\`\`

## Why \`symbol\`, \`name\`, and \`display\` at the top level
Every dropdown row needs **both** the ticker and the company name visible regardless of which one matched the query. A row that says only \"Apple\" without \"AAPL\" is unusable for placing a trade; same for the reverse. \`display\` is the pre-formatted \`SYMBOL — Name\` string so the frontend does not have to assemble it.

## Validation
- Empty / whitespace-only \`q\` → 400
- \`q\` > 64 chars → 400
- \`limit\` clamped to 50 server-side (never blows up on a malicious large value)

## Singleton + test wiring
- Process-level \`SearchIndex\` singleton; production wires once at startup.
- Tests inject seeded indexes via \`app.dependency_overrides[get_search_index]\` (mirrors the marketplace test pattern).

## Test plan
- [x] 14/14 tests pass
  - Ticker prefix / name prefix / typo-tolerant match
  - Empty + over-long query → 400
  - Default limit ≤ 10; explicit limit honored; large limit clamped
  - Asset-class filter applied
  - No-match returns empty list
  - \`symbol\` + \`name\` surfaced top-level on every row
  - \`display\` contains both ticker and name on a ticker-only match
  - \`display\` contains both ticker and name on a name-only match
- [x] \`ruff check\` clean
- [x] \`basedpyright\` 0 errors
- [ ] CI green

Mounted at \`/api/v1/reference\` under \`tags=[\"reference\"]\` so it shows up in the OpenAPI/Swagger UI.