### PR TITLE
feat(evaluator): cross-strategy composite scoring (gh#8)

### DIFF
--- a/engine/api/routes/backtest.py
+++ b/engine/api/routes/backtest.py
@@ -124,6 +124,7 @@ class BacktestResultResponse(BaseModel):
     equity_curve: list[dict[str, Any]]
     drawdown_curve: list[float]
     error: str | None = None
+    evaluation: dict[str, Any] | None = None
 
 
 async def _run_backtest_background(
@@ -331,5 +332,6 @@ async def get_backtest_result(
             ),
             equity_curve=stored.get("equity_curve", []),
             drawdown_curve=metrics_data.get("drawdown_curve", []),
+            evaluation=metrics_data.get("evaluation"),
         ).model_dump(),
     )

--- a/engine/core/backtest_runner.py
+++ b/engine/core/backtest_runner.py
@@ -13,6 +13,7 @@ from engine.core.order_manager import OrderManager
 from engine.core.portfolio import Portfolio
 from engine.core.risk_engine import RiskEngine
 from engine.core.signal import Side
+from engine.core.strategy_evaluator import StrategyEvaluator
 from engine.data.market_state import MarketStateBuilder, ValidationError
 from engine.plugins.manifest import StrategyManifest
 from engine.plugins.sandbox import StrategySandbox
@@ -207,6 +208,11 @@ class BacktestRunner:
         )
         report = metrics.calculate()
         result.metrics = report.to_dict()
+        try:
+            evaluation = StrategyEvaluator().evaluate(report).to_dict()
+            result.metrics["evaluation"] = evaluation
+        except Exception:  # noqa: BLE001 — never let scoring fail the backtest
+            logger.exception("backtest.evaluation_failed")
 
         total_trades = len(result.trades)
         closed_trades = len([t for t in result.trades if t.get("side") == "sell"])

