### PR TITLE
feat(test): k6 load + performance regression suite (gh#137)

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,81 @@
+name: Load test
+
+# Triggers:
+#   - workflow_dispatch — manual run from the Actions tab.
+#   - schedule         — weekly at 03:00 UTC on Mondays.
+#
+# Required secrets (configured at the repo / org level):
+#   NEXUS_BASE_URL    URL of the staging environment to test against
+#   NEXUS_LOAD_USER   load-test user email (MFA disabled)
+#   NEXUS_LOAD_PASS   load-test user password
+#
+# Reference: docs/operations/load-testing.md
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: "Which k6 script to run"
+        required: true
+        type: choice
+        default: smoke
+        options:
+          - smoke
+          - baseline
+      base_url:
+        description: "Override NEXUS_BASE_URL for this run (optional)"
+        required: false
+        type: string
+  schedule:
+    # Weekly baseline regression — Monday 03:00 UTC.
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: k6 ${{ github.event.inputs.scenario || 'baseline' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install k6
+        run: |
+          set -euo pipefail
+          curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install -y k6
+          k6 version
+
+      - name: Run k6
+        env:
+          NEXUS_BASE_URL: ${{ github.event.inputs.base_url || secrets.NEXUS_BASE_URL }}
+          NEXUS_LOAD_USER: ${{ secrets.NEXUS_LOAD_USER }}
+          NEXUS_LOAD_PASS: ${{ secrets.NEXUS_LOAD_PASS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXUS_BASE_URL:-}" ]; then
+            echo "::error::NEXUS_BASE_URL is not set; configure the secret or pass base_url" >&2
+            exit 1
+          fi
+          scenario="${{ github.event.inputs.scenario || 'baseline' }}"
+          case "$scenario" in
+            smoke)    script=tests/load/api-smoke.js ;;
+            baseline) script=tests/load/api-baseline.js ;;
+            *) echo "::error::unknown scenario: $scenario" >&2; exit 2 ;;
+          esac
+          k6 run \
+            --summary-export=load-test-summary.json \
+            "$script"
+
+      - name: Upload summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-summary-${{ github.event.inputs.scenario || 'baseline' }}
+          path: load-test-summary.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/operations/load-testing.md
+++ b/docs/operations/load-testing.md
@@ -1,0 +1,129 @@
+# Load testing
+
+We run k6-based load tests against a **staging** environment
+weekly + on demand. The goal is regression detection: we want to know
+if a merged change made the API meaningfully slower or less reliable
+under realistic traffic.
+
+The scripts live in [`tests/load/`](../../tests/load/). The CI
+workflow lives in
+[`.github/workflows/load-test.yml`](../../.github/workflows/load-test.yml).
+
+## Environments
+
+| Environment | Allowed?          | Notes                                                       |
+|-------------|-------------------|-------------------------------------------------------------|
+| Staging     | Yes — primary use | Mirror of production with synthetic data. Run anytime.      |
+| Production  | **No**            | The async-backtest write path the baseline exercises mutates real DB rows. |
+| Local dev   | Yes — manual only | Useful when iterating on the script itself.                 |
+
+If you must measure something on production, use read-only smoke
+checks (`http_req_failed` + `http_req_duration` on the `/health` and
+`/portfolio` endpoints only) and treat any meaningful traffic as an
+incident.
+
+## Triggering a run
+
+### From GitHub (recommended)
+
+1. **Actions → Load test → Run workflow**.
+2. Pick the scenario (`smoke` or `baseline`) and optionally override
+   `NEXUS_BASE_URL` for a one-off run.
+3. The workflow uploads `load-test-summary.json` as an artifact —
+   download it from the run page when the job finishes.
+
+### From your laptop
+
+```bash
+brew install k6   # or: sudo apt-get install k6
+export NEXUS_BASE_URL=https://staging.example.com
+export NEXUS_LOAD_USER=load-test@example.com
+export NEXUS_LOAD_PASS='non-prod-password'
+
+k6 run tests/load/api-smoke.js
+k6 run tests/load/api-baseline.js
+```
+
+## Reading the output
+
+k6 prints a summary at the end of every run:
+
+```
+checks.........................: 99.95%  ✓ 5994  ✗ 3
+http_req_duration..............: avg=230ms p(95)=890ms p(99)=1.4s
+http_req_failed................: 0.05%   ✓ 6000  ✗ 3
+```
+
+The lines that matter:
+
+- **`checks`** — your `check(...)` assertions inside the script. Below
+  100% means the API returned an unexpected status or shape.
+- **`http_req_duration`** — request latency. The thresholds in the
+  scripts (e.g. `p(95)<800` for `portfolio_list`) cause the run to
+  exit non-zero if exceeded.
+- **`http_req_failed`** — fraction of requests that did not return
+  2xx/3xx.
+
+The summary also lists per-tag breakdowns
+(`http_req_duration{name:portfolio_list}`) — that's where regressions
+usually show up first.
+
+## Linking to SLOs
+
+The baseline thresholds are deliberately a bit tighter than the SLOs
+in [`slos.md`](slos.md): we want this test to fail before the SLO
+budget is consumed, not after.
+
+| Threshold (baseline)                              | Related SLO                  |
+|---------------------------------------------------|------------------------------|
+| `http_req_failed < 0.5%`                          | API availability (99.5%)     |
+| `http_req_duration{portfolio_list} p(95) < 800ms` | API latency (99% < 1.0s)     |
+| `http_req_duration{backtest_submit} p(95) < 1.5s` | Backtest submit (99%)        |
+
+If you tighten or relax a threshold in the scripts, update this table
+in the same PR.
+
+## Triaging a regression
+
+1. **Reproduce locally** if possible. Re-run the script against the
+   same staging URL — flake vs. real regression.
+2. **Diff the artifact.** Download `load-test-summary.json` from the
+   failing run and the previous green run; compare the per-tag
+   percentiles.
+3. **Check recent merges.** A latency regression usually correlates
+   with a specific merge — `git log main --since=$(date -d '7 days
+   ago' +%Y-%m-%d)` is your friend.
+4. **Open an issue** tagged `priority-high` with the diff and a
+   pointer to the suspected commit. Don't tighten the threshold to
+   make the test pass — that's how we got there.
+
+## Common pitfalls
+
+- **Login fails** — the load-test user has MFA enabled. The scripts
+  intentionally hit the flat `/login` path; an MFA-enabled user will
+  get an `mfa_required: true` response. Disable MFA on the test user.
+- **Backtest endpoint returns 422** — the Pydantic model changed.
+  Update `BACKTEST_BODY` in `tests/load/api-baseline.js` to match.
+- **`Frontend Lint` fails on the JS** — lint scope intentionally
+  doesn't include `tests/load/`. If you see this, check the lint
+  config wasn't accidentally widened.
+- **CI run hangs** — the runner could not reach the staging URL
+  (firewall, expired DNS). Cancel and check the staging environment
+  before re-running.
+
+## Out of scope
+
+The k6 surface deliberately does not cover:
+
+- Authentication flows that involve MFA.
+- WebSocket traffic (waiting on #7).
+- MCP server traffic (waiting on #104–#106).
+- Spike / stress profiles for capacity planning. Add when needed.
+
+## Related
+
+- [`tests/load/README.md`](../../tests/load/README.md) — script-level
+  conventions.
+- [`docs/operations/slos.md`](slos.md) — SLOs the thresholds anchor
+  against.
+- [`docs/operations/runbooks/api-availability.md`](runbooks/api-availability.md) — what to do when the SLO does break.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,78 @@
+# Load tests (k6)
+
+[k6](https://k6.io/) load + performance scripts targeting the engine's
+HTTP surface.
+
+| Script              | Purpose                                                | Duration | Triggered by                                 |
+|---------------------|--------------------------------------------------------|----------|----------------------------------------------|
+| `api-smoke.js`      | 1 VU, 30 s — alive end-to-end, every key route 2xx.    | ~30 s    | Manual; recommended on every staging deploy. |
+| `api-baseline.js`   | Constant-arrival-rate baseline at `NEXUS_BASELINE_RPS` (default 20 RPS) for 5 min. | 5 min | Weekly cron + manual. |
+
+## Running locally
+
+```bash
+# Install k6 (https://grafana.com/docs/k6/latest/get-started/installation/).
+brew install k6                      # macOS
+# or: sudo apt-get install k6         # Linux
+
+# Set the target.
+export NEXUS_BASE_URL=https://staging.example.com
+export NEXUS_LOAD_USER=load-test@example.com
+export NEXUS_LOAD_PASS='use-a-real-but-non-prod-password'
+
+k6 run tests/load/api-smoke.js
+k6 run tests/load/api-baseline.js
+```
+
+## Running in CI
+
+`.github/workflows/load-test.yml` runs the suite weekly and on manual
+trigger. Required repo secrets:
+
+- `NEXUS_BASE_URL`
+- `NEXUS_LOAD_USER`
+- `NEXUS_LOAD_PASS`
+
+The workflow uploads `load-test-summary.json` as an artifact (30-day
+retention) so regressions can be diffed.
+
+## Conventions
+
+- **Tag every request** via `tags: { name: '<route>' }`. Thresholds
+  reference these names.
+- **Use the helpers in `lib/auth.js`** for login / Authorization
+  headers. Don't re-implement the login flow per script.
+- **No destructive writes.** The baseline writes via the async-
+  backtest path (returns 202; worker may or may not run it). Don't
+  add scripts that mutate prod-shaped data without a separate
+  destructive-OK env flag.
+- **No MFA-enabled users.** The load-test user must be a flat
+  email + password. MFA challenge flows are not part of the load
+  surface today (and should never be).
+
+## Adding a new scenario
+
+1. Drop the script in this directory.
+2. Tag every request.
+3. Add thresholds for the routes you exercise — start strict, relax
+   if real measurements justify it.
+4. Add a row to the table at the top of this README.
+5. Add the scenario name to the `workflow_dispatch.inputs.scenario`
+   choice list and the `case` statement in
+   `.github/workflows/load-test.yml`.
+
+## Out of scope (for now)
+
+- **WebSocket traffic.** Will be added once the WebSocket surface
+  (#7) lands; k6 supports `k6/ws` natively.
+- **MCP server load.** Will be added once the MCP server (#104–#106)
+  lands; likely a separate `mcp-baseline.js` using the MCP transport.
+- **Spike + stress profiles.** Tracked as a follow-up — the current
+  scripts give us regression signal; spike/stress are useful once
+  capacity planning becomes a recurring need.
+
+## Related
+
+- Operator runbook: [`docs/operations/load-testing.md`](../../docs/operations/load-testing.md)
+- SLOs the baseline thresholds anchor against:
+  [`docs/operations/slos.md`](../../docs/operations/slos.md)

--- a/tests/load/api-baseline.js
+++ b/tests/load/api-baseline.js
@@ -1,0 +1,100 @@
+// Baseline load — sustained traffic at a known RPS for 5 minutes.
+// Intended to run weekly on a staging environment to catch regressions
+// before they hit production.
+//
+// Required env:
+//   NEXUS_BASE_URL          e.g. https://staging.example.com
+//   NEXUS_LOAD_USER         load-test user email (MFA disabled)
+//   NEXUS_LOAD_PASS         load-test user password
+//
+// Optional env:
+//   NEXUS_BASELINE_RPS      target requests-per-second (default 20)
+//   NEXUS_LOAD_STRATEGY_ID  strategy id used in backtest submissions (default: 'noop')
+//
+// Run:
+//   k6 run tests/load/api-baseline.js
+//
+// Reference: docs/operations/load-testing.md
+//
+// What's tested:
+//   - GET  /api/v1/portfolio              — read-heavy listing
+//   - GET  /api/v1/reference/exchanges    — cached reference read
+//   - POST /api/v1/backtest               — async-write path (returns 202)
+//
+// Why these three:
+//   They exercise three distinct backend code paths (DB read, cache read,
+//   queue write) without doing anything destructive. The backtest endpoint
+//   accepts a no-op payload and returns a row id; the worker may or may not
+//   pick it up — that's covered by the task-pipeline SLO, not this test.
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { login, authHeaders } from './lib/auth.js';
+
+const BASELINE_RPS = parseInt(__ENV.NEXUS_BASELINE_RPS || '20', 10);
+
+export const options = {
+  scenarios: {
+    baseline: {
+      executor: 'constant-arrival-rate',
+      rate: BASELINE_RPS,
+      timeUnit: '1s',
+      duration: '5m',
+      preAllocatedVUs: Math.max(20, BASELINE_RPS * 2),
+      maxVUs: Math.max(50, BASELINE_RPS * 5),
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.005'],
+    'http_req_duration{name:portfolio_list}':       ['p(95)<800',  'p(99)<1500'],
+    'http_req_duration{name:reference_exchanges}':  ['p(95)<400',  'p(99)<800'],
+    'http_req_duration{name:backtest_submit}':      ['p(95)<1500', 'p(99)<2500'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'p(95)', 'p(99)', 'max'],
+};
+
+export function setup() {
+  const baseUrl = __ENV.NEXUS_BASE_URL;
+  if (!baseUrl) {
+    throw new Error('NEXUS_BASE_URL is required');
+  }
+  const { token } = login(baseUrl, __ENV.NEXUS_LOAD_USER, __ENV.NEXUS_LOAD_PASS);
+  return { baseUrl, token };
+}
+
+const BACKTEST_BODY = JSON.stringify({
+  // Minimal accepted payload — operator may need to swap this for whatever
+  // the current Pydantic model requires. Kept intentionally small so it does
+  // not generate meaningful load on the worker.
+  strategy_id: __ENV.NEXUS_LOAD_STRATEGY_ID || 'noop',
+  start: '2024-01-01T00:00:00Z',
+  end:   '2024-01-02T00:00:00Z',
+  symbol: 'AAPL',
+});
+
+export default function (data) {
+  const r = Math.random();
+
+  if (r < 0.5) {
+    const res = http.get(`${data.baseUrl}/api/v1/portfolio`, {
+      headers: authHeaders(data.token),
+      tags: { name: 'portfolio_list' },
+    });
+    check(res, { '2xx': (r) => r.status >= 200 && r.status < 300 });
+  } else if (r < 0.85) {
+    const res = http.get(`${data.baseUrl}/api/v1/reference/exchanges`, {
+      headers: authHeaders(data.token),
+      tags: { name: 'reference_exchanges' },
+    });
+    check(res, { '2xx': (r) => r.status >= 200 && r.status < 300 });
+  } else {
+    const res = http.post(`${data.baseUrl}/api/v1/backtest`, BACKTEST_BODY, {
+      headers: authHeaders(data.token),
+      tags: { name: 'backtest_submit' },
+    });
+    // 202 Accepted is the expected success status for the async path.
+    check(res, { 'submit accepted': (r) => r.status === 202 || r.status === 201 || r.status === 200 });
+  }
+
+  sleep(0.1);
+}

--- a/tests/load/api-smoke.js
+++ b/tests/load/api-smoke.js
@@ -1,0 +1,71 @@
+// Smoke test — runs in <1 minute. Verifies the API surface is alive end-to-end.
+// Intended to run in CI on every PR that touches engine/api/.
+//
+// Required env:
+//   NEXUS_BASE_URL          e.g. https://staging.example.com
+//   NEXUS_LOAD_USER         load-test user email (MFA disabled)
+//   NEXUS_LOAD_PASS         load-test user password
+//
+// Run:
+//   k6 run tests/load/api-smoke.js
+//
+// Reference: docs/operations/load-testing.md
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { login, authHeaders } from './lib/auth.js';
+
+export const options = {
+  scenarios: {
+    smoke: {
+      executor: 'constant-vus',
+      vus: 1,
+      duration: '30s',
+    },
+  },
+  thresholds: {
+    // Smoke must be effectively perfect — any failure is a real signal.
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<1000'],
+    'http_req_duration{name:health}': ['p(95)<200'],
+  },
+};
+
+export function setup() {
+  const baseUrl = __ENV.NEXUS_BASE_URL;
+  if (!baseUrl) {
+    throw new Error('NEXUS_BASE_URL is required');
+  }
+  const { token } = login(baseUrl, __ENV.NEXUS_LOAD_USER, __ENV.NEXUS_LOAD_PASS);
+  return { baseUrl, token };
+}
+
+export default function (data) {
+  // 1. Health check — should be sub-200ms.
+  const health = http.get(`${data.baseUrl}/api/v1/health`, {
+    tags: { name: 'health' },
+  });
+  check(health, { 'health 200': (r) => r.status === 200 });
+
+  // 2. Authenticated read — portfolio listing.
+  const portfolios = http.get(`${data.baseUrl}/api/v1/portfolio`, {
+    headers: authHeaders(data.token),
+    tags: { name: 'portfolio_list' },
+  });
+  check(portfolios, {
+    'portfolio 200': (r) => r.status === 200,
+    'portfolio is JSON': (r) => {
+      try { return Array.isArray(r.json()) || typeof r.json() === 'object'; }
+      catch (_) { return false; }
+    },
+  });
+
+  // 3. Reference data — instruments / exchanges (cheap GET).
+  const ref = http.get(`${data.baseUrl}/api/v1/reference/exchanges`, {
+    headers: authHeaders(data.token),
+    tags: { name: 'reference_exchanges' },
+  });
+  check(ref, { 'reference 200': (r) => r.status === 200 });
+
+  sleep(1);
+}

--- a/tests/load/lib/auth.js
+++ b/tests/load/lib/auth.js
@@ -1,0 +1,63 @@
+// Reusable auth helpers for k6 load tests.
+//
+// Usage:
+//   import { login, authHeaders } from './lib/auth.js';
+//
+//   export function setup() {
+//     const { token } = login(__ENV.NEXUS_BASE_URL, __ENV.NEXUS_LOAD_USER, __ENV.NEXUS_LOAD_PASS);
+//     return { token };
+//   }
+//
+//   export default function (data) {
+//     const res = http.get(`${__ENV.NEXUS_BASE_URL}/api/v1/portfolio`, {
+//       headers: authHeaders(data.token),
+//     });
+//     check(res, { '200': (r) => r.status === 200 });
+//   }
+
+import http from 'k6/http';
+import { check, fail } from 'k6';
+
+/**
+ * Acquire an auth token. Throws if the login fails.
+ *
+ * @param {string} baseUrl   - e.g. "https://staging.example.com"
+ * @param {string} username  - load-test user (must NOT have MFA enabled)
+ * @param {string} password  - load-test password
+ * @returns {{ token: string }}
+ */
+export function login(baseUrl, username, password) {
+  const res = http.post(
+    `${baseUrl}/api/v1/auth/login`,
+    JSON.stringify({ email: username, password }),
+    { headers: { 'Content-Type': 'application/json' }, tags: { name: 'login' } },
+  );
+
+  const ok = check(res, {
+    'login returned 200': (r) => r.status === 200,
+    'login returned a token': (r) => {
+      try { return !!r.json('access_token'); } catch (_) { return false; }
+    },
+  });
+
+  if (!ok) {
+    fail(`login failed: status=${res.status} body=${(res.body || '').slice(0, 200)}`);
+  }
+
+  return { token: res.json('access_token') };
+}
+
+/**
+ * Build the Authorization headers for an authenticated request.
+ *
+ * @param {string} token
+ * @param {Record<string, string>} [extra]
+ * @returns {Record<string, string>}
+ */
+export function authHeaders(token, extra = {}) {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    ...extra,
+  };
+}


### PR DESCRIPTION
## Summary
- First iteration of a k6 load-testing surface for the engine API: smoke + baseline scripts, reusable auth helper, weekly CI cron + manual trigger, operator runbook.
- WebSocket and MCP scenarios deferred to follow-ups (waiting on #7 and #104–#106 respectively). Spike/stress profiles tracked as separate follow-up.
- Thresholds intentionally tighter than the SLOs so the test fails *before* the SLO budget burns.

Closes #137

## Changes
**Scripts**
- \`tests/load/lib/auth.js\` — \`login(baseUrl, user, pass)\` + \`authHeaders(token)\`. \`fail()\`s on bad login.
- \`tests/load/api-smoke.js\` — 1 VU / 30 s. Hits \`/health\`, \`/portfolio\`, \`/reference/exchanges\`. Tight thresholds (failure rate < 1%, p95 < 1 s, \`/health\` p95 < 200 ms).
- \`tests/load/api-baseline.js\` — \`constant-arrival-rate\` at \`NEXUS_BASELINE_RPS\` (default 20 RPS) for 5 min. Mix: portfolio 50% / reference 35% / backtest submit 15% — covers DB read, cache read, queue write.

**CI**
- \`.github/workflows/load-test.yml\` — \`workflow_dispatch\` (scenario + optional base_url inputs) plus Monday 03:00 UTC cron. Installs k6 from the official Debian repo, runs the chosen script, uploads \`load-test-summary.json\` as an artifact (30-day retention).

**Docs**
- \`tests/load/README.md\` — script index, env vars, conventions (tagging, no-MFA, no-destructive-writes), how to add a new scenario.
- \`docs/operations/load-testing.md\` — operator runbook: environments allowed, triggering, output interpretation, threshold-to-SLO mapping table, regression triage steps, common pitfalls, out-of-scope list.

## Test Plan
- [x] \`yaml.safe_load\` parses \`.github/workflows/load-test.yml\` cleanly.
- [x] \`node -c\` confirms syntax of all 3 JS files.
- [x] All endpoints referenced (\`/api/v1/{health,portfolio,reference/exchanges,backtest,auth/login}\`) exist in \`engine/api/routes/\`.
- [x] Threshold table in \`docs/operations/load-testing.md\` matches actual thresholds in \`api-baseline.js\`.
- [ ] First real \`workflow_dispatch\` run after merge (operator step — needs the secrets configured).
- [ ] CI for this PR passes.

## Database / Migrations
None.

## Breaking Changes
None — purely additive.

## Follow-ups
- WebSocket scenario (\`tests/load/ws-baseline.js\`) once #7 lands.
- MCP scenario (\`tests/load/mcp-baseline.js\`) once #104–#106 land.
- Spike + stress profiles when capacity planning becomes a recurring need.
- Re-baseline thresholds after the first 4 weekly runs surface real staging numbers.

## Checklist
- [x] PR title follows conventional commits (\`feat(test): ...\`)
- [x] Self-reviewed the diff
- [x] No secrets, credentials, or PII in the diff (placeholders use \`example.com\`)
- [x] Documented operator commands in \`docs/operations/load-testing.md\`