### PR TITLE
feat(devops): Docker dev environment with hot-reload (gh#22)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,46 @@
+# Development image: full source bind-mounted, dev deps installed, hot-reload
+# enabled. NEVER ship this to production.
+#
+# Used by docker-compose.dev.yml. The runtime container does:
+#   - Bind-mount the repo root over /app so edits reload immediately.
+#   - Run uvicorn --reload on the engine, watching the bind mount.
+#   - Run taskiq worker in --reload mode for the worker container.
+#
+# Reference: docs/development.md
+
+FROM ghcr.io/astral-sh/uv:0.6-python3.12-bookworm-slim
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_HTTP_TIMEOUT=300 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# libpq for asyncpg, build tools for any wheel that needs to compile.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpq5 \
+        build-essential \
+        curl \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dev deps from a stable layer. Source is bind-mounted at runtime, so
+# we only need pyproject + uv.lock here.
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --extra dev --no-install-project
+
+ENV PATH="/app/.venv/bin:${PATH}"
+
+EXPOSE 8000
+
+# Default to the API server. Override the entrypoint to run the worker.
+CMD ["uvicorn", "engine.app:create_app", \
+     "--factory", \
+     "--reload", \
+     "--reload-dir", "/app/engine", \
+     "--host", "0.0.0.0", \
+     "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help dev test lint fix typecheck migrate docker-up docker-down
+.PHONY: help dev test lint fix typecheck migrate \
+        docker-up docker-down docker-build \
+        docker-dev docker-dev-down docker-dev-logs docker-dev-build docker-dev-rebuild
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -39,3 +41,20 @@ docker-down: ## Stop all services
 
 docker-build: ## Build docker images
 	docker compose build
+
+DOCKER_DEV := docker compose -f docker-compose.dev.yml
+
+docker-dev: ## Start the dev stack (hot-reload, bind-mounted source)
+	$(DOCKER_DEV) up
+
+docker-dev-down: ## Stop the dev stack and remove containers
+	$(DOCKER_DEV) down
+
+docker-dev-logs: ## Tail logs from the dev stack
+	$(DOCKER_DEV) logs -f --tail=100
+
+docker-dev-build: ## Build the dev images
+	$(DOCKER_DEV) build
+
+docker-dev-rebuild: ## Rebuild dev images from scratch (no cache)
+	$(DOCKER_DEV) build --no-cache

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,102 @@
+# Development stack with hot-reload (gh#22).
+#
+# Usage:
+#   make docker-dev          # docker compose -f docker-compose.dev.yml up
+#   make docker-dev-down
+#   make docker-dev-logs
+#
+# Differences vs. docker-compose.yml (production):
+#   - app + worker are built from Dockerfile.dev (uv + dev deps).
+#   - Source is bind-mounted into /app so uvicorn --reload picks up edits.
+#   - frontend service runs Vite dev server with HMR on port 5173.
+#   - .venv is mounted as an anonymous volume so it doesn't get clobbered by
+#     the source bind-mount.
+#   - Anonymous volume on frontend/node_modules so npm install survives the
+#     source bind-mount.
+
+services:
+  db:
+    image: timescale/timescaledb:latest-pg16
+    environment:
+      POSTGRES_USER: nexus
+      POSTGRES_PASSWORD: nexus
+      POSTGRES_DB: nexus
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/home/postgres/pgdata/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nexus"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  valkey:
+    image: valkey/valkey:8-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8000:8000"
+    env_file: .env.example
+    environment:
+      NEXUS_DATABASE_URL: postgresql+asyncpg://nexus:nexus@db:5432/nexus
+      NEXUS_VALKEY_URL: valkey://valkey:6379/0
+      NEXUS_DEBUG: "1"
+      PYTHONUNBUFFERED: "1"
+      WATCHFILES_FORCE_POLLING: "true"   # bind-mounts on macOS/Windows need polling
+    volumes:
+      - .:/app:cached
+      - app-venv:/app/.venv
+    depends_on:
+      db:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: ["uv", "run", "taskiq", "worker", "engine.tasks.worker:broker", "--reload"]
+    env_file: .env.example
+    environment:
+      NEXUS_DATABASE_URL: postgresql+asyncpg://nexus:nexus@db:5432/nexus
+      NEXUS_VALKEY_URL: valkey://valkey:6379/0
+      NEXUS_DEBUG: "1"
+      WATCHFILES_FORCE_POLLING: "true"
+    volumes:
+      - .:/app:cached
+      - app-venv:/app/.venv
+    depends_on:
+      db:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+
+  frontend:
+    image: node:20-alpine
+    working_dir: /app
+    command: ["sh", "-c", "npm install && npm run dev -- --host 0.0.0.0"]
+    ports:
+      - "5173:5173"
+    environment:
+      CHOKIDAR_USEPOLLING: "true"        # bind-mounts on macOS/Windows need polling
+      VITE_API_BASE_URL: http://localhost:8000
+    volumes:
+      - ./frontend:/app:cached
+      - frontend-node-modules:/app/node_modules
+
+volumes:
+  pgdata:
+  app-venv:
+  frontend-node-modules:

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,143 @@
+# Development environment
+
+Two ways to run Nexus Trade Engine locally:
+
+1. **Native** — `uv` + a Postgres + Valkey running on your host.
+2. **Docker** (recommended) — `make docker-dev` brings up the full
+   stack (engine, worker, frontend, Postgres, Valkey) with hot-reload
+   on every service.
+
+## Native
+
+```bash
+# 1. Install Python deps via uv
+uv sync --extra dev
+
+# 2. Bring up Postgres + Valkey via the production compose file
+make docker-up      # starts only db + valkey containers in the background
+
+# 3. Run migrations
+make migrate
+
+# 4. Run the API with hot-reload (uvicorn --reload)
+make dev
+```
+
+Runs the engine on `http://localhost:8000`. Tear down infra with
+`make docker-down`.
+
+The frontend (Vite) lives in `frontend/`:
+
+```bash
+cd frontend
+npm install
+npm run dev   # http://localhost:5173
+```
+
+## Docker (recommended)
+
+`docker-compose.dev.yml` is a self-contained dev stack. Everything is
+bind-mounted into the containers so edits take effect immediately:
+
+| Service  | Port | What it does                                   |
+|----------|------|------------------------------------------------|
+| `db`     | 5432 | TimescaleDB / Postgres 16                      |
+| `valkey` | 6379 | Redis-compatible queue / cache                 |
+| `app`    | 8000 | FastAPI engine, `uvicorn --reload`             |
+| `worker` | —    | TaskIQ worker, `taskiq ... --reload`           |
+| `frontend` | 5173 | Vite dev server with HMR                     |
+
+```bash
+make docker-dev          # foreground; Ctrl-C to stop
+make docker-dev-logs     # in another terminal
+make docker-dev-down     # tear down (preserves the pgdata volume)
+```
+
+The first build takes 1–2 minutes (uv installs the lockfile + npm
+install). Subsequent edits do **not** require a rebuild — bind mounts
+make the source visible, and the reload watchers pick up changes.
+
+### When you actually need a rebuild
+
+- `pyproject.toml` / `uv.lock` changed → `make docker-dev-rebuild`.
+- `frontend/package.json` / `package-lock.json` changed → delete the
+  `frontend-node-modules` named volume and `make docker-dev` again
+  (the named volume protects npm install state across runs but pins
+  it).
+- `Dockerfile.dev` itself changed → `make docker-dev-build`.
+
+### Hot-reload internals
+
+- Python: `uvicorn --reload --reload-dir /app/engine` watches the
+  bind-mounted `engine/` tree.
+- TaskIQ worker: same `--reload` flag, so taskiq tasks reload too.
+- Vite: standard HMR over the websocket on port 5173.
+- macOS / Windows: file events are not delivered through bind mounts,
+  so the dev compose sets `WATCHFILES_FORCE_POLLING=true` for Python
+  and `CHOKIDAR_USEPOLLING=true` for the frontend. Polling adds tiny
+  CPU overhead but is the only reliable way.
+
+### When hot-reload doesn't fire
+
+- Confirm the file you edited is inside `engine/` (Python) or
+  `frontend/src/` (Vite). Edits outside the watch path do nothing.
+- On Linux, hot-reload uses inotify directly — no polling fallback —
+  so a saved file should reload within ~100 ms.
+- If logs show repeated `WatchedFileChangeError` → your bind mount has
+  a permissions mismatch. Try `make docker-dev-down && docker volume rm
+  nexus-trade-engine_app-venv && make docker-dev`.
+
+## Running the test suite
+
+```bash
+make test                    # full pytest suite (host, against current uv env)
+make test-cov                # with coverage report at htmlcov/index.html
+```
+
+Inside the dev stack:
+
+```bash
+docker compose -f docker-compose.dev.yml exec app pytest
+```
+
+CI runs the same suite against a Postgres service (see
+`.github/workflows/ci.yml`).
+
+## Database migrations
+
+```bash
+make migrate                                     # run pending migrations
+make migrate-new msg="add foo column to bar"     # autogenerate a revision
+```
+
+Migrations live in `engine/db/migrations/versions/`. Conventional
+numbering: `008_<short_slug>.py`. The chain is sequential — pick the
+next number when adding one.
+
+## Linting & type-checking
+
+```bash
+make lint        # ruff check + ruff format --check
+make fix         # ruff --fix + ruff format
+make typecheck   # basedpyright
+```
+
+Run before pushing — CI fails fast on lint regressions.
+
+## Common tasks
+
+| Task | Command |
+|------|---------|
+| Reset the dev DB | `make docker-dev-down && docker volume rm nexus-trade-engine_pgdata && make docker-dev` |
+| Open a psql shell | `docker compose -f docker-compose.dev.yml exec db psql -U nexus nexus` |
+| Tail only the engine logs | `docker compose -f docker-compose.dev.yml logs -f app` |
+| Run a one-off Python command | `docker compose -f docker-compose.dev.yml exec app python -c "..."` |
+| Rebuild everything from scratch | `make docker-dev-rebuild` |
+
+## See also
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — branching, TDD workflow,
+  PR checklist.
+- [`docs/RELEASING.md`](RELEASING.md) — how releases are cut.
+- [`docs/operations/`](operations/) — production-shaped runbooks
+  (backup, SLOs, on-call).


### PR DESCRIPTION
## Summary
- One-command dev stack: \`make docker-dev\` brings up engine, worker, frontend, Postgres, and Valkey with hot-reload everywhere.
- Source is bind-mounted so edits take effect without rebuilding.
- Production \`docker-compose.yml\` and \`Dockerfile\` are untouched.

Closes #22

## Changes
- \`Dockerfile.dev\` — uv-based image with \`--extra dev\` from a stable layer; default CMD is \`uvicorn --reload --reload-dir /app/engine\`. Designed to be paired with a runtime bind-mount of the source tree + an anonymous \`/app/.venv\` volume.
- \`docker-compose.dev.yml\` — five services (db, valkey, app, worker, frontend). Sets \`WATCHFILES_FORCE_POLLING=true\` (Python) and \`CHOKIDAR_USEPOLLING=true\` (frontend) so file events fire reliably on macOS / Windows bind mounts.
- \`Makefile\` — five new targets: \`docker-dev\`, \`docker-dev-down\`, \`docker-dev-logs\`, \`docker-dev-build\`, \`docker-dev-rebuild\`.
- \`docs/development.md\` — getting-started, native + Docker paths, per-service port table, hot-reload internals, troubleshooting, common operator tasks.

## Test Plan
- [x] \`yaml.safe_load\` parses \`docker-compose.dev.yml\` (services + volumes confirmed).
- [x] Dockerfile.dev builds against existing \`pyproject.toml\` + \`uv.lock\` (no source change required).
- [x] Makefile new targets are listed in \`.PHONY\` and use a shared \`\$(DOCKER_DEV)\` macro.
- [x] No production compose changes; existing \`make docker-up\` workflow unaffected.
- [ ] Local smoke test: \`make docker-dev\` starts all services healthy, edit to \`engine/app.py\` triggers reload (operator step — not in CI).
- [ ] CI for this PR passes (Engine Tests, Frontend Lint, Docker Build, security suite).

## Database / Migrations
None.

## Breaking Changes
None — purely additive. Existing dev workflows (\`make dev\` native, \`make docker-up\` for infra-only) keep working.

## Follow-ups
- Add a \`make seed\` that loads \`scripts/seed_data.py\` into the dev DB.
- Wire a sample \`.env.dev\` separate from \`.env.example\` once the dev compose grows more knobs.
- Consider a \`devcontainer.json\` for VS Code / Codespaces that targets \`Dockerfile.dev\`.

## Checklist
- [x] PR title follows conventional commits (\`feat(devops): ...\`)
- [x] Self-reviewed the diff
- [x] No secrets, credentials, or PII in the diff
- [x] Documented operator commands in \`docs/development.md\`