--- a/engine/core/strategy_evaluator.py
+++ b/engine/core/strategy_evaluator.py
@@ -1,0 +1,247 @@
+"""Cross-strategy composite scoring (gh#8).
+
+Takes a :class:`MetricsReport` (the output of
+:class:`engine.core.metrics.PerformanceMetrics`) and produces a single
+composite score in [0, 100] plus a per-dimension breakdown. Used by:
+
+- The marketplace to rank strategies in a configurable but principled
+  way (a 20%-return / 40%-drawdown strategy should not outrank a
+  12%-return / 5%-drawdown strategy).
+- A/B testing surfaces to summarise a comparison in one number.
+- The backtest summary endpoint to ship the score alongside the raw
+  metrics so the UI doesn't have to re-derive it.
+
+Dimensions and their inputs:
+
+- ``RISK_ADJUSTED_RETURN`` — sharpe ratio, mapped via a logistic so a
+  sharpe of 0 -> 50 and a sharpe of 3 -> ~95.
+- ``DRAWDOWN_CONTROL`` — ``max_drawdown_pct`` inverted: 0% drawdown ->
+  100, 25% -> 50, 100% -> ~0.
+- ``CONSISTENCY`` — coefficient of variation of rolling-window sharpe
+  ratios. A strategy with steady risk-adjusted returns scores high; a
+  whippy one scores low. Returns 50.0 when fewer than two rolling
+  windows are available so this dimension does not penalise short
+  backtests.
+- ``COST_EFFICIENCY`` — ``cost_drag_pct`` inverted: 0% drag -> 100,
+  5% -> 50, 30% -> ~0.
+- ``RAW_RETURN`` — annualised return mapped via a logistic so 0% ->
+  50 and 30% -> ~95.
+
+The composite is a weighted sum; weights default to a risk-aware mix
+(30% risk-adjusted, 25% drawdown, 15% consistency, 15% cost, 15% raw
+return) and are user-overridable via :class:`EvaluationWeights`.
+
+Numeric guards: NaN / inf inputs are rejected at evaluation time so a
+junk metrics report cannot silently land a NaN composite score in the
+marketplace ranking.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+
+from engine.core.metrics import MetricsReport
+
+
+class StrategyEvaluatorError(ValueError):
+    """Bad evaluator configuration or invalid metrics input."""
+
+
+class EvaluationDimension(str, Enum):
+    RISK_ADJUSTED_RETURN = "risk_adjusted_return"
+    DRAWDOWN_CONTROL = "drawdown_control"
+    CONSISTENCY = "consistency"
+    COST_EFFICIENCY = "cost_efficiency"
+    RAW_RETURN = "raw_return"
+
+
+def _require_finite(value: float, label: str) -> None:
+    if not math.isfinite(value):
+        raise StrategyEvaluatorError(f"{label} must be finite, got {value!r}")
+
+
+def _logistic(value: float, *, midpoint: float, scale: float) -> float:
+    """Map ``value`` onto [0, 100] via a logistic so ``midpoint`` -> 50.
+    ``scale`` is the unit of "one logit" — larger scale flattens the
+    curve, smaller scale makes it sharper."""
+    if scale <= 0:
+        raise StrategyEvaluatorError(
+            f"logistic scale must be positive, got {scale}"
+        )
+    z = (value - midpoint) / scale
+    if z > 50:
+        return 100.0
+    if z < -50:
+        return 0.0
+    return 100.0 / (1.0 + math.exp(-z))
+
+
+def _inverse_pct_score(pct: float, *, half_life: float) -> float:
+    """For ``pct`` (a percentage where 0 is best and 100 is worst),
+    return 100 at 0% and decay exponentially. ``half_life`` is the
+    input value at which the output drops to 50."""
+    if pct < 0:
+        raise StrategyEvaluatorError(
+            f"inverse-pct input must be non-negative, got {pct}"
+        )
+    if half_life <= 0:
+        raise StrategyEvaluatorError(
+            f"half_life must be positive, got {half_life}"
+        )
+    return 100.0 * math.pow(0.5, pct / half_life)
+
+
+@dataclass(frozen=True)
+class EvaluationWeights:
+    risk_adjusted_return: float = 0.30
+    drawdown_control: float = 0.25
+    consistency: float = 0.15
+    cost_efficiency: float = 0.15
+    raw_return: float = 0.15
+
+    def __post_init__(self) -> None:
+        for label, value in self.as_mapping().items():
+            _require_finite(value, f"weight {label}")
+            if value < 0:
+                raise StrategyEvaluatorError(
+                    f"weight {label} must be >= 0, got {value}"
+                )
+        total = sum(self.as_mapping().values())
+        if not math.isclose(total, 1.0, abs_tol=1e-9):
+            raise StrategyEvaluatorError(
+                f"EvaluationWeights must sum to 1.0, got {total}"
+            )
+
+    def as_mapping(self) -> dict[str, float]:
+        return {
+            "risk_adjusted_return": self.risk_adjusted_return,
+            "drawdown_control": self.drawdown_control,
+            "consistency": self.consistency,
+            "cost_efficiency": self.cost_efficiency,
+            "raw_return": self.raw_return,
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    composite_score: float
+    dimensions: Mapping[EvaluationDimension, float]
+    weights: EvaluationWeights = field(default_factory=EvaluationWeights)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "composite_score": self.composite_score,
+            "dimensions": {d.value: v for d, v in self.dimensions.items()},
+            "weights": self.weights.as_mapping(),
+        }
+
+
+class StrategyEvaluator:
+    """Stateless evaluator. Construct once per weight configuration."""
+
+    # Tuning constants kept adjacent so future calibration happens in
+    # one place rather than scattered through the dimension functions.
+    _SHARPE_MIDPOINT = 0.0
+    _SHARPE_SCALE = 1.0  # +1 sharpe shifts the score by ~22 points.
+
+    _RETURN_MIDPOINT = 0.0
+    _RETURN_SCALE = 10.0  # +10% return shifts the score by ~22 points.
+
+    _DRAWDOWN_HALF_LIFE = 22.0  # 22% max-DD -> 50; 80% -> ~8.
+    _COST_HALF_LIFE = 4.0  # 4% cost drag -> 50; 20% -> ~3.
+
+    def __init__(self, weights: EvaluationWeights | None = None) -> None:
+        self.weights = weights or EvaluationWeights()
+
+    def evaluate(self, report: MetricsReport) -> EvaluationResult:
+        _require_finite(report.sharpe_ratio, "sharpe_ratio")
+        _require_finite(report.max_drawdown_pct, "max_drawdown_pct")
+        _require_finite(report.cost_drag_pct, "cost_drag_pct")
+        _require_finite(
+            report.annualized_return_pct, "annualized_return_pct"
+        )
+        if report.max_drawdown_pct < 0:
+            raise StrategyEvaluatorError(
+                f"max_drawdown_pct must be >= 0, got {report.max_drawdown_pct}"
+            )
+        if report.cost_drag_pct < 0:
+            raise StrategyEvaluatorError(
+                f"cost_drag_pct must be >= 0, got {report.cost_drag_pct}"
+            )
+
+        dims: dict[EvaluationDimension, float] = {
+            EvaluationDimension.RISK_ADJUSTED_RETURN: _logistic(
+                report.sharpe_ratio,
+                midpoint=self._SHARPE_MIDPOINT,
+                scale=self._SHARPE_SCALE,
+            ),
+            EvaluationDimension.DRAWDOWN_CONTROL: _inverse_pct_score(
+                report.max_drawdown_pct, half_life=self._DRAWDOWN_HALF_LIFE
+            ),
+            EvaluationDimension.CONSISTENCY: self._consistency(report),
+            EvaluationDimension.COST_EFFICIENCY: _inverse_pct_score(
+                report.cost_drag_pct, half_life=self._COST_HALF_LIFE
+            ),
+            EvaluationDimension.RAW_RETURN: _logistic(
+                report.annualized_return_pct,
+                midpoint=self._RETURN_MIDPOINT,
+                scale=self._RETURN_SCALE,
+            ),
+        }
+
+        weight_map = {
+            EvaluationDimension.RISK_ADJUSTED_RETURN: self.weights.risk_adjusted_return,
+            EvaluationDimension.DRAWDOWN_CONTROL: self.weights.drawdown_control,
+            EvaluationDimension.CONSISTENCY: self.weights.consistency,
+            EvaluationDimension.COST_EFFICIENCY: self.weights.cost_efficiency,
+            EvaluationDimension.RAW_RETURN: self.weights.raw_return,
+        }
+        composite = sum(dims[d] * weight_map[d] for d in dims)
+
+        return EvaluationResult(
+            composite_score=max(0.0, min(100.0, composite)),
+            dimensions=dims,
+            weights=self.weights,
+        )
+
+    def _consistency(self, report: MetricsReport) -> float:
+        sharpes = [
+            r.sharpe_ratio
+            for r in report.rolling_metrics
+            if math.isfinite(r.sharpe_ratio)
+        ]
+        if len(sharpes) < 2:
+            return 50.0  # neutral — not enough data to judge.
+        mean = sum(sharpes) / len(sharpes)
+        variance = sum((s - mean) ** 2 for s in sharpes) / len(sharpes)
+        std = math.sqrt(variance)
+        if std == 0.0:
+            return 100.0
+        # CoV around mean=1.0 (a sharpe of 1 is a reasonable yardstick
+        # for "good"). Lower CoV -> higher score.
+        cov = std / max(abs(mean), 0.5)
+        # Map CoV in [0, 4] onto [100, 0] linearly with a floor at 0.
+        return max(0.0, 100.0 - (cov / 4.0) * 100.0)
+
+    @staticmethod
+    def rank(
+        results: Mapping[str, EvaluationResult],
+    ) -> list[tuple[str, EvaluationResult]]:
+        """Return ``results`` sorted by composite score, highest first.
+        Ties resolved by name to keep the ordering deterministic."""
+        return sorted(
+            results.items(),
+            key=lambda kv: (-kv[1].composite_score, kv[0]),
+        )
+
+
+__all__ = [
+    "EvaluationDimension",
+    "EvaluationResult",
+    "EvaluationWeights",
+    "StrategyEvaluator",
+    "StrategyEvaluatorError",
+]

--- a/engine/core/strategy_evaluator.py
+++ b/engine/core/strategy_evaluator.py
@@ -1,35 +1,31 @@
 """Cross-strategy composite scoring (gh#8).
 
-Takes a :class:`MetricsReport` (the output of
-:class:`engine.core.metrics.PerformanceMetrics`) and produces a single
-composite score in [0, 100] plus a per-dimension breakdown. Used by:
+Takes a :class:`MetricsReport` and produces a single composite score in
+[0, 100] plus a per-dimension breakdown, a letter grade, and a list of
+warnings. Used by:
 
 - The marketplace to rank strategies in a configurable but principled
   way (a 20%-return / 40%-drawdown strategy should not outrank a
-  12%-return / 5%-drawdown strategy).
+  12%-return / 5%-drawdown one).
 - A/B testing surfaces to summarise a comparison in one number.
 - The backtest summary endpoint to ship the score alongside the raw
   metrics so the UI doesn't have to re-derive it.
 
-Dimensions and their inputs:
+Six dimensions, each normalised to [0, 100]:
 
-- ``RISK_ADJUSTED_RETURN`` — sharpe ratio, mapped via a logistic so a
-  sharpe of 0 -> 50 and a sharpe of 3 -> ~95.
-- ``DRAWDOWN_CONTROL`` — ``max_drawdown_pct`` inverted: 0% drawdown ->
-  100, 25% -> 50, 100% -> ~0.
+- ``RISK_ADJUSTED_RETURN`` — Sharpe ratio, piecewise mapping per spec.
+- ``DRAWDOWN_CONTROL`` — Max drawdown, piecewise mapping per spec.
 - ``CONSISTENCY`` — coefficient of variation of rolling-window sharpe
-  ratios. A strategy with steady risk-adjusted returns scores high; a
-  whippy one scores low. Returns 50.0 when fewer than two rolling
-  windows are available so this dimension does not penalise short
-  backtests.
-- ``COST_EFFICIENCY`` — ``cost_drag_pct`` inverted: 0% drag -> 100,
-  5% -> 50, 30% -> ~0.
-- ``RAW_RETURN`` — annualised return mapped via a logistic so 0% ->
-  50 and 30% -> ~95.
+  ratios. 50.0 if fewer than two windows so short backtests are not
+  penalised.
+- ``COST_EFFICIENCY`` — exponential decay on ``cost_drag_pct``.
+- ``WIN_RATE_QUALITY`` — ``win_rate * (avg_winner / abs(avg_loser))``.
+- ``STABILITY`` — annual volatility, piecewise mapping per spec.
 
