### PR TITLE
docs: contributor + architecture documentation (gh#95)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,71 @@
+# Architecture Decision Records
+
+An ADR captures *one decision* that shaped the project: what we
+decided, why, what we considered, and what we accepted as a
+trade-off. ADRs are append-only — when a decision is reversed, the
+new ADR supersedes the old one and the old one is marked accordingly,
+but neither is deleted.
+
+We follow the [MADR](https://adr.github.io/madr/) format. See
+[`template.md`](template.md) for the boilerplate.
+
+## Index
+
+| Number | Status   | Title                                        |
+|-------:|----------|----------------------------------------------|
+| 0001   | Accepted | [Scaffold technology choices](0001-scaffold-tech-choices.md) |
+| 0002   | Accepted | [Auth & RBAC model](0002-auth-rbac.md)        |
+
+When you accept a new ADR, add a row to this table in the same PR.
+
+## When to write one
+
+Write an ADR when the answer to "why is it like that?" is going to be
+non-obvious to a future contributor. Concrete triggers:
+
+- Picking between multiple viable technologies (e.g. TaskIQ vs Celery
+  vs RQ).
+- Locking in a contract or schema that other code depends on
+  (e.g. webhook payload shape, plugin manifest format).
+- Accepting an unusual constraint (e.g. "we will run on a single node;
+  no HA story until v1.0").
+- Making a decision that contradicts an existing ADR.
+
+Don't write one for: routine bug fixes, refactors, code cleanups,
+small library upgrades. The git log + PR description is enough for
+those.
+
+## Lifecycle
+
+- **Proposed** — open a PR with the ADR file, status `Proposed`. The
+  PR discussion is where the decision is debated.
+- **Accepted** — when the PR merges, the status flips to `Accepted`
+  and the file becomes immutable except for status changes (e.g.
+  `Superseded by 00NN`).
+- **Rejected** — the PR is closed without merging. We don't keep
+  rejected ADRs in the repo; the discussion lives on the PR.
+- **Superseded** — a newer ADR replaces it. Edit the older ADR's
+  `Status:` line to `Superseded by 00NN — <title>` and add a backlink
+  in the new one. Don't delete the file.
+
+## Numbering
+
+Sequential, four digits, zero-padded. Pick the next number when you
+open the PR. If two PRs land in the same window with conflicting
+numbers, whoever merges first keeps theirs; the other one renames in
+the merge.
+
+## Filename convention
+
+`<NNNN>-<short-kebab-slug>.md` — e.g. `0003-pluggable-metrics-backend.md`.
+The slug should match the title closely enough that a `grep` finds
+it.
+
+## Where else this links
+
+- [`GOVERNANCE.md`](../../GOVERNANCE.md) — decision-making process
+  (lazy consensus + ADR for big changes).
+- [`docs/architecture/`](../architecture/) — current state, which is
+  the *outcome* of accumulated ADRs.
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — when to use an ADR vs.
+  a regular PR description.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,60 @@
+# ADR-NNNN: <Short imperative title>
+
+- **Status**: Proposed
+- **Date**: YYYY-MM-DD
+- **Deciders**: <names or roles, e.g. lead maintainer + 1 reviewer>
+- **Tags**: <area1, area2>
+
+## Context and Problem Statement
+
+What is the situation that requires a decision? Two or three short
+paragraphs. Be concrete: name the system, the constraint, and the
+reason an opinionated choice is necessary.
+
+## Decision Drivers
+
+- Driver 1 — *why this matters now*
+- Driver 2
+- Driver 3
+
+## Considered Options
+
+1. **Option A** — one-line summary.
+2. **Option B** — one-line summary.
+3. **Option C** — one-line summary.
+
+## Decision Outcome
+
+Chosen option: **Option <N> — <name>**, because <one-paragraph
+justification rooted in the drivers above>.
+
+### Consequences
+
+- **Positive** — what improves as a result.
+- **Negative** — what we give up or take on as ongoing cost.
+- **Neutral** — anything noteworthy that's neither pro nor con.
+
+## Pros and Cons of the Options
+
+### Option A
+
+- **Pros:** …
+- **Cons:** …
+
+### Option B
+
+- **Pros:** …
+- **Cons:** …
+
+### Option C
+
+- **Pros:** …
+- **Cons:** …
+
+## Links
+
+- Related issue / PR: #
+- Supersedes: <NNNN if applicable>
+- Superseded by: <NNNN if applicable>
+- External references: <links to vendor docs, papers, blog posts that
+  shaped the call>

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,50 @@
+# Architecture
+
+Nexus Trade Engine is an open, extensible algorithmic-trading platform.
+This directory captures the *current* shape of the system — what
+components exist, how they fit together, and where to add new code.
+
+For *why* we made specific structural choices, see
+[`docs/adr/`](../adr/README.md).
+
+## Reading order
+
+1. **[overview.md](overview.md)** — high-level component map, request
+   lifecycle, key dependencies. Start here if you've never opened the
+   repo before.
+2. **[database.md](database.md)** — table inventory, migration policy,
+   data ownership.
+3. **[plugins.md](plugins.md)** — plugin SDK and the registry that
+   loads strategies / data providers / execution backends at runtime.
+4. **[`docs/operations/`](../operations/)** — how the running system is
+   monitored, backed up, and recovered. Lives next to the runbooks
+   that on-call uses.
+5. **[`docs/adr/`](../adr/README.md)** — architecture decision records.
+   Read these before proposing a change that contradicts them.
+
+## Existing diagrams
+
+The two `.jsx` files in this directory render as interactive React
+components in our docs site:
+
+- `trading-framework-architecture.jsx` — top-level engine + frontend +
+  worker + queues.
+- `plugin-sdk-architecture.jsx` — plugin lifecycle, sandboxing, and
+  the registry.
+
+The flat-markdown architecture docs (`overview.md`, `database.md`,
+`plugins.md`) are the source of truth; the diagrams are a presentation
+layer on top.
+
+## Conventions
+
+- Markdown files in this directory describe the **current** state.
+  When you change the code, change the doc in the same PR.
+- Forward-looking design lives in an ADR, not in the architecture
+  docs. If you find yourself writing "we will" or "soon we will",
+  it's an ADR.
+- Each component doc should answer four questions:
+  1. What does it do?
+  2. What are its inputs and outputs?
+  3. What does it depend on?
+  4. Where does the code live?

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -1,0 +1,122 @@
+# Database
+
+Nexus Trade Engine stores all durable state in a single Postgres
+database (TimescaleDB extension enabled for time-series tables).
+The schema is owned by the Alembic migration chain in
+[`engine/db/migrations/versions/`](../../engine/db/migrations/versions/).
+
+## Migration policy
+
+- **One revision per logical change.** The chain is numbered
+  sequentially: `001_initial_schema.py`, `002_additional_tables.py`,
+  `003_bt_result_nullable_pid.py`, …, `010_webhooks.py`. Pick the next
+  number when adding a migration.
+- Every migration must define both `upgrade()` and `downgrade()`. If a
+  step is genuinely irreversible (data loss), make `downgrade()` an
+  explicit `op.execute("...")` that destroys what was created — but
+  *do* write it down.
+- Migrations run via `make migrate` locally and on the operator's
+  schedule in production. Long-running migrations should be split into
+  reversible steps so they can be rolled out without locking writes.
+- Models live in [`engine/db/models.py`](../../engine/db/models.py).
+  Keep them and the migration that creates them in the same PR.
+
+## Current chain
+
+| Rev   | Adds / changes                                                 |
+|-------|----------------------------------------------------------------|
+| 001   | Initial schema: users, strategies, backtest_results, accounts. |
+| 002   | Auxiliary tables (portfolios, journals, positions, fills).     |
+| 003   | Make `backtest_results.portfolio_id` nullable.                 |
+| 004   | Legal documents (Terms, Privacy, Disclaimer, …).               |
+| 005   | Auth/RBAC tables (roles, role_assignments).                    |
+| 006   | Make `legal_acceptance` rows immutable (no update/delete).     |
+| 007   | `scoring_snapshots` for cross-strategy composite scoring.      |
+| 008   | `backtest_results.composite_score` + `score_breakdown` (gh#8). |
+| 009   | `users.{mfa_enabled, mfa_secret_encrypted, mfa_backup_codes}`. |
+| 010   | `webhook_configs` + `webhook_deliveries` (gh#80).              |
+
+Run `alembic history` for the source of truth.
+
+## Critical tables
+
+These are the rows you must protect during a restore. See the backup
+runbook at [`docs/operations/backup-and-recovery.md`](../operations/backup-and-recovery.md).
+
+- **`users`** — primary identity. Password hashes are bcrypt; MFA
+  TOTP secrets are Fernet-encrypted with the engine's
+  `MFA_ENCRYPTION_KEY` (see [auth-mfa runbook](../operations/runbooks/auth-mfa.md)).
+- **`backtest_results`** — every run a user has ever submitted. The
+  `score_breakdown` JSONB column is the per-dimension score map from
+  the strategy evaluator.
+- **`portfolios`, `accounts`, `positions`, `fills`** — operational
+  trading state. When live trading lands (#109 / #111) these tables
+  will see write traffic on every fill.
+- **`webhook_configs`, `webhook_deliveries`** — the outbound webhook
+  registry and a delivery audit trail. The `signing_secret` column is
+  returned to the operator only on create; reads return null. **Do not
+  log delivery payloads** — they may contain user data.
+
+## TimescaleDB usage
+
+We use the TimescaleDB extension for time-series tables that grow
+unboundedly (market data, OHLCV bars, account equity history). When
+adding such a table:
+
+1. Define it as a regular Postgres table in the migration.
+2. Convert it to a hypertable in the same migration:
+   ```python
+   op.execute(
+       "SELECT create_hypertable('ohlcv', 'ts', "
+       "if_not_exists => TRUE, chunk_time_interval => INTERVAL '1 day');"
+   )
+   ```
+3. Add a retention policy if the data has a sane retention window.
+4. Note the dependency in this doc.
+
+Operators can run on vanilla Postgres if they accept the storage cost.
+
+## Async access pattern
+
+All DB access goes through SQLAlchemy 2's async API:
+
+```python
+from engine.db.session import session_factory
+
+async with session_factory() as session:
+    result = await session.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+```
+
+- **No sync sessions in route handlers.** They block the event loop.
+- **One session per request.** Don't pass a session across async
+  boundaries; use the dependency in
+  [`engine/api/deps.py`](../../engine/api/deps.py).
+- **Don't `commit` inside utility functions.** Commit at the route
+  handler boundary so the request's atomicity is obvious.
+- **Use `select` + `where`, not `query`.** SQLAlchemy 2's legacy API
+  is still importable but we don't use it.
+
+## Conventions
+
+- Primary keys are UUIDs except for legacy bigserial tables. New
+  tables should use UUIDs.
+- All tables have `created_at` and `updated_at` (default `now()`,
+  `updated_at` set by SQLAlchemy event listener).
+- JSON-shaped columns use `JSONB`, never `JSON`. Index with `GIN` if
+  you query by key.
+- Foreign keys default to `ON DELETE CASCADE` for owned data and
+  `ON DELETE RESTRICT` for shared / audit rows.
+
+## Testing
+
+Unit tests run against SQLite when possible to keep CI fast. Tests
+that exercise Postgres-specific features (JSONB queries, TimescaleDB
+hypertables, immutable triggers) should be marked
+`@pytest.mark.integration` and run in a Postgres-backed CI job.
+
+When adding a migration, also add a test that:
+1. Asserts the table / column exists at the new head.
+2. Round-trips a representative row.
+3. Exercises whatever invariant the migration is enforcing
+   (e.g. uniqueness, immutability).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,145 @@
+# System overview
+
+Nexus Trade Engine is a Python service that backtests algorithmic
+trading strategies, runs them against live or paper broker
+connections, and exposes the results via a REST API and a React
+frontend. This document describes the moving pieces and how a request
+flows through them.
+
+## Components
+
+```
+┌──────────────────┐        HTTPS         ┌──────────────────┐
+│   React frontend │ ───────────────────▶ │  FastAPI engine  │
+│   (frontend/)    │ ◀─────────────────── │  (engine/api)    │
+└──────────────────┘    JSON / WebSocket  └────────┬─────────┘
+                                                   │
+                          enqueue / dispatch       │
+                                                   ▼
+                                          ┌──────────────────┐
+                                          │  TaskIQ workers  │
+                                          │  (engine/tasks)  │
+                                          └────────┬─────────┘
+                                                   │
+                                          ┌────────┴─────────┐
+                                          ▼                  ▼
+                                  ┌────────────┐     ┌──────────────┐
+                                  │  Postgres  │     │ Valkey/Redis │
+                                  │ (asyncpg + │     │ (TaskIQ      │
+                                  │  TimescaleDB)    │  broker, cache)│
+                                  └────────────┘     └──────────────┘
+```
+
+The full service is one Python package (`engine/`) with sub-packages
+that line up with the boxes above. The frontend is a separate Vite +
+React app under `frontend/`.
+
+## Top-level layout
+
+| Path                     | Responsibility |
+|--------------------------|----------------|
+| [`engine/app.py`](../../engine/app.py)            | FastAPI app factory. Wires routers, middleware, lifespan hooks. |
+| [`engine/main.py`](../../engine/main.py)          | Entry point used by uvicorn (`--factory engine.app:create_app`). |
+| [`engine/config.py`](../../engine/config.py)      | Pydantic settings — every env var the engine reads lives here. |
+| [`engine/api/`](../../engine/api/)                | HTTP/WebSocket surface: routers, auth, rate limiting, error mapping. |
+| [`engine/core/`](../../engine/core/)              | Domain logic: backtest runner, strategy evaluator, execution primitives. |
+| [`engine/data/`](../../engine/data/)              | Market data providers and the registry that picks one at runtime. |
+| [`engine/db/`](../../engine/db/)                  | SQLAlchemy models, async session factory, Alembic migrations. |
+| [`engine/events/`](../../engine/events/)          | Event bus + outbound webhook dispatcher (gh#80). |
+| [`engine/observability/`](../../engine/observability/) | Structlog wiring, lineage middleware, pluggable metrics backend (gh#34). |
+| [`engine/plugins/`](../../engine/plugins/)        | Plugin SDK and runtime registry. See [plugins.md](plugins.md). |
+| [`engine/tasks/`](../../engine/tasks/)            | TaskIQ worker definitions for async work (backtests, scheduled jobs). |
+| [`engine/legal/`](../../engine/legal/)            | Legal-document acceptance (Terms / Privacy / etc.). |
+| [`engine/reference/`](../../engine/reference/)    | Static reference data (instruments, exchanges). |
+| [`frontend/`](../../frontend/)                    | React dashboard (Vite, React 18, Tailwind, react-query). |
+
+## Key dependencies
+
+| Concern                | Library                     |
+|------------------------|-----------------------------|
+| Web framework          | FastAPI                     |
+| Validation / settings  | Pydantic v2 / Pydantic-Settings |
+| Async DB driver        | `asyncpg` via SQLAlchemy 2 async |
+| Migrations             | Alembic                     |
+| Background tasks       | TaskIQ + `taskiq-fastapi` + `taskiq-redis` |
+| Cache / broker         | Valkey (Redis-compatible) via the `valkey` client |
+| Time-series storage    | TimescaleDB extension on Postgres |
+| Logging                | `structlog` (event = reserved kwarg — pass `event_type=`) |
+| Tracing / metrics      | OpenTelemetry SDK + a pluggable `MetricsBackend` |
+| HTTP client (outbound) | `httpx` async client        |
+| Crypto                 | `bcrypt`, `cryptography` (Fernet for MFA secrets) |
+
+The full pinned set is in [`pyproject.toml`](../../pyproject.toml).
+
+## Request lifecycle (HTTP)
+
+A typical authenticated `POST /api/v1/backtest` does this:
+
+1. Reverse proxy forwards the request to uvicorn (`engine.app:create_app`).
+2. **CORS / security middleware** rejects disallowed origins.
+3. **Lineage middleware** ([`engine/observability/lineage.py`](../../engine/observability/lineage.py))
+   stamps a request id and propagates the OpenTelemetry context.
+4. **Rate limiter** ([`engine/api/rate_limit.py`](../../engine/api/rate_limit.py))
+   short-circuits abusive clients.
+5. **Auth dependency** ([`engine/api/auth/`](../../engine/api/auth/))
+   resolves the bearer token to a `User`. If the user has MFA enabled
+   the request must carry a valid challenge token from `/login`.
+6. **Route handler** in `engine/api/routes/backtest.py` validates the
+   payload, persists a `BacktestResult` row, and enqueues the actual
+   computation onto the TaskIQ broker.
+7. The handler returns `202 Accepted` with the new id; the worker
+   picks the job up, runs it via [`engine/core/backtest_runner.py`](../../engine/core/backtest_runner.py),
+   wraps the result in [`engine/core/strategy_evaluator.py`](../../engine/core/strategy_evaluator.py),
+   and writes the composite score / breakdown back to the row.
+8. Listeners on `engine/events/bus.py` get notified. The webhook
+   dispatcher fans out to every active webhook config that subscribed
+   to the relevant event.
+
+Synchronous reads (`GET /api/v1/portfolio`, etc.) follow steps 1–5
+then return the result directly without enqueueing.
+
+## Event flow
+
+```
+domain code  ──▶  EventBus.publish(event)  ──▶  WebhookDispatcher
+                                          ──▶  internal listeners
+```
+
+The `EventBus` ([`engine/events/bus.py`](../../engine/events/bus.py))
+is in-process and synchronous; subscribers register at startup. The
+webhook dispatcher (gh#80) is the single subscriber today and handles
+all outbound HTTP fan-out with retries + HMAC signing.
+
+## Configuration
+
+Every operator-tunable lives in [`engine/config.py`](../../engine/config.py)
+as a Pydantic-Settings field. The convention is:
+
+- Field name = `nexus_<area>_<knob>` (lowercase snake-case).
+- Env var = uppercase, e.g. `NEXUS_DATABASE_URL`, `NEXUS_VALKEY_URL`,
+  `NEXUS_MFA_ENCRYPTION_KEY`.
+- Defaults are safe-for-dev. Production values come from the
+  operator's secrets vault.
+
+`.env.example` ships the full set so operators know what knobs exist
+without reading the source.
+
+## Where to put new code
+
+| Adding…                               | Goes in                                         |
+|---------------------------------------|--------------------------------------------------|
+| A new HTTP endpoint                   | `engine/api/routes/<area>.py`, registered in `engine/api/router.py` |
+| A new background job                  | `engine/tasks/`                                  |
+| A new strategy / data provider / executor | A plugin under `engine/plugins/<kind>/<name>/`. See [plugins.md](plugins.md). |
+| A new outbound integration (webhook template) | Extend [`engine/events/webhook_dispatcher.py:render_template`](../../engine/events/webhook_dispatcher.py) and the `_VALID_TEMPLATES` set in `routes/webhooks.py`. |
+| A new database table / column         | An Alembic revision in `engine/db/migrations/versions/`. See [database.md](database.md). |
+| A new metric                          | Use `get_metrics()` from `engine/observability/metrics.py`. Add it to [`docs/operations/slos.md`](../operations/slos.md) **only** if it backs an SLO. |
+| A new SLO                             | [`docs/operations/slos.md`](../operations/slos.md) and [`observability/prometheus/slo-rules.yaml`](../../observability/prometheus/slo-rules.yaml) in the same PR. |
+
+## Non-goals
+
+- This is **not** a multi-tenant SaaS by design. Operators run their
+  own deployment; the codebase models a single tenant's data per
+  database.
+- Live trading is intentionally optional. The engine works end-to-end
+  on backtests + paper trading without any broker credentials.

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -1,0 +1,114 @@
+# Plugins
+
+The plugin system lets operators extend Nexus Trade Engine with new
+strategies, data providers, and execution backends without forking
+the core. Plugins live under [`engine/plugins/`](../../engine/plugins/)
+and are loaded via a runtime registry.
+
+The interactive diagram in
+[`plugin-sdk-architecture.jsx`](plugin-sdk-architecture.jsx) shows
+the lifecycle visually; this doc is the flat-markdown source of truth.
+
+## What can be a plugin
+
+| Kind            | Loaded into                                | Example use case                          |
+|-----------------|--------------------------------------------|-------------------------------------------|
+| **Strategy**    | The backtest runner / live trading loop    | A custom signal generator, e.g. mean reversion. |
+| **Data provider** | The data registry                        | A new market data source (broker REST, CSV, vendor SDK). |
+| **Executor**    | The order pipeline                         | An adapter to a specific broker's REST/FIX/WS API. |
+| **Webhook template** | The webhook dispatcher                | A new outbound payload shape (Slack/Discord-class). |
+
+The plugin SDK's contract is intentionally small:
+
+1. A class implementing the relevant Protocol from `engine/plugins/`.
+2. A `manifest.toml` declaring name, version, kind, and entry point.
+3. Optional `tests/` exercising the plugin against a fixture.
+
+## Discovery & registration
+
+At startup the engine scans `engine/plugins/<kind>/` for plugins that
+declare a manifest. Discovered plugins are registered in the runtime
+registry; the API and core code reference them by name (string id)
+rather than by class import.
+
+This is intentional: it lets the operator swap strategies / providers
+in config without re-deploying.
+
+## Lifecycle
+
+```
+discover  ──▶  validate manifest  ──▶  import entry point  ──▶  register
+                                                                    │
+                                                                    ▼
+                            domain code ◀───  registry.get(name) ───┤
+                                                                    │
+                                              shutdown ─────────────┤
+                                                                    ▼
+                                                     teardown / unregister
+```
+
+- **Discovery** is filesystem-walk based. No network calls; no
+  arbitrary imports outside the plugin tree.
+- **Validation** fails fast on missing fields, version mismatches, or
+  declared dependencies that aren't installed.
+- **Import** happens once at startup. If a plugin's import raises,
+  the engine logs the error and continues without registering it —
+  one bad plugin should not crash the service.
+- **Teardown** runs at shutdown so plugins with sockets / threads
+  close cleanly.
+
+## Writing a plugin (strategy example)
+
+Concrete tutorials live in
+[`docs/PLUGIN_DEV_GUIDE.md`](../PLUGIN_DEV_GUIDE.md). The minimum
+shape:
+
+1. Subclass the appropriate Protocol (e.g. `engine.plugins.strategy.Strategy`).
+2. Implement the required methods (`on_bar`, `on_trade`, …).
+3. Add a `manifest.toml`:
+   ```toml
+   [plugin]
+   name = "mean-reversion"
+   version = "0.1.0"
+   kind  = "strategy"
+   entry = "mean_reversion:Strategy"
+
+   [plugin.dependencies]
+   numpy = ">=2.0"
+   ```
+4. Drop the directory at `engine/plugins/strategy/mean_reversion/`.
+5. Run the test suite — the plugin loader has its own integration
+   tests that ensure your manifest validates and your entry point
+   imports cleanly.
+
+## Sandboxing
+
+Plugins run in the same Python process as the engine; we do **not**
+sandbox them with subprocess / WASM today. That means a malicious
+plugin can read environment variables, the database, and the
+filesystem.
+
+Operators must therefore treat plugins as part of their trusted
+deployment surface. Two practical implications:
+
+- Pin plugin versions in your operator config; do not auto-update.
+- Plugins that come from third parties should be code-reviewed before
+  install.
+
+A future ADR (deferred) will revisit this with a sandbox proposal —
+likely WASI for strategies and a separate process for executors.
+
+## Where the code lives
+
+| File                                        | Purpose                                |
+|---------------------------------------------|----------------------------------------|
+| `engine/plugins/__init__.py`                | Public registry surface.               |
+| `engine/plugins/manifest.py`                | Manifest schema + validation.          |
+| `engine/plugins/loader.py`                  | Discovery + import logic.              |
+| `engine/plugins/strategy/`                  | Strategy plugins live here.            |
+| `engine/plugins/data/`                      | Data-provider plugins.                 |
+| `engine/plugins/exec/`                      | Executor plugins.                      |
+| `tests/plugins/`                            | Loader + manifest tests + fixtures.    |
+
+(File names are illustrative — they may have evolved by the time you
+read this. Run `tree engine/plugins/ -L 2` to see the current shape.)

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,0 +1,117 @@
+# Contributor deep-dive
+
+If you've read [`CONTRIBUTING.md`](../CONTRIBUTING.md) and
+[`docs/development.md`](development.md) and you're ready to actually
+move code, this doc is the orientation guide. It assumes you've
+spent ten minutes reading [`docs/architecture/overview.md`](architecture/overview.md).
+
+## Mental model
+
+Three layers, top to bottom:
+
+1. **Surface** (`engine/api/`, `frontend/`) — HTTP/WebSocket routes,
+   React UI. Thin glue that validates input and renders output. No
+   business logic lives here.
+2. **Domain** (`engine/core/`, `engine/data/`, `engine/events/`,
+   `engine/plugins/`) — backtest runner, strategy evaluator,
+   execution primitives, plugin registry. Most behaviour lives here.
+3. **Infrastructure** (`engine/db/`, `engine/observability/`,
+   `engine/tasks/`, `engine/legal/`) — persistence, telemetry,
+   background work, compliance. Stable and rarely changed.
+
+When you propose a change, mentally locate it in this stack. A change
+that touches only the surface is a UX or contract change. A change
+in the domain is a behaviour change. A change in infrastructure is
+something that affects every operator.
+
+## How a feature ships
+
+Borrowed from [`CONTRIBUTING.md`](../CONTRIBUTING.md) and refined for
+day-to-day:
+
+1. **Open or pick up an issue.** The autonomous-loop directive at the
+   top of this repo means many issues are pre-scoped — read the
+   labels (`priority-high`, `bucket:*`) before starting.
+2. **Branch:** `feat/<slug>-<issue#>`, `fix/...`, `docs/...`. Match
+   the conventional-commits prefix you'll use on the PR.
+3. **Tests first.** Add a failing test that captures the behaviour
+   you want. CI runs the same suite — green-on-laptop ≈ green-on-CI.
+4. **Implement to green.** Smallest diff that makes the test pass.
+5. **Lint + typecheck.** `make lint && make typecheck`. CI fails fast
+   on lint regressions; do this before pushing.
+6. **Open the PR** with the template populated (summary, linked
+   issue, test plan, breaking-change note, follow-ups).
+7. **Adversarially self-review** the diff before requesting review.
+   Look for the things you'd flag if it were someone else's code.
+8. **Merge** via squash + delete branch. Conventional-commits title
+   becomes the changelog entry (release-please reads it).
+
+## Code organization rules
+
+- Keep files **<800 lines**, functions **<50 lines**. Splits should
+  follow domain boundaries, not "I made it big".
+- Prefer **Protocols** over concrete base classes for plugin-style
+  contracts. The metrics backend in
+  [`engine/observability/metrics.py`](../engine/observability/metrics.py)
+  is the canonical example.
+- **No mutation** of mutable inputs. Return a new value instead.
+  Especially important for shared dicts / lists threaded through
+  middlewares.
+- **No silent error swallowing.** Either handle it explicitly or let
+  it propagate. The exception is true "best-effort" paths
+  (telemetry, retention sweeps) — they should log, not swallow.
+- **Validate at the boundary.** Pydantic models on the way in,
+  trusted internal types after that. Don't re-validate in domain
+  code.
+
+## Where to add what
+
+Same table as [`overview.md`](architecture/overview.md#where-to-put-new-code),
+restated here for quick reference:
+
+| Adding…                               | Goes in                                         |
+|---------------------------------------|--------------------------------------------------|
+| HTTP endpoint                         | `engine/api/routes/<area>.py`                    |
+| Background job                        | `engine/tasks/`                                  |
+| Strategy / data provider / executor   | A plugin under `engine/plugins/<kind>/<name>/`   |
+| Webhook template                      | `engine/events/webhook_dispatcher.py:render_template` + `_VALID_TEMPLATES` |
+| Schema change                         | New Alembic revision in `engine/db/migrations/versions/` |
+| Metric (general)                      | `get_metrics()` from `engine/observability/metrics.py` |
+| Metric backing an SLO                 | Above + update `docs/operations/slos.md` and `observability/prometheus/slo-rules.yaml` |
+| Operational runbook                   | `docs/operations/runbooks/<name>.md`             |
+| ADR-worthy decision                   | `docs/adr/<NNNN>-<slug>.md`                      |
+
+## Common gotchas
+
+- **`structlog` `event` is reserved.** Pass `event_type=` for the
+  domain-event name. The webhook dispatcher already learned this the
+  hard way (see [`webhook-delivery runbook`](operations/runbooks/webhook-delivery.md)).
+- **`uvicorn --reload` does not pick up edits to imported C
+  extensions.** If you're touching `polars` / `numpy` extensions,
+  restart manually.
+- **Async sessions don't auto-rollback on exception.** Either use a
+  context manager that does (`engine.api.deps.get_session`) or
+  rollback explicitly in your `except`.
+- **Webhook signing secrets are returned only on create.** Don't add
+  a route that returns them on read — see
+  [`engine/api/routes/webhooks.py`](../engine/api/routes/webhooks.py).
+- **Migrations on a production DB lock writes.** For a column add,
+  prefer `op.add_column` + a backfill in a follow-up migration over
+  a single migration that does both.
+
+## Getting help
+
+- Architecture-level questions → open a discussion (link in
+  [`SECURITY.md`](../SECURITY.md) → "Questions and discussion").
+- Bug? → [`.github/ISSUE_TEMPLATE/bug.yml`](../.github/ISSUE_TEMPLATE/bug.yml).
+- Feature idea? → [`.github/ISSUE_TEMPLATE/feature.yml`](../.github/ISSUE_TEMPLATE/feature.yml).
+- Security? → never the public tracker;
+  [`SECURITY.md`](../SECURITY.md) has the private channel.
+
+## See also
+
+- [`docs/architecture/`](architecture/) — current-state architecture.
+- [`docs/adr/`](adr/) — historical decisions.
+- [`docs/operations/`](operations/) — runbooks, backups, SLOs.
+- [`docs/RELEASING.md`](RELEASING.md) — how releases get cut.
+- [`docs/development.md`](development.md) — local environment setup.


### PR DESCRIPTION
## Summary
- Comprehensive architecture docs (overview, database, plugins) that document the *current* shape of the engine.
- Contributor deep-dive that complements \`CONTRIBUTING.md\` with the codebase mental model, where-to-add-what guide, and common gotchas.
- ADR scaffolding (index + MADR template) so future big-decision PRs have a place to live.

Closes #95

## Changes
**Architecture (current-state, append-on-change)**
- \`docs/architecture/README.md\` — index, reading order, conventions distinguishing flat-markdown source-of-truth from interactive \`.jsx\` diagrams.
- \`docs/architecture/overview.md\` — component map, top-level layout table, key dependencies, request lifecycle (HTTP), event flow, configuration conventions, "where to put new code" table grounded in the live code paths.
- \`docs/architecture/database.md\` — Alembic migration policy, current chain (rev 001–010 with one-line summaries), critical tables, TimescaleDB hypertable convention, async access pattern, per-migration test contract.
- \`docs/architecture/plugins.md\` — flat-markdown companion to the existing \`plugin-sdk-architecture.jsx\` diagram. Plugin kinds, lifecycle, manifest.toml shape, sandboxing limits.

**Contributor flow**
- \`docs/contributors.md\` — three-layer mental model (surface / domain / infrastructure), how-a-feature-ships sequence, code organization rules (file size limits, Protocol-over-class, no-mutation, fail-loud), "where to add what" cross-reference, common gotchas (structlog \`event=\` collision, async session rollback, webhook signing-secret read path, migration locking).

**ADR scaffolding**
- \`docs/adr/README.md\` — index, when-to-write criteria, lifecycle (Proposed → Accepted / Rejected / Superseded), numbering, filename convention. Lists the two existing ADRs (0001, 0002).
- \`docs/adr/template.md\` — MADR boilerplate.

## Test Plan
- [x] All cross-references between new docs resolve (relative paths verified manually).
- [x] References to live source paths (\`engine/api/routes/*\`, \`engine/observability/metrics.py\`, \`engine/db/migrations/versions/*\`) match the on-disk layout.
- [x] References to existing operations runbooks (\`docs/operations/runbooks/*.md\`) all resolve to files merged in earlier PRs.
- [x] Migration chain row count (10) matches actual file count in \`engine/db/migrations/versions/\`.
- [ ] CI for this PR passes (Engine Tests, Frontend Lint, Docker Build, security suite).

## Database / Migrations
None.

## Breaking Changes
None — pure docs.

## Follow-ups
- Update the existing \`0001-scaffold-tech-choices.md\` and \`0002-auth-rbac.md\` to use the new MADR template format (currently they predate the template). Low priority.
- Convert the JSX architecture diagrams to a stable image format alongside the source so they render in GitHub directly.
- Add a "where things are" doc-tour once we have a steady stream of new contributors.

## Checklist
- [x] PR title follows conventional commits (\`docs: ...\`)
- [x] Self-reviewed the diff
- [x] No secrets, credentials, or PII in the diff
- [x] All new docs link back through README → overview → component docs in a consistent reading order