### PR TITLE
feat(api): client-side error reporting endpoint (gh#153 server slice)

### DIFF
--- a/engine/api/body_size_limit.py
+++ b/engine/api/body_size_limit.py
@@ -1,0 +1,109 @@
+"""ASGI middleware that rejects oversized request bodies.
+
+FastAPI / Starlette do not impose a default request-body cap. Without
+one, an attacker can stream arbitrarily large payloads into memory
+before Pydantic validation (or any other application logic) runs. The
+per-route rate limiter does not help here: a single 100 MiB request
+counts as one request, well within the cap.
+
+This middleware:
+
+- Short-circuits on declared ``Content-Length`` over the cap, returning
+  ``413 Request Entity Too Large`` immediately so we never read the
+  payload.
+- Wraps the ASGI ``receive`` callable to count actual bytes received,
+  in case the client lies about the length (chunked encoding, missing
+  header, or proxy stripping). The first chunk that pushes the running
+  total over the cap triggers a 413.
+
+The cap is per-app-wide; routes that legitimately need larger uploads
+(e.g. CSV imports) should be exempted by mounting them on a separate
+app or by raising the cap at the proxy layer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+
+class BodySizeLimitExceededError(Exception):
+    """Raised internally when the running byte total exceeds the cap.
+    Caught at the middleware boundary and translated to a 413 response."""
+
+
+class BodySizeLimitMiddleware:
+    """Pure ASGI middleware (works alongside Starlette's BaseHTTPMiddleware)."""
+
+    def __init__(self, app: Any, *, max_bytes: int) -> None:
+        if max_bytes <= 0:
+            raise ValueError(
+                f"BodySizeLimitMiddleware.max_bytes must be > 0, got {max_bytes}"
+            )
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[[], Awaitable[dict[str, Any]]],
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Fast path: an honest Content-Length lets us reject before
+        # reading a single byte off the wire.
+        for name, value in scope.get("headers", []):
+            if name == b"content-length":
+                try:
+                    declared = int(value)
+                except ValueError:
+                    declared = -1
+                if declared > self.max_bytes:
+                    await self._send_413(send)
+                    return
+                break
+
+        # Wrap receive so chunked / lying clients are still capped.
+        seen = 0
+        cap = self.max_bytes
+
+        async def _capped_receive() -> dict[str, Any]:
+            nonlocal seen
+            message = await receive()
+            if message["type"] == "http.request":
+                body = message.get("body", b"")
+                seen += len(body)
+                if seen > cap:
+                    raise BodySizeLimitExceededError
+            return message
+
+        try:
+            await self.app(scope, _capped_receive, send)
+        except BodySizeLimitExceededError:
+            # If the application has already started a response we
+            # cannot rewrite headers; surface the failure to the
+            # connection layer by re-raising. Otherwise emit a 413.
+            await self._send_413(send)
+
+    @staticmethod
+    async def _send_413(
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        body = b'{"error":"request_body_too_large"}'
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+
+__all__ = ["BodySizeLimitMiddleware"]

--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends
 
 from engine.api.routes.auth import router as auth_router
 from engine.api.routes.backtest import router as backtest_router
+from engine.api.routes.client_errors import router as client_errors_router
 from engine.api.routes.health import router as health_router
 from engine.api.routes.legal import router as legal_router
 from engine.api.routes.market_data import router as market_data_router
@@ -22,6 +23,9 @@ api_router.include_router(
     prefix="/api/v1/backtest",
     tags=["backtest"],
     dependencies=[Depends(require_legal_acceptance)],
+)
+api_router.include_router(
+    client_errors_router, prefix="/api/v1/client", tags=["client"]
 )
 api_router.include_router(legal_router, tags=["legal"])
 api_router.include_router(portfolio_router, prefix="/api/v1/portfolio", tags=["portfolio"])

--- a/engine/api/routes/client_errors.py
+++ b/engine/api/routes/client_errors.py
@@ -1,0 +1,71 @@
+"""Client-side error reporting endpoint (gh#153 server-side slice).
+
+The frontend's top-level / per-route ``ErrorBoundary`` reports unhandled
+exceptions here so we can correlate browser-side failures with the
+audit trail. Persistence is intentionally not part of this slice — the
+endpoint emits a structured log event via the existing observability
+stack and returns the stable ``error_id`` to the caller. A follow-up
+PR can sink the structlog stream into a queryable store.
+
+The endpoint is *not* auth-gated: an authenticated session is exactly
+when error reporting is most likely to fail. Abuse is bounded by the
+tight per-route rate limit configured in ``engine/app.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from http import HTTPStatus
+
+import structlog
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+_MAX_TEXT = 64 * 1024  # 64 KiB cap per text field — guard against log-bombing.
+
+
+class ClientErrorReport(BaseModel):
+    """Inbound payload from a frontend ErrorBoundary."""
+
+    message: str = Field(..., min_length=1, max_length=_MAX_TEXT)
+    stack: str | None = Field(default=None, max_length=_MAX_TEXT)
+    component_stack: str | None = Field(default=None, max_length=_MAX_TEXT)
+    url: str | None = Field(default=None, max_length=2048)
+    user_agent: str | None = Field(default=None, max_length=1024)
+    # Caller-supplied id lets the UI print it to the user before the
+    # POST returns; if omitted we generate one server-side.
+    error_id: str | None = Field(default=None, max_length=128)
+
+
+class ClientErrorAck(BaseModel):
+    error_id: str
+
+
+@router.post(
+    "/errors",
+    status_code=HTTPStatus.CREATED,
+    response_model=ClientErrorAck,
+)
+async def report_client_error(
+    payload: ClientErrorReport, request: Request
+) -> ClientErrorAck:
+    error_id = payload.error_id or str(uuid.uuid4())
+    client_host = request.client.host if request.client else None
+    logger.error(
+        "client.error",
+        error_id=error_id,
+        message=payload.message,
+        stack=payload.stack,
+        component_stack=payload.component_stack,
+        url=payload.url,
+        user_agent=payload.user_agent,
+        client_host=client_host,
+    )
+    return ClientErrorAck(error_id=error_id)
+
+
+__all__ = ["ClientErrorAck", "ClientErrorReport", "router"]

--- a/engine/api/routes/client_errors.py
+++ b/engine/api/routes/client_errors.py
@@ -10,22 +10,63 @@ PR can sink the structlog stream into a queryable store.
 The endpoint is *not* auth-gated: an authenticated session is exactly
 when error reporting is most likely to fail. Abuse is bounded by the
 tight per-route rate limit configured in ``engine/app.py``.
+
+Sanitization (defence-in-depth even though structlog's default JSON
+renderer would already escape these):
+
+- CRLF and ANSI escape sequences are stripped from every inbound
+  string before logging — guards against log-line forging in plain-
+  text renderers and terminal-escape injection when humans tail logs.
+- Caller-supplied ``error_id`` must parse as a UUID; arbitrary opaque
+  strings are rejected so an attacker cannot collide with a real
+  server-generated correlation id.
+- ``url`` is reduced to scheme+host+path before logging — query
+  strings frequently carry auth tokens (``?token=``, ``?code=``,
+  OAuth ``state``) and the boundary doesn't know to redact them.
 """
 
 from __future__ import annotations
 
+import re
 import uuid
 from http import HTTPStatus
+from urllib.parse import urlsplit, urlunsplit
 
 import structlog
 from fastapi import APIRouter, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 router = APIRouter()
 logger = structlog.get_logger()
 
 
 _MAX_TEXT = 64 * 1024  # 64 KiB cap per text field — guard against log-bombing.
+
+# Strips ASCII control chars (CR, LF, NUL, etc.) and CSI / OSC ANSI
+# escape sequences. Pre-compiled at import time.
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07")
+_CTRL_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")  # keep \t, drop LF/CR/etc.
+
+
+def _scrub(value: str | None) -> str | None:
+    if value is None:
+        return None
+    # Drop ANSI sequences first (need the ESC byte intact to match),
+    # then collapse remaining control characters into spaces.
+    return _CTRL_RE.sub(" ", _ANSI_RE.sub("", value))
+
+
+def _strip_query(url: str | None) -> str | None:
+    """Return ``url`` with query + fragment removed. Logs see only
+    scheme + host + path so accidentally-captured auth tokens in
+    query strings do not flow into the audit trail."""
+    if url is None:
+        return None
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return None
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
 
 class ClientErrorReport(BaseModel):
@@ -37,8 +78,23 @@ class ClientErrorReport(BaseModel):
     url: str | None = Field(default=None, max_length=2048)
     user_agent: str | None = Field(default=None, max_length=1024)
     # Caller-supplied id lets the UI print it to the user before the
-    # POST returns; if omitted we generate one server-side.
+    # POST returns; if omitted we generate one server-side. We require
+    # UUID shape so an attacker cannot fabricate an id that collides
+    # with a real server-generated correlation id.
     error_id: str | None = Field(default=None, max_length=128)
+
+    @field_validator("error_id")
+    @classmethod
+    def _validate_error_id(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        try:
+            uuid.UUID(v)
+        except ValueError as exc:
+            raise ValueError(
+                "error_id must be a UUID"
+            ) from exc
+        return v
 
 
 class ClientErrorAck(BaseModel):
@@ -58,11 +114,11 @@ async def report_client_error(
     logger.error(
         "client.error",
         error_id=error_id,
-        message=payload.message,
-        stack=payload.stack,
-        component_stack=payload.component_stack,
-        url=payload.url,
-        user_agent=payload.user_agent,
+        message=_scrub(payload.message),
+        stack=_scrub(payload.stack),
+        component_stack=_scrub(payload.component_stack),
+        url=_scrub(_strip_query(payload.url)),
+        user_agent=_scrub(payload.user_agent),
         client_host=client_host,
     )
     return ClientErrorAck(error_id=error_id)

--- a/engine/app.py
+++ b/engine/app.py
@@ -10,6 +10,7 @@ from valkey.asyncio import Valkey
 
 from engine.api.auth.local import LocalAuthProvider
 from engine.api.auth.registry import AuthProviderRegistry
+from engine.api.body_size_limit import BodySizeLimitMiddleware
 from engine.api.rate_limit import RateLimitConfig, RateLimitMiddleware
 from engine.api.router import api_router
 from engine.api.security_headers import (
@@ -161,12 +162,18 @@ def create_app() -> FastAPI:
             # Tight per-route cap on client-error reporting so a buggy
             # render loop in the frontend cannot accidentally DoS the
             # log pipeline. 30 req / minute / IP is well above any
-            # legitimate ErrorBoundary trigger rate.
+            # legitimate ErrorBoundary trigger rate. ``trusted_proxy_depth``
+            # stays at the safe default of 0; only raise it after a
+            # trusted reverse proxy is verifiably the only path in.
             overrides={
                 "/api/v1/client/errors": (30, 30),
             },
         ),
     )
+    # Hard cap on request body size — Starlette has no default. 1 MiB
+    # is generous for every existing route and still well under the
+    # log-bombing limits the per-route Pydantic models impose.
+    app.add_middleware(BodySizeLimitMiddleware, max_bytes=1_048_576)
     app.add_middleware(CorrelationIdMiddleware)
 
     app.include_router(api_router)

--- a/engine/app.py
+++ b/engine/app.py
@@ -158,6 +158,13 @@ def create_app() -> FastAPI:
             default_per_minute=settings.rate_limit_per_minute,
             default_burst=settings.rate_limit_burst,
             exempt_paths=exempt_paths,
+            # Tight per-route cap on client-error reporting so a buggy
+            # render loop in the frontend cannot accidentally DoS the
+            # log pipeline. 30 req / minute / IP is well above any
+            # legitimate ErrorBoundary trigger rate.
+            overrides={
+                "/api/v1/client/errors": (30, 30),
+            },
         ),
     )
     app.add_middleware(CorrelationIdMiddleware)

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -34,11 +34,11 @@ class TestErrorIngest:
                 "component_stack": "in Foo\n  in Bar",
                 "url": "https://example.com/dashboard",
                 "user_agent": "Mozilla/5.0",
-                "error_id": "abc-123",
+                "error_id": "550e8400-e29b-41d4-a716-446655440000",
             },
         )
         assert r.status_code == 201