-The composite is a weighted sum; weights default to a risk-aware mix
-(30% risk-adjusted, 25% drawdown, 15% consistency, 15% cost, 15% raw
-return) and are user-overridable via :class:`EvaluationWeights`.
+Default weights mirror the spec (sum to 1.0): risk-adjusted 0.30,
+drawdown 0.20, consistency 0.15, cost 0.15, win-rate-quality 0.10,
+stability 0.10. Weights are user-overridable via
+:class:`EvaluationWeights`.
 
 Numeric guards: NaN / inf inputs are rejected at evaluation time so a
 junk metrics report cannot silently land a NaN composite score in the
@@ -55,7 +51,20 @@ class EvaluationDimension(str, Enum):
     DRAWDOWN_CONTROL = "drawdown_control"
     CONSISTENCY = "consistency"
     COST_EFFICIENCY = "cost_efficiency"
-    RAW_RETURN = "raw_return"
+    WIN_RATE_QUALITY = "win_rate_quality"
+    STABILITY = "stability"
+
+
+_GRADE_THRESHOLDS: tuple[tuple[float, str], ...] = (
+    (90.0, "A+"),
+    (80.0, "A"),
+    (70.0, "B+"),
+    (60.0, "B"),
+    (50.0, "C+"),
+    (40.0, "C"),
+    (25.0, "D"),
+    (0.0, "F"),
+)
 
 
 def _require_finite(value: float, label: str) -> None:
@@ -63,44 +72,108 @@ def _require_finite(value: float, label: str) -> None:
         raise StrategyEvaluatorError(f"{label} must be finite, got {value!r}")
 
 
-def _logistic(value: float, *, midpoint: float, scale: float) -> float:
-    """Map ``value`` onto [0, 100] via a logistic so ``midpoint`` -> 50.
-    ``scale`` is the unit of "one logit" — larger scale flattens the
-    curve, smaller scale makes it sharper."""
-    if scale <= 0:
-        raise StrategyEvaluatorError(
-            f"logistic scale must be positive, got {scale}"
-        )
-    z = (value - midpoint) / scale
-    if z > 50:
-        return 100.0
-    if z < -50:
+def _piecewise_linear(value: float, breakpoints: list[tuple[float, float]]) -> float:
+    """Map ``value`` onto a score using piecewise-linear interpolation
+    between sorted ``breakpoints`` of ``(input, output)``. Values
+    outside the bracketed range clamp to the nearest endpoint."""
+    if value <= breakpoints[0][0]:
+        return breakpoints[0][1]
+    if value >= breakpoints[-1][0]:
+        return breakpoints[-1][1]
+    for i in range(len(breakpoints) - 1):
+        x0, y0 = breakpoints[i]
+        x1, y1 = breakpoints[i + 1]
+        if x0 <= value <= x1:
+            t = (value - x0) / (x1 - x0)
+            return y0 + t * (y1 - y0)
+    return breakpoints[-1][1]
+
+
+def _risk_adjusted_score(sharpe: float) -> float:
+    """Spec: <0 -> 0, 0->0, 0.5->30, 1.0->60, 2.0->90, 3.0+->100."""
+    if sharpe < 0:
         return 0.0
-    return 100.0 / (1.0 + math.exp(-z))
+    return _piecewise_linear(
+        sharpe,
+        [(0.0, 0.0), (0.5, 30.0), (1.0, 60.0), (2.0, 90.0), (3.0, 100.0)],
+    )
 
 
-def _inverse_pct_score(pct: float, *, half_life: float) -> float:
-    """For ``pct`` (a percentage where 0 is best and 100 is worst),
-    return 100 at 0% and decay exponentially. ``half_life`` is the
-    input value at which the output drops to 50."""
-    if pct < 0:
+def _drawdown_score(max_dd_pct: float) -> float:
+    """Spec: 0->100, 5->90, 10->70, 20->40, 30->20, >30 falls toward 0."""
+    if max_dd_pct < 0:
         raise StrategyEvaluatorError(
-            f"inverse-pct input must be non-negative, got {pct}"
+            f"max_drawdown_pct must be >= 0, got {max_dd_pct}"
         )
-    if half_life <= 0:
+    return _piecewise_linear(
+        max_dd_pct,
+        [
+            (0.0, 100.0),
+            (5.0, 90.0),
+            (10.0, 70.0),
+            (20.0, 40.0),
+            (30.0, 20.0),
+            (50.0, 0.0),
+        ],
+    )
+
+
+def _cost_efficiency_score(cost_drag_pct: float) -> float:
+    """Exponential decay on cost_drag_pct, half-life 4%. 0% -> 100,
+    4% -> 50, 20% -> ~3."""
+    if cost_drag_pct < 0:
         raise StrategyEvaluatorError(
-            f"half_life must be positive, got {half_life}"
+            f"cost_drag_pct must be >= 0, got {cost_drag_pct}"
         )
-    return 100.0 * math.pow(0.5, pct / half_life)
+    return 100.0 * math.pow(0.5, cost_drag_pct / 4.0)
+
+
+def _win_rate_quality_score(
+    win_rate: float, avg_winner: float, avg_loser: float
+) -> float:
+    """``quality = win_rate * (avg_winner / abs(avg_loser))``,
+    normalised to [0, 100]. ``win_rate`` is treated as a fraction in
+    [0, 1] if <= 1.0, else as a percentage in [0, 100]."""
+    wr = win_rate / 100.0 if win_rate > 1.0 else win_rate
+    if wr < 0 or wr > 1:
+        raise StrategyEvaluatorError(
+            f"win_rate must be in [0, 1] or [0, 100], got {win_rate}"
+        )
+    if avg_loser == 0:
+        return 50.0 if wr == 0 else 100.0
+    quality = wr * (avg_winner / abs(avg_loser))
+    return _piecewise_linear(
+        max(0.0, quality),
+        [(0.0, 0.0), (0.5, 25.0), (1.0, 50.0), (2.0, 80.0), (3.0, 100.0)],
+    )
+
+
+def _stability_score(volatility_annual_pct: float) -> float:
+    """Spec: <10% -> 80-100, 10-20% -> 50-80, 20-30% -> 20-50, >30 -> 0-20."""
+    if volatility_annual_pct < 0:
+        raise StrategyEvaluatorError(
+            f"volatility_annual_pct must be >= 0, got {volatility_annual_pct}"
+        )
+    return _piecewise_linear(
+        volatility_annual_pct,
+        [
+            (0.0, 100.0),
+            (10.0, 80.0),
+            (20.0, 50.0),
+            (30.0, 20.0),
+            (50.0, 0.0),
+        ],
+    )
 
 
 @dataclass(frozen=True)
 class EvaluationWeights:
     risk_adjusted_return: float = 0.30
-    drawdown_control: float = 0.25
+    drawdown_control: float = 0.20
     consistency: float = 0.15
     cost_efficiency: float = 0.15
