### PR TITLE
feat(ci): publish multi-arch GHCR images with cosign + SBOM on release (gh#141)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,123 @@
+name: Publish container images
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to publish (defaults to the ref)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    name: Build & publish multi-arch image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=sha,format=long,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=Nexus Trade Engine
+            org.opencontainers.image.description=Algorithmic trading backtesting and execution engine
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and push (multi-arch)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless, OIDC)
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+
+      - name: Generate SBOM (Syft, SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          artifact-name: sbom-spdx.json
+          upload-artifact: true
+          upload-release-assets: ${{ github.event_name == 'release' }}
+
+      - name: Attest SBOM
+        if: github.event_name == 'release'
+        uses: actions/attest-sbom@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-spdx.json
+          push-to-registry: true
+
+      - name: Summary
+        run: |
+          {
+            echo "## Published image"
+            echo ""
+            echo "- **Registry:** \`${REGISTRY}/${IMAGE_NAME}\`"
+            echo "- **Digest:** \`${DIGEST}\`"
+            echo "- **Tags:**"
+            for tag in ${TAGS}; do echo "  - \`${tag}\`"; done
+            echo ""
+            echo "Image is signed via cosign keyless OIDC and ships an SPDX SBOM attestation."
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -67,11 +67,50 @@ feat!: replace /api/v1/strategy with /api/v2/strategy
 4. Merging the release PR triggers release-please again, which:
    - Tags the commit (`vX.Y.Z`).
    - Creates a GitHub Release with the changelog excerpt.
-   - Triggers any downstream workflows that listen on `release: published`
-     (for example, container image and SBOM publishing — see issue #141).
+   - Triggers any downstream workflows that listen on `release: published`,
+     primarily `.github/workflows/publish-images.yml` which builds and pushes
+     a multi-arch (`linux/amd64`, `linux/arm64`) image to
+     `ghcr.io/<owner>/nexus-trade-engine`, signs it with cosign (keyless
+     OIDC), and attaches an SPDX SBOM attestation.
 
 No manual `git tag` or `gh release create` is required. Hand-rolled tags
 will desynchronise the manifest and should be avoided.
+
+## Container Images
+
+Every published release produces a multi-arch container image at:
+
+```
+ghcr.io/<owner>/nexus-trade-engine:<version>
+ghcr.io/<owner>/nexus-trade-engine:<major>.<minor>
+ghcr.io/<owner>/nexus-trade-engine:latest      # only on non-prerelease
+ghcr.io/<owner>/nexus-trade-engine:sha-<sha>
+```
+
+Architectures published: `linux/amd64`, `linux/arm64`. Provenance and SPDX
+SBOMs are attached as image attestations and pushed to the registry.
+
+### Verifying a published image
+
+```bash
+# Verify the cosign signature (keyless OIDC, GitHub Actions identity).
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/<owner>/nexus-trade-engine/.github/workflows/publish-images.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/<owner>/nexus-trade-engine:<version>
+
+# Pull the SBOM attestation (SPDX JSON).
+cosign download attestation \
+  --predicate-type https://spdx.dev/Document \
+  ghcr.io/<owner>/nexus-trade-engine:<version> \
+  | jq -r '.payload' | base64 -d | jq '.predicate'
+```
+
+### Manual republish
+
+The publish workflow can be re-run from the Actions tab via
+**Run workflow → Publish container images**. Use this if a release was
+published before the workflow existed, or to re-tag a digest.
 
 ## Cutting an Out-of-Cycle Patch
 


### PR DESCRIPTION
## Summary
- Trigger an automated container publish on every \`release: published\` event (fired by release-please) and on manual \`workflow_dispatch\`.
- Build multi-arch (\`linux/amd64\`, \`linux/arm64\`) and push to \`ghcr.io/<owner>/nexus-trade-engine\` with semver, major.minor, latest, and \`sha-\` tags.
- Sign every tag with cosign keyless OIDC and attach an SPDX SBOM attestation in-registry plus as a release asset.

Closes #141

## Changes
- \`.github/workflows/publish-images.yml\` — new workflow:
  - Permissions scoped: \`contents: read\`, \`packages: write\`, \`id-token: write\`, \`attestations: write\`.
  - QEMU + Buildx for multi-arch builds.
  - \`docker/metadata-action@v5\` produces the tag set (\`{{version}}\`, \`{{major}}.{{minor}}\`, \`{{major}}\` only post-1.0, \`latest\` only on non-prerelease, \`sha-<sha>\`).
  - \`docker/build-push-action@v6\` with \`provenance: true\`, \`sbom: true\`, GHA cache (\`type=gha\`, \`mode=max\`).
  - \`sigstore/cosign-installer@v3\` + \`cosign sign --yes\` per tag (keyless via OIDC).
  - \`anchore/sbom-action@v0\` generates SPDX JSON; \`actions/attest-sbom@v1\` pushes attestation to registry on release events.
  - Job summary lists registry, digest, and tags.
- \`docs/RELEASING.md\` — adds a Container Images section describing the published tag set, cosign verification command, and SBOM download command. Updates the release flow step that previously referenced \"see issue #141\" to reference the now-existing workflow.

## Test Plan
- [x] YAML lints (action versions are current major releases).
- [x] Permissions block is least-privilege for cosign keyless + attestations + GHCR push.
- [x] \`docker/metadata-action\` tag rules verified against current 0.x version (no \`{{major}}\` tag emitted while \`v0.\`, \`latest\` only when not prerelease).
- [ ] First real run after a release-please tag publishes a signed multi-arch image (verify post-merge by triggering a release).
- [ ] \`workflow_dispatch\` smoke test from the Actions tab (verify post-merge).
- [ ] CI for this PR passes (\`Engine Tests\`, \`Frontend Lint\`, \`Docker Build\`, security suite).

## Database / Migrations
None.

## Breaking Changes
None — adds a new release-time workflow. Does not alter \`Dockerfile\`, runtime behaviour, or existing CI.

## Follow-ups
- Add a frontend container Dockerfile + extend this workflow to publish \`ghcr.io/<owner>/nexus-trade-frontend\` too. Current \`frontend/Dockerfile\` is dev-mode only.
- Wire SLO / Grafana dashboards (#146, #147) to the published-image lifecycle so deployments can be tied back to image digest.
- Document image-pull / verification in \`README.md\` once the first real release is cut.

## Checklist
- [x] PR title follows conventional commits (\`feat(ci): ...\`)
- [x] Self-reviewed the diff
- [x] No secrets, credentials, or PII in the diff
- [x] Documented operator-facing commands in \`docs/RELEASING.md\`