### PR TITLE
feat(signal): multi-strategy SignalAggregator (gh#21)

### DIFF
--- a/engine/core/signal_aggregator.py
+++ b/engine/core/signal_aggregator.py
@@ -1,0 +1,222 @@
+"""Multi-strategy signal aggregation (gh#21).
+
+When multiple strategies run on the same portfolio they may emit
+conflicting signals on the same symbol (BUY vs. SELL). The aggregator
+collapses each strategy's :class:`SignalBatch` into a final per-symbol
+:class:`Signal` according to a configurable :class:`AggregationMethod`.
+
+HOLD semantics: ``Side.HOLD`` is treated as "no opinion" rather than as
+an active vote. A strategy that emits HOLD for a symbol does not block
+unanimous consensus among the strategies that did take a position, and
+does not count toward majority-vote denominators. If every strategy
+emits HOLD on a symbol, the aggregator emits a single HOLD signal so
+downstream code has a record that the symbol was considered.
+
+Aggregation methods
+-------------------
+
+UNANIMOUS
+    Every strategy that voted (BUY or SELL) must agree. Disagreement
+    emits HOLD.
+
+MAJORITY
+    Side with strictly more than half of the BUY-vs-SELL votes wins.
+    Tie emits HOLD.
+
+WEIGHTED
+    Same as MAJORITY but each strategy's vote is multiplied by its
+    weight from ``strategy_weights`` (default 1.0 for unknown
+    strategies). Side with strictly higher weighted total wins.
+
+PRIORITY
+    Strategy with the highest weight that voted on the symbol wins
+    outright. ``strategy_weights`` here is interpreted as priority
+    (higher number = higher priority).
+
+INDEPENDENT
+    No aggregation. Concatenate every strategy's signals as-is and
+    return them. The downstream consumer is expected to apply its own
+    conflict resolution (typical use: each strategy targets a disjoint
+    sub-portfolio).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from enum import Enum
+
+from engine.core.signal import Side, Signal, SignalBatch
+
+
+class AggregationMethod(str, Enum):
+    UNANIMOUS = "unanimous"
+    MAJORITY = "majority"
+    WEIGHTED = "weighted"
+    PRIORITY = "priority"
+    INDEPENDENT = "independent"
+
+
+class SignalAggregatorError(ValueError):
+    """Bad aggregator configuration (unknown method, invalid weight)."""
+
+
+_AGGREGATED_STRATEGY_ID = "aggregated"
+
+
+class SignalAggregator:
+    """Stateless aggregator. Construct once, reuse across cycles."""
+
+    def __init__(
+        self,
+        method: AggregationMethod,
+        strategy_weights: dict[str, float] | None = None,
+    ) -> None:
+        # Allow a string for ergonomics; reject anything outside the enum.
+        try:
+            self.method = AggregationMethod(method)
+        except ValueError as exc:
+            valid = ", ".join(m.value for m in AggregationMethod)
+            raise SignalAggregatorError(
+                f"unknown aggregation method {method!r}; expected one of {valid}"
+            ) from exc
+
+        weights = dict(strategy_weights or {})
+        for sid, w in weights.items():
+            if not math.isfinite(w):
+                raise SignalAggregatorError(
+                    f"strategy_weights[{sid!r}] must be finite, got {w!r}"
+                )
+            if w < 0:
+                raise SignalAggregatorError(
+                    f"strategy_weights[{sid!r}] must be non-negative, got {w!r}"
+                )
+        self.weights = weights
+
+    def aggregate(self, batches: Iterable[SignalBatch]) -> list[Signal]:
+        if self.method is AggregationMethod.INDEPENDENT:
+            return [s for b in batches for s in b.signals]
+
+        # Group signals by symbol. We deliberately keep one signal per
+        # (strategy, symbol); if a strategy emitted multiple signals on
+        # the same symbol within a single batch, the LAST one wins -
+        # that matches how a strategy's own internal tie-break should
+        # already be reflected in the final emitted batch.
+        per_symbol: dict[str, dict[str, Signal]] = defaultdict(dict)
+        for batch in batches:
+            for sig in batch.signals:
+                per_symbol[sig.symbol][batch.strategy_id] = sig
+
+        out: list[Signal] = []
+        for _symbol, by_strategy in per_symbol.items():
+            decision = self._decide(by_strategy)
+            if decision is None:
+                continue
+            out.append(decision)
+        return out
+
+    # --- per-method decision functions ---------------------------------
+
+    def _decide(self, by_strategy: dict[str, Signal]) -> Signal | None:
+        if self.method is AggregationMethod.UNANIMOUS:
+            return self._decide_unanimous(by_strategy)
+        if self.method is AggregationMethod.MAJORITY:
+            return self._decide_majority(by_strategy)
+        if self.method is AggregationMethod.WEIGHTED:
+            return self._decide_weighted(by_strategy)
+        if self.method is AggregationMethod.PRIORITY:
+            return self._decide_priority(by_strategy)
+        # INDEPENDENT was handled in aggregate(); reaching here is a bug.
+        raise SignalAggregatorError(  # pragma: no cover - defensive
+            f"unhandled aggregation method {self.method!r}"
+        )
+
+    def _decide_unanimous(
+        self, by_strategy: dict[str, Signal]
+    ) -> Signal | None:
+        active = [s for s in by_strategy.values() if s.side != Side.HOLD]
+        if not active:
+            template = next(iter(by_strategy.values()))
+            return _hold_like(template)
+        sides = {s.side for s in active}
+        if len(sides) == 1:
+            template = active[0]
+            return _aggregated(template, template.side)
+        return _hold_like(active[0])
+
+    def _decide_majority(
+        self, by_strategy: dict[str, Signal]
+    ) -> Signal | None:
+        return self._decide_weighted_with(
+            by_strategy, weight_for=lambda _sid: 1.0
+        )
+
+    def _decide_weighted(
+        self, by_strategy: dict[str, Signal]
+    ) -> Signal | None:
+        return self._decide_weighted_with(
+            by_strategy, weight_for=lambda sid: self.weights.get(sid, 1.0)
+        )
+
+    def _decide_weighted_with(
+        self,
+        by_strategy: dict[str, Signal],
+        *,
+        weight_for: Callable[[str], float],
+    ) -> Signal | None:
+        totals: dict[Side, float] = defaultdict(float)
+        for sid, sig in by_strategy.items():
+            if sig.side == Side.HOLD:
+                continue
+            totals[sig.side] += weight_for(sid)
+
+        if not totals:
+            return _hold_like(next(iter(by_strategy.values())))
+
+        ranked = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
+        if len(ranked) == 1 or ranked[0][1] > ranked[1][1]:
+            winning_side = ranked[0][0]
+            template = next(
+                s for s in by_strategy.values() if s.side == winning_side
+            )
+            return _aggregated(template, winning_side)
+        return _hold_like(next(iter(by_strategy.values())))
+
+    def _decide_priority(
+        self, by_strategy: dict[str, Signal]
+    ) -> Signal | None:
+        # Highest priority wins. Strategies absent from `weights` are
+        # treated as priority 0, so a configured strategy always beats
+        # an unconfigured one.
+        active = [
+            (self.weights.get(sid, 0.0), sid, sig)
+            for sid, sig in by_strategy.items()
+            if sig.side != Side.HOLD
+        ]
+        if not active:
+            return _hold_like(next(iter(by_strategy.values())))
+        active.sort(key=lambda t: t[0], reverse=True)
+        _prio, _sid, sig = active[0]
+        return _aggregated(sig, sig.side)
+
+
+def _aggregated(template: Signal, side: Side) -> Signal:
+    """Build a Signal whose side is the aggregator's decision but whose
+    other metadata mirrors a representative input. ``strategy_id`` is
+    overwritten so the audit log shows the aggregator, not the original
+    strategy."""
+    return template.model_copy(
+        update={"side": side, "strategy_id": _AGGREGATED_STRATEGY_ID}
+    )
+
+
+def _hold_like(template: Signal) -> Signal:
+    return _aggregated(template, Side.HOLD)
+
+
+__all__ = [
+    "AggregationMethod",
+    "SignalAggregator",
+    "SignalAggregatorError",
+]

--- a/engine/core/signal_aggregator.py
+++ b/engine/core/signal_aggregator.py
@@ -31,7 +31,9 @@ WEIGHTED
 PRIORITY
     Strategy with the highest weight that voted on the symbol wins
     outright. ``strategy_weights`` here is interpreted as priority
-    (higher number = higher priority).
+    (higher number = higher priority). Two strategies tied for the
+    highest priority on the same symbol with conflicting sides emit
+    HOLD (consistent with MAJORITY / WEIGHTED tie semantics).
 
 INDEPENDENT
     No aggregation. Concatenate every strategy's signals as-is and
@@ -92,6 +94,17 @@ class SignalAggregator:
                 raise SignalAggregatorError(
                     f"strategy_weights[{sid!r}] must be non-negative, got {w!r}"
                 )
+        # All-zero weights silently degenerate to HOLD on every symbol;
+        # treat that as a misconfiguration rather than allow it through.
+        if (
+            self.method is AggregationMethod.WEIGHTED
+            and weights
+            and sum(weights.values()) == 0
+        ):
+            raise SignalAggregatorError(
+                "WEIGHTED requires at least one positive strategy weight; "
+                "all configured weights sum to zero"
+            )
         self.weights = weights
 
     def aggregate(self, batches: Iterable[SignalBatch]) -> list[Signal]:
@@ -188,7 +201,10 @@ class SignalAggregator:
     ) -> Signal | None:
         # Highest priority wins. Strategies absent from `weights` are
         # treated as priority 0, so a configured strategy always beats
-        # an unconfigured one.
+        # an unconfigured one. Two strategies tied for the highest
+        # priority on conflicting sides emit HOLD — relying on dict
+        # iteration order for tie-break would be non-deterministic
+        # across Python versions.
         active = [
             (self.weights.get(sid, 0.0), sid, sig)
             for sid, sig in by_strategy.items()
@@ -196,8 +212,12 @@ class SignalAggregator:
         ]
         if not active:
             return _hold_like(next(iter(by_strategy.values())))
-        active.sort(key=lambda t: t[0], reverse=True)
-        _prio, _sid, sig = active[0]
+        top_prio = max(t[0] for t in active)
+        top = [t for t in active if t[0] == top_prio]
+        top_sides = {sig.side for _p, _sid, sig in top}
+        if len(top_sides) > 1:
+            return _hold_like(top[0][2])
+        _prio, _sid, sig = top[0]
         return _aggregated(sig, sig.side)
 
 
@@ -205,9 +225,15 @@ def _aggregated(template: Signal, side: Side) -> Signal:
     """Build a Signal whose side is the aggregator's decision but whose
     other metadata mirrors a representative input. ``strategy_id`` is
     overwritten so the audit log shows the aggregator, not the original
-    strategy."""
+    strategy. The ``metadata`` dict is shallow-copied so that downstream
+    mutation of the aggregated signal cannot leak back into the source
+    strategy's signal object."""
     return template.model_copy(
-        update={"side": side, "strategy_id": _AGGREGATED_STRATEGY_ID}
+        update={
+            "side": side,
+            "strategy_id": _AGGREGATED_STRATEGY_ID,
+            "metadata": dict(template.metadata),
+        }
     )
 
 
@@ -215,7 +241,14 @@ def _hold_like(template: Signal) -> Signal:
     return _aggregated(template, Side.HOLD)
 
 
+#: Public sentinel: aggregator output sets ``Signal.strategy_id`` to this
+#: so downstream audit code can distinguish aggregated decisions from raw
+#: per-strategy signals.
+AGGREGATED_STRATEGY_ID = _AGGREGATED_STRATEGY_ID
+
+
 __all__ = [
+    "AGGREGATED_STRATEGY_ID",
     "AggregationMethod",
     "SignalAggregator",
     "SignalAggregatorError",

--- a/tests/test_signal_aggregator.py
+++ b/tests/test_signal_aggregator.py
@@ -1,0 +1,246 @@
+"""Tests for engine.core.signal_aggregator — multi-strategy aggregation."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.signal import Side, Signal, SignalBatch
+from engine.core.signal_aggregator import (
+    AggregationMethod,
+    SignalAggregator,
+    SignalAggregatorError,
+)
+
+
+def _batch(strategy_id: str, *signals: Signal) -> SignalBatch:
+    return SignalBatch(strategy_id=strategy_id, signals=list(signals))
+
+
+def _sig(symbol: str, side: Side, strategy_id: str, **kw) -> Signal:
+    return Signal(symbol=symbol, side=side, strategy_id=strategy_id, **kw)
+
+
+class TestUnanimous:
+    def test_all_agree_emits_signal(self):
+        agg = SignalAggregator(AggregationMethod.UNANIMOUS)
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.BUY, "s2")),
+                _batch("s3", _sig("AAPL", Side.BUY, "s3")),
+            ]
+        )
+        assert len(out) == 1
+        assert out[0].symbol == "AAPL"
+        assert out[0].side == Side.BUY
+
+    def test_one_dissents_emits_hold(self):
+        agg = SignalAggregator(AggregationMethod.UNANIMOUS)
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.BUY, "s2")),
+                _batch("s3", _sig("AAPL", Side.SELL, "s3")),
+            ]
+        )
+        assert len(out) == 1
+        assert out[0].symbol == "AAPL"
+        assert out[0].side == Side.HOLD
+
+    def test_partial_coverage_does_not_block(self):
+        # Only s1 voted on AAPL; unanimous over the strategies that did
+        # express an opinion is still a clear signal.
+        agg = SignalAggregator(AggregationMethod.UNANIMOUS)
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2"),  # no signals at all
+            ]
+        )
+        assert len(out) == 1
+        assert out[0].side == Side.BUY
+
+
+class TestMajority:
+    def test_majority_buys_emits_buy(self):
+        agg = SignalAggregator(AggregationMethod.MAJORITY)
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.BUY, "s2")),
+                _batch("s3", _sig("AAPL", Side.SELL, "s3")),
+            ]
+        )
+        assert len(out) == 1
+        assert out[0].side == Side.BUY
+
+    def test_tie_emits_hold(self):
+        agg = SignalAggregator(AggregationMethod.MAJORITY)
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.SELL, "s2")),
+            ]
+        )
+        assert len(out) == 1
+        assert out[0].side == Side.HOLD
+
+
+class TestWeighted:
+    def test_higher_weight_wins(self):
+        agg = SignalAggregator(
+            AggregationMethod.WEIGHTED,
+            strategy_weights={"s1": 0.7, "s2": 0.2, "s3": 0.1},
+        )
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.SELL, "s2")),
+                _batch("s3", _sig("AAPL", Side.SELL, "s3")),
+            ]
+        )
+        # buy weight 0.7, sell weight 0.3 -> BUY wins
+        assert len(out) == 1
+        assert out[0].side == Side.BUY
+
+    def test_unknown_strategy_defaults_to_unit_weight(self):
+        agg = SignalAggregator(
+            AggregationMethod.WEIGHTED, strategy_weights={"s1": 0.5}
+        )
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.SELL, "s2")),
+            ]
+        )
+        # buy=0.5, sell=1.0 -> SELL
+        assert out[0].side == Side.SELL
+
+
+class TestPriority:
+    def test_highest_priority_wins(self):
+        agg = SignalAggregator(
+            AggregationMethod.PRIORITY,
+            strategy_weights={"s1": 1.0, "s2": 5.0, "s3": 3.0},
+        )
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.SELL, "s2")),
+                _batch("s3", _sig("AAPL", Side.BUY, "s3")),
+            ]
+        )
+        # s2 has the highest priority -> SELL wins
+        assert len(out) == 1
+        assert out[0].side == Side.SELL
+
+    def test_priority_falls_back_when_top_silent(self):
+        agg = SignalAggregator(
+            AggregationMethod.PRIORITY,
+            strategy_weights={"s1": 1.0, "s2": 5.0, "s3": 3.0},
+        )
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2"),  # silent on AAPL
+                _batch("s3", _sig("AAPL", Side.SELL, "s3")),
+            ]
+        )
+        assert out[0].side == Side.SELL
+
+
+class TestIndependent:
+    def test_passthrough_concatenates(self):
+        agg = SignalAggregator(AggregationMethod.INDEPENDENT)
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("MSFT", Side.SELL, "s2")),
+                _batch("s3", _sig("AAPL", Side.SELL, "s3")),
+            ]
+        )
+        assert len(out) == 3
+        sides = sorted(
+            (s.symbol, s.side.value, s.strategy_id) for s in out
+        )
+        assert sides == [
+            ("AAPL", "buy", "s1"),
+            ("AAPL", "sell", "s3"),
+            ("MSFT", "sell", "s2"),
+        ]
+
+
+class TestMultiSymbol:
+    def test_per_symbol_aggregation_is_independent(self):
+        agg = SignalAggregator(AggregationMethod.MAJORITY)
+        out = agg.aggregate(
+            [
+                _batch(
+                    "s1",
+                    _sig("AAPL", Side.BUY, "s1"),
+                    _sig("MSFT", Side.SELL, "s1"),
+                ),
+                _batch(
+                    "s2",
+                    _sig("AAPL", Side.BUY, "s2"),
+                    _sig("MSFT", Side.SELL, "s2"),
+                ),
+            ]
+        )
+        by_symbol = {s.symbol: s.side for s in out}
+        assert by_symbol == {"AAPL": Side.BUY, "MSFT": Side.SELL}
+
+
+class TestHoldHandling:
+    def test_holds_dont_count_against_unanimous(self):
+        # HOLD = "no opinion"; unanimous among the strategies that did
+        # take a position should still emit the agreed-upon side.
+        agg = SignalAggregator(AggregationMethod.UNANIMOUS)
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.HOLD, "s2")),
+                _batch("s3", _sig("AAPL", Side.BUY, "s3")),
+            ]
+        )
+        assert out[0].side == Side.BUY
+
+    def test_only_holds_emits_hold(self):
+        agg = SignalAggregator(AggregationMethod.MAJORITY)
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.HOLD, "s1")),
+                _batch("s2", _sig("AAPL", Side.HOLD, "s2")),
+            ]
+        )
+        assert out[0].side == Side.HOLD
+
+
+class TestEmptyInput:
+    def test_no_batches_returns_empty(self):
+        agg = SignalAggregator(AggregationMethod.MAJORITY)
+        assert agg.aggregate([]) == []
+
+    def test_only_empty_batches_returns_empty(self):
+        agg = SignalAggregator(AggregationMethod.MAJORITY)
+        assert agg.aggregate([_batch("s1"), _batch("s2")]) == []
+
+
+class TestValidation:
+    def test_unknown_method_rejected(self):
+        with pytest.raises(SignalAggregatorError):
+            SignalAggregator("not-a-real-method")  # type: ignore[arg-type]
+
+    def test_negative_weight_rejected(self):
+        with pytest.raises(SignalAggregatorError):
+            SignalAggregator(
+                AggregationMethod.WEIGHTED,
+                strategy_weights={"s1": -1.0},
+            )
+
+    def test_nan_weight_rejected(self):
+        with pytest.raises(SignalAggregatorError):
+            SignalAggregator(
+                AggregationMethod.WEIGHTED,
+                strategy_weights={"s1": float("nan")},
+            )

--- a/tests/test_signal_aggregator.py
+++ b/tests/test_signal_aggregator.py
@@ -226,6 +226,67 @@ class TestEmptyInput:
         assert agg.aggregate([_batch("s1"), _batch("s2")]) == []
 
 
+class TestPriorityTie:
+    def test_equal_priority_conflicting_sides_emit_hold(self):
+        # s1 and s2 both have priority 5; they disagree -> HOLD rather
+        # than dict-order-dependent winner.
+        agg = SignalAggregator(
+            AggregationMethod.PRIORITY,
+            strategy_weights={"s1": 5.0, "s2": 5.0, "s3": 1.0},
+        )
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.SELL, "s2")),
+                _batch("s3", _sig("AAPL", Side.BUY, "s3")),
+            ]
+        )
+        assert out[0].side == Side.HOLD
+
+    def test_equal_priority_agreeing_sides_emit_signal(self):
+        agg = SignalAggregator(
+            AggregationMethod.PRIORITY,
+            strategy_weights={"s1": 5.0, "s2": 5.0, "s3": 1.0},
+        )
+        out = agg.aggregate(
+            [
+                _batch("s1", _sig("AAPL", Side.BUY, "s1")),
+                _batch("s2", _sig("AAPL", Side.BUY, "s2")),
+                _batch("s3", _sig("AAPL", Side.SELL, "s3")),
+            ]
+        )
+        assert out[0].side == Side.BUY
+
+
+class TestDuplicateSignalsWithinBatch:
+    def test_last_signal_in_batch_overrides_earlier(self):
+        # If a strategy emits two signals on the same symbol within one
+        # batch, the LAST one is the one the aggregator considers.
+        agg = SignalAggregator(AggregationMethod.UNANIMOUS)
+        out = agg.aggregate(
+            [
+                _batch(
+                    "s1",
+                    _sig("AAPL", Side.BUY, "s1"),
+                    _sig("AAPL", Side.SELL, "s1"),
+                ),
+            ]
+        )
+        assert len(out) == 1
+        assert out[0].side == Side.SELL
+
+
+class TestMetadataIsolation:
+    def test_output_metadata_is_independent_of_source(self):
+        # Mutating the aggregated signal's metadata must not leak back
+        # into the source strategy's signal.
+        src = _sig("AAPL", Side.BUY, "s1", metadata={"k": 1})
+        agg = SignalAggregator(AggregationMethod.UNANIMOUS)
+        out = agg.aggregate([_batch("s1", src)])
+        out[0].metadata["k"] = 999
+        assert src.metadata == {"k": 1}
+
+
 class TestValidation:
     def test_unknown_method_rejected(self):
         with pytest.raises(SignalAggregatorError):
@@ -243,4 +304,11 @@ class TestValidation:
             SignalAggregator(
                 AggregationMethod.WEIGHTED,
                 strategy_weights={"s1": float("nan")},
+            )
+
+    def test_weighted_all_zero_weights_rejected(self):
+        with pytest.raises(SignalAggregatorError):
+            SignalAggregator(
+                AggregationMethod.WEIGHTED,
+                strategy_weights={"s1": 0.0, "s2": 0.0},
             )


### PR DESCRIPTION
Closes gh#21.

## Summary
Multi-strategy aggregator collapsing per-strategy \`SignalBatch\`es into a final per-symbol \`Signal\` according to a configurable method.

## Methods
| Method | Behaviour | Tie / no opinion |
|---|---|---|
| UNANIMOUS | All active voters must agree | Any disagreement → HOLD |
| MAJORITY | Strict majority of votes wins | Tie → HOLD |
| WEIGHTED | Votes multiplied by \`strategy_weights\` | Tie → HOLD |
| PRIORITY | Highest-weight strategy wins outright | Top strategy silent → fall through to next |
| INDEPENDENT | Pass-through, no aggregation | n/a |

## HOLD semantics
HOLD = "no opinion." It does not block unanimity among active voters and does not count toward majority denominators. If every strategy emits HOLD on a symbol, the aggregator emits a single HOLD record so the audit trail captures the consideration.

## Output provenance
Aggregated signals carry \`strategy_id="aggregated"\` so downstream code can distinguish aggregator output from raw per-strategy signals in the audit log.

## Validation
Rejects unknown method strings, negative weights, NaN/inf weights at construction.

## Test plan
- [x] 18 unit tests across 9 classes — every method, multi-symbol independence, HOLD handling, empty input, validation
- [x] All pass locally
- [ ] CI green
- [ ] Adversarial review