### PR TITLE
feat(risk): pre-trade risk gate (gh#110)

### DIFF
--- a/engine/core/risk_limits.py
+++ b/engine/core/risk_limits.py
@@ -1,0 +1,177 @@
+"""Pre-trade risk gate (gh#110).
+
+Decoupled from order/portfolio concrete types — operates on plain immutable
+dataclasses so the gate can be reused by paper trading, live trading, and
+backtests without dragging in the broker stack.
+
+The gate checks an :class:`OrderIntent` against an :class:`AccountState` under
+configured :class:`RiskLimits` and returns a :class:`RiskDecision`. All breaches
+in a single check are reported together (not short-circuited) so callers can
+log the full picture.
+
+Stateful policies tracked on the gate instance:
+- velocity:  rolling timestamps of approved orders within ``velocity_window_seconds``
+- circuit_breaker: tripped when ``daily_pnl <= -max_daily_loss``; sticks until
+  :meth:`RiskGate.reset_circuit_breaker` is called.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+
+class RiskLimitsError(ValueError):
+    """Invalid risk inputs (negative notional, unknown side, etc.)."""
+
+
+_VALID_SIDES = frozenset({"buy", "sell"})
+
+
+@dataclass(frozen=True)
+class OrderIntent:
+    symbol: str
+    side: str
+    notional: float
+    sector: str
+    asset_class: str
+
+    def __post_init__(self) -> None:
+        if self.notional < 0:
+            raise RiskLimitsError(
+                f"OrderIntent.notional must be >= 0, got {self.notional}"
+            )
+        if self.side not in _VALID_SIDES:
+            raise RiskLimitsError(
+                f"OrderIntent.side must be one of {sorted(_VALID_SIDES)}, "
+                f"got {self.side!r}"
+            )
+
+
+@dataclass(frozen=True)
+class AccountState:
+    cash: float
+    total_value: float
+    daily_pnl: float
+    exposures: dict[str, float]
+    sector_exposures: dict[str, float]
+    asset_class_exposures: dict[str, float]
+
+    def __post_init__(self) -> None:
+        if self.total_value < 0:
+            raise RiskLimitsError(
+                f"AccountState.total_value must be >= 0, got {self.total_value}"
+            )
+
+
+@dataclass(frozen=True)
+class RiskLimits:
+    max_single_order_notional: float | None = None
+    max_position_notional: dict[str, float] = field(default_factory=dict)
+    max_sector_concentration_pct: dict[str, float] = field(default_factory=dict)
+    max_asset_class_concentration_pct: dict[str, float] = field(default_factory=dict)
+    max_orders_per_window: int | None = None
+    velocity_window_seconds: float = 60.0
+    max_daily_loss: float | None = None
+
+
+@dataclass(frozen=True)
+class RiskDecision:
+    approved: bool
+    breached_limits: list[str]
+    warnings: list[str]
+
+
+class RiskGate:
+    """Pre-trade risk gate. Aggregates all breaches per check."""
+
+    def __init__(
+        self,
+        limits: RiskLimits,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.limits = limits
+        self._clock: Callable[[], float] = clock or time.monotonic
+        self._order_timestamps: list[float] = []
+        self._circuit_breaker_tripped: bool = False
+
+    def reset_circuit_breaker(self) -> None:
+        self._circuit_breaker_tripped = False
+
+    def check(self, intent: OrderIntent, state: AccountState) -> RiskDecision:
+        breaches: list[str] = []
+
+        if self._circuit_breaker_tripped:
+            breaches.append("circuit_breaker")
+        elif (
+            self.limits.max_daily_loss is not None
+            and state.daily_pnl <= -self.limits.max_daily_loss
+        ):
+            self._circuit_breaker_tripped = True
+            breaches.append("daily_loss")
+
+        if (
+            self.limits.max_single_order_notional is not None
+            and intent.notional > self.limits.max_single_order_notional
+        ):
+            breaches.append("single_order_notional")
+
+        if intent.side == "buy":
+            sym_cap = self.limits.max_position_notional.get(intent.symbol)
+            if sym_cap is not None:
+                projected = state.exposures.get(intent.symbol, 0.0) + intent.notional
+                if projected > sym_cap:
+                    breaches.append(f"position_notional[{intent.symbol}]")
+
+        if state.total_value > 0:
+            sector_cap = self.limits.max_sector_concentration_pct.get(intent.sector)
+            if sector_cap is not None:
+                projected = (
+                    state.sector_exposures.get(intent.sector, 0.0) + intent.notional
+                )
+                if projected / state.total_value > sector_cap:
+                    breaches.append(f"sector_concentration[{intent.sector}]")
+
+            ac_cap = self.limits.max_asset_class_concentration_pct.get(
+                intent.asset_class
+            )
+            if ac_cap is not None:
+                projected = (
+                    state.asset_class_exposures.get(intent.asset_class, 0.0)
+                    + intent.notional
+                )
+                if projected / state.total_value > ac_cap:
+                    breaches.append(
+                        f"asset_class_concentration[{intent.asset_class}]"
+                    )
+
+        if self.limits.max_orders_per_window is not None:
+            now = self._clock()
+            window_start = now - self.limits.velocity_window_seconds
+            self._order_timestamps = [
+                t for t in self._order_timestamps if t >= window_start
+            ]
+            if len(self._order_timestamps) >= self.limits.max_orders_per_window:
+                breaches.append("velocity")
+
+        approved = not breaches
+
+        if approved and self.limits.max_orders_per_window is not None:
+            self._order_timestamps.append(self._clock())
+
+        return RiskDecision(
+            approved=approved,
+            breached_limits=breaches,
+            warnings=[],
+        )
+
+
+__all__ = [
+    "AccountState",
+    "OrderIntent",
+    "RiskDecision",
+    "RiskGate",
+    "RiskLimits",
+    "RiskLimitsError",
+]

--- a/engine/core/risk_limits.py
+++ b/engine/core/risk_limits.py
@@ -13,20 +13,50 @@ Stateful policies tracked on the gate instance:
 - velocity:  rolling timestamps of approved orders within ``velocity_window_seconds``
 - circuit_breaker: tripped when ``daily_pnl <= -max_daily_loss``; sticks until
   :meth:`RiskGate.reset_circuit_breaker` is called.
+
+Comparison semantics (intentional, asymmetric):
+- circuit breaker:        ``daily_pnl <= -max_daily_loss``  — tripping AT the
+  threshold is the conservative choice for a kill-switch.
+- order / concentration:  ``projected > cap`` — an order whose projected value
+  is exactly equal to the cap is permitted; this matches the natural English
+  "exceeds cap" reading and stays consistent across all four order-side caps.
+
+Numeric inputs (notional, total_value, daily_pnl, exposure dict values) must
+be finite — NaN / inf inputs raise :class:`RiskLimitsError` at construction so a
+misconfigured upstream cannot silently bypass the gate.
 """
 
 from __future__ import annotations
 
+import math
+import threading
 import time
-from collections.abc import Callable
+import types
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 
 
 class RiskLimitsError(ValueError):
-    """Invalid risk inputs (negative notional, unknown side, etc.)."""
+    """Invalid risk inputs (negative notional, unknown side, NaN, etc.)."""
 
 
 _VALID_SIDES = frozenset({"buy", "sell"})
+
+
+def _require_finite(value: float, label: str) -> None:
+    if not math.isfinite(value):
+        raise RiskLimitsError(f"{label} must be finite, got {value!r}")
+
+
+def _freeze_mapping(name: str, src: Mapping[str, float]) -> Mapping[str, float]:
+    """Defensively copy + wrap a caller-supplied dict so subsequent mutation
+    of the original cannot poison gate state. Validates each value is finite."""
+    snap: dict[str, float] = {}
+    for k, v in src.items():
+        f = float(v)
+        _require_finite(f, f"{name}[{k}]")
+        snap[k] = f
+    return types.MappingProxyType(snap)
 
 
 @dataclass(frozen=True)
@@ -38,6 +68,7 @@ class OrderIntent:
     asset_class: str
 
     def __post_init__(self) -> None:
+        _require_finite(self.notional, "OrderIntent.notional")
         if self.notional < 0:
             raise RiskLimitsError(
                 f"OrderIntent.notional must be >= 0, got {self.notional}"
@@ -54,37 +85,93 @@ class AccountState:
     cash: float
     total_value: float
     daily_pnl: float
-    exposures: dict[str, float]
-    sector_exposures: dict[str, float]
-    asset_class_exposures: dict[str, float]
+    exposures: Mapping[str, float]
+    sector_exposures: Mapping[str, float]
+    asset_class_exposures: Mapping[str, float]
 
     def __post_init__(self) -> None:
+        _require_finite(self.cash, "AccountState.cash")
+        _require_finite(self.total_value, "AccountState.total_value")
+        _require_finite(self.daily_pnl, "AccountState.daily_pnl")
         if self.total_value < 0:
             raise RiskLimitsError(
                 f"AccountState.total_value must be >= 0, got {self.total_value}"
             )
+        # Deep-copy + freeze the exposure dicts so post-construction mutation
+        # of the caller's source dict cannot change what the gate sees.
+        object.__setattr__(
+            self, "exposures", _freeze_mapping("exposures", self.exposures)
+        )
+        object.__setattr__(
+            self,
+            "sector_exposures",
+            _freeze_mapping("sector_exposures", self.sector_exposures),
+        )
+        object.__setattr__(
+            self,
+            "asset_class_exposures",
+            _freeze_mapping("asset_class_exposures", self.asset_class_exposures),
+        )
 
 
 @dataclass(frozen=True)
 class RiskLimits:
     max_single_order_notional: float | None = None
-    max_position_notional: dict[str, float] = field(default_factory=dict)
-    max_sector_concentration_pct: dict[str, float] = field(default_factory=dict)
-    max_asset_class_concentration_pct: dict[str, float] = field(default_factory=dict)
+    max_position_notional: Mapping[str, float] = field(default_factory=dict)
+    max_sector_concentration_pct: Mapping[str, float] = field(default_factory=dict)
+    max_asset_class_concentration_pct: Mapping[str, float] = field(
+        default_factory=dict
+    )
     max_orders_per_window: int | None = None
     velocity_window_seconds: float = 60.0
     max_daily_loss: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_single_order_notional is not None:
+            _require_finite(
+                self.max_single_order_notional, "max_single_order_notional"
+            )
+        if self.max_daily_loss is not None:
+            _require_finite(self.max_daily_loss, "max_daily_loss")
+        _require_finite(self.velocity_window_seconds, "velocity_window_seconds")
+        # Same defensive freeze as AccountState — limits should not change
+        # mid-flight via aliased dicts the caller still holds.
+        object.__setattr__(
+            self,
+            "max_position_notional",
+            _freeze_mapping("max_position_notional", self.max_position_notional),
+        )
+        object.__setattr__(
+            self,
+            "max_sector_concentration_pct",
+            _freeze_mapping(
+                "max_sector_concentration_pct", self.max_sector_concentration_pct
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_asset_class_concentration_pct",
+            _freeze_mapping(
+                "max_asset_class_concentration_pct",
+                self.max_asset_class_concentration_pct,
+            ),
+        )
 
 
 @dataclass(frozen=True)
 class RiskDecision:
     approved: bool
-    breached_limits: list[str]
-    warnings: list[str]
+    breached_limits: tuple[str, ...]
+    warnings: tuple[str, ...]
 
 
 class RiskGate:
-    """Pre-trade risk gate. Aggregates all breaches per check."""
+    """Pre-trade risk gate. Aggregates all breaches per check.
+
+    Thread-safe: :meth:`check` and :meth:`reset_circuit_breaker` are protected
+    by an internal :class:`threading.Lock` so concurrent callers cannot corrupt
+    the rolling-velocity buffer or the circuit-breaker flag.
+    """
 
     def __init__(
         self,
@@ -95,11 +182,19 @@ class RiskGate:
         self._clock: Callable[[], float] = clock or time.monotonic
         self._order_timestamps: list[float] = []
         self._circuit_breaker_tripped: bool = False
+        self._lock = threading.Lock()
 
     def reset_circuit_breaker(self) -> None:
-        self._circuit_breaker_tripped = False
+        with self._lock:
+            self._circuit_breaker_tripped = False
 
     def check(self, intent: OrderIntent, state: AccountState) -> RiskDecision:
+        with self._lock:
+            return self._check_locked(intent, state)
+
+    def _check_locked(
+        self, intent: OrderIntent, state: AccountState
+    ) -> RiskDecision:
         breaches: list[str] = []
 
         if self._circuit_breaker_tripped:
@@ -146,6 +241,9 @@ class RiskGate:
                         f"asset_class_concentration[{intent.asset_class}]"
                     )
 
+        # Cache `now` once so the window-start filter and the appended
+        # timestamp for an approved order share the same instant — avoids
+        # subtle ordering drift when the injected clock is non-monotonic.
         if self.limits.max_orders_per_window is not None:
             now = self._clock()
             window_start = now - self.limits.velocity_window_seconds
@@ -155,15 +253,16 @@ class RiskGate:
             if len(self._order_timestamps) >= self.limits.max_orders_per_window:
                 breaches.append("velocity")
 
-        approved = not breaches
-
-        if approved and self.limits.max_orders_per_window is not None:
-            self._order_timestamps.append(self._clock())
+            approved = not breaches
+            if approved:
+                self._order_timestamps.append(now)
+        else:
+            approved = not breaches
 
         return RiskDecision(
             approved=approved,
-            breached_limits=breaches,
-            warnings=[],
+            breached_limits=tuple(breaches),
+            warnings=(),
         )
 
 

--- a/tests/test_risk_limits.py
+++ b/tests/test_risk_limits.py
@@ -253,5 +253,93 @@ class TestRiskDecisionShape:
         gate = RiskGate(RiskLimits())
         out = gate.check(_intent(), _state())
         assert out.approved is True
-        assert out.breached_limits == []
-        assert out.warnings == []
+        assert out.breached_limits == ()
+        assert out.warnings == ()
+
+
+class TestImmutability:
+    def test_account_state_dict_mutation_does_not_leak(self):
+        # Caller mutating their source dict after constructing AccountState
+        # must NOT change what the gate sees — defends against silent state
+        # corruption in long-running gates.
+        exposures = {"AAPL": 30_000.0}
+        state = AccountState(
+            cash=100_000.0,
+            total_value=100_000.0,
+            daily_pnl=0.0,
+            exposures=exposures,
+            sector_exposures={},
+            asset_class_exposures={},
+        )
+        exposures["AAPL"] = 999_999_999.0  # caller mutates AFTER construction
+        gate = RiskGate(RiskLimits(max_position_notional={"AAPL": 50_000.0}))
+        out = gate.check(_intent(symbol="AAPL", notional=10_000.0), state)
+        assert out.approved is True  # gate saw the snapshot, not the mutation
+
+    def test_risk_decision_breaches_are_immutable(self):
+        gate = RiskGate(RiskLimits(max_single_order_notional=1.0))
+        out = gate.check(_intent(notional=100.0), _state())
+        with pytest.raises((AttributeError, TypeError)):
+            out.breached_limits.append("forged")  # type: ignore[attr-defined]
+
+
+class TestNumericValidation:
+    def test_nan_notional_rejected(self):
+        with pytest.raises(RiskLimitsError):
+            OrderIntent(
+                symbol="AAPL",
+                side="buy",
+                notional=float("nan"),
+                sector="tech",
+                asset_class="equity",
+            )
+
+    def test_inf_notional_rejected(self):
+        with pytest.raises(RiskLimitsError):
+            OrderIntent(
+                symbol="AAPL",
+                side="buy",
+                notional=float("inf"),
+                sector="tech",
+                asset_class="equity",
+            )
+
+    def test_nan_daily_pnl_rejected(self):
+        with pytest.raises(RiskLimitsError):
+            AccountState(
+                cash=0.0,
+                total_value=1.0,
+                daily_pnl=float("nan"),
+                exposures={},
+                sector_exposures={},
+                asset_class_exposures={},
+            )
+
+
+class TestThreadSafety:
+    def test_concurrent_checks_do_not_corrupt_velocity_buffer(self):
+        # Drives 8 threads × 100 checks each at a 500-cap. With a lock the
+        # rolling buffer stays internally consistent (no IndexError, no
+        # list mutation during iteration).
+        import threading as _t
+
+        gate = RiskGate(
+            RiskLimits(max_orders_per_window=500, velocity_window_seconds=60)
+        )
+
+        errors: list[BaseException] = []
+
+        def worker():
+            try:
+                for _ in range(100):
+                    gate.check(_intent(), _state())
+            except BaseException as exc:  # noqa: BLE001 - want all failures
+                errors.append(exc)
+
+        threads = [_t.Thread(target=worker) for _ in range(8)]
+        for thr in threads:
+            thr.start()
+        for thr in threads:
+            thr.join()
+
+        assert errors == []

--- a/tests/test_risk_limits.py
+++ b/tests/test_risk_limits.py
@@ -1,0 +1,257 @@
+"""Tests for engine.core.risk_limits — pre-trade risk gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.risk_limits import (
+    AccountState,
+    OrderIntent,
+    RiskGate,
+    RiskLimits,
+    RiskLimitsError,
+)
+
+
+def _intent(
+    *,
+    symbol: str = "AAPL",
+    notional: float = 10_000.0,
+    side: str = "buy",
+    sector: str = "tech",
+    asset_class: str = "equity",
+) -> OrderIntent:
+    return OrderIntent(
+        symbol=symbol,
+        side=side,
+        notional=notional,
+        sector=sector,
+        asset_class=asset_class,
+    )
+
+
+def _state(
+    *,
+    cash: float = 100_000.0,
+    total_value: float = 100_000.0,
+    daily_pnl: float = 0.0,
+    exposures: dict[str, float] | None = None,
+    sector_exposures: dict[str, float] | None = None,
+    asset_class_exposures: dict[str, float] | None = None,
+) -> AccountState:
+    return AccountState(
+        cash=cash,
+        total_value=total_value,
+        daily_pnl=daily_pnl,
+        exposures=exposures or {},
+        sector_exposures=sector_exposures or {},
+        asset_class_exposures=asset_class_exposures or {},
+    )
+
+
+class TestSingleOrderCap:
+    def test_below_cap_approved(self):
+        gate = RiskGate(RiskLimits(max_single_order_notional=50_000.0))
+        out = gate.check(_intent(notional=10_000.0), _state())
+        assert out.approved is True
+
+    def test_above_cap_rejected(self):
+        gate = RiskGate(RiskLimits(max_single_order_notional=5_000.0))
+        out = gate.check(_intent(notional=10_000.0), _state())
+        assert out.approved is False
+        assert "single_order_notional" in out.breached_limits
+
+
+class TestPerSymbolNotional:
+    def test_existing_position_room_remaining(self):
+        gate = RiskGate(RiskLimits(max_position_notional={"AAPL": 50_000.0}))
+        out = gate.check(
+            _intent(symbol="AAPL", notional=10_000.0),
+            _state(exposures={"AAPL": 30_000.0}),
+        )
+        assert out.approved is True
+
+    def test_existing_position_breached(self):
+        gate = RiskGate(RiskLimits(max_position_notional={"AAPL": 50_000.0}))
+        out = gate.check(
+            _intent(symbol="AAPL", notional=10_000.0),
+            _state(exposures={"AAPL": 45_000.0}),
+        )
+        assert out.approved is False
+        assert "position_notional[AAPL]" in out.breached_limits
+
+    def test_unconfigured_symbol_unbounded(self):
+        gate = RiskGate(RiskLimits(max_position_notional={"AAPL": 50_000.0}))
+        out = gate.check(
+            _intent(symbol="MSFT", notional=1_000_000.0),
+            _state(),
+        )
+        assert out.approved is True
+
+    def test_sell_does_not_breach_long_cap(self):
+        gate = RiskGate(RiskLimits(max_position_notional={"AAPL": 50_000.0}))
+        out = gate.check(
+            _intent(symbol="AAPL", side="sell", notional=10_000.0),
+            _state(exposures={"AAPL": 60_000.0}),
+        )
+        assert out.approved is True
+
+
+class TestSectorConcentration:
+    def test_below_cap(self):
+        gate = RiskGate(RiskLimits(max_sector_concentration_pct={"tech": 0.40}))
+        out = gate.check(
+            _intent(sector="tech", notional=10_000.0),
+            _state(sector_exposures={"tech": 20_000.0}, total_value=100_000.0),
+        )
+        assert out.approved is True
+
+    def test_above_cap(self):
+        gate = RiskGate(RiskLimits(max_sector_concentration_pct={"tech": 0.40}))
+        out = gate.check(
+            _intent(sector="tech", notional=20_000.0),
+            _state(sector_exposures={"tech": 30_000.0}, total_value=100_000.0),
+        )
+        assert out.approved is False
+        assert "sector_concentration[tech]" in out.breached_limits
+
+
+class TestAssetClassConcentration:
+    def test_above_cap(self):
+        gate = RiskGate(
+            RiskLimits(max_asset_class_concentration_pct={"crypto": 0.10})
+        )
+        out = gate.check(
+            _intent(asset_class="crypto", notional=8_000.0),
+            _state(
+                asset_class_exposures={"crypto": 5_000.0},
+                total_value=100_000.0,
+            ),
+        )
+        assert out.approved is False
+        assert "asset_class_concentration[crypto]" in out.breached_limits
+
+
+class TestVelocity:
+    def test_within_window(self):
+        gate = RiskGate(
+            RiskLimits(max_orders_per_window=3, velocity_window_seconds=60)
+        )
+        for _ in range(3):
+            out = gate.check(_intent(), _state())
+            assert out.approved is True
+
+    def test_exceeds_window(self):
+        gate = RiskGate(
+            RiskLimits(max_orders_per_window=2, velocity_window_seconds=60)
+        )
+        gate.check(_intent(), _state())
+        gate.check(_intent(), _state())
+        out = gate.check(_intent(), _state())
+        assert out.approved is False
+        assert "velocity" in out.breached_limits
+
+    def test_window_rolls_off(self):
+        clock = [1000.0]
+        gate = RiskGate(
+            RiskLimits(max_orders_per_window=2, velocity_window_seconds=60),
+            clock=lambda: clock[0],
+        )
+        gate.check(_intent(), _state())
+        gate.check(_intent(), _state())
+        clock[0] = 1100.0
+        out = gate.check(_intent(), _state())
+        assert out.approved is True
+
+
+class TestDailyLossBreaker:
+    def test_below_loss_threshold(self):
+        gate = RiskGate(RiskLimits(max_daily_loss=5_000.0))
+        out = gate.check(_intent(), _state(daily_pnl=-1_000.0))
+        assert out.approved is True
+
+    def test_at_loss_threshold_trips(self):
+        gate = RiskGate(RiskLimits(max_daily_loss=5_000.0))
+        out = gate.check(_intent(), _state(daily_pnl=-5_000.0))
+        assert out.approved is False
+        assert "daily_loss" in out.breached_limits
+
+    def test_breaker_stays_tripped_after_pnl_recovers(self):
+        gate = RiskGate(RiskLimits(max_daily_loss=5_000.0))
+        gate.check(_intent(), _state(daily_pnl=-6_000.0))
+        out = gate.check(_intent(), _state(daily_pnl=-1_000.0))
+        assert out.approved is False
+        assert "circuit_breaker" in out.breached_limits
+
+    def test_manual_reset(self):
+        gate = RiskGate(RiskLimits(max_daily_loss=5_000.0))
+        gate.check(_intent(), _state(daily_pnl=-6_000.0))
+        gate.reset_circuit_breaker()
+        out = gate.check(_intent(), _state(daily_pnl=-1_000.0))
+        assert out.approved is True
+
+
+class TestMultipleBreaches:
+    def test_all_breaches_reported(self):
+        gate = RiskGate(
+            RiskLimits(
+                max_single_order_notional=1_000.0,
+                max_position_notional={"AAPL": 1_000.0},
+            )
+        )
+        out = gate.check(
+            _intent(symbol="AAPL", notional=10_000.0),
+            _state(exposures={"AAPL": 5_000.0}),
+        )
+        assert out.approved is False
+        assert "single_order_notional" in out.breached_limits
+        assert "position_notional[AAPL]" in out.breached_limits
+
+
+class TestValidation:
+    def test_negative_notional_rejected_at_construction(self):
+        with pytest.raises(RiskLimitsError):
+            OrderIntent(
+                symbol="AAPL",
+                side="buy",
+                notional=-1.0,
+                sector="tech",
+                asset_class="equity",
+            )
+
+    def test_unknown_side_rejected(self):
+        with pytest.raises(RiskLimitsError):
+            OrderIntent(
+                symbol="AAPL",
+                side="floof",
+                notional=1.0,
+                sector="tech",
+                asset_class="equity",
+            )
+
+    def test_negative_total_value_rejected(self):
+        with pytest.raises(RiskLimitsError):
+            AccountState(
+                cash=0.0,
+                total_value=-1.0,
+                daily_pnl=0.0,
+                exposures={},
+                sector_exposures={},
+                asset_class_exposures={},
+            )
+
+    def test_zero_total_value_skips_concentration_checks(self):
+        gate = RiskGate(
+            RiskLimits(max_sector_concentration_pct={"tech": 0.10})
+        )
+        out = gate.check(_intent(), _state(total_value=0.0))
+        assert out.approved is True
+
+
+class TestRiskDecisionShape:
+    def test_approved_decision_has_no_breaches(self):
+        gate = RiskGate(RiskLimits())
+        out = gate.check(_intent(), _state())
+        assert out.approved is True
+        assert out.breached_limits == []
+        assert out.warnings == []


### PR DESCRIPTION
Closes gh#110.

## Summary
- Decoupled pre-trade risk gate operating on plain immutable dataclasses (`OrderIntent`, `AccountState`, `RiskLimits`).
- Aggregated breach reporting — single check returns *all* breaches, not just the first, so logs reflect full risk picture.
- Limit families: single-order notional, per-symbol notional cap, sector concentration %, asset-class concentration %, rolling velocity window, daily-loss circuit breaker (sticky until manual reset).
- Construction-time validation (negative notional / total_value / unknown side raises `RiskLimitsError`).

## Why a new module
`engine/core/risk_engine.py` already exists but is hard-coupled to `Order` + `Portfolio` types and uses initial-capital drawdown semantics. The new `risk_limits.py` is broker-agnostic so the same gate can run in paper, live, and backtest contexts. The order flow will be re-wired to use it in a follow-up PR.

## Test plan
- [x] `tests/test_risk_limits.py` — 22 tests covering cap enforcement, sticky breaker, rolling velocity (with injected clock), validation errors, multi-breach aggregation.
- [x] All pass locally (`uv run pytest tests/test_risk_limits.py -x` — 22 passed).
- [ ] CI green
- [ ] Adversarial review