### PR TITLE
feat(observability): pluggable metrics backend (gh#34)

### DIFF
--- a/engine/observability/metrics.py
+++ b/engine/observability/metrics.py
@@ -1,0 +1,211 @@
+"""Pluggable metrics backend (gh#34).
+
+Engine code emits metrics through a thin :class:`MetricsBackend`
+Protocol so the operator decides at deploy time which exporter (or
+none) to wire up. The default is :class:`NullBackend` — every call is
+a no-op — so importing this module does not pull in any monitoring
+dependency.
+
+Backend choices:
+
+- :class:`NullBackend` — production default until an exporter is
+  configured. Zero-cost.
+- :class:`RecordingBackend` — in-memory test double. Records counters,
+  gauges, and histograms with their tag tuples so unit tests can assert
+  on emitted metrics directly. Never used in production paths.
+
+Future backends (deferred to follow-up PRs once the call sites have
+been instrumented):
+
+- ``OTelBackend`` — delegates to ``opentelemetry.metrics`` Meter.
+- ``StatsDBackend`` — for installations with a StatsD relay.
+- ``PrometheusBackend`` — pull-mode exporter via ``prometheus_client``.
+
+Naming convention: ``namespace.metric_name`` (lowercase, dots between
+levels). Tags are arbitrary string -> string. Tag-order is normalised
+before aggregation so callers don't have to thread a canonical tag
+order through their code.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Iterator, Mapping
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MetricsBackend(Protocol):
+    """Pluggable metrics surface. All methods are fire-and-forget."""
+
+    def counter(
+        self,
+        name: str,
+        value: float = 1.0,
+        tags: Mapping[str, str] | None = None,
+    ) -> None: ...
+
+    def gauge(
+        self,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] | None = None,
+    ) -> None: ...
+
+    def histogram(
+        self,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] | None = None,
+    ) -> None: ...
+
+    def timer(
+        self,
+        name: str,
+        tags: Mapping[str, str] | None = None,
+    ) -> "contextlib.AbstractContextManager[None]": ...
+
+
+def _check_name(name: str) -> None:
+    if not name or not name.strip():
+        raise ValueError("metric name must be non-empty")
+
+
+def _canonical_tags(tags: Mapping[str, str] | None) -> tuple[tuple[str, str], ...]:
+    """Sort tags by key so equivalent tag sets share an aggregation key."""
+    if not tags:
+        return ()
+    return tuple(sorted((str(k), str(v)) for k, v in tags.items()))
+
+
+class NullBackend:
+    """Zero-cost no-op backend. Used when no exporter is configured."""
+
+    def counter(
+        self,
+        name: str,
+        value: float = 1.0,
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        _check_name(name)
+
+    def gauge(
+        self,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        _check_name(name)
+
+    def histogram(
+        self,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        _check_name(name)
+
+    @contextlib.contextmanager
+    def timer(
+        self,
+        name: str,
+        tags: Mapping[str, str] | None = None,
+    ) -> Iterator[None]:
+        _check_name(name)
+        yield
+
+
+class RecordingBackend:
+    """In-memory test double. Aggregates counters, captures every gauge
+    write (last-write-wins), and stores every histogram observation."""
+
+    def __init__(self) -> None:
+        self.counters: dict[tuple[str, tuple[tuple[str, str], ...]], float] = (
+            defaultdict(float)
+        )
+        self.gauges: dict[tuple[str, tuple[tuple[str, str], ...]], float] = {}
+        self.histograms: dict[
+            tuple[str, tuple[tuple[str, str], ...]], list[float]
+        ] = defaultdict(list)
+        self._lock = threading.Lock()
+
+    def counter(
+        self,
+        name: str,
+        value: float = 1.0,
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        _check_name(name)
+        key = (name, _canonical_tags(tags))
+        with self._lock:
+            self.counters[key] += float(value)
+
+    def gauge(
+        self,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        _check_name(name)
+        key = (name, _canonical_tags(tags))
+        with self._lock:
+            self.gauges[key] = float(value)
+
+    def histogram(
+        self,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        _check_name(name)
+        key = (name, _canonical_tags(tags))
+        with self._lock:
+            self.histograms[key].append(float(value))
+
+    @contextlib.contextmanager
+    def timer(
+        self,
+        name: str,
+        tags: Mapping[str, str] | None = None,
+    ) -> Iterator[None]:
+        _check_name(name)
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+            self.histogram(name, elapsed_ms, tags)
+
+
+# ---------------------------------------------------------------------------
+# Process-singleton getter / setter.
+# ---------------------------------------------------------------------------
+
+_BACKEND: MetricsBackend = NullBackend()
+_BACKEND_LOCK = threading.Lock()
+
+
+def get_metrics() -> MetricsBackend:
+    """Return the active metrics backend."""
+    return _BACKEND
+
+
+def set_metrics(backend: MetricsBackend) -> None:
+    """Install ``backend`` as the active singleton. Wired once at app
+    startup based on ``settings.metrics_backend`` (when that's added);
+    tests use this to swap in a :class:`RecordingBackend`."""
+    global _BACKEND  # noqa: PLW0603 - process-wide singleton
+    with _BACKEND_LOCK:
+        _BACKEND = backend
+
+
+__all__ = [
+    "MetricsBackend",
+    "NullBackend",
+    "RecordingBackend",
+    "get_metrics",
+    "set_metrics",
+]

--- a/tests/observability/test_metrics.py
+++ b/tests/observability/test_metrics.py
@@ -1,0 +1,131 @@
+"""Tests for engine.observability.metrics — pluggable metrics backend."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from engine.observability.metrics import (
+    MetricsBackend,
+    NullBackend,
+    RecordingBackend,
+    get_metrics,
+    set_metrics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    # Each test gets a clean slate; metrics is a process-singleton so
+    # state would otherwise leak.
+    yield
+    set_metrics(NullBackend())
+
+
+class TestProtocolShape:
+    def test_null_backend_satisfies_protocol(self):
+        assert isinstance(NullBackend(), MetricsBackend)
+
+    def test_recording_backend_satisfies_protocol(self):
+        assert isinstance(RecordingBackend(), MetricsBackend)
+
+
+class TestNullBackend:
+    def test_counter_does_not_raise(self):
+        b = NullBackend()
+        b.counter("orders.placed", 1)
+        b.counter("orders.placed", 5, tags={"side": "buy"})
+
+    def test_gauge_does_not_raise(self):
+        NullBackend().gauge("queue.depth", 42)
+
+    def test_histogram_does_not_raise(self):
+        NullBackend().histogram("request.latency_ms", 12.3)
+
+    def test_timer_is_no_op_context_manager(self):
+        with NullBackend().timer("request.latency_ms"):
+            time.sleep(0.001)
+
+
+class TestRecordingBackend:
+    # In-memory test double; production code never uses this but it's
+    # the most ergonomic way to write assertions against emitted
+    # metrics in unit tests.
+
+    def test_counter_records_name_value_and_tags(self):
+        b = RecordingBackend()
+        b.counter("orders.placed", 1, tags={"side": "buy"})
+        b.counter("orders.placed", 2, tags={"side": "buy"})
+        assert b.counters == {("orders.placed", (("side", "buy"),)): 3.0}
+
+    def test_counter_default_value_is_one(self):
+        b = RecordingBackend()
+        b.counter("orders.placed")
+        b.counter("orders.placed")
+        assert b.counters == {("orders.placed", ()): 2.0}
+
+    def test_gauge_records_last_value(self):
+        b = RecordingBackend()
+        b.gauge("queue.depth", 10)
+        b.gauge("queue.depth", 5)
+        assert b.gauges == {("queue.depth", ()): 5.0}
+
+    def test_histogram_records_observation_list(self):
+        b = RecordingBackend()
+        b.histogram("latency_ms", 1.0)
+        b.histogram("latency_ms", 2.0)
+        b.histogram("latency_ms", 3.0)
+        assert b.histograms == {("latency_ms", ()): [1.0, 2.0, 3.0]}
+
+    def test_timer_emits_histogram_observation(self):
+        b = RecordingBackend()
+        with b.timer("request.latency_ms"):
+            pass
+        key = ("request.latency_ms", ())
+        assert key in b.histograms
+        observations = b.histograms[key]
+        assert len(observations) == 1
+        assert observations[0] >= 0.0  # duration in ms
+
+    def test_timer_records_even_on_exception(self):
+        b = RecordingBackend()
+        with pytest.raises(RuntimeError):
+            with b.timer("request.latency_ms"):
+                raise RuntimeError("boom")
+        # Failure latency must still be captured.
+        assert ("request.latency_ms", ()) in b.histograms
+
+    def test_tag_order_does_not_change_aggregation_key(self):
+        b = RecordingBackend()
+        b.counter("x", 1, tags={"a": "1", "b": "2"})
+        b.counter("x", 1, tags={"b": "2", "a": "1"})
+        assert sum(b.counters.values()) == 2.0
+        assert len(b.counters) == 1
+
+
+class TestSingleton:
+    def test_default_singleton_is_null_backend(self):
+        assert isinstance(get_metrics(), NullBackend)
+
+    def test_set_metrics_replaces_singleton(self):
+        rec = RecordingBackend()
+        set_metrics(rec)
+        assert get_metrics() is rec
+
+    def test_singleton_persists_across_calls(self):
+        rec = RecordingBackend()
+        set_metrics(rec)
+        get_metrics().counter("x", 1)
+        get_metrics().counter("x", 2)
+        assert rec.counters == {("x", ()): 3.0}
+
+
+class TestNameValidation:
+    def test_empty_name_rejected(self):
+        with pytest.raises(ValueError):
+            RecordingBackend().counter("")
+
+    def test_whitespace_only_name_rejected(self):
+        with pytest.raises(ValueError):
+            RecordingBackend().counter("   ")


### PR DESCRIPTION
First slice of gh#34. Wires the abstract metric primitives — call-site instrumentation + concrete OTel/StatsD/Prometheus backends are intentionally deferred to follow-up PRs to keep this one reviewable.

## Surface
\`MetricsBackend\` Protocol with four methods:
| Method | Purpose |
|---|---|
| \`counter(name, value, tags)\` | Monotonically increasing — orders placed, errors caught, etc. |
| \`gauge(name, value, tags)\` | Last-write-wins — queue depth, open positions, cash balance. |
| \`histogram(name, value, tags)\` | Distribution — request latency, fill slippage, P&L. |
| \`timer(name, tags)\` | Context manager that records duration as a histogram (ms). |

## Backends in this PR
- **NullBackend** — production default. Zero allocation per call. Importing this module does not pull in any monitoring dependency.
- **RecordingBackend** — in-memory test double. Aggregates under canonical \`(name, sorted-tag-tuple)\` keys. Used in unit tests for any module that wants to assert "X metric was emitted N times."

## Backends NOT in this PR (deferred follow-ups)
- \`OTelBackend\` — \`opentelemetry-api\` is already a dep, so this is the natural first concrete exporter once call sites exist.
- \`StatsDBackend\`, \`PrometheusBackend\` — operator preference.

## Why split this from instrumentation
Adding the abstraction first lets every subsequent PR sprinkle \`get_metrics().counter(...)\` calls into hot paths without churning the metrics surface itself. The Null default means landing this PR has zero runtime cost.

## Test plan
- [x] 18 tests — protocol shape, every backend method, tag-order canonicalisation, name validation, timer-on-exception, singleton lifecycle
- [x] All pass locally
- [ ] CI green
- [ ] Adversarial review