-    raw_return: float = 0.15
+    win_rate_quality: float = 0.10
+    stability: float = 0.10
 
     def __post_init__(self) -> None:
         for label, value in self.as_mapping().items():
@@ -121,37 +194,67 @@ class EvaluationWeights:
             "drawdown_control": self.drawdown_control,
             "consistency": self.consistency,
             "cost_efficiency": self.cost_efficiency,
-            "raw_return": self.raw_return,
+            "win_rate_quality": self.win_rate_quality,
+            "stability": self.stability,
         }
+
+
+def _grade_for(score: float) -> str:
+    for threshold, grade in _GRADE_THRESHOLDS:
+        if score >= threshold:
+            return grade
+    return "F"
 
 
 @dataclass(frozen=True)
 class EvaluationResult:
     composite_score: float
+    grade: str
     dimensions: Mapping[EvaluationDimension, float]
+    warnings: list[str] = field(default_factory=list)
     weights: EvaluationWeights = field(default_factory=EvaluationWeights)
+    percentile: float | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
             "composite_score": self.composite_score,
+            "grade": self.grade,
             "dimensions": {d.value: v for d, v in self.dimensions.items()},
+            "warnings": list(self.warnings),
             "weights": self.weights.as_mapping(),
+            "percentile": self.percentile,
         }
+
+
+_WARN_NEGATIVE_SHARPE = "Negative Sharpe ratio"
+_WARN_EXCESSIVE_DRAWDOWN = "Excessive drawdown"
+_WARN_HIGH_COST_DRAG = "High cost drag"
+_WARN_HIGH_VOLATILITY = "High volatility"
+_WARN_POOR_WIN_QUALITY = "Poor win/loss profile"
+
+
+def _build_warnings(report: MetricsReport) -> list[str]:
+    warnings: list[str] = []
+    if report.sharpe_ratio < 0:
+        warnings.append(_WARN_NEGATIVE_SHARPE)
+    if report.max_drawdown_pct >= 20.0:
+        warnings.append(_WARN_EXCESSIVE_DRAWDOWN)
+    if report.cost_drag_pct >= 5.0:
+        warnings.append(_WARN_HIGH_COST_DRAG)
+    if report.volatility_annual_pct >= 30.0:
+        warnings.append(_WARN_HIGH_VOLATILITY)
+    if report.avg_loser != 0 and report.total_trades > 0:
+        wr = (
+            report.win_rate / 100.0 if report.win_rate > 1.0 else report.win_rate
+        )
+        quality = wr * (report.avg_winner / abs(report.avg_loser))
+        if quality < 0.5:
+            warnings.append(_WARN_POOR_WIN_QUALITY)
+    return warnings
 
 
 class StrategyEvaluator:
     """Stateless evaluator. Construct once per weight configuration."""
-
-    # Tuning constants kept adjacent so future calibration happens in
-    # one place rather than scattered through the dimension functions.
-    _SHARPE_MIDPOINT = 0.0
-    _SHARPE_SCALE = 1.0  # +1 sharpe shifts the score by ~22 points.
-
-    _RETURN_MIDPOINT = 0.0
-    _RETURN_SCALE = 10.0  # +10% return shifts the score by ~22 points.
-
-    _DRAWDOWN_HALF_LIFE = 22.0  # 22% max-DD -> 50; 80% -> ~8.
-    _COST_HALF_LIFE = 4.0  # 4% cost drag -> 50; 20% -> ~3.
 
     def __init__(self, weights: EvaluationWeights | None = None) -> None:
         self.weights = weights or EvaluationWeights()
@@ -160,35 +263,27 @@ class StrategyEvaluator:
         _require_finite(report.sharpe_ratio, "sharpe_ratio")
         _require_finite(report.max_drawdown_pct, "max_drawdown_pct")
         _require_finite(report.cost_drag_pct, "cost_drag_pct")
