### PR TITLE
docs(community): add community + governance docs (gh#161)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Report something that doesn't work as expected.
+title: "bug: <short description>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. The more
+        context you can give us, the faster we can fix it.
+
+        **Security issue?** Please don't file it here — see
+        [SECURITY.md](https://github.com/SevFle/nexus-trade-engine/blob/main/SECURITY.md)
+        for the private channels.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps a maintainer can follow.
+      placeholder: |
+        1. Run `nexus-trade-engine ...`
+        2. Send request `...`
+        3. Observe `...`
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Tag, release, or commit SHA you reproduced this on.
+      placeholder: "v0.4.2 / commit a0db600"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      description: How are you running Nexus Trade Engine?
+      options:
+        - Local dev (docker compose)
+        - Local dev (bare metal / venv)
+        - Self-hosted (containers)
+        - Self-hosted (Kubernetes)
+        - Other (please describe in "What happened?")
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: |
+        OS, Python version, database, broker, anything else that might matter.
+      placeholder: |
+        - OS: macOS 14.5 / Ubuntu 24.04
+        - Python: 3.14.0
+        - DB: Postgres 16
+        - Broker: paper / Alpaca / IBKR
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / error output
+      description: |
+        Paste a short log excerpt. Please scrub any secrets or PII first.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: pre-checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I'm running a supported version (latest tag from the last 90 days, or `main`).
+          required: false
+        - label: I scrubbed any secrets / PII from the logs above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/SevFle/nexus-trade-engine/security/advisories/new
+    about: Please report security issues privately. Do not open a public issue.
+  - name: Questions and discussion
+    url: https://github.com/SevFle/nexus-trade-engine/discussions
+    about: Use Discussions for setup help, design questions, and proposals.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,80 @@
+name: Feature request
+description: Propose a new capability or a meaningful improvement.
+title: "feat: <short description>"
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Filling this out fully helps
+        us decide quickly whether the change belongs in core, in a plugin,
+        or in a downstream fork.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user / operator problem are you trying to solve?
+      placeholder: |
+        As a <user role>, I want to <do something> so that <outcome>.
+        Right now this is hard / impossible because <reason>.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        What should we build? API shape, UX sketch, or rough design notes
+        are all welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        Other approaches you ruled out, plugins / forks that already do
+        something similar, etc.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Where should this live?
+      options:
+        - Core (engine, API, frontend)
+        - Plugin / extension
+        - Documentation only
+        - Tooling / CI
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: |
+        Bulleted list of "this is done when..." statements. The clearer
+        these are, the easier it is to scope the work.
+      placeholder: |
+        - [ ] Operator can do X via the UI
+        - [ ] API returns shape Y
+        - [ ] Documented in docs/...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: pre-checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues / discussions and this is not a duplicate.
+          required: true
+        - label: This is in scope for the project (not a personal fork-only need).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,68 @@
+<!--
+Thanks for opening a PR! Please fill in each section below — empty
+sections will slow down review.
+-->
+
+## Summary
+
+<!-- 1–3 bullets: what this PR does and why. -->
+
+-
+-
+
+## Linked Issues
+
+<!-- Use "Closes #123" / "Fixes #123" so the issue auto-closes on merge. -->
+
+Closes #
+
+## Changes
+
+<!-- Notable code, schema, config, or behavioural changes. -->
+
+-
+
+## Test Plan
+
+<!--
+Markdown checklist of how reviewers (or CI) will verify this works.
+Include manual steps for anything CI doesn't cover.
+-->
+
+- [ ] Unit tests added / updated
+- [ ] Integration tests added / updated (if DB or HTTP boundary changed)
+- [ ] `make test` passes locally
+- [ ] `make lint` passes locally
+- [ ] Manual verification: <describe>
+
+## Database / Migrations
+
+<!-- Delete this section if no schema change. -->
+
+- [ ] Added an Alembic revision in `engine/db/migrations/versions/`
+- [ ] Migration is reversible OR the down-migration is intentionally a no-op
+- [ ] Tested against an existing dev database (no destructive surprises)
+
+## Breaking Changes
+
+<!--
+List any API, config, env var, or behaviour change that would break an
+existing operator. If none, write "None".
+-->
+
+None
+
+## Follow-ups
+
+<!--
+Anything intentionally deferred. Link to a tracking issue when possible.
+-->
+
+-
+
+## Checklist
+
+- [ ] PR title follows conventional commits (`feat:`, `fix:`, `docs:`, ...)
+- [ ] Self-reviewed the diff
+- [ ] No secrets, credentials, or PII in the diff
+- [ ] Updated relevant docs (README, ADR, in-code docstrings)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,62 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the
+Nexus Trade Engine community a harassment-free experience for everyone,
+regardless of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers via a private channel listed in
+[SECURITY.md](SECURITY.md). All complaints will be reviewed and investigated
+promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to Nexus Trade Engine
+
+Thanks for your interest in improving Nexus Trade Engine. This document
+covers everything you need to land a change quickly and predictably.
+
+## Quick Start
+
+```bash
+# 1. Fork, then clone your fork
+git clone git@github.com:<you>/nexus-trade-engine.git
+cd nexus-trade-engine
+
+# 2. Set up the dev environment
+make setup            # installs Python deps, pre-commit hooks, etc.
+cp .env.example .env  # fill in any local secrets
+
+# 3. Run the test suite to confirm a clean baseline
+make test
+```
+
+If `make` is not available, see the equivalent commands in
+[`docs/development.md`](docs/development.md) (or the Makefile itself).
+
+## Branching
+
+- Branch from `main`.
+- Use a descriptive prefix: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`,
+  `perf/`, `ci/`, or `test/`, followed by a short slug and (when relevant)
+  the GitHub issue number, e.g. `feat/oms-shadow-mode-111`.
+- Keep branches focused — one logical change per PR is much easier to review
+  than a sprawling branch.
+
+## Development Workflow
+
+We follow a TDD-leaning workflow:
+
+1. **Write or update tests first.** New behaviour without a test will be
+   asked to add one in review.
+2. **Implement** the smallest change that makes the test pass.
+3. **Refactor** with the tests green.
+4. **Run the full local check** before pushing:
+
+   ```bash
+   make lint     # ruff / black / mypy where configured
+   make test    # pytest
+   make build   # docker build, sanity check
+   ```
+
+5. Open the PR — see the template for the expected fields.
+
+For larger features, please open an issue first or start a draft PR so we
+can align on the approach before you spend a lot of time.
+
+## Coding Standards
+
+- **Python:** 3.14+, formatted with `ruff format` (Black-compatible). Imports
+  are sorted by `ruff`. Type hints are expected on public functions.
+- **Async first:** server code uses async SQLAlchemy / FastAPI. Avoid mixing
+  blocking I/O into async paths.
+- **Migrations:** add an Alembic revision in `engine/db/migrations/versions/`
+  for any schema change. The chain is numbered (e.g. `010_webhooks.py`) —
+  pick the next number.
+- **Logging:** use `structlog`. The `event` kwarg is reserved by structlog;
+  pass domain-event names as `event_type=` instead.
+- **Secrets:** never commit secrets. The CI secret scan (gitleaks) will
+  block the PR if it finds any.
+
+## Testing
+
+- We aim for >= 80% coverage on new code. Use `pytest --cov` locally to
+  check.
+- Prefer integration tests against the real DB layer for anything that
+  touches SQL — mock-only tests have masked migration bugs in the past.
+- Long-running or external-network tests should be marked and skipped by
+  default.
+
+## Pull Requests
+
+- Fill in the PR template completely (`.github/PULL_REQUEST_TEMPLATE.md`).
+- Reference the GitHub issue (`Closes #123`) when applicable.
+- Keep the PR title under 70 characters and use the conventional-commits
+  style: `feat:`, `fix:`, `docs:`, `chore:`, etc.
+- Self-review the diff before requesting review.
+- Make sure CI is green — if a check is flaky, mention it explicitly so
+  reviewers know.
+
+## Reporting Bugs and Requesting Features
+
+Use the issue forms in `.github/ISSUE_TEMPLATE/`. The forms exist to make
+sure we capture enough context to triage quickly. Security issues do **not**
+go in public issues — see [`SECURITY.md`](SECURITY.md).
+
+## Code of Conduct
+
+By participating you agree to follow our
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). Reports of violations go through
+the channels in [`SECURITY.md`](SECURITY.md).
+
+## Licensing
+
+Contributions are accepted under the project's existing license (see
+[`LICENSE`](LICENSE)). Submitting a pull request signals that you have the
+right to contribute the code under that license.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,65 @@
+# Project Governance
+
+## Mission
+
+Nexus Trade Engine ships an open, extensible algorithmic-trading platform
+for retail and prosumer quants. Governance exists to keep contributions
+flowing, decisions transparent, and the project usable by people who do
+not have time to follow every commit.
+
+## Roles
+
+### Users
+Anyone running the engine. No formal commitment.
+
+### Contributors
+Anyone whose pull request was merged. Recognized in the release notes.
+
+### Maintainers
+Have merge / release rights. They review PRs, triage issues, and shepherd
+releases. Listed in `MAINTAINERS.md` (or the GitHub "maintainers" team)
+once the role is formalized for this fork.
+
+### Lead Maintainer
+A single person who breaks ties on contested decisions and represents the
+project externally. Currently the original author / fork owner. The role
+rotates by mutual consent of active maintainers; rotation is announced in
+a release note when it happens.
+
+## Decision Making
+
+We aim for **lazy consensus**: a maintainer proposes a change, waits 72
+hours, and merges if no maintainer raises a substantive objection. For
+larger changes (architecture, dependencies, breaking-change releases) we
+prefer a written ADR (`docs/adr/`) and an explicit approval from at least
+two maintainers.
+
+When consensus cannot be reached, the lead maintainer decides. Their
+decision is documented in the relevant ADR or PR.
+
+## Becoming a Maintainer
+
+Sustained, substantive contributions over several months — code review,
+issue triage, releases, documentation — and a nomination from an existing
+maintainer. The current maintainer team votes; a simple majority approves.
+
+Maintainers can step down at any time and are marked `Emeritus` once they
+do.
+
+## Releases
+
+We follow semantic versioning. Patch releases are cut on demand by any
+maintainer; minor and major releases are announced one week in advance in
+the Discussions area to gather final feedback. The release workflow
+publishes container images, SDKs, and the changelog automatically.
+
+## Code of Conduct
+
+All participation is governed by [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+Reports of violations go through the channels in [`SECURITY.md`](SECURITY.md).
+
+## Funding & Trademarks
+
+Any external funding, sponsorships, or trademark filings are disclosed in
+a public ADR before being executed. The project does not accept directed
+funding that would constrain technical decisions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+
+## Supported Versions
+
+Only the `main` branch and the latest tagged release receive security fixes.
+Older releases are best-effort. We recommend always running on a tag from the
+last 90 days.
+
+## Reporting a Vulnerability
+
+**Do not file public GitHub issues for security vulnerabilities.**
+
+Use one of these private channels:
+
+1. **GitHub Security Advisories** — preferred. Open a draft advisory at
+   <https://github.com/SevFle/nexus-trade-engine/security/advisories/new>.
+   This keeps the discussion private until coordinated disclosure.
+2. **Email** — `security@example.com` (operators forking this repo should
+   replace with the address configured for their deployment). Encrypt with
+   the maintainer's PGP key if available.
+
+Include:
+
+- A clear description of the vulnerability and its impact
+- A minimal reproduction (commit hash, request, configuration)
+- The version / commit you found it on
+- Whether you would like credit in the advisory
+
+We will acknowledge your report within **3 business days** and aim to issue
+a fix or mitigation within **30 days** for critical issues. We will keep you
+updated on progress and will coordinate disclosure timing with you.
+
+## Scope
+
+In scope:
+
+- The Nexus Trade Engine API, frontend, plugins, MCP server, and
+  infrastructure templates shipped from this repository.
+- Authentication, authorization, MFA, rate limiting, CSRF / CSP / CORS handling.
+- Data integrity issues that could mislead users about portfolio state, P&L,
+  or trade fills.
+
+Out of scope:
+
+- Social engineering of maintainers.
+- Denial of service that requires excessive request volume against
+  unauthenticated endpoints — operators are expected to deploy a rate
+  limiter / WAF.
+- Vulnerabilities in third-party dependencies that we have not yet pulled
+  in — please report those upstream first.
+- Theoretical attacks without a working proof of concept.
+
+## Safe Harbor
+
+If you make a good-faith effort to comply with this policy, we will:
+
+- Not pursue civil action or report you to law enforcement.
+- Work with you to understand and resolve the issue quickly.
+- Recognize your contribution if you wish.
+
+## Disclosures
+
+Past advisories: <https://github.com/SevFle/nexus-trade-engine/security/advisories>


### PR DESCRIPTION
## Summary
- Add the standard OSS community docs missing from the repo: Code of Conduct, Security policy, Governance, Contributing guide, plus PR + issue templates.
- Wires private security disclosure through GitHub Security Advisories.
- Establishes lazy-consensus governance with ADR process and semver releases.

Closes #161

## Changes
- \`CODE_OF_CONDUCT.md\` — Contributor Covenant 2.1.
- \`SECURITY.md\` — private vuln reporting (GHSA + email), 3-day ack / 30-day fix SLA, scope + safe harbor.
- \`GOVERNANCE.md\` — roles (User/Contributor/Maintainer/Lead), lazy consensus, ADRs for big changes, semver.
- \`CONTRIBUTING.md\` — branch naming (\`feat/...\`-style with issue suffix), TDD workflow, coding standards (structlog \`event_type=\`, alembic chain, async-first), PR checklist.
- \`.github/PULL_REQUEST_TEMPLATE.md\` — summary, linked issues, test plan, migrations, breaking changes, follow-ups, checklist.
- \`.github/ISSUE_TEMPLATE/{bug.yml, feature.yml, config.yml}\` — form schemas + redirects to Discussions / Security Advisories.

## Test Plan
- [x] \`git status\` clean after staging community files only
- [x] CoC, Security, Governance, Contributing render correctly as Markdown
- [ ] Issue picker on GitHub shows the two forms + Security/Discussions contact links (verify post-merge)
- [ ] PR template auto-populates on next PR (verify post-merge)

## Breaking Changes
None — pure additive docs / templates.

## Follow-ups
- Replace \`security@example.com\` placeholder once a real mailbox exists.
- Add \`MAINTAINERS.md\` once the maintainer list is formalized (referenced by GOVERNANCE.md).