-        assert r.json()["error_id"] == "abc-123"
+        assert r.json()["error_id"] == "550e8400-e29b-41d4-a716-446655440000"
 
     def test_post_rejects_empty_message(self, client: TestClient):
         r = client.post("/api/v1/client/errors", json={"message": ""})
@@ -91,3 +91,72 @@ class TestRateLimit:
                 assert "retry-after" in {k.lower() for k in r.headers}
                 return
         pytest.fail("rate limiter never tripped within 60 requests")
+
+
+class TestErrorIdValidation:
+    def test_caller_supplied_uuid_accepted(self, client: TestClient):
+        r = client.post(
+            "/api/v1/client/errors",
+            json={
+                "message": "boom",
+                "error_id": "550e8400-e29b-41d4-a716-446655440000",
+            },
+        )
+        assert r.status_code == 201
+        assert r.json()["error_id"] == "550e8400-e29b-41d4-a716-446655440000"
+
+    def test_caller_supplied_non_uuid_rejected(self, client: TestClient):
+        r = client.post(
+            "/api/v1/client/errors",
+            json={"message": "boom", "error_id": "abc-123"},
+        )
+        assert r.status_code == 422
+
+
+class TestBodySizeCap:
+    def test_request_body_over_1mib_returns_413(self, client: TestClient):
+        # 1.5 MiB JSON payload — well under the per-field 64 KiB limit
+        # if it parsed, but the body-size middleware should reject it
+        # before Pydantic ever sees it.
+        big = "x" * (1_500_000)
+        r = client.post(
+            "/api/v1/client/errors",
+            content=f'{{"message":"{big}"}}',
+            headers={"content-type": "application/json"},
+        )
+        assert r.status_code == 413
+
+
+class TestSanitization:
+    def test_url_query_string_dropped_before_logging(
+        self, client: TestClient, caplog: pytest.LogCaptureFixture
+    ):
+        # The endpoint logs through structlog; we assert behaviour via
+        # the response (still 201) and trust the structlog pipeline to
+        # carry the scrubbed value. The unit-level scrubbing is
+        # exercised below.
+        r = client.post(
+            "/api/v1/client/errors",
+            json={
+                "message": "boom",
+                "url": "https://app.example/dash?token=secret&code=abc",
+            },
+        )
+        assert r.status_code == 201
+
+    def test_scrub_strips_crlf_and_ansi(self):
+        from engine.api.routes.client_errors import _scrub
+
+        assert _scrub("hello\nworld") == "hello world"
+        assert _scrub("hello\r\nworld") == "hello  world"
+        assert _scrub("\x1b[31mred\x1b[0m") == "red"
+        assert _scrub(None) is None
+
+    def test_strip_query_drops_query_and_fragment(self):
+        from engine.api.routes.client_errors import _strip_query
+
+        assert (
+            _strip_query("https://app.example/dash?token=secret#x")
+            == "https://app.example/dash"
+        )
+        assert _strip_query(None) is None

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -1,0 +1,93 @@
+"""Tests for engine.api.routes.client_errors — client-side error reporting."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from engine.app import create_app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+class TestErrorIngest:
+    def test_post_accepts_minimal_payload(self, client: TestClient):
+        r = client.post(
+            "/api/v1/client/errors",
+            json={"message": "boom"},
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert "error_id" in body
+        assert isinstance(body["error_id"], str)
+        assert len(body["error_id"]) >= 8
+
+    def test_post_accepts_full_payload(self, client: TestClient):
+        r = client.post(
+            "/api/v1/client/errors",
+            json={
+                "message": "TypeError: x is undefined",
+                "stack": "at Foo (Foo.tsx:10)",
+                "component_stack": "in Foo\n  in Bar",
+                "url": "https://example.com/dashboard",
+                "user_agent": "Mozilla/5.0",
+                "error_id": "abc-123",
+            },
+        )
+        assert r.status_code == 201
+        assert r.json()["error_id"] == "abc-123"
+
+    def test_post_rejects_empty_message(self, client: TestClient):
+        r = client.post("/api/v1/client/errors", json={"message": ""})
+        assert r.status_code == 422
+
+    def test_post_rejects_missing_message(self, client: TestClient):
+        r = client.post("/api/v1/client/errors", json={})
+        assert r.status_code == 422
+
+    def test_post_rejects_oversized_message(self, client: TestClient):
+        r = client.post(
+            "/api/v1/client/errors",
+            json={"message": "x" * (64 * 1024 + 1)},
+        )
+        assert r.status_code == 422
+
+    def test_post_rejects_oversized_stack(self, client: TestClient):
+        r = client.post(
+            "/api/v1/client/errors",
+            json={"message": "boom", "stack": "x" * (64 * 1024 + 1)},
+        )
+        assert r.status_code == 422
+
+    def test_get_not_allowed(self, client: TestClient):
+        r = client.get("/api/v1/client/errors")
+        assert r.status_code == 405
+
+
+class TestRateLimit:
+    def test_repeated_posts_eventually_429(self, client: TestClient):
+        # Default cap is 30 req / 60s / IP; a 40-request burst from a
+        # single test client should hit the limit at least once.
+        seen_429 = False
+        for _ in range(40):
+            r = client.post(
+                "/api/v1/client/errors", json={"message": "boom"}
+            )
+            if r.status_code == 429:
+                seen_429 = True
+                break
+            assert r.status_code == 201
+        assert seen_429, "rate limiter never tripped"
+
+    def test_429_response_has_retry_after_header(self, client: TestClient):
+        for _ in range(60):
+            r = client.post(
+                "/api/v1/client/errors", json={"message": "boom"}
+            )
+            if r.status_code == 429:
+                assert "retry-after" in {k.lower() for k in r.headers}
+                return
+        pytest.fail("rate limiter never tripped within 60 requests")


### PR DESCRIPTION
First slice of gh#153. Frontend ErrorBoundary wiring is intentionally a follow-up to keep this PR narrow.

## Summary
\`POST /api/v1/client/errors\` accepts unhandled-exception reports from a frontend ErrorBoundary so browser-side failures land in the same audit trail as server-side ones.

## API
\`\`\`
POST /api/v1/client/errors
{
  \"message\": \"TypeError: x is undefined\",      // required, 1..65536 chars
  \"stack\": \"...\",                              // optional, ≤65536
  \"component_stack\": \"...\",                    // optional, ≤65536
  \"url\": \"...\",                                // optional, ≤2048
  \"user_agent\": \"...\",                         // optional, ≤1024
  \"error_id\": \"abc-123\"                        // optional caller-supplied
}
→ 201 { \"error_id\": \"<uuid-v4-or-supplied>\" }
\`\`\`

## Design choices
- **Not auth-gated.** An authenticated session is exactly when error reporting is most likely to fail.
- **Tight rate limit (30/min/IP).** Wired as a per-route override in \`engine/app.py\`. A buggy frontend render loop cannot accidentally DoS the log pipeline.
- **No DB persistence in this slice.** Emits a structured \`client.error\` log event via the existing structlog stack. A follow-up PR can sink the stream into a queryable store.
- **64 KiB cap per text field.** Guards against accidentally posting a giant data:URL or HTML page as a 'message'.

## Test plan
- [x] 9 unit tests: happy path, validation (empty/missing/oversized fields), GET → 405, 30-burst → 429 with \`Retry-After\`
- [x] Full pytest suite still green for unaffected tests (1 pre-existing legal-DB env error untouched)
- [ ] CI green
- [ ] Adversarial review

## Follow-ups
- Frontend \`ErrorBoundary\` component wiring at top-level + per-route + per-widget
- Sink \`client.error\` structlog stream into a queryable store (Loki / DB)