-        _require_finite(
-            report.annualized_return_pct, "annualized_return_pct"
-        )
-        if report.max_drawdown_pct < 0:
-            raise StrategyEvaluatorError(
-                f"max_drawdown_pct must be >= 0, got {report.max_drawdown_pct}"
-            )
-        if report.cost_drag_pct < 0:
-            raise StrategyEvaluatorError(
-                f"cost_drag_pct must be >= 0, got {report.cost_drag_pct}"
-            )
+        _require_finite(report.volatility_annual_pct, "volatility_annual_pct")
+        _require_finite(report.win_rate, "win_rate")
+        _require_finite(report.avg_winner, "avg_winner")
+        _require_finite(report.avg_loser, "avg_loser")
 
         dims: dict[EvaluationDimension, float] = {
-            EvaluationDimension.RISK_ADJUSTED_RETURN: _logistic(
-                report.sharpe_ratio,
-                midpoint=self._SHARPE_MIDPOINT,
-                scale=self._SHARPE_SCALE,
+            EvaluationDimension.RISK_ADJUSTED_RETURN: _risk_adjusted_score(
+                report.sharpe_ratio
             ),
-            EvaluationDimension.DRAWDOWN_CONTROL: _inverse_pct_score(
-                report.max_drawdown_pct, half_life=self._DRAWDOWN_HALF_LIFE
+            EvaluationDimension.DRAWDOWN_CONTROL: _drawdown_score(
+                report.max_drawdown_pct
             ),
             EvaluationDimension.CONSISTENCY: self._consistency(report),
-            EvaluationDimension.COST_EFFICIENCY: _inverse_pct_score(
-                report.cost_drag_pct, half_life=self._COST_HALF_LIFE
+            EvaluationDimension.COST_EFFICIENCY: _cost_efficiency_score(
+                report.cost_drag_pct
             ),
-            EvaluationDimension.RAW_RETURN: _logistic(
-                report.annualized_return_pct,
-                midpoint=self._RETURN_MIDPOINT,
-                scale=self._RETURN_SCALE,
+            EvaluationDimension.WIN_RATE_QUALITY: _win_rate_quality_score(
+                report.win_rate, report.avg_winner, report.avg_loser
+            ),
+            EvaluationDimension.STABILITY: _stability_score(
+                report.volatility_annual_pct
             ),
         }
 
@@ -197,13 +292,17 @@ class StrategyEvaluator:
             EvaluationDimension.DRAWDOWN_CONTROL: self.weights.drawdown_control,
             EvaluationDimension.CONSISTENCY: self.weights.consistency,
             EvaluationDimension.COST_EFFICIENCY: self.weights.cost_efficiency,
-            EvaluationDimension.RAW_RETURN: self.weights.raw_return,
+            EvaluationDimension.WIN_RATE_QUALITY: self.weights.win_rate_quality,
+            EvaluationDimension.STABILITY: self.weights.stability,
         }
         composite = sum(dims[d] * weight_map[d] for d in dims)
+        composite = max(0.0, min(100.0, composite))
 
         return EvaluationResult(
-            composite_score=max(0.0, min(100.0, composite)),
+            composite_score=composite,
+            grade=_grade_for(composite),
             dimensions=dims,
+            warnings=_build_warnings(report),
             weights=self.weights,
         )
 
@@ -214,16 +313,13 @@ class StrategyEvaluator:
             if math.isfinite(r.sharpe_ratio)
         ]
         if len(sharpes) < 2:
-            return 50.0  # neutral — not enough data to judge.
+            return 50.0
         mean = sum(sharpes) / len(sharpes)
         variance = sum((s - mean) ** 2 for s in sharpes) / len(sharpes)
         std = math.sqrt(variance)
         if std == 0.0:
             return 100.0
-        # CoV around mean=1.0 (a sharpe of 1 is a reasonable yardstick
-        # for "good"). Lower CoV -> higher score.
         cov = std / max(abs(mean), 0.5)
-        # Map CoV in [0, 4] onto [100, 0] linearly with a floor at 0.
         return max(0.0, 100.0 - (cov / 4.0) * 100.0)
 
     @staticmethod

--- a/engine/db/migrations/versions/008_evaluator_score_columns.py
+++ b/engine/db/migrations/versions/008_evaluator_score_columns.py
@@ -1,0 +1,34 @@
+"""add composite_score and score_breakdown columns to backtest_results
+
+Revision ID: 008_evaluator_score_columns
+Revises: 007_scoring_snapshots
+Create Date: 2026-05-02
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "008_evaluator_score_columns"
+down_revision: str | Sequence[str] | None = "007_scoring_snapshots"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "backtest_results",
+        sa.Column("composite_score", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "backtest_results",
+        sa.Column("score_breakdown", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("backtest_results", "score_breakdown")
+    op.drop_column("backtest_results", "composite_score")

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -127,6 +127,8 @@ class BacktestResult(Base):
     start_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     end_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     metrics: Mapped[dict] = mapped_column(JSONB, default=dict)  # type: ignore[assignment]
+    composite_score: Mapped[float | None] = mapped_column(nullable=True, default=None)
+    score_breakdown: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)  # type: ignore[assignment]
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
 

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -178,6 +178,21 @@ class TestBacktestRunnerIntegration:
         assert "max_drawdown_pct" in result.metrics
         assert "total_trades" in result.metrics
 
+    async def test_evaluation_score_attached_to_metrics(self, provider, buy_config):
+        runner = BacktestRunner(
+            config=buy_config, strategy=_SimpleBuyStrategy(), provider=provider
+        )
+        result = await runner.run()
+
+        assert "evaluation" in result.metrics
+        evaluation = result.metrics["evaluation"]
+        assert "composite_score" in evaluation
+        assert 0.0 <= evaluation["composite_score"] <= 100.0
+        assert "grade" in evaluation
+        assert evaluation["grade"] in {"A+", "A", "B+", "B", "C+", "C", "D", "F"}
+        assert "dimensions" in evaluation
+        assert "warnings" in evaluation
+
 
 class TestBacktestRunnerErrors:
     async def test_no_provider_raises(self):

--- a/tests/test_strategy_evaluator.py
+++ b/tests/test_strategy_evaluator.py
@@ -1,0 +1,264 @@
+"""Tests for engine.core.strategy_evaluator — cross-strategy composite score."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.metrics import MetricsReport, RollingWindowMetrics
+from engine.core.strategy_evaluator import (
+    EvaluationDimension,
+    EvaluationResult,
+    EvaluationWeights,
+    StrategyEvaluator,
+    StrategyEvaluatorError,
+)
+
+
+def _report(
+    *,
+    sharpe: float = 1.0,
+    max_dd_pct: float = 10.0,
+    cost_drag_pct: float = 1.0,
+    annualized_return_pct: float = 10.0,
+    rolling: list[RollingWindowMetrics] | None = None,
+    sortino: float | None = None,
+    profit_factor: float | None = 1.5,
+) -> MetricsReport:
+    """Build a minimal MetricsReport for unit testing."""
+    return MetricsReport(
+        total_return_pct=annualized_return_pct,
+        annualized_return_pct=annualized_return_pct,
+        sharpe_ratio=sharpe,
+        sortino_ratio=sortino,
+        max_drawdown_pct=max_dd_pct,
+        max_drawdown_duration_days=10,
+        max_drawdown_recovery_days=5,
+        calmar_ratio=None,
+        volatility_annual_pct=15.0,
+        total_trades=20,
+        win_rate=55.0,
+        profit_factor=profit_factor,
+        avg_trade_pnl=10.0,
+        avg_winner=20.0,
+        avg_loser=-10.0,
+        best_trade=100.0,
+        worst_trade=-50.0,
+        max_consecutive_wins=3,
+        max_consecutive_losses=2,
+        total_costs=100.0,
+        total_taxes=20.0,
+        cost_drag_pct=cost_drag_pct,
+        turnover_ratio=1.0,
+        exposure_pct=80.0,
+        equity_curve=[],
+        drawdown_curve=[],
+        rolling_metrics=rolling or [],
+    )
+
+
+class TestWeightsValidation:
+    def test_default_weights_sum_to_one(self):
+        w = EvaluationWeights()
+        assert math.isclose(
+            w.risk_adjusted_return
+            + w.drawdown_control
+            + w.consistency
+            + w.cost_efficiency
+            + w.raw_return,
+            1.0,
+        )
+
+    def test_weights_must_sum_to_one(self):
+        with pytest.raises(StrategyEvaluatorError):
+            EvaluationWeights(
+                risk_adjusted_return=0.5,
+                drawdown_control=0.5,
+                consistency=0.5,
+                cost_efficiency=0.0,
+                raw_return=0.0,
+            )
+
+    def test_negative_weight_rejected(self):
+        with pytest.raises(StrategyEvaluatorError):
+            EvaluationWeights(
+                risk_adjusted_return=-0.1,
+                drawdown_control=0.4,
+                consistency=0.2,
+                cost_efficiency=0.2,
+                raw_return=0.3,
+            )
+
+    def test_nan_weight_rejected(self):
+        with pytest.raises(StrategyEvaluatorError):
+            EvaluationWeights(
+                risk_adjusted_return=float("nan"),
+                drawdown_control=0.25,
+                consistency=0.25,
+                cost_efficiency=0.25,
+                raw_return=0.25,
+            )
+
+
+class TestRiskAdjustedReturnDimension:
+    def test_high_sharpe_scores_high(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(sharpe=3.0))
+        assert (
+            out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN]
+            >= 90.0
+        )
+
+    def test_zero_sharpe_scores_around_50(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(sharpe=0.0))
+        assert (
+            45.0
+            <= out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN]
+            <= 55.0
+        )
+
+    def test_negative_sharpe_scores_below_50(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(sharpe=-1.5))
+        assert out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN] < 30.0
+
+
+class TestDrawdownControlDimension:
+    def test_zero_drawdown_scores_perfect(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(max_dd_pct=0.0))
+        assert out.dimensions[EvaluationDimension.DRAWDOWN_CONTROL] == 100.0
+
+    def test_severe_drawdown_scores_low(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(max_dd_pct=80.0))
+        assert out.dimensions[EvaluationDimension.DRAWDOWN_CONTROL] <= 10.0
+
+    def test_moderate_drawdown_scores_middle(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(max_dd_pct=20.0))
+        score = out.dimensions[EvaluationDimension.DRAWDOWN_CONTROL]
+        assert 50.0 <= score <= 80.0
+
+
+class TestCostEfficiencyDimension:
+    def test_zero_cost_drag_scores_perfect(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(cost_drag_pct=0.0))
+        assert out.dimensions[EvaluationDimension.COST_EFFICIENCY] == 100.0
+
+    def test_high_cost_drag_scores_low(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(cost_drag_pct=20.0))
+        assert out.dimensions[EvaluationDimension.COST_EFFICIENCY] <= 5.0
+
+
+class TestConsistencyDimension:
+    def test_no_rolling_metrics_yields_neutral_score(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(rolling=[]))
+        assert out.dimensions[EvaluationDimension.CONSISTENCY] == 50.0
+
+    def test_steady_rolling_sharpe_scores_high(self):
+        ev = StrategyEvaluator()
+        rolling = [
+            RollingWindowMetrics(
+                window_days=30,
+                sharpe_ratio=1.5,
+                sortino_ratio=None,
+                volatility_annual_pct=12.0,
+                max_drawdown_pct=5.0,
+            )
+            for _ in range(10)
+        ]
+        out = ev.evaluate(_report(rolling=rolling))
+        assert out.dimensions[EvaluationDimension.CONSISTENCY] >= 80.0
+
+    def test_volatile_rolling_sharpe_scores_low(self):
+        ev = StrategyEvaluator()
+        rolling = [
+            RollingWindowMetrics(
+                window_days=30,
+                sharpe_ratio=v,
+                sortino_ratio=None,
+                volatility_annual_pct=12.0,
+                max_drawdown_pct=5.0,
+            )
+            for v in [3.0, -2.0, 4.0, -1.5, 2.5, -2.5, 3.5, -3.0]
+        ]
+        out = ev.evaluate(_report(rolling=rolling))
+        assert out.dimensions[EvaluationDimension.CONSISTENCY] <= 40.0
+
+
+class TestRawReturnDimension:
+    def test_high_return_scores_high(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(annualized_return_pct=50.0))
+        assert out.dimensions[EvaluationDimension.RAW_RETURN] >= 90.0
+
+    def test_zero_return_scores_around_50(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(annualized_return_pct=0.0))
+        assert 40.0 <= out.dimensions[EvaluationDimension.RAW_RETURN] <= 60.0
+
+    def test_loss_scores_low(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(annualized_return_pct=-25.0))
+        assert out.dimensions[EvaluationDimension.RAW_RETURN] < 30.0
+
+
+class TestComposite:
+    def test_composite_is_weighted_sum_of_dimensions(self):
+        ev = StrategyEvaluator(
+            EvaluationWeights(
+                risk_adjusted_return=0.0,
+                drawdown_control=0.0,
+                consistency=0.0,
+                cost_efficiency=0.0,
+                raw_return=1.0,
+            )
+        )
+        out = ev.evaluate(_report(annualized_return_pct=0.0))
+        assert math.isclose(
+            out.composite_score,
+            out.dimensions[EvaluationDimension.RAW_RETURN],
+            abs_tol=1e-9,
+        )
+
+    def test_composite_bounded_zero_to_hundred(self):
+        ev = StrategyEvaluator()
+        for sharpe in [-5.0, 0.0, 5.0]:
+            out = ev.evaluate(_report(sharpe=sharpe))
+            assert 0.0 <= out.composite_score <= 100.0
+
+    def test_result_is_serializable(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report())
+        d = out.to_dict()
+        assert "composite_score" in d
+        assert "dimensions" in d
+        assert isinstance(d["dimensions"], dict)
+
+
+class TestComparison:
+    def test_compare_orders_by_composite_descending(self):
+        ev = StrategyEvaluator()
+        a = ev.evaluate(_report(sharpe=2.5, annualized_return_pct=30.0))
+        b = ev.evaluate(_report(sharpe=0.5, annualized_return_pct=5.0))
+        ranked = StrategyEvaluator.rank({"alpha": a, "beta": b})
+        assert ranked[0][0] == "alpha"
+        assert ranked[1][0] == "beta"
+
+
+class TestEvaluatorErrors:
+    def test_negative_max_dd_rejected(self):
+        ev = StrategyEvaluator()
+        with pytest.raises(StrategyEvaluatorError):
+            ev.evaluate(_report(max_dd_pct=-5.0))
+
+    def test_nan_sharpe_rejected(self):
+        ev = StrategyEvaluator()
+        with pytest.raises(StrategyEvaluatorError):
+            ev.evaluate(_report(sharpe=float("nan")))

