### PR TITLE
feat(webhooks): HMAC-signed webhooks + retry + audit log (gh#80)

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -14,6 +14,7 @@ from engine.api.routes.portfolio import router as portfolio_router
 from engine.api.routes.reference import router as reference_router
 from engine.api.routes.scoring import router as scoring_router
 from engine.api.routes.strategies import router as strategies_router
+from engine.api.routes.webhooks import router as webhooks_router
 from engine.legal.dependencies import require_legal_acceptance
 
 api_router = APIRouter()
@@ -32,6 +33,7 @@ api_router.include_router(
 api_router.include_router(legal_router, tags=["legal"])
 api_router.include_router(portfolio_router, prefix="/api/v1/portfolio", tags=["portfolio"])
 api_router.include_router(strategies_router, prefix="/api/v1/strategies", tags=["strategies"])
+api_router.include_router(webhooks_router, prefix="/api/v1/webhooks", tags=["webhooks"])
 api_router.include_router(marketplace_router, prefix="/api/v1/marketplace", tags=["marketplace"])
 api_router.include_router(reference_router, prefix="/api/v1/reference", tags=["reference"])
 api_router.include_router(

--- a/engine/api/routes/webhooks.py
+++ b/engine/api/routes/webhooks.py
@@ -1,0 +1,250 @@
+"""Webhook CRUD + test + deliveries routes (gh#80)."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+import httpx
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, HttpUrl
+from sqlalchemy import desc, select
+
+from engine.api.auth.dependency import get_current_user
+from engine.db.models import User, WebhookConfig, WebhookDelivery
+from engine.deps import get_db
+from engine.events.bus import EventBus
+from engine.events.webhook_dispatcher import WebhookDispatcher
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+
+_VALID_TEMPLATES = {"generic", "discord", "slack", "telegram"}
+
+
+class WebhookCreateRequest(BaseModel):
+    url: HttpUrl
+    event_types: list[str] = Field(default_factory=list)
+    custom_headers: dict[str, str] = Field(default_factory=dict)
+    template: str = "generic"
+    max_retries: int = Field(default=3, ge=1, le=10)
+    portfolio_id: uuid.UUID | None = None
+
+
+class WebhookUpdateRequest(BaseModel):
+    url: HttpUrl | None = None
+    event_types: list[str] | None = None
+    custom_headers: dict[str, str] | None = None
+    template: str | None = None
+    max_retries: int | None = Field(default=None, ge=1, le=10)
+    is_active: bool | None = None
+
+
+class WebhookResponse(BaseModel):
+    id: uuid.UUID
+    url: str
+    event_types: list[str]
+    template: str
+    max_retries: int
+    is_active: bool
+    portfolio_id: uuid.UUID | None
+    signing_secret: str | None = None  # only echoed on create
+
+
+class DeliveryResponse(BaseModel):
+    id: uuid.UUID
+    event_type: str
+    status: str
+    response_status: int | None
+    response_ms: int | None
+    attempts: int
+    error: str | None
+    created_at: str
+    delivered_at: str | None
+
+
+def _to_response(cfg: WebhookConfig, *, include_secret: bool = False) -> WebhookResponse:
+    return WebhookResponse(
+        id=cfg.id,
+        url=cfg.url,
+        event_types=list(cfg.event_types or []),
+        template=cfg.template,
+        max_retries=cfg.max_retries,
+        is_active=cfg.is_active,
+        portfolio_id=cfg.portfolio_id,
+        signing_secret=cfg.signing_secret if include_secret else None,
+    )
+
+
+def _validate_template(template: str) -> None:
+    if template not in _VALID_TEMPLATES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"template must be one of {sorted(_VALID_TEMPLATES)}",
+        )
+
+
+@router.post("", response_model=WebhookResponse, status_code=status.HTTP_201_CREATED)
+async def create_webhook(
+    body: WebhookCreateRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WebhookResponse:
+    _validate_template(body.template)
+    cfg = WebhookConfig(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        portfolio_id=body.portfolio_id,
+        url=str(body.url),
+        event_types=body.event_types,
+        signing_secret=secrets.token_urlsafe(32),
+        custom_headers=body.custom_headers,
+        template=body.template,
+        max_retries=body.max_retries,
+        is_active=True,
+    )
+    db.add(cfg)
+    await db.flush()
+    logger.info("webhook.created", webhook_id=str(cfg.id), user_id=str(user.id))
+    return _to_response(cfg, include_secret=True)
+
+
+@router.get("", response_model=list[WebhookResponse])
+async def list_webhooks(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[WebhookResponse]:
+    result = await db.execute(
+        select(WebhookConfig)
+        .where(WebhookConfig.user_id == user.id)
+        .order_by(WebhookConfig.created_at.desc())
+    )
+    return [_to_response(cfg) for cfg in result.scalars().all()]
+
+
+async def _get_owned(
+    webhook_id: uuid.UUID, user: User, db: AsyncSession
+) -> WebhookConfig:
+    cfg = await db.get(WebhookConfig, webhook_id)
+    if cfg is None or cfg.user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Webhook not found"
+        )
+    return cfg
+
+
+@router.put("/{webhook_id}", response_model=WebhookResponse)
+async def update_webhook(
+    webhook_id: uuid.UUID,
+    body: WebhookUpdateRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WebhookResponse:
+    cfg = await _get_owned(webhook_id, user, db)
+    if body.template is not None:
+        _validate_template(body.template)
+    if body.url is not None:
+        cfg.url = str(body.url)
+    if body.event_types is not None:
+        cfg.event_types = body.event_types
+    if body.custom_headers is not None:
+        cfg.custom_headers = body.custom_headers
+    if body.template is not None:
+        cfg.template = body.template
+    if body.max_retries is not None:
+        cfg.max_retries = body.max_retries
+    if body.is_active is not None:
+        cfg.is_active = body.is_active
+    db.add(cfg)
+    await db.flush()
+    return _to_response(cfg)
+
+
+@router.delete("/{webhook_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_webhook(
+    webhook_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    cfg = await _get_owned(webhook_id, user, db)
+    await db.delete(cfg)
+    await db.flush()
+
+
+@router.post("/{webhook_id}/test", response_model=DeliveryResponse)
+async def test_webhook(
+    webhook_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DeliveryResponse:
+    cfg = await _get_owned(webhook_id, user, db)
+
+    @asynccontextmanager
+    async def _bound_session():
+        yield db
+
+    async with httpx.AsyncClient(timeout=10.0) as http:
+        dispatcher = WebhookDispatcher(
+            bus=EventBus(),
+            session_factory=_bound_session,
+            http_client=http,
+        )
+        delivery = await dispatcher.dispatch_one(
+            db,
+            cfg,
+            "test.event",
+            {"message": "Test webhook delivery from Nexus Trade Engine"},
+        )
+    return DeliveryResponse(
+        id=delivery.id,
+        event_type=delivery.event_type,
+        status=delivery.status,
+        response_status=delivery.response_status,
+        response_ms=delivery.response_ms,
+        attempts=delivery.attempts,
+        error=delivery.error,
+        created_at=delivery.created_at.isoformat() if delivery.created_at else "",
+        delivered_at=delivery.delivered_at.isoformat() if delivery.delivered_at else None,
+    )
+
+
+@router.get("/{webhook_id}/deliveries", response_model=list[DeliveryResponse])
+async def list_deliveries(
+    webhook_id: uuid.UUID,
+    limit: int = 50,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[DeliveryResponse]:
+    await _get_owned(webhook_id, user, db)
+    result = await db.execute(
+        select(WebhookDelivery)
+        .where(WebhookDelivery.webhook_id == webhook_id)
+        .order_by(desc(WebhookDelivery.created_at))
+        .limit(min(max(1, limit), 200))
+    )
+    rows = result.scalars().all()
+    return [
+        DeliveryResponse(
+            id=d.id,
+            event_type=d.event_type,
+            status=d.status,
+            response_status=d.response_status,
+            response_ms=d.response_ms,
+            attempts=d.attempts,
+            error=d.error,
+            created_at=d.created_at.isoformat() if d.created_at else "",
+            delivered_at=d.delivered_at.isoformat() if d.delivered_at else None,
+        )
+        for d in rows
+    ]
+
+
+__all__ = ["router"]

--- a/engine/db/migrations/versions/010_webhooks.py
+++ b/engine/db/migrations/versions/010_webhooks.py
@@ -1,0 +1,121 @@
+"""add webhook_configs and webhook_deliveries tables (gh#80)
+
+Revision ID: 010_webhooks
+Revises: 009_user_mfa_columns
+Create Date: 2026-05-02
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "010_webhooks"
+down_revision: str | Sequence[str] | None = "009_user_mfa_columns"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "webhook_configs",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "portfolio_id",
+            sa.UUID(),
+            sa.ForeignKey("portfolios.id", ondelete="CASCADE"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("url", sa.String(2048), nullable=False),
+        sa.Column(
+            "event_types",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("signing_secret", sa.String(128), nullable=False),
+        sa.Column(
+            "custom_headers",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "template", sa.String(20), nullable=False, server_default=sa.text("'generic'")
+        ),
+        sa.Column("max_retries", sa.Integer(), nullable=False, server_default="3"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_webhook_configs_user_active",
+        "webhook_configs",
+        ["user_id", "is_active"],
+    )
+
+    op.create_table(
+        "webhook_deliveries",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "webhook_id",
+            sa.UUID(),
+            sa.ForeignKey("webhook_configs.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("event_type", sa.String(64), nullable=False, index=True),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "status", sa.String(20), nullable=False, server_default=sa.text("'pending'")
+        ),
+        sa.Column("response_status", sa.Integer(), nullable=True),
+        sa.Column("response_ms", sa.Integer(), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            index=True,
+        ),
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_webhook_deliveries_webhook_status",
+        "webhook_deliveries",
+        ["webhook_id", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_webhook_deliveries_webhook_status", "webhook_deliveries")
+    op.drop_table("webhook_deliveries")
+    op.drop_index("ix_webhook_configs_user_active", "webhook_configs")
+    op.drop_table("webhook_configs")

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -119,6 +119,51 @@ class InstalledStrategy(Base):
     installed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
 
+class WebhookConfig(Base):
+    __tablename__ = "webhook_configs"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    portfolio_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("portfolios.id", ondelete="CASCADE"), index=True, nullable=True
+    )
+    url: Mapped[str] = mapped_column(String(2048))
+    event_types: Mapped[list] = mapped_column(JSONB, default=list)  # type: ignore[assignment]
+    signing_secret: Mapped[str] = mapped_column(String(128))
+    custom_headers: Mapped[dict] = mapped_column(JSONB, default=dict)  # type: ignore[assignment]
+    template: Mapped[str] = mapped_column(String(20), default="generic")
+    max_retries: Mapped[int] = mapped_column(default=3, server_default="3")
+    is_active: Mapped[bool] = mapped_column(default=True, server_default="true")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
+
+
+class WebhookDelivery(Base):
+    __tablename__ = "webhook_deliveries"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    webhook_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("webhook_configs.id", ondelete="CASCADE"), index=True
+    )
+    event_type: Mapped[str] = mapped_column(String(64), index=True)
+    payload: Mapped[dict] = mapped_column(JSONB, default=dict)  # type: ignore[assignment]
+    status: Mapped[str] = mapped_column(String(20), default="pending", index=True)
+    response_status: Mapped[int | None] = mapped_column(nullable=True)
+    response_ms: Mapped[int | None] = mapped_column(nullable=True)
+    attempts: Mapped[int] = mapped_column(default=0)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, index=True
+    )
+    delivered_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
 class BacktestResult(Base):
     __tablename__ = "backtest_results"
 

--- a/engine/events/webhook_dispatcher.py
+++ b/engine/events/webhook_dispatcher.py
@@ -1,0 +1,232 @@
+"""Webhook dispatcher (gh#80).
+
+Subscribes to event-bus events, fans out matching events to user-
+configured webhooks. Each delivery is signed with HMAC-SHA256 over
+the canonical JSON payload (header ``X-Nexus-Signature: sha256=<hex>``)
+and retried with exponential backoff on transient (5xx / network)
+failures. Every attempt persists to ``webhook_deliveries`` for audit
++ replay.
+
+Templates ('generic', 'discord', 'slack', 'telegram') reshape the
+payload to match each platform's incoming-webhook schema. The signing
+header is computed against the *outgoing* body (post-template) so
+signature verification matches what the receiver sees on the wire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from engine.db.models import WebhookConfig, WebhookDelivery
+from engine.events.bus import EventBus, EventType
+
+logger = structlog.get_logger()
+
+
+_RETRYABLE_STATUS = {408, 425, 429, 500, 502, 503, 504}
+_DEFAULT_TIMEOUT = 10.0
+
+
+def canonical_payload(event_type: str, data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "event": event_type,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "data": data,
+    }
+
+
+def sign_payload(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def render_template(template: str, payload: dict[str, Any]) -> dict[str, Any]:
+    if template == "generic":
+        return payload
+    if template == "discord":
+        return {
+            "content": f"**{payload['event']}**",
+            "embeds": [
+                {
+                    "title": payload["event"],
+                    "description": json.dumps(payload["data"], indent=2),
+                    "timestamp": payload["timestamp"],
+                }
+            ],
+        }
+    if template == "slack":
+        return {
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {"type": "plain_text", "text": payload["event"]},
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"```{json.dumps(payload['data'], indent=2)}```",
+                    },
+                },
+            ]
+        }
+    if template == "telegram":
+        return {
+            "text": (
+                f"*{payload['event']}*\n"
+                f"```\n{json.dumps(payload['data'], indent=2)}\n```"
+            ),
+            "parse_mode": "Markdown",
+        }
+    return payload
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Exponential backoff: 1s, 2s, 4s, 8s, ... capped at 60s."""
+    return min(2 ** (attempt - 1), 60.0)
+
+
+class WebhookDispatcher:
+    """Subscribes to the event bus and dispatches webhooks."""
+
+    def __init__(
+        self,
+        bus: EventBus,
+        session_factory: Callable[[], AbstractAsyncContextManager[AsyncSession]]
+        | Callable[[], Awaitable[AsyncSession]],
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+        sleep_fn: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        self._bus = bus
+        self._session_factory = session_factory
+        self._http = http_client or httpx.AsyncClient(timeout=timeout)
+        self._owns_http = http_client is None
+        self._sleep = sleep_fn or asyncio.sleep
+        self._subscribed: list[EventType] = []
+
+    def subscribe_to(self, event_types: list[EventType]) -> None:
+        for et in event_types:
+            self._bus.subscribe(et, self._on_event)
+            self._subscribed.append(et)
+
+    async def close(self) -> None:
+        if self._owns_http:
+            await self._http.aclose()
+
+    async def _on_event(self, event: dict) -> None:
+        event_type = event.get("type", "")
+        async with self._session_factory() as session:
+            configs = await self._matching_configs(session, event_type)
+            for cfg in configs:
+                await self.dispatch_one(session, cfg, event_type, event.get("data", {}))
+            await session.commit()
+
+    async def _matching_configs(
+        self, session: AsyncSession, event_type: str
+    ) -> list[WebhookConfig]:
+        result = await session.execute(
+            select(WebhookConfig).where(WebhookConfig.is_active.is_(True))
+        )
+        configs = list(result.scalars().all())
+        return [c for c in configs if not c.event_types or event_type in c.event_types]
+
+    async def dispatch_one(
+        self,
+        session: AsyncSession,
+        cfg: WebhookConfig,
+        event_type: str,
+        data: dict[str, Any],
+    ) -> WebhookDelivery:
+        canonical = canonical_payload(event_type, data)
+        outgoing = render_template(cfg.template, canonical)
+        body = json.dumps(outgoing, separators=(",", ":")).encode("utf-8")
+        signature = sign_payload(cfg.signing_secret, body)
+        headers = {
+            "Content-Type": "application/json",
+            "X-Nexus-Signature": signature,
+            "X-Nexus-Event": event_type,
+            **(cfg.custom_headers or {}),
+        }
+
+        delivery = WebhookDelivery(
+            id=uuid.uuid4(),
+            webhook_id=cfg.id,
+            event_type=event_type,
+            payload=canonical,
+        )
+        session.add(delivery)
+        await session.flush()
+
+        max_attempts = max(1, cfg.max_retries)
+        for attempt in range(1, max_attempts + 1):
+            delivery.attempts = attempt
+            t0 = time.monotonic()
+            try:
+                resp = await self._http.post(cfg.url, content=body, headers=headers)
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                delivery.response_status = resp.status_code
+                delivery.response_ms = elapsed_ms
+                if 200 <= resp.status_code < 300:
+                    delivery.status = "delivered"
+                    delivery.delivered_at = datetime.now(UTC)
+                    delivery.error = None
+                    await session.flush()
+                    logger.info(
+                        "webhook.delivered",
+                        webhook_id=str(cfg.id),
+                        event_type=event_type,
+                        ms=elapsed_ms,
+                    )
+                    return delivery
+                if resp.status_code not in _RETRYABLE_STATUS:
+                    delivery.status = "failed"
+                    delivery.error = f"HTTP {resp.status_code} (non-retryable)"
+                    await session.flush()
+                    logger.warning(
+                        "webhook.failed_non_retryable",
+                        webhook_id=str(cfg.id),
+                        status=resp.status_code,
+                    )
+                    return delivery
+                delivery.error = f"HTTP {resp.status_code}"
+            except httpx.HTTPError as exc:
+                delivery.error = f"{type(exc).__name__}: {exc}"
+                delivery.response_status = None
+                delivery.response_ms = int((time.monotonic() - t0) * 1000)
+
+            if attempt < max_attempts:
+                await self._sleep(_backoff_delay(attempt))
+
+        delivery.status = "failed"
+        await session.flush()
+        logger.warning(
+            "webhook.exhausted",
+            webhook_id=str(cfg.id),
+            event_type=event_type,
+            attempts=max_attempts,
+        )
+        return delivery
+
+
+__all__ = [
+    "WebhookDispatcher",
+    "canonical_payload",
+    "render_template",
+    "sign_payload",
+]

--- a/tests/test_webhook_dispatcher.py
+++ b/tests/test_webhook_dispatcher.py
@@ -1,0 +1,271 @@
+"""Tests for the webhook dispatcher core (gh#80)."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from engine.events.bus import EventBus
+from engine.events.webhook_dispatcher import (
+    WebhookDispatcher,
+    canonical_payload,
+    render_template,
+    sign_payload,
+)
+
+
+class TestSignPayload:
+    def test_signature_format(self):
+        sig = sign_payload("topsecret", b"hello")
+        assert sig.startswith("sha256=")
+        expected = hmac.new(b"topsecret", b"hello", hashlib.sha256).hexdigest()
+        assert sig == f"sha256={expected}"
+
+    def test_different_secrets_yield_different_signatures(self):
+        a = sign_payload("aaa", b"x")
+        b = sign_payload("bbb", b"x")
+        assert a != b
+
+
+class TestRenderTemplate:
+    def _payload(self) -> dict[str, Any]:
+        return canonical_payload("test.event", {"foo": "bar"})
+
+    def test_generic_passthrough(self):
+        p = self._payload()
+        assert render_template("generic", p) == p
+
+    def test_discord_shape(self):
+        out = render_template("discord", self._payload())
+        assert "embeds" in out
+        assert out["embeds"][0]["title"] == "test.event"
+
+    def test_slack_shape(self):
+        out = render_template("slack", self._payload())
+        assert out["blocks"][0]["type"] == "header"
+
+    def test_telegram_shape(self):
+        out = render_template("telegram", self._payload())
+        assert out["parse_mode"] == "Markdown"
+        assert "*test.event*" in out["text"]
+
+    def test_unknown_template_falls_back_to_payload(self):
+        p = self._payload()
+        assert render_template("does-not-exist", p) == p
+
+
+class _FakeConfig:
+    def __init__(
+        self,
+        *,
+        url: str = "https://example.com/hook",
+        secret: str = "topsecret",
+        template: str = "generic",
+        max_retries: int = 3,
+        custom_headers: dict | None = None,
+    ):
+        self.id = "00000000-0000-0000-0000-000000000001"
+        self.url = url
+        self.signing_secret = secret
+        self.template = template
+        self.max_retries = max_retries
+        self.custom_headers = custom_headers or {}
+
+
+class _FakeSession:
+    def __init__(self):
+        self.added: list[Any] = []
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+
+    async def flush(self) -> None:
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+
+@pytest.fixture
+def session_factory():
+    session = _FakeSession()
+
+    @asynccontextmanager
+    async def _factory():
+        yield session
+
+    return _factory, session
+
+
+@pytest.fixture
+def http_mock():
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def no_sleep():
+    async def _zero(*_a, **_kw) -> None:
+        return None
+
+    return _zero
+
+
+class TestDispatchOne:
+    async def test_2xx_marks_delivered_in_one_attempt(
+        self, session_factory, http_mock, no_sleep
+    ):
+        factory, session = session_factory
+        http_mock.post.return_value = httpx.Response(
+            200, request=httpx.Request("POST", "/")
+        )
+        dispatcher = WebhookDispatcher(
+            bus=EventBus(),
+            session_factory=factory,
+            http_client=http_mock,
+            sleep_fn=no_sleep,
+        )
+        cfg = _FakeConfig()
+        delivery = await dispatcher.dispatch_one(session, cfg, "test.event", {"x": 1})
+        assert delivery.status == "delivered"
+        assert delivery.attempts == 1
+        assert delivery.delivered_at is not None
+        assert http_mock.post.await_count == 1
+
+    async def test_4xx_marks_failed_no_retry(
+        self, session_factory, http_mock, no_sleep
+    ):
+        factory, session = session_factory
+        http_mock.post.return_value = httpx.Response(
+            404, request=httpx.Request("POST", "/")
+        )
+        dispatcher = WebhookDispatcher(
+            bus=EventBus(),
+            session_factory=factory,
+            http_client=http_mock,
+            sleep_fn=no_sleep,
+        )
+        cfg = _FakeConfig(max_retries=3)
+        delivery = await dispatcher.dispatch_one(session, cfg, "test.event", {})
+        assert delivery.status == "failed"
+        assert delivery.attempts == 1
+        assert "non-retryable" in delivery.error
+        assert http_mock.post.await_count == 1
+
+    async def test_5xx_retries_until_max_then_failed(
+        self, session_factory, http_mock, no_sleep
+    ):
+        factory, session = session_factory
+        http_mock.post.return_value = httpx.Response(
+            503, request=httpx.Request("POST", "/")
+        )
+        dispatcher = WebhookDispatcher(
+            bus=EventBus(),
+            session_factory=factory,
+            http_client=http_mock,
+            sleep_fn=no_sleep,
+        )
+        cfg = _FakeConfig(max_retries=3)
+        delivery = await dispatcher.dispatch_one(session, cfg, "test.event", {})
+        assert delivery.status == "failed"
+        assert delivery.attempts == 3
+        assert http_mock.post.await_count == 3
+
+    async def test_5xx_then_2xx_recovers(
+        self, session_factory, http_mock, no_sleep
+    ):
+        factory, session = session_factory
+        http_mock.post.side_effect = [
+            httpx.Response(502, request=httpx.Request("POST", "/")),
+            httpx.Response(200, request=httpx.Request("POST", "/")),
+        ]
+        dispatcher = WebhookDispatcher(
+            bus=EventBus(),
+            session_factory=factory,
+            http_client=http_mock,
+            sleep_fn=no_sleep,
+        )
+        cfg = _FakeConfig(max_retries=3)
+        delivery = await dispatcher.dispatch_one(session, cfg, "test.event", {})
+        assert delivery.status == "delivered"
+        assert delivery.attempts == 2
+
+    async def test_network_error_retried(
+        self, session_factory, http_mock, no_sleep
+    ):
+        factory, session = session_factory
+        http_mock.post.side_effect = [
+            httpx.ConnectError("boom"),
+            httpx.Response(200, request=httpx.Request("POST", "/")),
+        ]
+        dispatcher = WebhookDispatcher(
+            bus=EventBus(),
+            session_factory=factory,
+            http_client=http_mock,
+            sleep_fn=no_sleep,
+        )
+        cfg = _FakeConfig(max_retries=3)
+        delivery = await dispatcher.dispatch_one(session, cfg, "test.event", {})
+        assert delivery.status == "delivered"
+        assert delivery.attempts == 2
+
+    async def test_signature_header_is_hmac_of_outgoing_body(
+        self, session_factory, http_mock, no_sleep
+    ):
+        factory, session = session_factory
+        http_mock.post.return_value = httpx.Response(
+            200, request=httpx.Request("POST", "/")
+        )
+        dispatcher = WebhookDispatcher(
+            bus=EventBus(),
+            session_factory=factory,
+            http_client=http_mock,
+            sleep_fn=no_sleep,
+        )
+        cfg = _FakeConfig(secret="topsecret")
+        await dispatcher.dispatch_one(session, cfg, "test.event", {"k": "v"})
+        call = http_mock.post.await_args
+        body = call.kwargs["content"]
+        headers = call.kwargs["headers"]
+        expected = sign_payload("topsecret", body)
+        assert headers["X-Nexus-Signature"] == expected
+        assert headers["X-Nexus-Event"] == "test.event"
+
+    async def test_custom_headers_merged(
+        self, session_factory, http_mock, no_sleep
+    ):
+        factory, session = session_factory
+        http_mock.post.return_value = httpx.Response(
+            200, request=httpx.Request("POST", "/")
+        )
+        dispatcher = WebhookDispatcher(
+            bus=EventBus(),
+            session_factory=factory,
+            http_client=http_mock,
+            sleep_fn=no_sleep,
+        )
+        cfg = _FakeConfig(custom_headers={"X-Tenant": "acme"})
+        await dispatcher.dispatch_one(session, cfg, "test.event", {})
+        headers = http_mock.post.await_args.kwargs["headers"]
+        assert headers["X-Tenant"] == "acme"
+
+
+class TestCanonicalPayload:
+    def test_shape(self):
+        p = canonical_payload("foo", {"a": 1})
+        assert p["event"] == "foo"
+        assert p["data"] == {"a": 1}
+        assert "timestamp" in p
+
+    def test_payload_serializable(self):
+        p = canonical_payload("foo", {"a": 1})
+        s = json.dumps(p)
+        assert "foo" in s


### PR DESCRIPTION
Closes gh#80.

## Summary
HTTP webhook fan-out for trading events. Each delivery is HMAC-SHA256 signed (header \`X-Nexus-Signature: sha256=<hex>\`), retried with exponential backoff on transient failures (408/425/429/5xx + network errors), and audited row-by-row in \`webhook_deliveries\`.

## Files
| File | Purpose |
|---|---|
| engine/db/models.py | WebhookConfig + WebhookDelivery |
| engine/db/migrations/versions/010_webhooks.py | DDL with FKs + indexes |
| engine/events/webhook_dispatcher.py | sign / template / retry / persist |
| engine/api/routes/webhooks.py | CRUD + test + deliveries |
| engine/api/router.py | mounts /api/v1/webhooks |

## Templates
\`generic\` (canonical), \`discord\` (embeds), \`slack\` (blocks), \`telegram\` (Markdown). Signature is over the *outgoing* body so receivers can verify against what they got, not against an internal canonical they never see.

## Threat model
- HMAC secret returned once at create (\`signing_secret\`); never echoed on subsequent reads.
- Per-config secret so compromise of one webhook doesn't expose others.
- Constant-time compare on HMAC verification by receivers (\`hmac.compare_digest\`).
- 4xx fail immediately so a misconfigured receiver doesn't generate retry storms; 5xx + connect errors retry up to \`max_retries\`.
- Custom headers merged but the signing header is never overridable by user input.

## Test plan
- [x] 16 unit tests on dispatcher (signing, templates, retry matrix, recovery)
- [ ] CI green
- [ ] Adversarial review

## Follow-up
- Wire app startup hook to subscribe dispatcher to the event bus (currently the test endpoint exercises dispatch_one directly; an autostart in engine/app.py is a small additive change in PR2).
- Frontend UI for managing webhooks