### PR TITLE
feat(observability): Grafana dashboards-as-code + alert runbook library (gh#146)

### DIFF
--- a/docs/operations/runbooks/README.md
+++ b/docs/operations/runbooks/README.md
@@ -1,0 +1,28 @@
+# Alert runbooks
+
+One runbook per SLO, matched 1:1 to the alert groups in
+[`observability/prometheus/slo-rules.yaml`](../../../observability/prometheus/slo-rules.yaml).
+The `runbook` annotation on every alert points back here.
+
+| Runbook                                   | Linked alerts                                                                       |
+|-------------------------------------------|--------------------------------------------------------------------------------------|
+| [api-availability.md](api-availability.md) | `APIAvailabilityFastBurn`, `APIAvailabilityMediumBurn`, `APIAvailabilitySlowBurn`, `APIAvailabilityBudgetExhaustion` |
+| [api-latency.md](api-latency.md)          | `APILatencyFastBurn`, `APILatencyMediumBurn`, `APILatencySlowBurn`, `APILatencyBudgetExhaustion` |
+| [auth-mfa.md](auth-mfa.md)                | `AuthMFAFastBurn`, `AuthMFAMediumBurn`, `AuthMFASlowBurn`, `AuthMFABudgetExhaustion` |
+| [backtest-submit.md](backtest-submit.md)  | `BacktestSubmitSlowBurn`, `BacktestSubmitBudgetExhaustion`                          |
+| [webhook-delivery.md](webhook-delivery.md) | `WebhookDeliverySlowBurn`, `WebhookDeliveryBudgetExhaustion`                        |
+| [task-pipeline.md](task-pipeline.md)      | `TaskPipelineSlowBurn`, `TaskPipelineBudgetExhaustion`                              |
+
+## Runbook structure
+
+Every runbook follows the same shape so on-call can scan them at 03:00:
+
+1. **What this means** — one paragraph, plain language.
+2. **First 60 seconds** — confirm the alert is real, not a probe failure.
+3. **Triage** — how to localize the cause (logs, dashboards, recent merges).
+4. **Common causes** — known failure modes with the fix path each maps to.
+5. **Escalation** — who to ping when the cause is not in this runbook.
+6. **Post-incident** — what to capture so the runbook gets better.
+
+Add new runbooks when a new SLO lands. Don't ship an alert without a
+runbook — the `runbook` annotation is part of the contract.

--- a/docs/operations/runbooks/api-availability.md
+++ b/docs/operations/runbooks/api-availability.md
@@ -1,0 +1,76 @@
+# Runbook — API availability
+
+**Alerts**: `APIAvailabilityFastBurn`, `APIAvailabilityMediumBurn`,
+`APIAvailabilitySlowBurn`, `APIAvailabilityBudgetExhaustion`
+
+**SLO**: 99.5% non-5xx HTTP responses over 28 days
+([slos.md](../slos.md#critical-user-journeys)).
+
+## What this means
+
+A non-trivial fraction of HTTP responses from the engine API are 5xx.
+Real users (or other systems) are seeing failed requests. Page severity
+because this is the most visible failure mode.
+
+## First 60 seconds
+
+1. Open the **Nexus / SLO overview** dashboard. Confirm the 1h error
+   ratio is genuinely above the threshold (not a single-scrape blip).
+2. Curl the public health endpoint:
+   ```bash
+   curl -fsS https://<your-host>/api/v1/health
+   ```
+   If this fails, the engine is down — skip ahead to "Common causes →
+   Process down".
+3. If health is fine, open the **Nexus / API traffic (RED)** dashboard
+   and look for which `route` or `status_code` is dominating the 5xx
+   share.
+
+## Triage
+
+- **Which routes are failing?** `topk(5, sum by (route, status_code)
+  (rate(nexus_http_requests_total{status_code=~"5.."}[5m])))`
+- **Did this start with a deploy?** Cross-reference the spike on the
+  dashboard with the `release: published` events in
+  [`docs/RELEASING.md`](../../RELEASING.md). If a release just rolled
+  out, consider pinning to the previous image tag.
+- **Are downstream dependencies healthy?** Postgres, Redis/Valkey,
+  TaskIQ broker, any broker integrations. The
+  `engine.observability.lineage` middleware tags these in logs.
+- **Is the error concentrated to one user / tenant?** If so, the cause is
+  more likely user-visible bad data than a systemic failure.
+
+## Common causes
+
+- **Process down** — one of the engine replicas is crash-looping. Check
+  pod / container logs, restart policies, and recent config changes.
+  Roll back to the previous image if a recent deploy is the cause.
+- **DB unavailable** — `asyncpg` or SQLAlchemy connection errors in the
+  logs. See [`backup-and-recovery.md`](../backup-and-recovery.md) if
+  this looks like a primary failure rather than a network blip.
+- **Migration mid-flight** — a long-running `alembic upgrade` is
+  blocking. Either let it finish or roll the deploy back.
+- **Bad request shape from a new client** — 5xx where the engine should
+  have returned 4xx. Open a follow-up to harden validation; in the
+  meantime, the alert will resolve once the bad client backs off.
+- **Resource exhaustion** — OOM, file-descriptor limit, or worker pool
+  saturation. Look at host metrics; bump replica count or limits as a
+  short-term mitigation.
+
+## Escalation
+
+If the cause is not obvious within 15 minutes:
+- Ping the on-call engineer for the affected component (storage / API /
+  deploy).
+- Open an incident channel and start a timeline.
+- If user-visible for more than 30 minutes, post a status update.
+
+## Post-incident
+
+- Capture the start time, end time, root cause, and mitigation in the
+  on-call log.
+- Open issues for any gap that extended detection or recovery.
+- If a class of cause is missing from "Common causes" above, add it.
+- If the alert fired but the root cause was a probe / monitoring artifact,
+  consider tightening the recording-rule denominator or excluding the
+  probe from the SLI.

--- a/docs/operations/runbooks/api-latency.md
+++ b/docs/operations/runbooks/api-latency.md
@@ -1,0 +1,71 @@
+# Runbook — API latency
+
+**Alerts**: `APILatencyFastBurn`, `APILatencyMediumBurn`,
+`APILatencySlowBurn`, `APILatencyBudgetExhaustion`
+
+**SLO**: 99% of HTTP responses complete in `< 1.0 s` over 28 days
+([slos.md](../slos.md#critical-user-journeys)).
+
+## What this means
+
+A meaningful fraction of HTTP responses are slower than 1 second. Users
+will perceive the API as sluggish even if no requests outright fail. Page
+severity at fast and medium burn rates because slow APIs are usually the
+first sign of a deeper resource problem.
+
+## First 60 seconds
+
+1. Open the **Nexus / API traffic (RED)** dashboard — look at the
+   "Latency p99 by route" panel. One outlier route is a different
+   problem than every route slowing down at once.
+2. Check `nexus:slo:api_latency:slow_ratio:rate5m` against
+   `:rate1h`. If the 5m rate is much higher than the 1h, you're at the
+   leading edge of a degradation.
+
+## Triage
+
+- **Which route?** `topk(5, histogram_quantile(0.99, sum by (route, le)
+  (rate(nexus_http_request_duration_seconds_bucket[5m]))))`
+- **Is there latency on the DB side?** Postgres `pg_stat_activity` for
+  long-running queries. The `engine.observability.lineage` span tags will
+  show whether the time is spent in Python, awaiting DB, or awaiting an
+  outbound HTTP call.
+- **Has traffic spiked?** A 4× RPS increase against a constant pool
+  size will look like latency degradation. Compare RPS to historical
+  baseline on the same dashboard.
+- **TaskIQ backlog?** If async-handing routes are slow, the workers may
+  be saturated — see [`task-pipeline.md`](task-pipeline.md).
+
+## Common causes
+
+- **Slow query** — a recently added query lacks an index, or an existing
+  one is using a bad plan. Run `EXPLAIN (ANALYZE, BUFFERS)` and add the
+  appropriate index in a follow-up migration.
+- **Connection pool exhaustion** — `asyncpg` errors like "too many
+  clients" in logs, or sustained queue depth. Bump the pool ceiling or
+  shrink the worker count to match.
+- **Outbound dependency slow** — broker / data-provider API on the wrong
+  side of an SLA. Mitigation: shorten timeouts, add a circuit breaker,
+  fail fast.
+- **GC / event-loop stall** — Python event loop is blocked by sync code
+  on the hot path. Profile with `py-spy` to find the offender; convert
+  to async or offload to a thread.
+- **Cold start after deploy** — first requests after a roll are slow
+  because connections / caches haven't warmed up. Should self-heal
+  within 5 min; otherwise treat as one of the above.
+
+## Escalation
+
+- If p99 doubles for any route within a 5-minute window and stays there,
+  page the API on-call.
+- If multiple routes spike together, suspect a shared dependency
+  (DB, queue) and page that on-call instead.
+
+## Post-incident
+
+- Record the slowest route and the cause in the on-call log.
+- If a query was the culprit, file the index migration before closing
+  the incident.
+- If the SLO target itself is wrong (chronically violated under healthy
+  traffic), open a PR adjusting `docs/operations/slos.md` and the rule
+  file together.

--- a/docs/operations/runbooks/auth-mfa.md
+++ b/docs/operations/runbooks/auth-mfa.md
@@ -1,0 +1,86 @@
+# Runbook — Auth & MFA
+
+**Alerts**: `AuthMFAFastBurn`, `AuthMFAMediumBurn`, `AuthMFASlowBurn`,
+`AuthMFABudgetExhaustion`
+
+**SLO**: 99.9% non-failure auth + MFA-verify outcomes over 28 days
+([slos.md](../slos.md#critical-user-journeys)).
+
+## What this means
+
+Legitimate users cannot reliably log in. Auth is one nine higher than
+general API availability because login is a binary cliff: a 1% failure
+rate locks ≈ 1% of users out completely. **Page severity at every burn
+rate.** Treat as a security-adjacent incident: do not investigate
+quickly *and* sloppily.
+
+## First 60 seconds
+
+1. Open the **Nexus / SLO overview** dashboard. Check the "Auth & MFA"
+   panel. Confirm the failure ratio is real, not a single noisy probe.
+2. Try logging in with a known-good test account. If it works, the
+   alert may be firing on a specific user cohort — not all users.
+3. If it fails, capture the response body (redact sensitive fields)
+   and the request id. Move to "Common causes → MFA verification
+   broken".
+
+## Triage
+
+- **Is the failure on password verification or on MFA verification?**
+  - `nexus_auth_attempts_total{outcome="failure"}` is split by neither
+    today; look at engine logs for the request id to disambiguate.
+  - The relevant call-sites are
+    [`engine/api/routes/auth.py`](../../../engine/api/routes/auth.py)
+    (password / login) and
+    [`engine/api/auth/mfa_service.py`](../../../engine/api/auth/mfa_service.py)
+    (`verify_login_code`, `verify_challenge`).
+- **Spike correlated with a deploy?** Cross-reference the spike with
+  release-please tag history. A botched MFA-encryption-key roll is the
+  most damaging cause and is documented under "Common causes".
+- **Spike correlated with a brute-force attempt?** Look at
+  `nexus_auth_attempts_total{outcome="failure"}` partitioned by source
+  IP if your edge proxy attaches it. A spike that doesn't move
+  `outcome="success"` means the SLO is firing on probably-malicious
+  traffic — the SLO definition deliberately includes failed attempts,
+  so this is "working as designed" but the on-call still needs to
+  decide whether to rate-limit harder.
+
+## Common causes
+
+- **MFA encryption key drift** — the running engine's
+  `MFA_ENCRYPTION_KEY` does not match the one used when the user's
+  secret was encrypted. Symptom: every MFA verify returns "failure"
+  for users with `mfa_enabled = true`. Fix: restore the previous key
+  from the secrets vault, see
+  [`backup-and-recovery.md → Secrets`](../backup-and-recovery.md#secrets-and-keys).
+  **Do not** rotate the key under load — it must be a coordinated
+  re-encryption.
+- **MFA challenge token expired** — challenge TTL is `mfa_challenge_ttl_seconds`
+  (default 300 s). If users are slow to enter codes, this will look like
+  failures. Consider raising the TTL if the SLO violation correlates
+  with operator-set TTL.
+- **Clock skew** — TOTP relies on synchronized clocks. NTP drift on
+  hosts > ±1 step causes legitimate codes to be rejected. Verify with
+  `chronyc tracking` or equivalent.
+- **DB unavailable for the `users` table read path** — login fails to
+  even fetch the user record. Treat as a DB incident
+  ([`backup-and-recovery.md`](../backup-and-recovery.md)) and remediate
+  there first.
+- **Brute-force / credential-stuffing campaign** — failures dominated by
+  one ASN / set of IPs. Engage the rate-limit / WAF surface; do not
+  relax the SLO.
+
+## Escalation
+
+Auth failures touch security: page the security on-call alongside the
+service on-call. Time-to-page should be **immediate** for the fast-burn
+alert.
+
+## Post-incident
+
+- Capture how many user accounts were affected and for how long.
+- If MFA secrets had to be re-encrypted, document the rotation in the
+  on-call log and confirm the new key is in the secrets vault with
+  cross-region replication.
+- If the cause was a brute-force attempt, file a security advisory only
+  if user accounts were actually compromised.

--- a/docs/operations/runbooks/backtest-submit.md
+++ b/docs/operations/runbooks/backtest-submit.md
@@ -1,0 +1,71 @@
+# Runbook — Backtest submission
+
+**Alerts**: `BacktestSubmitSlowBurn`, `BacktestSubmitBudgetExhaustion`
+
+**SLO**: 99% of `POST /api/v1/backtest` calls accepted (no 4xx/5xx error)
+over 28 days
+([slos.md](../slos.md#critical-user-journeys)).
+
+## What this means
+
+Users submitting backtests are getting rejected or erroring out. This
+is a write path tied to user research — failed submissions waste user
+time and obscure deeper problems with the strategy DSL or input data.
+Ticket severity (not page); investigate within business hours.
+
+## First 60 seconds
+
+1. Open the **Nexus / API traffic (RED)** dashboard, filter to
+   `route="/api/v1/backtest"`. Confirm the rejected/error count is
+   actually rising versus the baseline.
+2. Pull the last 10 failed submissions from logs by request id and
+   skim their response bodies. If they're all the same validation
+   error, the cause is a bad client deploy or schema change.
+
+## Triage
+
+- **What's the breakdown of `outcome` labels?**
+  `sum by (outcome) (rate(nexus_backtest_submissions_total[1h]))`
+- **Is `error` (server-side) dominating, or `rejected` (validation)?**
+  - `rejected` means the user got a 4xx — usually a DSL or input-data
+    problem. Not on-call's job to fix; file as a product bug.
+  - `error` means the engine itself failed. Look at log entries with
+    `event_type="backtest.evaluation_failed"` (the path that wraps
+    `StrategyEvaluator().evaluate`).
+- **Did the schema change?** Look at recent merges that touched
+  `engine/api/routes/backtest.py` or its Pydantic models.
+
+## Common causes
+
+- **`StrategyEvaluator` regression** — a recent change to
+  [`engine/core/strategy_evaluator.py`](../../../engine/core/strategy_evaluator.py)
+  fails on a class of input. The submission still saves the result row
+  but populates `error` because the runner wraps evaluation in
+  try/except (intentional — see
+  [`backtest_runner.py`](../../../engine/core/backtest_runner.py)). The
+  evaluator failure is logged but does not fail the request, so this
+  case will *not* trip this SLO unless the entire route 5xxs.
+  Investigate why the route itself is failing.
+- **Bad input data** — data provider returned an unexpected schema
+  (missing column, NaN-only series). Confirm by attempting one of the
+  failing submissions against a known-good provider.
+- **DB write failure** — `backtest_results` insert blocked. Check the
+  schema is at the right Alembic head (gh#8 added two columns,
+  `composite_score` + `score_breakdown`).
+- **Quota / rate limit** — submissions blocked by the rate-limit
+  surface. Check `engine/api/rate_limit.py` configuration; if the limit
+  was recently lowered, this is a config problem.
+
+## Escalation
+
+Backtest failures rarely page-able; if they spike to >25% of
+submissions, ping the strategy / backtest engineers in addition to the
+API on-call.
+
+## Post-incident
+
+- If a class of input now reliably 5xxs, add a regression test under
+  `tests/test_backtest_runner.py` or `tests/test_strategy_evaluator.py`.
+- If the SLO violation was caused by an upstream client deploy
+  (e.g. the React frontend now sends a new field), file the issue on
+  the frontend side and consider tightening Pydantic validation.

--- a/docs/operations/runbooks/task-pipeline.md
+++ b/docs/operations/runbooks/task-pipeline.md
@@ -1,0 +1,70 @@
+# Runbook — Task pipeline (TaskIQ)
+
+**Alerts**: `TaskPipelineSlowBurn`, `TaskPipelineBudgetExhaustion`
+
+**SLO**: 99.5% of TaskIQ jobs reach `completed` (vs. `failed` / `dead`)
+over 28 days
+([slos.md](../slos.md#critical-user-journeys)).
+
+## What this means
+
+The async pipeline that runs backtests, scheduled rebalances, and
+reporting is producing failed or dead jobs at a rate that erodes the
+SLO budget. Ticket severity — most failures are recoverable on retry —
+but a stuck pipeline silently breaks user-facing features.
+
+## First 60 seconds
+
+1. Confirm workers are alive: count of TaskIQ worker pods / processes
+   matches the configured replica count.
+2. `sum by (outcome) (rate(nexus_task_runs_total[5m]))` — is the
+   `dead` outcome dominating? Dead = exceeded retry budget.
+
+## Triage
+
+- **Which task is failing?**
+  `topk(5, sum by (task) (rate(nexus_task_runs_total{outcome=~"failed|dead"}[1h])))`
+- **Are workers actually consuming?** Look at the broker (Redis/Valkey)
+  for queue depth. If depth is climbing while the failure ratio is low,
+  workers may be wedged rather than failing — check pod logs for
+  hangs / coroutine stuck states.
+- **Does the failed task share a dependency?** A class of tasks that
+  all hit the same broker / data provider failing together points at
+  that downstream rather than the task itself.
+
+## Common causes
+
+- **Broker (Redis/Valkey) outage** — `taskiq_redis` errors in worker
+  logs. Workers can't enqueue or fetch; everything stalls. Restore the
+  broker first, then drain the backlog.
+- **Worker pool too small for the spike** — sustained backlog with
+  healthy completion ratio. Bump replica count temporarily; file a
+  capacity follow-up.
+- **Bad code path on the task** — exception in the task body that
+  retries until exhaustion. Look for the structlog `event_type`
+  pattern from the offending task and a stable stack trace. Add a
+  regression test, ship the fix, replay the dead-letter queue once
+  the new code is live.
+- **DB lock contention** — tasks that write to the same row pile up
+  and time out. Mitigation: serialize via a queue per resource, or
+  switch to an upsert pattern.
+- **Memory leak** — workers slowly grow until OOM-killed mid-task,
+  marking the in-flight job dead. Restart cadence is the workaround;
+  fix is to find and remove the leak.
+
+## Escalation
+
+If the broker is down or queue depth keeps climbing despite a healthy
+worker count, page the platform / infra on-call. Backtest results
+and webhook fan-out depend on this pipeline; a stuck queue manifests
+to users as "I submitted a backtest 20 minutes ago and nothing
+happened".
+
+## Post-incident
+
+- Capture the root cause and the dead-letter handling decision (replayed,
+  dropped, manually fixed) in the on-call log.
+- If a task is not idempotent, file a follow-up to make it so —
+  retries should be safe by default.
+- If the SLO target is wrong (chronically violated by a known-flaky
+  task class), either fix the task or move it out of the SLO surface.

--- a/docs/operations/runbooks/webhook-delivery.md
+++ b/docs/operations/runbooks/webhook-delivery.md
@@ -1,0 +1,73 @@
+# Runbook — Webhook delivery
+
+**Alerts**: `WebhookDeliverySlowBurn`, `WebhookDeliveryBudgetExhaustion`
+
+**SLO**: 99% of webhook deliveries reach `delivered` (vs. `failed`) at
+their terminal state, over 28 days
+([slos.md](../slos.md#critical-user-journeys)).
+
+## What this means
+
+Outbound webhooks fired by the engine are landing in `failed` state
+more often than the SLO budget allows. The dispatcher in
+[`engine/events/webhook_dispatcher.py`](../../../engine/events/webhook_dispatcher.py)
+retries on 5xx and network errors, but gives up on 4xx — so this alert
+fires when *terminal* failures rise, not just when individual attempts
+fail. Ticket severity.
+
+## First 60 seconds
+
+1. Open the **Nexus / Webhook pipeline** dashboard. The "Terminal
+   deliveries per second by outcome" panel should show whether
+   `failed` has overtaken `delivered`.
+2. Look at "Failed (last 1h)" — single-digit failures over 1h with
+   100k deliveries is normal noise; double-digits or above is the
+   alert speaking.
+
+## Triage
+
+- **Is one webhook config dominating the failures?** Pull the last 50
+  rows of `webhook_deliveries` ordered by `created_at desc` filtered
+  on `status='failed'` and group by `webhook_id`. A single registry of
+  bad endpoints will dominate.
+- **Are 4xx terminations or 5xx exhaustion the cause?** Inspect the
+  `error` column on the failed delivery rows. The dispatcher's
+  `_RETRYABLE_STATUS` set is `{408, 425, 429, 500, 502, 503, 504}`; any
+  other 4xx terminates immediately with `error` containing
+  "non-retryable". Sustained 5xx → "max retries exceeded".
+- **Did anything change in `webhook_dispatcher.py` recently?** Check
+  recent merges; the structlog `event` kwarg collision was a class of
+  bug — pass `event_type=` not `event=`.
+
+## Common causes
+
+- **Operator mis-configured a webhook endpoint** — wrong URL, expired
+  signing secret on the receiver side, etc. The endpoint returns 400
+  / 401 / 404 and the dispatcher gives up. Reach out to the
+  operator / contact the user; do not change retry behaviour.
+- **Receiver outage** — a Slack / Discord / Telegram outage will spike
+  failed-because-5xx terminations. The engine retries 3 times by
+  default (`max_retries=3` on `WebhookConfig`); if the outage lasts
+  longer the dispatcher correctly marks them failed.
+- **DNS or egress issue** — `httpx.ConnectError` errors in the logs.
+  Check egress firewall / proxy configuration.
+- **Custom-headers regression** — operator added a custom header that
+  the receiver rejects. Inspect `webhook_configs.custom_headers`.
+- **Signing-secret rotation gone wrong** — receiver rejects with 401
+  because they verified an HMAC against the old secret. Coordinate the
+  secret rotation with the receiver next time.
+
+## Escalation
+
+Webhook failures rarely require pagers; if a single high-traffic
+webhook starts terminating most deliveries, ping the operator who owns
+that endpoint. Don't quietly disable a customer's webhook — open a
+ticket.
+
+## Post-incident
+
+- If a class of failure was missed by the retry classifier, propose a
+  change to `_RETRYABLE_STATUS` in a follow-up PR with tests.
+- If a customer's webhook needs to be disabled to stop the bleeding,
+  prefer setting `is_active=false` over deleting the row — preserves
+  the audit trail.

--- a/observability/grafana/README.md
+++ b/observability/grafana/README.md
@@ -1,0 +1,70 @@
+# Grafana dashboards
+
+Dashboards-as-code for Nexus Trade Engine. All dashboards target the
+recording rules and SLI metrics defined in
+[`docs/operations/slos.md`](../../docs/operations/slos.md) and
+[`observability/prometheus/slo-rules.yaml`](../prometheus/slo-rules.yaml).
+
+| File | Purpose |
+|------|---------|
+| `dashboards/slo-overview.json`     | Single-pane SLO health (1h burn rates, multi-window trends, alert list). Start here. |
+| `dashboards/api-traffic.json`      | HTTP RED metrics: RPS by route, error rate by route, p50/p95/p99 latency. |
+| `dashboards/webhook-pipeline.json` | Webhook dispatcher operations: terminal outcomes, delivered ratio, failure trend. |
+
+Each dashboard ships a `DS_PROMETHEUS` template variable so it works
+regardless of how the operator names their Prometheus datasource.
+
+## Provisioning
+
+The two YAML files in `provisioning/` are example
+[Grafana provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/)
+configs:
+
+- `provisioning/dashboards.yaml` — points Grafana at a directory of
+  dashboard JSON. The example mounts dashboards under
+  `/var/lib/grafana/dashboards/nexus`.
+- `provisioning/datasources.yaml` — example Prometheus datasource. Edit
+  the `url`, auth fields, and version to match your deployment.
+
+A typical Docker Compose / Kubernetes mount looks like:
+
+```yaml
+# docker compose
+services:
+  grafana:
+    image: grafana/grafana:latest
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning
+      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards/nexus
+```
+
+## Editing
+
+- Dashboards are committed in their exported JSON form. After editing in
+  Grafana, click **Share → JSON** and paste the result back into the
+  matching file. Keep `id: null` and `version: 1` (Grafana ignores them
+  on import).
+- Don't hard-code datasource UIDs — always use `${DS_PROMETHEUS}` so the
+  dashboard is portable.
+- New dashboards should reference recording rules with the
+  `nexus:slo:<journey>:<kind>:rate<window>` shape rather than raw
+  `nexus_*_total` counters where possible. Recording rules are cheaper at
+  render time and centralize the SLI math.
+
+## Validating
+
+GitHub renders the JSON on hover, but to confirm the schema parses run:
+
+```bash
+python3 -c "import json, glob; [json.load(open(p)) for p in glob.glob('observability/grafana/dashboards/*.json')]"
+```
+
+For a deeper check, import each file into a throwaway Grafana instance
+and verify panels render without query errors against an empty
+Prometheus.
+
+## Helm packaging
+
+Once a Helm chart exists for Nexus Trade Engine the dashboard JSON should
+be shipped as ConfigMaps mounted into the Grafana deployment. That
+packaging is intentionally out of scope until the chart itself lands.

--- a/observability/grafana/dashboards/api-traffic.json
+++ b/observability/grafana/dashboards/api-traffic.json
@@ -1,0 +1,139 @@
+{
+  "annotations": { "list": [] },
+  "description": "HTTP RED metrics for the FastAPI surface. RPS, error rate, and latency percentiles by route.",
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Requests per second by route",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "stacking": { "mode": "normal" } }
+        }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] } },
+      "targets": [
+        {
+          "expr": "sum by (route) (rate(nexus_http_requests_total[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Error rate (5xx) by route",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 }
+        }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] } },
+      "targets": [
+        {
+          "expr": "sum by (route) (rate(nexus_http_requests_total{status_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum by (route) (rate(nexus_http_requests_total[$__rate_interval])), 1)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Latency (p50 / p95 / p99) — global",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 9, "w": 12, "h": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 }
+        }
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(nexus_http_request_duration_seconds_bucket[$__rate_interval])))", "legendFormat": "p50", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(nexus_http_request_duration_seconds_bucket[$__rate_interval])))", "legendFormat": "p95", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(nexus_http_request_duration_seconds_bucket[$__rate_interval])))", "legendFormat": "p99", "refId": "C" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Latency p99 by route",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 12, "y": 9, "w": 12, "h": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 }
+        }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (route, le) (rate(nexus_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "Top 10 noisiest routes (last 1h)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 18, "w": 24, "h": 9 },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (route, status_code) (rate(nexus_http_requests_total[1h])))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["nexus", "api", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Nexus / API traffic (RED)",
+  "uid": "nexus-api-traffic",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/grafana/dashboards/slo-overview.json
+++ b/observability/grafana/dashboards/slo-overview.json
@@ -1,0 +1,247 @@
+{
+  "annotations": { "list": [] },
+  "description": "Single-pane SLO health for Nexus Trade Engine. Pairs with docs/operations/slos.md and observability/prometheus/slo-rules.yaml.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "title": "SLO definitions",
+      "type": "link",
+      "url": "https://github.com/SevFle/nexus-trade-engine/blob/main/docs/operations/slos.md",
+      "icon": "doc",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Burn rate (28d window)",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "API availability — error ratio (1h)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 1, "w": 6, "h": 5 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "orange", "value": 0.03 },
+              { "color": "red",    "value": 0.072 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "nexus:slo:api_availability:error_ratio:rate1h",
+          "legendFormat": "1h",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "API latency — slow ratio (1h)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 6, "y": 1, "w": 6, "h": 5 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "orange", "value": 0.06 },
+              { "color": "red",    "value": 0.144 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "nexus:slo:api_latency:slow_ratio:rate1h",
+          "legendFormat": "1h",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Auth & MFA — failure ratio (1h)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 12, "y": 1, "w": 6, "h": 5 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 0.001 },
+              { "color": "orange", "value": 0.006 },
+              { "color": "red",    "value": 0.0144 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "nexus:slo:auth_mfa:error_ratio:rate1h",
+          "legendFormat": "1h",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Task pipeline — failure ratio (24h)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 18, "y": 1, "w": 6, "h": 5 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "orange", "value": 0.015 },
+              { "color": "red",    "value": 0.05 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "nexus:slo:task_pipeline:error_ratio:rate24h",
+          "legendFormat": "24h",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "Burn-rate trends",
+      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "API availability — error ratio (multi-window)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 7, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 }
+        }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } },
+      "targets": [
+        { "expr": "nexus:slo:api_availability:error_ratio:rate5m",  "legendFormat": "5m",  "refId": "A" },
+        { "expr": "nexus:slo:api_availability:error_ratio:rate1h",  "legendFormat": "1h",  "refId": "B" },
+        { "expr": "nexus:slo:api_availability:error_ratio:rate6h",  "legendFormat": "6h",  "refId": "C" },
+        { "expr": "nexus:slo:api_availability:error_ratio:rate24h", "legendFormat": "24h", "refId": "D" }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Webhook delivery — failure ratio (multi-window)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 12, "y": 7, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 }
+        }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } },
+      "targets": [
+        { "expr": "nexus:slo:webhook_delivery:error_ratio:rate5m",  "legendFormat": "5m",  "refId": "A" },
+        { "expr": "nexus:slo:webhook_delivery:error_ratio:rate2h",  "legendFormat": "2h",  "refId": "B" },
+        { "expr": "nexus:slo:webhook_delivery:error_ratio:rate24h", "legendFormat": "24h", "refId": "C" }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["nexus", "slo", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Nexus / SLO overview",
+  "uid": "nexus-slo-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/grafana/dashboards/webhook-pipeline.json
+++ b/observability/grafana/dashboards/webhook-pipeline.json
@@ -1,0 +1,180 @@
+{
+  "annotations": { "list": [] },
+  "description": "Operational view of the webhook dispatcher: terminal-state outcomes, retry distribution, and SLO ratio.",
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "title": "Dispatcher source",
+      "type": "link",
+      "url": "https://github.com/SevFle/nexus-trade-engine/blob/main/engine/events/webhook_dispatcher.py",
+      "icon": "doc",
+      "targetBlank": true
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Terminal deliveries per second by outcome",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "delivered" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(nexus_webhook_deliveries_terminal_total[$__rate_interval]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Webhook SLO failure ratio (multi-window)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 }
+        }
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "expr": "nexus:slo:webhook_delivery:error_ratio:rate5m",  "legendFormat": "5m",  "refId": "A" },
+        { "expr": "nexus:slo:webhook_delivery:error_ratio:rate2h",  "legendFormat": "2h",  "refId": "B" },
+        { "expr": "nexus:slo:webhook_delivery:error_ratio:rate24h", "legendFormat": "24h", "refId": "C" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Delivered (last 1h)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 9, "w": 6, "h": 5 },
+      "fieldConfig": {
+        "defaults": { "unit": "short" }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(nexus_webhook_deliveries_terminal_total{outcome=\"delivered\"}[1h]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Failed (last 1h)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 6, "y": 9, "w": 6, "h": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 25 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(nexus_webhook_deliveries_terminal_total{outcome=\"failed\"}[1h]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Delivered ratio (1h)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 12, "y": 9, "w": 12, "h": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "yellow", "value": 0.97 },
+              { "color": "green",  "value": 0.99 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(nexus_webhook_deliveries_terminal_total{outcome=\"delivered\"}[1h])) / clamp_min(sum(rate(nexus_webhook_deliveries_terminal_total[1h])), 1)",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["nexus", "webhooks", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Nexus / Webhook pipeline",
+  "uid": "nexus-webhook-pipeline",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/grafana/provisioning/dashboards.yaml
+++ b/observability/grafana/provisioning/dashboards.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: nexus
+    orgId: 1
+    folder: Nexus
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards/nexus
+      foldersFromFilesStructure: false

--- a/observability/grafana/provisioning/datasources.yaml
+++ b/observability/grafana/provisioning/datasources.yaml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+# Example Prometheus datasource. Operators should override `url`, `name`, and
+# (if using auth) `basicAuth*` / `secureJsonData` to match their stack.
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      manageAlerts: false
+      prometheusType: Prometheus
+      prometheusVersion: 2.50.0
+      timeInterval: 30s

--- a/observability/prometheus/slo-rules.yaml
+++ b/observability/prometheus/slo-rules.yaml
@@ -73,7 +73,7 @@ groups:
         labels: { severity: page, slo: api_availability, burn_rate: "14.4" }
         annotations:
           summary: API availability burning error budget fast (≈ 2 days to exhaustion)
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: APIAvailabilityMediumBurn
         expr: |
           (nexus:slo:api_availability:error_ratio:rate6h   > (6 * 0.005))
@@ -83,7 +83,7 @@ groups:
         labels: { severity: page, slo: api_availability, burn_rate: "6" }
         annotations:
           summary: API availability burning error budget at 6× rate
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: APIAvailabilitySlowBurn
         expr: |
           (nexus:slo:api_availability:error_ratio:rate24h  > (3 * 0.005))
@@ -93,7 +93,7 @@ groups:
         labels: { severity: ticket, slo: api_availability, burn_rate: "3" }
         annotations:
           summary: API availability slowly eroding error budget
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: APIAvailabilityBudgetExhaustion
         expr: |
           (nexus:slo:api_availability:error_ratio:rate72h  > (1 * 0.005))
@@ -164,7 +164,7 @@ groups:
         labels: { severity: page, slo: api_latency, burn_rate: "14.4" }
         annotations:
           summary: API latency violating 1.0s SLO fast (≈ 2 days to budget exhaustion)
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: APILatencyMediumBurn
         expr: |
           (nexus:slo:api_latency:slow_ratio:rate6h   > (6 * 0.01))
@@ -174,7 +174,7 @@ groups:
         labels: { severity: page, slo: api_latency, burn_rate: "6" }
         annotations:
           summary: API latency burning latency budget at 6× rate
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: APILatencySlowBurn
         expr: |
           (nexus:slo:api_latency:slow_ratio:rate24h  > (3 * 0.01))
@@ -184,7 +184,7 @@ groups:
         labels: { severity: ticket, slo: api_latency, burn_rate: "3" }
         annotations:
           summary: API latency slowly eroding 1.0s SLO budget
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: APILatencyBudgetExhaustion
         expr: |
           (nexus:slo:api_latency:slow_ratio:rate72h  > (1 * 0.01))
@@ -248,7 +248,7 @@ groups:
         labels: { severity: page, slo: auth_mfa, burn_rate: "14.4" }
         annotations:
           summary: Auth/MFA failure rate exhausting budget fast — investigate immediately
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: AuthMFAMediumBurn
         expr: |
           (nexus:slo:auth_mfa:error_ratio:rate6h   > (6 * 0.001))
@@ -258,7 +258,7 @@ groups:
         labels: { severity: page, slo: auth_mfa, burn_rate: "6" }
         annotations:
           summary: Auth/MFA failures burning budget at 6× — likely outage
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: AuthMFASlowBurn
         expr: |
           (nexus:slo:auth_mfa:error_ratio:rate24h  > (3 * 0.001))
@@ -268,7 +268,7 @@ groups:
         labels: { severity: ticket, slo: auth_mfa, burn_rate: "3" }
         annotations:
           summary: Auth/MFA failure rate elevated — investigate within the day
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: AuthMFABudgetExhaustion
         expr: |
           (nexus:slo:auth_mfa:error_ratio:rate72h  > (1 * 0.001))
@@ -327,7 +327,7 @@ groups:
         labels: { severity: ticket, slo: backtest_submit, burn_rate: "3" }
         annotations:
           summary: Backtest submission failure rate elevated
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: BacktestSubmitBudgetExhaustion
         expr: |
           (nexus:slo:backtest_submit:error_ratio:rate72h  > (1 * 0.01))
@@ -386,7 +386,7 @@ groups:
         labels: { severity: ticket, slo: webhook_delivery, burn_rate: "3" }
         annotations:
           summary: Webhook delivery failure rate elevated
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: WebhookDeliveryBudgetExhaustion
         expr: |
           (nexus:slo:webhook_delivery:error_ratio:rate72h  > (1 * 0.01))
@@ -445,7 +445,7 @@ groups:
         labels: { severity: ticket, slo: task_pipeline, burn_rate: "3" }
         annotations:
           summary: TaskIQ failure rate elevated — workers may be stuck
-          runbook: docs/operations/slos.md#critical-user-journeys
+          runbook: docs/operations/runbooks/README.md
       - alert: TaskPipelineBudgetExhaustion
         expr: |
           (nexus:slo:task_pipeline:error_ratio:rate72h  > (1 * 0.005))


### PR DESCRIPTION
## Summary
- Ship 3 Grafana dashboards (SLO overview, API RED, webhook pipeline) consuming the SLO recording rules from gh#147.
- Provide Grafana provisioning configs for auto-loading dashboards + datasource.
- Add a 6-runbook alert library (one per SLO) with consistent on-call structure.
- Repoint every alert's \`runbook\` annotation in \`slo-rules.yaml\` at the new runbook index.

Closes #146

## Changes
**Dashboards** — all use \`\${DS_PROMETHEUS}\` so they're portable
- \`observability/grafana/dashboards/slo-overview.json\` — 1h burn-rate stats per journey, multi-window timeseries for API availability + webhook delivery.
- \`observability/grafana/dashboards/api-traffic.json\` — RPS / 5xx rate / latency percentiles by route, plus top-10 noisiest routes table.
- \`observability/grafana/dashboards/webhook-pipeline.json\` — terminal outcomes, multi-window failure ratio, delivered/failed counters, delivered-ratio gauge.

**Provisioning**
- \`observability/grafana/provisioning/dashboards.yaml\` — file provider pointed at \`/var/lib/grafana/dashboards/nexus\`.
- \`observability/grafana/provisioning/datasources.yaml\` — example Prometheus datasource.

**Alert runbook library** (one per SLO, matched 1:1 to alert groups)
- \`docs/operations/runbooks/README.md\` — index + 6-section runbook structure contract (what-this-means, first-60s, triage, common-causes, escalation, post-incident).
- \`api-availability.md\`, \`api-latency.md\`, \`auth-mfa.md\`, \`backtest-submit.md\`, \`webhook-delivery.md\`, \`task-pipeline.md\` — each calls out concrete code paths, column names, and known failure modes from the existing engine.

**Wiring**
- \`observability/prometheus/slo-rules.yaml\` — \`runbook:\` annotations now point at \`docs/operations/runbooks/README.md\` instead of an SLO-doc anchor (the README's table maps each alert name to its runbook file).

## Test Plan
- [x] All 3 dashboards parse: \`json.load\` succeeds for each.
- [x] Both provisioning configs parse: \`yaml.safe_load\` succeeds.
- [x] \`slo-rules.yaml\` re-parses cleanly with new annotations.
- [x] Every alert in the rule file has a non-empty \`runbook\` annotation, and that annotation resolves to a markdown file in this PR.
- [ ] Import each dashboard into a throwaway Grafana instance and verify panels render (operator step — Grafana not in this repo's CI).
- [ ] CI for this PR passes.

## Database / Migrations
None.

## Breaking Changes
None — pure additive observability config + docs.

## Follow-ups
- Helm packaging: ship dashboard JSON as ConfigMaps once a chart exists. Documented in \`observability/grafana/README.md\`.
- Wire a real \`PrometheusBackend\` (gh#34 follow-up) so the engine actually emits the metrics referenced by the dashboards.
- Add per-tenant variants of \`api-traffic.json\` and \`webhook-pipeline.json\` once multi-tenant labels are added.
- Consider per-alert \`runbook:\` URLs (currently all point at the index README) once the rule file's structure makes that easier without sed.

## Checklist
- [x] PR title follows conventional commits (\`feat(observability): ...\`)
- [x] Self-reviewed the diff
- [x] No secrets, credentials, or PII in the diff
- [x] Runbook structure is consistent across all 6 files (verified manually)