### PR TITLE
docs(ops): document backup, PITR restore, and DR drill (gh#143)

### DIFF
--- a/docs/operations/backup-and-recovery.md
+++ b/docs/operations/backup-and-recovery.md
@@ -1,0 +1,209 @@
+# Backup, Restore, and Disaster Recovery
+
+This runbook describes how to back up the Postgres instance that backs Nexus
+Trade Engine and how to restore it — either from a specific snapshot or to
+an arbitrary point in time (PITR). It is written for operators running their
+own deployment; managed-Postgres users (RDS, Cloud SQL, Crunchy, Supabase,
+Neon, etc.) should use the equivalent vendor-native primitives where they
+exist.
+
+## Recovery Objectives
+
+These are the targets we recommend for a production-class deployment:
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| RPO (recovery point objective) | ≤ 5 minutes | WAL ship interval. |
+| RTO (recovery time objective)  | ≤ 1 hour    | Median full restore. |
+| Backup retention               | 30 days     | Plus weekly archives ≥ 1 year. |
+| Restore drill cadence          | Quarterly   | See [DR drill checklist](dr-drill-checklist.md). |
+
+If your deployment cannot meet these, treat the gap as a known incident and
+document the deviation in your operations log.
+
+## Data Surface to Protect
+
+Nexus Trade Engine stores all durable state in a single Postgres database.
+The schema is owned by the Alembic migration chain in
+`engine/db/migrations/versions/`. The most critical tables for recovery are:
+
+- `users`, including MFA secrets (encrypted at rest with the engine's
+  Fernet key — back up that key separately, see [Secrets](#secrets-and-keys)).
+- `backtest_results` (composite scores, breakdowns).
+- `webhook_configs`, `webhook_deliveries` — operational audit trail.
+- Any `strategies_*`, `orders_*`, and `portfolios_*` tables introduced by
+  later issues (#109 / #111).
+
+Object storage (logs, large artifacts) is **out of scope** — back it up via
+the bucket's native versioning + replication features.
+
+## Backup Strategy
+
+We rely on three layers, each compensating for the failure modes of the
+others:
+
+### 1. Continuous WAL archiving (PITR foundation)
+
+Configure Postgres to ship WAL segments to durable, off-host object storage:
+
+```ini
+# postgresql.conf
+wal_level = replica
+archive_mode = on
+archive_command = 'aws s3 cp %p s3://your-bucket/wal/%f --no-progress'
+archive_timeout = '5min'      # bounds RPO at five minutes
+max_wal_senders = 3
+wal_keep_size = 1GB
+```
+
+Use the bucket's lifecycle policy to expire WAL older than the retention
+window (e.g. 30 days). For non-AWS environments, swap `aws s3 cp` for the
+equivalent `gcloud storage cp`, `az storage blob upload`, `mc cp` (MinIO),
+or `wal-g`.
+
+### 2. Periodic base backups
+
+Take a full physical base backup on a schedule (default: daily at 02:00
+UTC). PITR works by replaying WAL forward from the most recent base backup,
+so without a recent base backup the WAL chain is useless.
+
+The shipped helper at `scripts/ops/pg_basebackup.sh` is a thin wrapper
+around `pg_basebackup`:
+
+```bash
+PGHOST=primary.internal \
+PGUSER=replicator \
+PGPASSWORD=... \
+BACKUP_DEST=s3://your-bucket/base/$(date -u +%F) \
+  scripts/ops/pg_basebackup.sh
+```
+
+Consider `pgbackrest` or `wal-g` for production: both consolidate base
+backups + WAL archiving, support incremental backups, and ship encryption
+out of the box.
+
+### 3. Daily logical dumps (low-cost portability)
+
+A nightly `pg_dump` is cheap insurance against logical corruption that PITR
+will replay forward (e.g. an operator running `DELETE` without a `WHERE`).
+The shipped helper at `scripts/ops/pg_logical_backup.sh` performs a
+custom-format dump and uploads it:
+
+```bash
+PGHOST=primary.internal \
+PGUSER=ntx_backup \
+PGDATABASE=nexus \
+BACKUP_DEST=s3://your-bucket/logical/ \
+RETENTION_DAYS=30 \
+  scripts/ops/pg_logical_backup.sh
+```
+
+Do **not** rely on logical dumps as your only backup — they are a snapshot,
+not a continuous record, and large databases make them painful.
+
+## Encryption and Retention
+
+- Enable server-side encryption on the backup bucket (SSE-S3 / SSE-KMS or
+  vendor equivalent).
+- Object lock / versioning protects against accidental or malicious
+  deletion of past backups. Enable it.
+- Default retention: 30 days for daily; 1 year for weekly archives. Tune
+  based on your compliance regime.
+
+## Secrets and Keys
+
+The engine encrypts MFA secrets and (in future) broker credentials with a
+Fernet key supplied via environment configuration (`MFA_ENCRYPTION_KEY`).
+**Back up that key out-of-band** — losing it makes the encrypted columns
+unrecoverable even with a valid database backup. A typical pattern:
+
+- Store the key in a managed secrets vault (AWS Secrets Manager, Hashicorp
+  Vault, GCP Secret Manager) with versioning enabled.
+- Cross-region replicate the secret if your DB backup is cross-region.
+- Test rotation quarterly using the [DR drill](dr-drill-checklist.md).
+
+Never commit the key to git, and never include it in logical dumps. Rotate
+the key if it has ever been on a developer laptop.
+
+## Restore Procedures
+
+### Full restore from a logical dump
+
+For straightforward "recover yesterday's data" cases:
+
+```bash
+# Provision a clean Postgres at the same major version.
+createdb -h $TARGET_HOST -U $TARGET_USER nexus
+
+# Stream the dump (custom-format) directly from object storage.
+aws s3 cp s3://your-bucket/logical/2026-05-01.dump - | \
+  pg_restore -h $TARGET_HOST -U $TARGET_USER -d nexus \
+             --no-owner --no-privileges --jobs 4
+```
+
+After the restore, run `alembic upgrade head` to confirm the schema is at
+the expected revision.
+
+### Point-in-time recovery (PITR)
+
+Use this when you need to roll back to a specific timestamp — e.g. just
+before a destructive query, or just before a buggy migration ran.
+
+1. Identify the recovery target. Examples:
+   - `2026-05-01 14:33:00 UTC` (timestamp).
+   - The transaction id immediately before the offending one (read it
+     from logs and use `recovery_target_xid`).
+   - A named restore point, if one was created via
+     `SELECT pg_create_restore_point('pre-migration');`.
+2. Stop writes to the failing primary and put it in maintenance mode. Do
+   **not** delete it — you may need it for forensics.
+3. Provision a fresh Postgres at the same major version.
+4. Run the helper:
+
+   ```bash
+   BACKUP_DEST=s3://your-bucket \
+   RECOVERY_TARGET_TIME='2026-05-01 14:33:00 UTC' \
+   PGDATA=/var/lib/postgresql/data \
+     scripts/ops/pg_pitr_restore.sh
+   ```
+
+   The script will:
+   - Download the most recent base backup that predates the recovery
+     target.
+   - Restore it into `$PGDATA`.
+   - Write `recovery.signal` and the appropriate
+     `restore_command` / `recovery_target_*` settings.
+   - Start Postgres in recovery mode and watch until promotion.
+5. Run a smoke test query against the recovered DB before pointing the
+   application at it.
+6. Once verified, repoint the application's `DATABASE_URL`, then take a
+   fresh base backup so the new lineage is protected.
+
+### Recovering MFA-encrypted columns
+
+After a restore, log in as a user with MFA enabled and run through the
+full `/api/v1/auth/login` → `/verify` flow. If the MFA code fails, the
+Fernet key from the running engine does not match the key the backup was
+encrypted with — restore the key from the secrets vault before continuing.
+
+## Monitoring
+
+At minimum, alert on:
+
+- `archive_failures_total` (Postgres `pg_stat_archiver`) > 0 in the last
+  10 minutes.
+- No WAL segment archived in the last `archive_timeout * 3` window.
+- Last successful base backup older than 36 hours.
+- Last successful logical dump older than 36 hours.
+- Backup bucket free space / object count regression.
+
+These map cleanly onto the Grafana dashboards in #146 and the SLOs in #147
+once they land.
+
+## Related
+
+- [DR drill checklist](dr-drill-checklist.md)
+- [`SECURITY.md`](../../SECURITY.md) — disclosure timelines that may force
+  out-of-cycle restores.
+- [`docs/RELEASING.md`](../RELEASING.md) — release runbook (separate from
+  recovery).

--- a/docs/operations/dr-drill-checklist.md
+++ b/docs/operations/dr-drill-checklist.md
@@ -1,0 +1,85 @@
+# DR Drill Checklist
+
+Run this drill **at least once per quarter**. The goal is not to "pass" — it
+is to find the gap before a real incident does. Record every drill (date,
+operator, observations, RTO actually achieved) in your operations log.
+
+## Pre-Drill (T-1 day)
+
+- [ ] Pick a date with at least one other engineer available as a co-pilot.
+- [ ] Notify stakeholders that a drill will run. State that **no production
+      writes will be affected** — the drill restores into a sandbox.
+- [ ] Confirm the latest base backup is < 36 hours old.
+- [ ] Confirm WAL archive is current (no `archive_failures_total`).
+- [ ] Confirm the Fernet key version in the secrets vault matches what
+      production is using.
+
+## Drill (T+0)
+
+### 1. Restore from logical dump (15 min target)
+
+- [ ] Pull the most recent logical dump from the bucket.
+- [ ] Restore into a sandbox Postgres at the same major version.
+- [ ] Run `alembic current` and confirm the schema head matches production.
+- [ ] Run a representative read query (e.g. `SELECT count(*) FROM users`).
+
+### 2. Point-in-time recovery (45 min target)
+
+- [ ] Pick a recovery target ~30 minutes in the past (real-clock-aligned).
+- [ ] Run `scripts/ops/pg_pitr_restore.sh` against the sandbox.
+- [ ] Confirm Postgres reaches `recovery_target` and is promoted.
+- [ ] Verify the recovered DB does **not** contain rows committed after
+      the recovery target. Pick a row inserted between the target and
+      "now" and confirm its absence.
+
+### 3. Application bring-up
+
+- [ ] Repoint a sandbox engine instance at the recovered DB.
+- [ ] Hit `/api/v1/health` — expect `200`.
+- [ ] Log in with an MFA-enabled test user. Confirm the code is accepted
+      (verifies the Fernet key recovery path).
+- [ ] Hit a representative read (e.g. `GET /api/v1/strategies`) and a
+      representative write (e.g. `POST /api/v1/webhooks`) and confirm the
+      write lands.
+
+### 4. Tear down
+
+- [ ] Drop the sandbox database and instance.
+- [ ] Remove the temporary IAM credentials used for the drill.
+
+## Post-Drill (T+1 day)
+
+- [ ] Record actual RTO measured during the drill.
+- [ ] Open issues for every gap found (missing alerts, slow steps, broken
+      docs, undocumented manual steps). Tag them `priority-high` if they
+      would have extended RTO during a real incident.
+- [ ] Update `docs/operations/backup-and-recovery.md` with anything you
+      learned.
+- [ ] Confirm no production resources were left running.
+
+## What to Practice Quarterly
+
+Rotate the scenario each quarter so the team hits every failure mode
+within a year:
+
+| Quarter | Scenario                                                     |
+|---------|--------------------------------------------------------------|
+| Q1      | Logical dump restore to fresh DB.                            |
+| Q2      | PITR to a timestamp.                                         |
+| Q3      | PITR to a transaction id (read from logs).                   |
+| Q4      | Full DR — primary destroyed, restore in a different region.  |
+
+If you only ever rehearse Q1, you have not actually tested PITR.
+
+## Failure Modes to Force
+
+When you have time, deliberately introduce these and verify the runbook
+still works:
+
+- The Fernet key version differs between the running engine and what is
+  in the vault.
+- The latest base backup is corrupt — fall back to the prior one.
+- The WAL bucket is missing a segment — confirm the alert fires before
+  you have to recover.
+- Alembic head differs between dump and code — confirm the operator
+  knows whether to upgrade or downgrade.

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -1,0 +1,30 @@
+# Operations scripts
+
+Operator-facing helper scripts. These are **examples** — review them, fork
+them, and adapt to your storage backend, secrets model, and scheduler
+before depending on them.
+
+| Script | Purpose | Trigger |
+|--------|---------|---------|
+| `pg_logical_backup.sh` | Daily `pg_dump` (custom format) → object storage. Prunes by `RETENTION_DAYS`. | Cron, e.g. `0 2 * * *` |
+| `pg_basebackup.sh`     | Periodic physical base backup (`pg_basebackup` tar+gzip) → object storage. | Cron, e.g. `0 3 * * *` |
+| `pg_pitr_restore.sh`   | Restore a base backup into a fresh `$PGDATA`, then replay WAL to a recovery target and promote. | Manual, during recovery / DR drill |
+
+See [`docs/operations/backup-and-recovery.md`](../../docs/operations/backup-and-recovery.md)
+for the runbook these scripts implement, and
+[`docs/operations/dr-drill-checklist.md`](../../docs/operations/dr-drill-checklist.md)
+for the quarterly drill that exercises them.
+
+## Prerequisites
+
+- `aws` CLI (or set `AWS_CMD` to the equivalent for your object store).
+- `pg_dump`, `pg_basebackup`, `pg_ctl` matching the running Postgres major version.
+- An IAM role / credential with read+write on the backup bucket and read on
+  the WAL prefix.
+
+## Production guidance
+
+For a production deployment we recommend swapping these scripts for
+[pgbackrest](https://pgbackrest.org/) or [wal-g](https://github.com/wal-g/wal-g):
+both consolidate base backups + WAL archiving, support incremental
+backups, ship encryption, and have first-class restore tooling.

--- a/scripts/ops/pg_basebackup.sh
+++ b/scripts/ops/pg_basebackup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Take a physical base backup with pg_basebackup and upload it to object
+# storage. The base backup is what PITR replays WAL forward from.
+#
+# Required env:
+#   PGHOST, PGUSER, PGPASSWORD
+#   BACKUP_DEST   e.g. s3://your-bucket/base/   (must end with /)
+#
+# Optional env:
+#   AWS_CMD     aws CLI binary (default: aws)
+#   COMPRESS    gzip|none      (default: gzip)
+#
+# Reference: docs/operations/backup-and-recovery.md
+
+set -euo pipefail
+
+: "${PGHOST:?PGHOST is required}"
+: "${PGUSER:?PGUSER is required}"
+: "${BACKUP_DEST:?BACKUP_DEST is required (e.g. s3://your-bucket/base/)}"
+
+AWS_CMD="${AWS_CMD:-aws}"
+COMPRESS="${COMPRESS:-gzip}"
+
+case "$BACKUP_DEST" in
+  */) ;;
+  *) BACKUP_DEST="${BACKUP_DEST}/" ;;
+esac
+
+stamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+prefix="${stamp}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+work="${tmp}/${prefix}"
+mkdir -p "$work"
+
+echo "[pg_basebackup] streaming base backup -> ${work}"
+gzip_arg=""
+if [ "$COMPRESS" = "gzip" ]; then
+  gzip_arg="--gzip"
+fi
+
+PGPASSWORD="${PGPASSWORD:-}" pg_basebackup \
+  --host="$PGHOST" \
+  --username="$PGUSER" \
+  --pgdata="$work" \
+  --format=tar \
+  ${gzip_arg} \
+  --progress \
+  --wal-method=fetch \
+  --checkpoint=fast \
+  --verbose
+
+echo "[pg_basebackup] uploading -> ${BACKUP_DEST}${prefix}/"
+"$AWS_CMD" s3 cp --no-progress --recursive "$work" "${BACKUP_DEST}${prefix}/"
+
+echo "[pg_basebackup] done"

--- a/scripts/ops/pg_logical_backup.sh
+++ b/scripts/ops/pg_logical_backup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Take a logical pg_dump of the engine DB and upload it to object storage.
+#
+# Required env:
+#   PGHOST, PGUSER, PGPASSWORD, PGDATABASE
+#   BACKUP_DEST   e.g. s3://your-bucket/logical/   (must end with /)
+#
+# Optional env:
+#   RETENTION_DAYS    purge older dumps after N days (default: 30)
+#   DUMP_JOBS         parallel jobs (default: 4)
+#   AWS_CMD           aws CLI binary (default: aws)
+#
+# Reference: docs/operations/backup-and-recovery.md
+
+set -euo pipefail
+
+: "${PGHOST:?PGHOST is required}"
+: "${PGUSER:?PGUSER is required}"
+: "${PGDATABASE:?PGDATABASE is required}"
+: "${BACKUP_DEST:?BACKUP_DEST is required (e.g. s3://your-bucket/logical/)}"
+
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+DUMP_JOBS="${DUMP_JOBS:-4}"
+AWS_CMD="${AWS_CMD:-aws}"
+
+case "$BACKUP_DEST" in
+  */) ;;
+  *) BACKUP_DEST="${BACKUP_DEST}/" ;;
+esac
+
+stamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+key="${stamp}-${PGDATABASE}.dump"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+dumpfile="${tmp}/${key}"
+
+echo "[pg_logical_backup] dumping ${PGDATABASE} -> ${dumpfile}"
+PGPASSWORD="${PGPASSWORD:-}" pg_dump \
+  --host="$PGHOST" \
+  --username="$PGUSER" \
+  --dbname="$PGDATABASE" \
+  --format=custom \
+  --jobs="$DUMP_JOBS" \
+  --no-owner \
+  --no-privileges \
+  --file="$dumpfile" \
+  --verbose
+
+bytes=$(wc -c < "$dumpfile" | tr -d ' ')
+echo "[pg_logical_backup] dump complete: ${bytes} bytes"
+
+echo "[pg_logical_backup] uploading -> ${BACKUP_DEST}${key}"
+"$AWS_CMD" s3 cp --no-progress "$dumpfile" "${BACKUP_DEST}${key}"
+
+# Best-effort retention pass. Fails closed (warns but exits 0).
+echo "[pg_logical_backup] pruning objects older than ${RETENTION_DAYS} days"
+cutoff=$(date -u -v-"${RETENTION_DAYS}"d +%s 2>/dev/null \
+  || date -u -d "${RETENTION_DAYS} days ago" +%s)
+
+"$AWS_CMD" s3 ls "$BACKUP_DEST" | while read -r line; do
+  obj_date=$(echo "$line" | awk '{print $1, $2}')
+  obj_name=$(echo "$line" | awk '{print $4}')
+  [ -z "$obj_name" ] && continue
+  obj_ts=$(date -u -j -f "%Y-%m-%d %H:%M:%S" "$obj_date" +%s 2>/dev/null \
+    || date -u -d "$obj_date" +%s 2>/dev/null \
+    || true)
+  if [ -n "$obj_ts" ] && [ "$obj_ts" -lt "$cutoff" ]; then
+    echo "[pg_logical_backup]   deleting expired ${obj_name}"
+    "$AWS_CMD" s3 rm "${BACKUP_DEST}${obj_name}" || \
+      echo "[pg_logical_backup]   WARN failed to delete ${obj_name}"
+  fi
+done
+
+echo "[pg_logical_backup] done"

--- a/scripts/ops/pg_pitr_restore.sh
+++ b/scripts/ops/pg_pitr_restore.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Restore Postgres to a point in time by:
+#   1. Downloading the most recent base backup that predates the recovery target
+#   2. Materializing it into $PGDATA
+#   3. Writing recovery.signal + the right restore_command / recovery_target_*
+#   4. Letting Postgres replay WAL until the target, then promote
+#
+# This is intentionally written for the most common operator stack
+# (Postgres 14+, S3-compatible object storage, vanilla pg_basebackup output).
+# Production deployments should consider pgbackrest / wal-g instead.
+#
+# Required env:
+#   BACKUP_DEST           e.g. s3://your-bucket
+#   PGDATA                target data directory (must NOT contain a live cluster)
+#
+# Exactly one of these recovery targets:
+#   RECOVERY_TARGET_TIME  e.g. '2026-05-01 14:33:00 UTC'
+#   RECOVERY_TARGET_XID   e.g. '12345678'
+#   RECOVERY_TARGET_NAME  named restore point
+#
+# Optional env:
+#   AWS_CMD                aws CLI binary    (default: aws)
+#   PG_CTL                 pg_ctl binary     (default: pg_ctl)
+#   POLL_INTERVAL_SEC      promote check     (default: 5)
+#   PROMOTE_TIMEOUT_SEC    abort after N sec (default: 1800)
+#
+# Reference: docs/operations/backup-and-recovery.md
+
+set -euo pipefail
+
+: "${BACKUP_DEST:?BACKUP_DEST is required (e.g. s3://your-bucket)}"
+: "${PGDATA:?PGDATA is required}"
+
+AWS_CMD="${AWS_CMD:-aws}"
+PG_CTL="${PG_CTL:-pg_ctl}"
+POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-5}"
+PROMOTE_TIMEOUT_SEC="${PROMOTE_TIMEOUT_SEC:-1800}"
+
+case "$BACKUP_DEST" in
+  */) BACKUP_DEST="${BACKUP_DEST%/}" ;;
+esac
+
+target_count=0
+[ -n "${RECOVERY_TARGET_TIME:-}" ] && target_count=$((target_count + 1))
+[ -n "${RECOVERY_TARGET_XID:-}"  ] && target_count=$((target_count + 1))
+[ -n "${RECOVERY_TARGET_NAME:-}" ] && target_count=$((target_count + 1))
+if [ "$target_count" -ne 1 ]; then
+  echo "[pitr] ERROR: set exactly one of RECOVERY_TARGET_{TIME,XID,NAME}" >&2
+  exit 2
+fi
+
+if [ -e "${PGDATA}/PG_VERSION" ]; then
+  echo "[pitr] ERROR: ${PGDATA} already contains a cluster — refuse to overwrite" >&2
+  exit 2
+fi
+
+mkdir -p "$PGDATA"
+chmod 700 "$PGDATA"
+
+# Pick the most recent base backup whose prefix sorts <= the target time.
+echo "[pitr] listing base backups under ${BACKUP_DEST}/base/"
+listing=$("$AWS_CMD" s3 ls "${BACKUP_DEST}/base/" | awk '{print $2}' | sed 's:/$::' | sort)
+if [ -z "$listing" ]; then
+  echo "[pitr] ERROR: no base backups found at ${BACKUP_DEST}/base/" >&2
+  exit 1
+fi
+
+if [ -n "${RECOVERY_TARGET_TIME:-}" ]; then
+  target_iso=$(date -u -d "$RECOVERY_TARGET_TIME" +%Y-%m-%dT%H-%M-%SZ 2>/dev/null \
+    || date -u -j -f "%Y-%m-%d %H:%M:%S %Z" "$RECOVERY_TARGET_TIME" +%Y-%m-%dT%H-%M-%SZ)
+  base=$(printf '%s\n' "$listing" | awk -v t="$target_iso" '$0 <= t' | tail -n1)
+else
+  base=$(printf '%s\n' "$listing" | tail -n1)
+fi
+
+if [ -z "$base" ]; then
+  echo "[pitr] ERROR: no base backup predates the recovery target" >&2
+  exit 1
+fi
+
+echo "[pitr] using base backup: ${base}"
+"$AWS_CMD" s3 cp --no-progress --recursive "${BACKUP_DEST}/base/${base}/" "${PGDATA}/"
+
+# Untar any tar.gz archives produced by pg_basebackup --format=tar --gzip
+shopt -s nullglob
+for archive in "${PGDATA}"/*.tar.gz; do
+  echo "[pitr] extracting ${archive}"
+  tar -xzf "$archive" -C "${PGDATA}"
+  rm -f "$archive"
+done
+shopt -u nullglob
+
+# Restore command: download a WAL segment from the archive on demand.
+restore_cmd="${AWS_CMD} s3 cp ${BACKUP_DEST}/wal/%f %p --no-progress"
+
+{
+  echo "# Written by pg_pitr_restore.sh"
+  echo "restore_command = '${restore_cmd}'"
+  if [ -n "${RECOVERY_TARGET_TIME:-}" ]; then
+    echo "recovery_target_time = '${RECOVERY_TARGET_TIME}'"
+  elif [ -n "${RECOVERY_TARGET_XID:-}" ]; then
+    echo "recovery_target_xid = '${RECOVERY_TARGET_XID}'"
+  elif [ -n "${RECOVERY_TARGET_NAME:-}" ]; then
+    echo "recovery_target_name = '${RECOVERY_TARGET_NAME}'"
+  fi
+  echo "recovery_target_action = 'promote'"
+} >> "${PGDATA}/postgresql.auto.conf"
+
+touch "${PGDATA}/recovery.signal"
+
+echo "[pitr] starting Postgres in recovery mode"
+"$PG_CTL" -D "$PGDATA" -l "${PGDATA}/recovery.log" start
+
+deadline=$(( $(date +%s) + PROMOTE_TIMEOUT_SEC ))
+while true; do
+  if [ ! -f "${PGDATA}/recovery.signal" ] && [ ! -f "${PGDATA}/standby.signal" ]; then
+    echo "[pitr] cluster promoted — recovery target reached"
+    break
+  fi
+  if [ "$(date +%s)" -gt "$deadline" ]; then
+    echo "[pitr] ERROR: promote timed out after ${PROMOTE_TIMEOUT_SEC}s — see recovery.log" >&2
+    exit 1
+  fi
+  sleep "$POLL_INTERVAL_SEC"
+done
+
+echo "[pitr] done. Take a fresh base backup before serving traffic."


### PR DESCRIPTION
## Summary
- Add an end-to-end Postgres backup + recovery story for self-hosted operators: runbook, DR-drill checklist, and three example helper scripts.
- Establish concrete RPO (≤ 5 min) / RTO (≤ 1 h) / retention (30 d daily, 1 y weekly) / drill-cadence (quarterly) targets.
- Cover MFA-key recovery hand-off so encrypted columns survive a restore.

Closes #143

## Changes
**Docs**
- \`docs/operations/backup-and-recovery.md\` — three-layer strategy (continuous WAL archiving for PITR, periodic base backups, daily logical dumps), encryption + retention guidance, secrets/key recovery, restore playbooks (logical + PITR), monitoring hooks aligned with #146/#147.
- \`docs/operations/dr-drill-checklist.md\` — quarterly drill: pre-flight, drill steps with explicit per-step RTO targets, post-drill review, scenario rotation matrix, and failure-modes-to-force.

**Helper scripts** (examples; operators should fork before adopting)
- \`scripts/ops/pg_logical_backup.sh\` — \`pg_dump --format=custom\` → S3-compatible storage with retention-based pruning.
- \`scripts/ops/pg_basebackup.sh\` — \`pg_basebackup\` tar+gzip, uploaded under a UTC-stamped prefix.
- \`scripts/ops/pg_pitr_restore.sh\` — picks the latest base backup that predates the recovery target, materializes it, writes \`recovery.signal\` + correct \`recovery_target_{time,xid,name}\`, polls until promotion. Refuses to overwrite an existing cluster.
- \`scripts/ops/README.md\` — index + production guidance pointing at pgbackrest / wal-g for serious deployments.

## Test Plan
- [x] All scripts \`bash -n\` parse cleanly.
- [x] Scripts are committed executable (\`chmod +x\`).
- [x] All cross-references between docs and scripts resolve (relative paths verified).
- [x] No production secrets, hostnames, or bucket names in any file (env-var placeholders only).
- [ ] Operator dry-run against a sandbox Postgres before relying on these in prod (out of scope for this PR — covered by the quarterly DR drill).
- [ ] CI for this PR passes (Engine Tests, Frontend Lint, Docker Build, security suite).

## Database / Migrations
None — this is documentation + standalone shell scripts. No code paths or schema change.

## Breaking Changes
None.

## Follow-ups
- \`#146\` Grafana dashboards should include \`pg_stat_archiver.archive_failures_total\` and \"last successful logical/base backup\" panels.
- \`#147\` SLOs should encode the RPO/RTO targets defined here as alertable burn-rate budgets.
- Once the engine grows broker-credential storage, extend the \"Secrets and Keys\" section with that key's recovery flow.

## Checklist
- [x] PR title follows conventional commits (\`docs(ops): ...\`)
- [x] Self-reviewed the diff
- [x] No secrets, credentials, or PII in the diff
- [x] Updated relevant docs index (\`scripts/ops/README.md\`)