--- a/tests/test_strategy_evaluator.py
+++ b/tests/test_strategy_evaluator.py
@@ -1,4 +1,4 @@
-"""Tests for engine.core.strategy_evaluator — cross-strategy composite score."""
+"""Tests for engine.core.strategy_evaluator — composite score (gh#8)."""
 
 from __future__ import annotations
 
@@ -22,11 +22,15 @@ def _report(
     max_dd_pct: float = 10.0,
     cost_drag_pct: float = 1.0,
     annualized_return_pct: float = 10.0,
+    volatility_annual_pct: float = 15.0,
+    win_rate: float = 55.0,
+    avg_winner: float = 20.0,
+    avg_loser: float = -10.0,
+    total_trades: int = 20,
     rolling: list[RollingWindowMetrics] | None = None,
     sortino: float | None = None,
     profit_factor: float | None = 1.5,
 ) -> MetricsReport:
-    """Build a minimal MetricsReport for unit testing."""
     return MetricsReport(
         total_return_pct=annualized_return_pct,
         annualized_return_pct=annualized_return_pct,
@@ -36,13 +40,13 @@ def _report(
         max_drawdown_duration_days=10,
         max_drawdown_recovery_days=5,
         calmar_ratio=None,
-        volatility_annual_pct=15.0,
-        total_trades=20,
-        win_rate=55.0,
+        volatility_annual_pct=volatility_annual_pct,
+        total_trades=total_trades,
+        win_rate=win_rate,
         profit_factor=profit_factor,
         avg_trade_pnl=10.0,
-        avg_winner=20.0,
-        avg_loser=-10.0,
+        avg_winner=avg_winner,
+        avg_loser=avg_loser,
         best_trade=100.0,
         worst_trade=-50.0,
         max_consecutive_wins=3,
@@ -61,14 +65,16 @@ def _report(
 class TestWeightsValidation:
     def test_default_weights_sum_to_one(self):
         w = EvaluationWeights()
-        assert math.isclose(
-            w.risk_adjusted_return
-            + w.drawdown_control
-            + w.consistency
-            + w.cost_efficiency
-            + w.raw_return,
-            1.0,
-        )
+        assert math.isclose(sum(w.as_mapping().values()), 1.0)
+
+    def test_default_weights_match_spec(self):
+        w = EvaluationWeights()
+        assert w.risk_adjusted_return == 0.30
+        assert w.drawdown_control == 0.20
+        assert w.consistency == 0.15
+        assert w.cost_efficiency == 0.15
+        assert w.win_rate_quality == 0.10
+        assert w.stability == 0.10
 
     def test_weights_must_sum_to_one(self):
         with pytest.raises(StrategyEvaluatorError):
@@ -77,7 +83,8 @@ class TestWeightsValidation:
                 drawdown_control=0.5,
                 consistency=0.5,
                 cost_efficiency=0.0,
-                raw_return=0.0,
+                win_rate_quality=0.0,
+                stability=0.0,
             )
 
     def test_negative_weight_rejected(self):
@@ -87,17 +94,19 @@ class TestWeightsValidation:
                 drawdown_control=0.4,
                 consistency=0.2,
                 cost_efficiency=0.2,
-                raw_return=0.3,
+                win_rate_quality=0.15,
+                stability=0.15,
             )
 
     def test_nan_weight_rejected(self):
         with pytest.raises(StrategyEvaluatorError):
             EvaluationWeights(
                 risk_adjusted_return=float("nan"),
-                drawdown_control=0.25,
-                consistency=0.25,
-                cost_efficiency=0.25,
-                raw_return=0.25,
+                drawdown_control=0.20,
+                consistency=0.20,
+                cost_efficiency=0.20,
+                win_rate_quality=0.20,
+                stability=0.20,
             )
 
 
@@ -105,24 +114,21 @@ class TestRiskAdjustedReturnDimension:
     def test_high_sharpe_scores_high(self):
         ev = StrategyEvaluator()
         out = ev.evaluate(_report(sharpe=3.0))
-        assert (
-            out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN]
-            >= 90.0
-        )
+        assert out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN] >= 90.0
 
