### PR TITLE
docs(observability): define SLOs + burn-rate alerts (gh#147)

### DIFF
--- a/docs/operations/slos.md
+++ b/docs/operations/slos.md
@@ -1,0 +1,146 @@
+# Service Level Objectives
+
+This document defines the Service Level Objectives (SLOs) and error
+budgets that operators of Nexus Trade Engine should treat as the floor
+for "production-acceptable" service. The accompanying Prometheus
+recording and alerting rules live at
+[`observability/prometheus/slo-rules.yaml`](../../observability/prometheus/slo-rules.yaml).
+
+The SLO model follows Google SRE multi-window multi-burn-rate (MWMBR)
+alerting. It is deliberately simple — six SLOs, one error-budget window,
+two alert severities — so it survives contact with the on-call rotation.
+
+## Critical User Journeys
+
+| Journey         | SLI                                                   | SLO (28d)   | Severity if violated |
+|-----------------|-------------------------------------------------------|-------------|----------------------|
+| API availability | Non-5xx HTTP responses / total HTTP responses        | **99.5 %**  | Page                 |
+| API latency      | HTTP responses with `duration < 1.0s` / total        | **99.0 %**  | Page                 |
+| Auth & MFA       | Non-5xx auth + MFA-verify responses / total          | **99.9 %**  | Page                 |
+| Backtest submit  | Successful `POST /api/v1/backtest` / total submissions | **99.0 %**  | Ticket               |
+| Webhook delivery | Webhook deliveries terminating in `delivered` / total terminal deliveries | **99.0 %** | Ticket |
+| Task pipeline    | TaskIQ jobs reaching `completed` / total scheduled   | **99.5 %**  | Ticket               |
+
+"Page" means an alert wakes the on-call. "Ticket" means it lands in the
+backlog within business hours.
+
+## Why these SLOs
+
+- **API availability + latency** — direct user experience. 99.5 % over 28
+  days = ≈ 3.6 hours of downtime per month, which is consistent with a
+  single self-hosted node without HA.
+- **Auth & MFA** — security-critical and unforgiving (a failure means
+  legitimate users cannot log in). One nine higher than general API.
+- **Backtest submit** — a write path tied to user money decisions; we want
+  to know quickly if it stops accepting work. Latency is intentionally
+  not SLOed here — backtests are async; latency belongs to the task
+  pipeline SLO.
+- **Webhook delivery** — outbound side-effect; the dispatcher in
+  [`engine/events/webhook_dispatcher.py`](../../engine/events/webhook_dispatcher.py)
+  retries 5xx but gives up on 4xx. Drops in delivered-rate that aren't
+  attributable to bad operator config indicate either a registry of bad
+  endpoints or a bug in retry handling.
+- **Task pipeline** — taskiq workers must drain. Stuck queues silently
+  break backtests, scheduled rebalances, and reporting.
+
+## Error Budget
+
+For an SLO of `S` over a 28-day window the error budget is `(1 − S)` of
+the qualifying events, equivalent in time to:
+
+```
+budget_minutes = (1 − S) × 28 × 24 × 60
+```
+
+| SLO       | Budget per 28d (events) | Time-equivalent (uptime view) |
+|-----------|--------------------------|-------------------------------|
+| 99.0 %    | 1.00 % of events         | ≈ 6 h 43 min                  |
+| 99.5 %    | 0.50 % of events         | ≈ 3 h 22 min                  |
+| 99.9 %    | 0.10 % of events         | ≈ 40 min                      |
+
+When the budget is exhausted the on-call is expected to:
+
+1. Stop pushing risky changes (no migrations, no infra swaps) until the
+   budget recovers.
+2. Open a follow-up issue tagged `priority-high` to prevent recurrence.
+3. Optionally relax the SLO temporarily if the breach was caused by a
+   one-off external event — note the relaxation in the on-call log so it
+   is not silently absorbed.
+
+## Burn-Rate Alerts (MWMBR)
+
+We use four burn-rate alerts per SLO, paired by severity:
+
+| Severity | Long window | Short window | Burn rate | Triggers if budget would be exhausted in… |
+|----------|-------------|--------------|-----------|-------------------------------------------|
+| Page     | 1 h         | 5 min        | 14.4 ×    | ≈ 2 days                                  |
+| Page     | 6 h         | 30 min       | 6 ×       | ≈ 5 days                                  |
+| Ticket   | 24 h        | 2 h          | 3 ×       | ≈ 10 days                                 |
+| Ticket   | 72 h        | 6 h          | 1 ×       | ≈ 30 days                                 |
+
+The "short window" gate prevents alerts from firing on a brief blip
+already absorbed by the budget; the "long window" gate prevents alerts
+from firing on noise. Both windows must exceed the burn-rate threshold
+simultaneously for the alert to fire — see Google SRE Workbook chapter 5
+for the original derivation.
+
+The Prometheus rule file at
+[`observability/prometheus/slo-rules.yaml`](../../observability/prometheus/slo-rules.yaml)
+encodes these alerts as four `alert:` blocks per SLO. Recording rules
+pre-compute the SLI numerator + denominator at 5 m, 1 h, 6 h, 24 h, and
+72 h windows so the alert expressions are cheap.
+
+## Wiring
+
+The metrics backend is currently `NullBackend` by default — the engine
+emits to a no-op until an exporter is configured at deploy time. To
+collect real SLI data you need:
+
+1. A Prometheus-compatible scrape endpoint. The intended path is to set
+   `metrics_backend = "prometheus"` once the exporter lands and expose
+   `/metrics` from the FastAPI app. The metric names below are what the
+   recording rules expect; they should match what the eventual exporter
+   emits.
+2. The Prometheus rule file loaded into your Prometheus / Alertmanager
+   stack. See [`observability/prometheus/README.md`](../../observability/prometheus/README.md).
+3. A receiver in Alertmanager for both `severity: page` and
+   `severity: ticket`. Page receivers should be paging-grade
+   (PagerDuty / Opsgenie / on-call SMS), ticket receivers can be Slack
+   / GitHub issue / email.
+
+## SLI Reference
+
+The SLOs above expect metrics in this shape (units in parentheses):
+
+| Metric                                  | Type        | Tags                                     | Notes                                                                 |
+|-----------------------------------------|-------------|------------------------------------------|-----------------------------------------------------------------------|
+| `nexus.http.requests_total`             | counter     | `route`, `method`, `status_code`         | One per FastAPI response.                                             |
+| `nexus.http.request_duration_seconds`   | histogram   | `route`, `method`, `status_code`         | Total handler duration.                                               |
+| `nexus.auth.attempts_total`             | counter     | `outcome` (`success` / `failure` / `mfa_required`) | Auth + MFA verify combined.                                  |
+| `nexus.backtest.submissions_total`      | counter     | `outcome` (`accepted` / `rejected` / `error`)      | One per `POST /api/v1/backtest`.                            |
+| `nexus.webhook.deliveries_terminal_total` | counter   | `outcome` (`delivered` / `failed`)       | Emitted by the dispatcher when a delivery row reaches a terminal state. |
+| `nexus.task.runs_total`                 | counter     | `task`, `outcome` (`completed` / `failed` / `dead`) | One per taskiq worker run.                                  |
+
+Add or change metrics? Update both the rules file and the SLI table here
+in the same change so they don't drift.
+
+## Reviewing & Evolving SLOs
+
+- Review SLO targets quarterly. Adjust if the SLI shape changed (e.g. a
+  new endpoint dominates traffic) or if the targets are demonstrably
+  wrong (chronically over- or under-shooting without corresponding user
+  impact).
+- Treat each adjustment as a code change — bump the rule file and this
+  document together, and capture the rationale in the PR description.
+- New journeys (live trading loop, OMS) added in #109 / #111 will need
+  their own SLOs. Add them to this table when they land; do not ship a
+  new write-path without one.
+
+## Related
+
+- [`observability/prometheus/slo-rules.yaml`](../../observability/prometheus/slo-rules.yaml)
+- [`docs/operations/backup-and-recovery.md`](backup-and-recovery.md) —
+  RPO/RTO live in that runbook; they are not SLOs in the strict sense
+  but feed the same alert pipeline.
+- [`docs/observability/logging.md`](../observability/logging.md) — log
+  schema that pairs with these metrics.

--- a/observability/prometheus/README.md
+++ b/observability/prometheus/README.md
@@ -1,0 +1,65 @@
+# Prometheus rules
+
+This directory contains Prometheus configuration that operators can pull
+into their own monitoring stack.
+
+| File | Purpose |
+|------|---------|
+| `slo-rules.yaml` | Recording + multi-window multi-burn-rate alert rules for the six SLOs defined in [`docs/operations/slos.md`](../../docs/operations/slos.md). |
+
+## Loading the rules
+
+In your `prometheus.yml`:
+
+```yaml
+rule_files:
+  - /etc/prometheus/rules/slo-rules.yaml
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+```
+
+Then mount or copy `slo-rules.yaml` into `/etc/prometheus/rules/`.
+
+## Validating
+
+Before deploying changes, run `promtool` against the file:
+
+```bash
+promtool check rules observability/prometheus/slo-rules.yaml
+promtool test rules <your-test-file>          # optional, when adding new SLOs
+```
+
+`promtool` is shipped with the Prometheus binary release.
+
+## Routing in Alertmanager
+
+Two severities are emitted: `severity: page` (wakes the on-call) and
+`severity: ticket` (business-hours follow-up). A minimal Alertmanager
+route looks like:
+
+```yaml
+route:
+  receiver: ticket-default
+  group_by: [slo]
+  routes:
+    - matchers: [severity="page"]
+      receiver: pager
+      group_wait: 30s
+      repeat_interval: 4h
+    - matchers: [severity="ticket"]
+      receiver: ticket-default
+      repeat_interval: 24h
+```
+
+## Editing rules
+
+- Keep the SLI table in `docs/operations/slos.md` in sync with whatever
+  metric names appear in `slo-rules.yaml`. The table is the contract; the
+  rule file is the implementation.
+- Burn-rate thresholds are derived from the SLO target and the
+  long/short window pair — see [`docs/operations/slos.md#burn-rate-alerts-mwmbr`](../../docs/operations/slos.md#burn-rate-alerts-mwmbr).
+- Recording-rule names follow `nexus:slo:<journey>:<kind>:rate<window>`.
+  Adding a new journey? Stick to the same shape so dashboards (#146) can
+  pattern-match on the prefix.

--- a/observability/prometheus/slo-rules.yaml
+++ b/observability/prometheus/slo-rules.yaml
@@ -1,0 +1,458 @@
+# Prometheus recording + alerting rules for the SLOs defined in
+# docs/operations/slos.md
+#
+# Metric naming
+# -------------
+# The engine's internal MetricsBackend uses dotted names
+# (e.g. nexus.http.requests_total). Prometheus exporters translate dots
+# into underscores, so this file references the underscore form
+# (nexus_http_requests_total). If your exporter uses a different
+# convention, search-and-replace the metric names here in one pass — the
+# alert math does not change.
+#
+# Convention for recording-rule names:
+#   nexus:slo:<journey>:<numerator|denominator|error_ratio>:rate<window>
+#
+# Each journey produces error_ratio rates at multiple windows so alerts
+# can pair a long and a short window per Google SRE MWMBR pattern.
+#
+# Severity contract:
+#   severity: page    — wakes the on-call (paging-grade receiver)
+#   severity: ticket  — opens a backlog ticket within business hours
+
+groups:
+  # =========================================================================
+  # 1. API availability — 99.5%
+  # =========================================================================
+  - name: nexus.slo.api_availability
+    interval: 30s
+    rules:
+      - record: nexus:slo:api_availability:error_ratio:rate5m
+        expr: |
+          sum(rate(nexus_http_requests_total{status_code=~"5.."}[5m]))
+          /
+          clamp_min(sum(rate(nexus_http_requests_total[5m])), 1)
+      - record: nexus:slo:api_availability:error_ratio:rate30m
+        expr: |
+          sum(rate(nexus_http_requests_total{status_code=~"5.."}[30m]))
+          /
+          clamp_min(sum(rate(nexus_http_requests_total[30m])), 1)
+      - record: nexus:slo:api_availability:error_ratio:rate1h
+        expr: |
+          sum(rate(nexus_http_requests_total{status_code=~"5.."}[1h]))
+          /
+          clamp_min(sum(rate(nexus_http_requests_total[1h])), 1)
+      - record: nexus:slo:api_availability:error_ratio:rate6h
+        expr: |
+          sum(rate(nexus_http_requests_total{status_code=~"5.."}[6h]))
+          /
+          clamp_min(sum(rate(nexus_http_requests_total[6h])), 1)
+      - record: nexus:slo:api_availability:error_ratio:rate2h
+        expr: |
+          sum(rate(nexus_http_requests_total{status_code=~"5.."}[2h]))
+          /
+          clamp_min(sum(rate(nexus_http_requests_total[2h])), 1)
+      - record: nexus:slo:api_availability:error_ratio:rate24h
+        expr: |
+          sum(rate(nexus_http_requests_total{status_code=~"5.."}[24h]))
+          /
+          clamp_min(sum(rate(nexus_http_requests_total[24h])), 1)
+      - record: nexus:slo:api_availability:error_ratio:rate72h
+        expr: |
+          sum(rate(nexus_http_requests_total{status_code=~"5.."}[72h]))
+          /
+          clamp_min(sum(rate(nexus_http_requests_total[72h])), 1)
+
+      # SLO = 99.5%, error_budget = 0.005, burn-rate threshold = burn × budget.
+      - alert: APIAvailabilityFastBurn
+        expr: |
+          (nexus:slo:api_availability:error_ratio:rate1h  > (14.4 * 0.005))
+          and
+          (nexus:slo:api_availability:error_ratio:rate5m  > (14.4 * 0.005))
+        for: 2m
+        labels: { severity: page, slo: api_availability, burn_rate: "14.4" }
+        annotations:
+          summary: API availability burning error budget fast (≈ 2 days to exhaustion)
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: APIAvailabilityMediumBurn
+        expr: |
+          (nexus:slo:api_availability:error_ratio:rate6h   > (6 * 0.005))
+          and
+          (nexus:slo:api_availability:error_ratio:rate30m  > (6 * 0.005))
+        for: 15m
+        labels: { severity: page, slo: api_availability, burn_rate: "6" }
+        annotations:
+          summary: API availability burning error budget at 6× rate
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: APIAvailabilitySlowBurn
+        expr: |
+          (nexus:slo:api_availability:error_ratio:rate24h  > (3 * 0.005))
+          and
+          (nexus:slo:api_availability:error_ratio:rate2h   > (3 * 0.005))
+        for: 1h
+        labels: { severity: ticket, slo: api_availability, burn_rate: "3" }
+        annotations:
+          summary: API availability slowly eroding error budget
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: APIAvailabilityBudgetExhaustion
+        expr: |
+          (nexus:slo:api_availability:error_ratio:rate72h  > (1 * 0.005))
+          and
+          (nexus:slo:api_availability:error_ratio:rate6h   > (1 * 0.005))
+        for: 3h
+        labels: { severity: ticket, slo: api_availability, burn_rate: "1" }
+        annotations:
+          summary: API availability error budget will exhaust within the 28d window
+          runbook: docs/operations/slos.md#error-budget
+
+  # =========================================================================
+  # 2. API latency — 99% of requests < 1.0s
+  # =========================================================================
+  - name: nexus.slo.api_latency
+    interval: 30s
+    rules:
+      - record: nexus:slo:api_latency:slow_ratio:rate5m
+        expr: |
+          (sum(rate(nexus_http_request_duration_seconds_count[5m]))
+           - sum(rate(nexus_http_request_duration_seconds_bucket{le="1"}[5m])))
+          /
+          clamp_min(sum(rate(nexus_http_request_duration_seconds_count[5m])), 1)
+      - record: nexus:slo:api_latency:slow_ratio:rate30m
+        expr: |
+          (sum(rate(nexus_http_request_duration_seconds_count[30m]))
+           - sum(rate(nexus_http_request_duration_seconds_bucket{le="1"}[30m])))
+          /
+          clamp_min(sum(rate(nexus_http_request_duration_seconds_count[30m])), 1)
+      - record: nexus:slo:api_latency:slow_ratio:rate1h
+        expr: |
+          (sum(rate(nexus_http_request_duration_seconds_count[1h]))
+           - sum(rate(nexus_http_request_duration_seconds_bucket{le="1"}[1h])))
+          /
+          clamp_min(sum(rate(nexus_http_request_duration_seconds_count[1h])), 1)
+      - record: nexus:slo:api_latency:slow_ratio:rate6h
+        expr: |
+          (sum(rate(nexus_http_request_duration_seconds_count[6h]))
+           - sum(rate(nexus_http_request_duration_seconds_bucket{le="1"}[6h])))
+          /
+          clamp_min(sum(rate(nexus_http_request_duration_seconds_count[6h])), 1)
+      - record: nexus:slo:api_latency:slow_ratio:rate2h
+        expr: |
+          (sum(rate(nexus_http_request_duration_seconds_count[2h]))
+           - sum(rate(nexus_http_request_duration_seconds_bucket{le="1"}[2h])))
+          /
+          clamp_min(sum(rate(nexus_http_request_duration_seconds_count[2h])), 1)
+      - record: nexus:slo:api_latency:slow_ratio:rate24h
+        expr: |
+          (sum(rate(nexus_http_request_duration_seconds_count[24h]))
+           - sum(rate(nexus_http_request_duration_seconds_bucket{le="1"}[24h])))
+          /
+          clamp_min(sum(rate(nexus_http_request_duration_seconds_count[24h])), 1)
+      - record: nexus:slo:api_latency:slow_ratio:rate72h
+        expr: |
+          (sum(rate(nexus_http_request_duration_seconds_count[72h]))
+           - sum(rate(nexus_http_request_duration_seconds_bucket{le="1"}[72h])))
+          /
+          clamp_min(sum(rate(nexus_http_request_duration_seconds_count[72h])), 1)
+
+      # SLO = 99.0%, error_budget = 0.01.
+      - alert: APILatencyFastBurn
+        expr: |
+          (nexus:slo:api_latency:slow_ratio:rate1h   > (14.4 * 0.01))
+          and
+          (nexus:slo:api_latency:slow_ratio:rate5m   > (14.4 * 0.01))
+        for: 2m
+        labels: { severity: page, slo: api_latency, burn_rate: "14.4" }
+        annotations:
+          summary: API latency violating 1.0s SLO fast (≈ 2 days to budget exhaustion)
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: APILatencyMediumBurn
+        expr: |
+          (nexus:slo:api_latency:slow_ratio:rate6h   > (6 * 0.01))
+          and
+          (nexus:slo:api_latency:slow_ratio:rate30m  > (6 * 0.01))
+        for: 15m
+        labels: { severity: page, slo: api_latency, burn_rate: "6" }
+        annotations:
+          summary: API latency burning latency budget at 6× rate
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: APILatencySlowBurn
+        expr: |
+          (nexus:slo:api_latency:slow_ratio:rate24h  > (3 * 0.01))
+          and
+          (nexus:slo:api_latency:slow_ratio:rate2h   > (3 * 0.01))
+        for: 1h
+        labels: { severity: ticket, slo: api_latency, burn_rate: "3" }
+        annotations:
+          summary: API latency slowly eroding 1.0s SLO budget
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: APILatencyBudgetExhaustion
+        expr: |
+          (nexus:slo:api_latency:slow_ratio:rate72h  > (1 * 0.01))
+          and
+          (nexus:slo:api_latency:slow_ratio:rate6h   > (1 * 0.01))
+        for: 3h
+        labels: { severity: ticket, slo: api_latency, burn_rate: "1" }
+        annotations:
+          summary: API latency budget will exhaust within the 28d window
+          runbook: docs/operations/slos.md#error-budget
+
+  # =========================================================================
+  # 3. Auth & MFA — 99.9%
+  # =========================================================================
+  - name: nexus.slo.auth_mfa
+    interval: 30s
+    rules:
+      - record: nexus:slo:auth_mfa:error_ratio:rate5m
+        expr: |
+          sum(rate(nexus_auth_attempts_total{outcome="failure"}[5m]))
+          /
+          clamp_min(sum(rate(nexus_auth_attempts_total[5m])), 1)
+      - record: nexus:slo:auth_mfa:error_ratio:rate30m
+        expr: |
+          sum(rate(nexus_auth_attempts_total{outcome="failure"}[30m]))
+          /
+          clamp_min(sum(rate(nexus_auth_attempts_total[30m])), 1)
+      - record: nexus:slo:auth_mfa:error_ratio:rate1h
+        expr: |
+          sum(rate(nexus_auth_attempts_total{outcome="failure"}[1h]))
+          /
+          clamp_min(sum(rate(nexus_auth_attempts_total[1h])), 1)
+      - record: nexus:slo:auth_mfa:error_ratio:rate6h
+        expr: |
+          sum(rate(nexus_auth_attempts_total{outcome="failure"}[6h]))
+          /
+          clamp_min(sum(rate(nexus_auth_attempts_total[6h])), 1)
+      - record: nexus:slo:auth_mfa:error_ratio:rate2h
+        expr: |
+          sum(rate(nexus_auth_attempts_total{outcome="failure"}[2h]))
+          /
+          clamp_min(sum(rate(nexus_auth_attempts_total[2h])), 1)
+      - record: nexus:slo:auth_mfa:error_ratio:rate24h
+        expr: |
+          sum(rate(nexus_auth_attempts_total{outcome="failure"}[24h]))
+          /
+          clamp_min(sum(rate(nexus_auth_attempts_total[24h])), 1)
+      - record: nexus:slo:auth_mfa:error_ratio:rate72h
+        expr: |
+          sum(rate(nexus_auth_attempts_total{outcome="failure"}[72h]))
+          /
+          clamp_min(sum(rate(nexus_auth_attempts_total[72h])), 1)
+
+      # SLO = 99.9%, error_budget = 0.001.
+      - alert: AuthMFAFastBurn
+        expr: |
+          (nexus:slo:auth_mfa:error_ratio:rate1h  > (14.4 * 0.001))
+          and
+          (nexus:slo:auth_mfa:error_ratio:rate5m  > (14.4 * 0.001))
+        for: 2m
+        labels: { severity: page, slo: auth_mfa, burn_rate: "14.4" }
+        annotations:
+          summary: Auth/MFA failure rate exhausting budget fast — investigate immediately
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: AuthMFAMediumBurn
+        expr: |
+          (nexus:slo:auth_mfa:error_ratio:rate6h   > (6 * 0.001))
+          and
+          (nexus:slo:auth_mfa:error_ratio:rate30m  > (6 * 0.001))
+        for: 15m
+        labels: { severity: page, slo: auth_mfa, burn_rate: "6" }
+        annotations:
+          summary: Auth/MFA failures burning budget at 6× — likely outage
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: AuthMFASlowBurn
+        expr: |
+          (nexus:slo:auth_mfa:error_ratio:rate24h  > (3 * 0.001))
+          and
+          (nexus:slo:auth_mfa:error_ratio:rate2h   > (3 * 0.001))
+        for: 1h
+        labels: { severity: ticket, slo: auth_mfa, burn_rate: "3" }
+        annotations:
+          summary: Auth/MFA failure rate elevated — investigate within the day
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: AuthMFABudgetExhaustion
+        expr: |
+          (nexus:slo:auth_mfa:error_ratio:rate72h  > (1 * 0.001))
+          and
+          (nexus:slo:auth_mfa:error_ratio:rate6h   > (1 * 0.001))
+        for: 3h
+        labels: { severity: ticket, slo: auth_mfa, burn_rate: "1" }
+        annotations:
+          summary: Auth/MFA error budget will exhaust within the 28d window
+          runbook: docs/operations/slos.md#error-budget
+
+  # =========================================================================
+  # 4. Backtest submission — 99%
+  # =========================================================================
+  - name: nexus.slo.backtest_submit
+    interval: 30s
+    rules:
+      - record: nexus:slo:backtest_submit:error_ratio:rate5m
+        expr: |
+          sum(rate(nexus_backtest_submissions_total{outcome=~"rejected|error"}[5m]))
+          /
+          clamp_min(sum(rate(nexus_backtest_submissions_total[5m])), 1)
+      - record: nexus:slo:backtest_submit:error_ratio:rate30m
+        expr: |
+          sum(rate(nexus_backtest_submissions_total{outcome=~"rejected|error"}[30m]))
+          /
+          clamp_min(sum(rate(nexus_backtest_submissions_total[30m])), 1)
+      - record: nexus:slo:backtest_submit:error_ratio:rate2h
+        expr: |
+          sum(rate(nexus_backtest_submissions_total{outcome=~"rejected|error"}[2h]))
+          /
+          clamp_min(sum(rate(nexus_backtest_submissions_total[2h])), 1)
+      - record: nexus:slo:backtest_submit:error_ratio:rate6h
+        expr: |
+          sum(rate(nexus_backtest_submissions_total{outcome=~"rejected|error"}[6h]))
+          /
+          clamp_min(sum(rate(nexus_backtest_submissions_total[6h])), 1)
+      - record: nexus:slo:backtest_submit:error_ratio:rate24h
+        expr: |
+          sum(rate(nexus_backtest_submissions_total{outcome=~"rejected|error"}[24h]))
+          /
+          clamp_min(sum(rate(nexus_backtest_submissions_total[24h])), 1)
+      - record: nexus:slo:backtest_submit:error_ratio:rate72h
+        expr: |
+          sum(rate(nexus_backtest_submissions_total{outcome=~"rejected|error"}[72h]))
+          /
+          clamp_min(sum(rate(nexus_backtest_submissions_total[72h])), 1)
+
+      # SLO = 99.0%, ticket-only severity (write-path; not page).
+      - alert: BacktestSubmitSlowBurn
+        expr: |
+          (nexus:slo:backtest_submit:error_ratio:rate24h  > (3 * 0.01))
+          and
+          (nexus:slo:backtest_submit:error_ratio:rate2h   > (3 * 0.01))
+        for: 1h
+        labels: { severity: ticket, slo: backtest_submit, burn_rate: "3" }
+        annotations:
+          summary: Backtest submission failure rate elevated
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: BacktestSubmitBudgetExhaustion
+        expr: |
+          (nexus:slo:backtest_submit:error_ratio:rate72h  > (1 * 0.01))
+          and
+          (nexus:slo:backtest_submit:error_ratio:rate6h   > (1 * 0.01))
+        for: 3h
+        labels: { severity: ticket, slo: backtest_submit, burn_rate: "1" }
+        annotations:
+          summary: Backtest submission budget will exhaust within the 28d window
+          runbook: docs/operations/slos.md#error-budget
+
+  # =========================================================================
+  # 5. Webhook delivery — 99%
+  # =========================================================================
+  - name: nexus.slo.webhook_delivery
+    interval: 30s
+    rules:
+      - record: nexus:slo:webhook_delivery:error_ratio:rate5m
+        expr: |
+          sum(rate(nexus_webhook_deliveries_terminal_total{outcome="failed"}[5m]))
+          /
+          clamp_min(sum(rate(nexus_webhook_deliveries_terminal_total[5m])), 1)
+      - record: nexus:slo:webhook_delivery:error_ratio:rate30m
+        expr: |
+          sum(rate(nexus_webhook_deliveries_terminal_total{outcome="failed"}[30m]))
+          /
+          clamp_min(sum(rate(nexus_webhook_deliveries_terminal_total[30m])), 1)
+      - record: nexus:slo:webhook_delivery:error_ratio:rate2h
+        expr: |
+          sum(rate(nexus_webhook_deliveries_terminal_total{outcome="failed"}[2h]))
+          /
+          clamp_min(sum(rate(nexus_webhook_deliveries_terminal_total[2h])), 1)
+      - record: nexus:slo:webhook_delivery:error_ratio:rate6h
+        expr: |
+          sum(rate(nexus_webhook_deliveries_terminal_total{outcome="failed"}[6h]))
+          /
+          clamp_min(sum(rate(nexus_webhook_deliveries_terminal_total[6h])), 1)
+      - record: nexus:slo:webhook_delivery:error_ratio:rate24h
+        expr: |
+          sum(rate(nexus_webhook_deliveries_terminal_total{outcome="failed"}[24h]))
+          /
+          clamp_min(sum(rate(nexus_webhook_deliveries_terminal_total[24h])), 1)
+      - record: nexus:slo:webhook_delivery:error_ratio:rate72h
+        expr: |
+          sum(rate(nexus_webhook_deliveries_terminal_total{outcome="failed"}[72h]))
+          /
+          clamp_min(sum(rate(nexus_webhook_deliveries_terminal_total[72h])), 1)
+
+      # SLO = 99.0%, ticket-only severity.
+      - alert: WebhookDeliverySlowBurn
+        expr: |
+          (nexus:slo:webhook_delivery:error_ratio:rate24h  > (3 * 0.01))
+          and
+          (nexus:slo:webhook_delivery:error_ratio:rate2h   > (3 * 0.01))
+        for: 1h
+        labels: { severity: ticket, slo: webhook_delivery, burn_rate: "3" }
+        annotations:
+          summary: Webhook delivery failure rate elevated
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: WebhookDeliveryBudgetExhaustion
+        expr: |
+          (nexus:slo:webhook_delivery:error_ratio:rate72h  > (1 * 0.01))
+          and
+          (nexus:slo:webhook_delivery:error_ratio:rate6h   > (1 * 0.01))
+        for: 3h
+        labels: { severity: ticket, slo: webhook_delivery, burn_rate: "1" }
+        annotations:
+          summary: Webhook delivery budget will exhaust within the 28d window
+          runbook: docs/operations/slos.md#error-budget
+
+  # =========================================================================
+  # 6. Task pipeline — 99.5%
+  # =========================================================================
+  - name: nexus.slo.task_pipeline
+    interval: 30s
+    rules:
+      - record: nexus:slo:task_pipeline:error_ratio:rate5m
+        expr: |
+          sum(rate(nexus_task_runs_total{outcome=~"failed|dead"}[5m]))
+          /
+          clamp_min(sum(rate(nexus_task_runs_total[5m])), 1)
+      - record: nexus:slo:task_pipeline:error_ratio:rate30m
+        expr: |
+          sum(rate(nexus_task_runs_total{outcome=~"failed|dead"}[30m]))
+          /
+          clamp_min(sum(rate(nexus_task_runs_total[30m])), 1)
+      - record: nexus:slo:task_pipeline:error_ratio:rate2h
+        expr: |
+          sum(rate(nexus_task_runs_total{outcome=~"failed|dead"}[2h]))
+          /
+          clamp_min(sum(rate(nexus_task_runs_total[2h])), 1)
+      - record: nexus:slo:task_pipeline:error_ratio:rate6h
+        expr: |
+          sum(rate(nexus_task_runs_total{outcome=~"failed|dead"}[6h]))
+          /
+          clamp_min(sum(rate(nexus_task_runs_total[6h])), 1)
+      - record: nexus:slo:task_pipeline:error_ratio:rate24h
+        expr: |
+          sum(rate(nexus_task_runs_total{outcome=~"failed|dead"}[24h]))
+          /
+          clamp_min(sum(rate(nexus_task_runs_total[24h])), 1)
+      - record: nexus:slo:task_pipeline:error_ratio:rate72h
+        expr: |
+          sum(rate(nexus_task_runs_total{outcome=~"failed|dead"}[72h]))
+          /
+          clamp_min(sum(rate(nexus_task_runs_total[72h])), 1)
+
+      # SLO = 99.5%.
+      - alert: TaskPipelineSlowBurn
+        expr: |
+          (nexus:slo:task_pipeline:error_ratio:rate24h  > (3 * 0.005))
+          and
+          (nexus:slo:task_pipeline:error_ratio:rate2h   > (3 * 0.005))
+        for: 1h
+        labels: { severity: ticket, slo: task_pipeline, burn_rate: "3" }
+        annotations:
+          summary: TaskIQ failure rate elevated — workers may be stuck
+          runbook: docs/operations/slos.md#critical-user-journeys
+      - alert: TaskPipelineBudgetExhaustion
+        expr: |
+          (nexus:slo:task_pipeline:error_ratio:rate72h  > (1 * 0.005))
+          and
+          (nexus:slo:task_pipeline:error_ratio:rate6h   > (1 * 0.005))
+        for: 3h
+        labels: { severity: ticket, slo: task_pipeline, burn_rate: "1" }
+        annotations:
+          summary: TaskIQ budget will exhaust within the 28d window
+          runbook: docs/operations/slos.md#error-budget


### PR DESCRIPTION
## Summary
- Define six SLOs covering the engine's critical user journeys (API availability, API latency, auth/MFA, backtest submit, webhook delivery, task pipeline) with concrete 28-day targets and error budgets.
- Ship Prometheus recording + multi-window multi-burn-rate (MWMBR) alert rules implementing the SLOs.
- Document the SLI metric contract so future instrumentation work has a target to satisfy.

Closes #147

## Changes
- \`docs/operations/slos.md\` — six-journey SLO table, why-these-targets, error-budget math, MWMBR alert design, wiring instructions, SLI reference table, and a quarterly review process.
- \`observability/prometheus/slo-rules.yaml\` — 6 rule groups, 39 recording rules, 18 alerts paired Google-SRE-style at 1h+5m / 6h+30m / 24h+2h / 72h+6h. Burn-rate thresholds derived per-SLO (14.4× / 6× / 3× / 1× of error budget).
- \`observability/prometheus/README.md\` — loading guide, \`promtool\` validation, sample Alertmanager route.

## Severity model
| Journey | SLO | Severity |
|---|---|---|
| API availability | 99.5% | page |
| API latency (p99 < 1s) | 99.0% | page |
| Auth & MFA | 99.9% | page |
| Backtest submit | 99.0% | ticket |
| Webhook delivery | 99.0% | ticket |
| Task pipeline | 99.5% | ticket |

User-facing journeys page; write-paths and pipelines open tickets. Both severities run through the four-alert MWMBR ladder.

## Test Plan
- [x] \`yaml.safe_load\` parses cleanly. Counts: 6 groups, 39 recording rules, 18 alerts.
- [x] Each alert has matching long+short window expressions and a \`severity\` label.
- [x] Recording-rule names follow \`nexus:slo:<journey>:<kind>:rate<window>\`.
- [x] All metric names match the conventions used by the existing \`MetricsBackend\` (\`nexus.<area>.<name>\` → \`nexus_<area>_<name>\` after the exporter translation).
- [ ] \`promtool check rules observability/prometheus/slo-rules.yaml\` (operator step — promtool not in this repo's CI).
- [ ] CI for this PR passes (Engine Tests, Frontend Lint, Docker Build, security suite).

## Database / Migrations
None.

## Breaking Changes
None — no code paths change. The metrics backend already defaults to no-op (\`NullBackend\`).

## Follow-ups
- Wire a real \`PrometheusBackend\` (gh#34 follow-up) so the engine actually emits the metrics referenced here.
- \`#146\` Grafana dashboards should consume the \`nexus:slo:*:error_ratio:rate*\` recording rules directly — they're cheap enough to render at 30s refresh.
- When live trading (\`#109\`) and OMS (\`#111\`) land, add their journeys to \`docs/operations/slos.md\` and the rule file in the same PR as the metrics are introduced.

## Checklist
- [x] PR title follows conventional commits (\`docs(observability): ...\`)
- [x] Self-reviewed the diff
- [x] No secrets, credentials, or PII in the diff
- [x] SLI metric table in \`docs/operations/slos.md\` matches metric names in \`slo-rules.yaml\`