### PR TITLE
feat(frontend): ErrorBoundary + client-error reporting (gh#153 frontend slice)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "./auth/AuthContext";
 import { ProtectedRoute } from "./auth/ProtectedRoute";
 import { Shell } from "./components/layout/Shell";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { LegalProvider } from "./context/LegalContext";
 import { ConsentModal } from "./components/legal/ConsentModal";
 import Login from "./pages/Login";
@@ -36,7 +37,11 @@ function ShellLayout() {
     <LegalProvider>
       <ConsentModal />
       <Shell>
-        <Outlet />
+        {/* Per-route boundary so a failure on one screen doesn't nuke
+            the shell, sidebar, or legal context. */}
+        <ErrorBoundary scope="page">
+          <Outlet />
+        </ErrorBoundary>
       </Shell>
     </LegalProvider>
   );
@@ -47,6 +52,10 @@ export default function App() {
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AuthProvider>
+          {/* Top-level boundary catches anything the per-route boundary
+              missed (errors thrown above the route shell — auth init,
+              query-client setup, etc.). */}
+          <ErrorBoundary scope="app">
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
@@ -73,6 +82,7 @@ export default function App() {
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
           </Routes>
+          </ErrorBoundary>
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/frontend/src/api/clientErrors.js
+++ b/frontend/src/api/clientErrors.js
@@ -1,0 +1,42 @@
+/**
+ * Report an unhandled frontend exception to the backend audit trail.
+ *
+ * Backend: POST /api/v1/client/errors
+ * Returns { error_id }. We send a caller-supplied UUID so the boundary
+ * can show the user the id immediately, even if the network call is
+ * still in flight.
+ *
+ * Failures here are deliberately swallowed — the boundary is already
+ * showing a recovery UI, and a network error in error reporting must
+ * not turn into another exception.
+ *
+ * @param {{message: string, stack?: string, componentStack?: string,
+ *          url?: string, userAgent?: string, errorId: string}} report
+ * @returns {Promise<{error_id: string}>}
+ */
+export async function reportClientError(report) {
+  const apiBase = import.meta.env.VITE_API_URL || "http://localhost:8000";
+  const body = JSON.stringify({
+    message: report.message,
+    stack: report.stack,
+    component_stack: report.componentStack,
+    url: report.url,
+    user_agent: report.userAgent,
+    error_id: report.errorId,
+  });
+  try {
+    const res = await fetch(`${apiBase}/api/v1/client/errors`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      // Auth not required; the endpoint is intentionally unauthenticated
+      // because reporting is most likely to fire when auth is broken.
+      credentials: "omit",
+      keepalive: true,
+    });
+    if (!res.ok) return { error_id: report.errorId };
+    return await res.json();
+  } catch {
+    return { error_id: report.errorId };
+  }
+}

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { reportClientError } from "../api/clientErrors";
+
+/**
+ * React error boundary. Catches render-time exceptions in its subtree,
+ * reports them to the backend audit trail, and renders a recovery UI
+ * with a copyable error id.
+ *
+ * Hooks cannot catch render exceptions; this stays a class component.
+ *
+ * Props:
+ *   - children: subtree to guard
+ *   - scope: short label included in the recovery message
+ *           (e.g. "page", "widget"). Lets per-route boundaries say
+ *           "this page failed" while the top-level says "the app
+ *           failed."
+ *   - fallback: optional render prop
+ *           ({ error, errorId, reset }) => ReactNode
+ *           overriding the default recovery UI
+ */
+export class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null, errorId: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Generate a stable id at render time — synchronous so the UI can
+    // print it before the network call completes. Modern browsers
+    // ship crypto.randomUUID; fall back to a manual UUID-v4-shaped
+    // hex if the polyfill is missing.
+    const errorId =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : _uuidV4Shape();
+    return { error, errorId };
+  }
+
+  componentDidCatch(error, info) {
+    const { errorId } = this.state;
+    if (!errorId) return;
+    reportClientError({
+      message: error?.message || String(error),
+      stack: error?.stack,
+      componentStack: info?.componentStack,
+      url: typeof window !== "undefined" ? window.location.href : undefined,
+      userAgent:
+        typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      errorId,
+    });
+  }
+
+  reset = () => {
+    this.setState({ error: null, errorId: null });
+  };
+
+  render() {
+    const { error, errorId } = this.state;
+    if (!error) return this.props.children;
+
+    if (typeof this.props.fallback === "function") {
+      return this.props.fallback({ error, errorId, reset: this.reset });
+    }
+
+    const scope = this.props.scope || "view";
+    return (
+      <div
+        role="alert"
+        className="flex flex-col items-center justify-center gap-md p-xl text-nx-text-primary"
+        style={{ minHeight: 240 }}
+      >
+        <span className="text-label font-mono uppercase text-nx-accent">
+          ERROR — {scope}
+        </span>
+        <h1 className="text-heading font-display text-nx-text-display">
+          Something broke.
+        </h1>
+        <p className="text-body text-nx-text-secondary text-center max-w-md">
+          The {scope} hit an unexpected exception. The error has been
+          reported. Try again, or copy the id below into a support ticket
+          so we can correlate it with the audit log.
+        </p>
+        <code className="font-mono text-label bg-nx-surface border border-nx-border rounded-md px-md py-sm select-all">
+          {errorId}
+        </code>
+        <div className="flex gap-sm">
+          <button
+            type="button"
+            onClick={this.reset}
+            className="bg-nx-accent-subtle text-nx-text-display border border-nx-border rounded-md px-md py-sm font-mono uppercase text-label hover:bg-nx-accent hover:text-white transition-colors"
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (typeof window !== "undefined") window.location.href = "/";
+            }}
+            className="bg-nx-surface text-nx-text-primary border border-nx-border rounded-md px-md py-sm font-mono uppercase text-label hover:bg-nx-accent-subtle transition-colors"
+          >
+            Go home
+          </button>
+        </div>
+        {import.meta.env?.DEV && error?.stack ? (
+          <details className="mt-md w-full max-w-3xl">
+            <summary className="cursor-pointer text-label font-mono uppercase text-nx-text-secondary">
+              Stack (dev mode)
+            </summary>
+            <pre className="text-label font-mono whitespace-pre-wrap bg-nx-surface border border-nx-border rounded-md p-md mt-sm overflow-auto">
+              {error.stack}
+            </pre>
+          </details>
+        ) : null}
+      </div>
+    );
+  }
+}
+
+function _uuidV4Shape() {
+  // Crypto-randomness fallback. Not used in production browsers
+  // (crypto.randomUUID exists everywhere modern); included so the
+  // boundary still works in test/jsdom environments without crypto.
+  const r = () => Math.floor(Math.random() * 16).toString(16);
+  let out = "";
+  for (let i = 0; i < 32; i += 1) {
+    if (i === 8 || i === 12 || i === 16 || i === 20) out += "-";
+    if (i === 12) out += "4";
+    else if (i === 16) out += ((Math.random() * 4) | 8).toString(16);
+    else out += r();
+  }
+  return out;
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
Companion to PR #260's server endpoint. The frontend now catches render-time exceptions and reports them to the backend audit trail.

## Components
- \`frontend/src/components/ErrorBoundary.jsx\` — class component (hooks cannot catch render exceptions). Generates a UUID at error time so the user sees a copyable id immediately.
- \`frontend/src/api/clientErrors.js\` — thin \`POST /api/v1/client/errors\` wrapper. Swallows network failures so a failure inside the boundary cannot become another exception.

## Mount points (\`App.jsx\`)
| Scope | Wraps | Purpose |
|---|---|---|
| \`app\` | \`<Routes>\` | Catches failures above the shell — auth init, query client, providers. |
| \`page\` | \`<Outlet/>\` inside \`ShellLayout\` | One screen's render exception doesn't blow away the shell, sidebar, or legal context. |

## Recovery UI
- Error id rendered in a copyable \`<code>\` block.
- **Try again** resets the boundary subtree without a full reload.
- **Go home** does a full \`window.location.href = \"/\"\` for the top-level case.
- Dev mode reveals the full stack inside a collapsed \`<details>\`; prod hides internals.

## Test plan
- [x] \`npm run build\` green
- [ ] Manually verify: throwing inside a screen shows the per-page recovery UI without breaking the sidebar
- [ ] Manually verify: the POST to \`/api/v1/client/errors\` carries a valid UUID
- [ ] Manually verify: \"Try again\" remounts the subtree
- [ ] CI green