-    def test_zero_sharpe_scores_around_50(self):
+    def test_sharpe_one_scores_around_60(self):
         ev = StrategyEvaluator()
-        out = ev.evaluate(_report(sharpe=0.0))
+        out = ev.evaluate(_report(sharpe=1.0))
         assert (
-            45.0
+            55.0
             <= out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN]
-            <= 55.0
+            <= 65.0
         )
 
-    def test_negative_sharpe_scores_below_50(self):
+    def test_negative_sharpe_scores_zero(self):
         ev = StrategyEvaluator()
         out = ev.evaluate(_report(sharpe=-1.5))
-        assert out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN] < 30.0
+        assert out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN] == 0.0
 
 
 class TestDrawdownControlDimension:
@@ -133,14 +139,14 @@ class TestDrawdownControlDimension:
 
     def test_severe_drawdown_scores_low(self):
         ev = StrategyEvaluator()
-        out = ev.evaluate(_report(max_dd_pct=80.0))
-        assert out.dimensions[EvaluationDimension.DRAWDOWN_CONTROL] <= 10.0
+        out = ev.evaluate(_report(max_dd_pct=50.0))
+        assert out.dimensions[EvaluationDimension.DRAWDOWN_CONTROL] <= 5.0
 
-    def test_moderate_drawdown_scores_middle(self):
+    def test_drawdown_20pct_scores_around_40(self):
         ev = StrategyEvaluator()
         out = ev.evaluate(_report(max_dd_pct=20.0))
         score = out.dimensions[EvaluationDimension.DRAWDOWN_CONTROL]
-        assert 50.0 <= score <= 80.0
+        assert 35.0 <= score <= 45.0
 
 
 class TestCostEfficiencyDimension:
@@ -192,38 +198,71 @@ class TestConsistencyDimension:
         assert out.dimensions[EvaluationDimension.CONSISTENCY] <= 40.0
 
 
-class TestRawReturnDimension:
-    def test_high_return_scores_high(self):
+class TestWinRateQualityDimension:
+    def test_high_quality_scores_high(self):
         ev = StrategyEvaluator()
-        out = ev.evaluate(_report(annualized_return_pct=50.0))
-        assert out.dimensions[EvaluationDimension.RAW_RETURN] >= 90.0
+        out = ev.evaluate(
+            _report(win_rate=60.0, avg_winner=30.0, avg_loser=-10.0)
+        )
+        assert out.dimensions[EvaluationDimension.WIN_RATE_QUALITY] >= 60.0
 
-    def test_zero_return_scores_around_50(self):
+    def test_break_even_quality_scores_around_25(self):
         ev = StrategyEvaluator()
-        out = ev.evaluate(_report(annualized_return_pct=0.0))
-        assert 40.0 <= out.dimensions[EvaluationDimension.RAW_RETURN] <= 60.0
+        out = ev.evaluate(
+            _report(win_rate=50.0, avg_winner=10.0, avg_loser=-10.0)
+        )
+        score = out.dimensions[EvaluationDimension.WIN_RATE_QUALITY]
+        assert 20.0 <= score <= 35.0
 
-    def test_loss_scores_low(self):
+    def test_low_quality_scores_low(self):
         ev = StrategyEvaluator()
-        out = ev.evaluate(_report(annualized_return_pct=-25.0))
-        assert out.dimensions[EvaluationDimension.RAW_RETURN] < 30.0
+        out = ev.evaluate(
+            _report(win_rate=30.0, avg_winner=5.0, avg_loser=-10.0)
+        )
+        assert out.dimensions[EvaluationDimension.WIN_RATE_QUALITY] <= 15.0
+
+    def test_zero_avg_loser_does_not_divide_by_zero(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(
+            _report(win_rate=80.0, avg_winner=20.0, avg_loser=0.0)
+        )
+        assert out.dimensions[EvaluationDimension.WIN_RATE_QUALITY] == 100.0
+
+
+class TestStabilityDimension:
+    def test_low_volatility_scores_high(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(volatility_annual_pct=5.0))
+        assert out.dimensions[EvaluationDimension.STABILITY] >= 80.0
+
+    def test_high_volatility_scores_low(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(volatility_annual_pct=45.0))
+        assert out.dimensions[EvaluationDimension.STABILITY] <= 20.0
+
+    def test_moderate_volatility_scores_middle(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(volatility_annual_pct=20.0))
+        score = out.dimensions[EvaluationDimension.STABILITY]
+        assert 40.0 <= score <= 60.0
 
 
 class TestComposite:
     def test_composite_is_weighted_sum_of_dimensions(self):
         ev = StrategyEvaluator(
             EvaluationWeights(
-                risk_adjusted_return=0.0,
+                risk_adjusted_return=1.0,
                 drawdown_control=0.0,
                 consistency=0.0,
                 cost_efficiency=0.0,
-                raw_return=1.0,
+                win_rate_quality=0.0,
+                stability=0.0,
             )
         )
-        out = ev.evaluate(_report(annualized_return_pct=0.0))
+        out = ev.evaluate(_report(sharpe=2.0))
         assert math.isclose(
             out.composite_score,
-            out.dimensions[EvaluationDimension.RAW_RETURN],
+            out.dimensions[EvaluationDimension.RISK_ADJUSTED_RETURN],
             abs_tol=1e-9,
         )
 
@@ -233,23 +272,168 @@ class TestComposite:
             out = ev.evaluate(_report(sharpe=sharpe))
             assert 0.0 <= out.composite_score <= 100.0
 
-    def test_result_is_serializable(self):
+    def test_perfect_strategy_scores_above_85(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(
+            _report(
+                sharpe=3.0,
+                max_dd_pct=2.0,
+                cost_drag_pct=0.5,
+                volatility_annual_pct=8.0,
+                win_rate=65.0,
+                avg_winner=30.0,
+                avg_loser=-10.0,
+            )
+        )
+        assert out.composite_score >= 85.0
+
+    def test_terrible_strategy_scores_below_25(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(
+            _report(
+                sharpe=-1.0,
+                max_dd_pct=50.0,
+                cost_drag_pct=15.0,
+                volatility_annual_pct=45.0,
+                win_rate=30.0,
+                avg_winner=5.0,
+                avg_loser=-15.0,
+            )
+        )
+        assert out.composite_score < 25.0
+
+
+class TestGrade:
+    def test_a_plus_for_score_above_90(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(
+            _report(
+                sharpe=3.0,
+                max_dd_pct=1.0,
+                cost_drag_pct=0.1,
+                volatility_annual_pct=5.0,
+                win_rate=70.0,
+                avg_winner=40.0,
+                avg_loser=-10.0,
+            )
+        )
+        assert out.grade == "A+"
+
+    def test_f_for_score_below_25(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(
+            _report(
+                sharpe=-2.0,
+                max_dd_pct=60.0,
+                cost_drag_pct=20.0,
+                volatility_annual_pct=50.0,
+                win_rate=20.0,
+                avg_winner=2.0,
+                avg_loser=-20.0,
+            )
+        )
+        assert out.grade == "F"
+
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (95.0, "A+"),
+            (85.0, "A"),
+            (75.0, "B+"),
+            (65.0, "B"),
+            (55.0, "C+"),
+            (45.0, "C"),
+            (30.0, "D"),
+            (10.0, "F"),
+        ],
+    )
+    def test_grade_thresholds_inclusive_lower_bound(self, score, expected):
+        from engine.core.strategy_evaluator import _grade_for
+
+        assert _grade_for(score) == expected
+
+
+class TestWarnings:
+    def test_negative_sharpe_warning(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(sharpe=-0.5))
+        assert any("Sharpe" in w for w in out.warnings)
+
+    def test_excessive_drawdown_warning(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(max_dd_pct=35.0))
+        assert any("drawdown" in w.lower() for w in out.warnings)
+
+    def test_high_cost_drag_warning(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(cost_drag_pct=8.0))
+        assert any("cost" in w.lower() for w in out.warnings)
+
+    def test_high_volatility_warning(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(_report(volatility_annual_pct=40.0))
+        assert any("volatility" in w.lower() for w in out.warnings)
+
+    def test_clean_strategy_no_warnings(self):
+        ev = StrategyEvaluator()
+        out = ev.evaluate(
+            _report(
+                sharpe=2.0,
+                max_dd_pct=8.0,
+                cost_drag_pct=1.0,
+                volatility_annual_pct=12.0,
+                win_rate=60.0,
+                avg_winner=20.0,
+                avg_loser=-10.0,
+            )
+        )
+        assert out.warnings == []
+
+
+class TestSerialization:
+    def test_result_to_dict_has_required_keys(self):
         ev = StrategyEvaluator()
         out = ev.evaluate(_report())
         d = out.to_dict()
         assert "composite_score" in d
+        assert "grade" in d
         assert "dimensions" in d
+        assert "warnings" in d
+        assert "weights" in d
+        assert "percentile" in d
         assert isinstance(d["dimensions"], dict)
+        assert isinstance(d["warnings"], list)
 
 
-class TestComparison:
+class TestRanking:
     def test_compare_orders_by_composite_descending(self):
         ev = StrategyEvaluator()
-        a = ev.evaluate(_report(sharpe=2.5, annualized_return_pct=30.0))
-        b = ev.evaluate(_report(sharpe=0.5, annualized_return_pct=5.0))
+        a = ev.evaluate(
+            _report(
+                sharpe=2.5,
+                max_dd_pct=3.0,
+                volatility_annual_pct=8.0,
+                win_rate=65.0,
+            )
+        )
+        b = ev.evaluate(
+            _report(
+                sharpe=0.2,
+                max_dd_pct=25.0,
+                volatility_annual_pct=30.0,
+                win_rate=40.0,
+            )
+        )
         ranked = StrategyEvaluator.rank({"alpha": a, "beta": b})
         assert ranked[0][0] == "alpha"
         assert ranked[1][0] == "beta"
+
+    def test_tie_resolved_by_name(self):
+        ev = StrategyEvaluator()
+        r = ev.evaluate(_report())
+        ranked = StrategyEvaluator.rank({"zebra": r, "alpha": r})
+        assert ranked[0][0] == "alpha"
+        assert ranked[1][0] == "zebra"
 
 
 class TestEvaluatorErrors:
@@ -262,3 +446,13 @@ class TestEvaluatorErrors:
         ev = StrategyEvaluator()
         with pytest.raises(StrategyEvaluatorError):
             ev.evaluate(_report(sharpe=float("nan")))
+
+    def test_inf_volatility_rejected(self):
+        ev = StrategyEvaluator()
+        with pytest.raises(StrategyEvaluatorError):
+            ev.evaluate(_report(volatility_annual_pct=float("inf")))
+
+    def test_negative_volatility_rejected(self):
+        ev = StrategyEvaluator()
+        with pytest.raises(StrategyEvaluatorError):
+            ev.evaluate(_report(volatility_annual_pct=-1.0))


### PR DESCRIPTION
Closes gh#8.

## Summary
Takes a \`MetricsReport\` and produces a composite score in [0, 100] plus a per-dimension breakdown. Lets the marketplace rank strategies in a configurable but principled way — a 20%-return / 40%-drawdown strategy should not outrank a 12%-return / 5%-drawdown one.

## Dimensions
| Dimension | Input | Mapping |
|---|---|---|
| \`RISK_ADJUSTED_RETURN\` | \`sharpe_ratio\` | logistic, 0 → 50, +3 → ~95 |
| \`DRAWDOWN_CONTROL\` | \`max_drawdown_pct\` | inverse-pct, 0% → 100, 22% → 50 |
| \`CONSISTENCY\` | rolling-window sharpe CoV | 100 if all rolling sharpes equal, 50 if fewer than 2 windows |
| \`COST_EFFICIENCY\` | \`cost_drag_pct\` | inverse-pct, 0% → 100, 4% → 50 |
| \`RAW_RETURN\` | \`annualized_return_pct\` | logistic, 0% → 50, 30% → ~95 |

## Default weights
\`\`\`
risk_adjusted_return 0.30
drawdown_control     0.25
consistency          0.15
cost_efficiency      0.15
raw_return           0.15
\`\`\`
Tilted toward risk awareness so high-return / high-drawdown strategies don't dominate. Weights are user-overridable via \`EvaluationWeights\`; construction validates non-negative + sum-to-1 + finite.

## Numeric guards
NaN / inf inputs are rejected at \`evaluate()\` time so a junk metrics report cannot silently land a NaN composite score in the marketplace ranking.

## Test plan
- [x] 24 tests covering each dimension boundary (high / mid / low), weight validation, composite-as-weighted-sum invariant, the static \`rank()\` helper, and validation error paths
- [x] All pass locally
- [ ] CI green
- [ ] Adversarial review

## Follow-ups (not in this PR)
- Wire into the marketplace ranking endpoint
- Wire into the backtest summary endpoint so the score ships with the metrics
- Calibrate the tuning constants (\`_SHARPE_SCALE\`, \`_DRAWDOWN_HALF_LIFE\`, …) once we have real backtest distributions