### PR TITLE
feat(api): long-lived API keys + system status endpoint (gh#94)

### DIFF
--- a/engine/api/auth/api_keys.py
+++ b/engine/api/auth/api_keys.py
@@ -1,0 +1,172 @@
+"""API key issuance and verification (gh#94).
+
+Token format
+------------
+    nxs_<env>_<random>
+
+- ``nxs_`` is a fixed prefix that lets us recognise an engine-issued
+  key vs. a JWT or another credential at the auth boundary.
+- ``<env>`` is operator-chosen text (e.g. ``live``, ``test``) and is
+  baked into the token at issue time. Default: ``live``.
+- ``<random>`` is 32 hex characters of cryptographically random data
+  (~128 bits of entropy).
+
+The first 12 characters of the issued token are stored in the DB as
+``api_keys.prefix`` for human-readable identification (e.g.
+``nxs_live_aB3``); the full token is bcrypt-hashed into
+``api_keys.key_hash``. The full token is shown to the operator
+exactly once, on creation.
+
+Verification
+------------
+Given an inbound token, we look up the row by ``prefix`` (first 12
+chars) and bcrypt-verify the full token against ``key_hash``. If the
+row is revoked, expired, or missing, verification fails.
+
+Scope strings
+-------------
+- ``read``  — GET-only access.
+- ``trade`` — submit backtests, place orders.
+- ``admin`` — everything; treat as equivalent to the operator role.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import bcrypt
+from sqlalchemy import select
+
+from engine.db.models import ApiKey
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+VALID_SCOPES: frozenset[str] = frozenset({"read", "trade", "admin"})
+
+# Length of the random tail in hex characters (~128 bits of entropy).
+_RANDOM_TAIL_BYTES = 16
+
+# Number of characters we keep in plaintext for identification.
+_PREFIX_DISPLAY_CHARS = 12
+
+
+class ApiKeyError(ValueError):
+    """Raised when an inbound token cannot be parsed or validated."""
+
+
+def _is_engine_token(token: str) -> bool:
+    return token.startswith("nxs_")
+
+
+def generate_token(env: str = "live") -> str:
+    """Issue a fresh API token. Caller must persist the hash before returning."""
+    if not env or not env.replace("_", "").isalnum():
+        raise ValueError("env must be a non-empty alphanumeric label")
+    random_tail = secrets.token_hex(_RANDOM_TAIL_BYTES)
+    return f"nxs_{env}_{random_tail}"
+
+
+def split_token(token: str) -> tuple[str, str]:
+    """Split a full token into its display prefix and the bcrypt input.
+
+    The bcrypt input is the *full* token rather than just the random tail —
+    that way an attacker who guesses a tail can't trivially reuse it across
+    environments.
+    """
+    if not _is_engine_token(token) or len(token) < _PREFIX_DISPLAY_CHARS + 1:
+        raise ApiKeyError("not an engine API key")
+    prefix = token[:_PREFIX_DISPLAY_CHARS]
+    return prefix, token
+
+
+def hash_token(token: str) -> str:
+    return bcrypt.hashpw(token.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_token(token: str, key_hash: str) -> bool:
+    try:
+        return bcrypt.checkpw(token.encode("utf-8"), key_hash.encode("utf-8"))
+    except (TypeError, ValueError):
+        return False
+
+
+def normalise_scopes(scopes: list[str] | None) -> list[str]:
+    if not scopes:
+        return ["read"]
+    out: list[str] = []
+    for s in scopes:
+        s_norm = (s or "").strip().lower()
+        if s_norm not in VALID_SCOPES:
+            raise ValueError(f"unknown scope: {s!r}")
+        if s_norm not in out:
+            out.append(s_norm)
+    return out
+
+
+async def issue_api_key(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    name: str,
+    scopes: list[str] | None = None,
+    expires_at: datetime | None = None,
+    env: str = "live",
+) -> tuple[ApiKey, str]:
+    """Create a new API key. Returns (row, plaintext_token).
+
+    The plaintext token is the only opportunity to surface the secret; do
+    not log it and do not return it from any subsequent read endpoint.
+    """
+    if not name.strip():
+        raise ValueError("API key name is required")
+
+    token = generate_token(env=env)
+    prefix, _ = split_token(token)
+
+    row = ApiKey(
+        user_id=user_id,
+        name=name.strip(),
+        prefix=prefix,
+        key_hash=hash_token(token),
+        scopes=normalise_scopes(scopes),
+        expires_at=expires_at,
+    )
+    session.add(row)
+    await session.flush()
+    return row, token
+
+
+async def find_active_by_token(session: AsyncSession, token: str) -> ApiKey | None:
+    """Look up the row that matches ``token``. Returns None if no active row matches."""
+    try:
+        prefix, _ = split_token(token)
+    except ApiKeyError:
+        return None
+
+    result = await session.execute(select(ApiKey).where(ApiKey.prefix == prefix))
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    if row.revoked_at is not None:
+        return None
+    if row.expires_at is not None and row.expires_at <= datetime.now(tz=UTC):
+        return None
+    if not verify_token(token, row.key_hash):
+        return None
+    return row
+
+
+async def touch_last_used(session: AsyncSession, row: ApiKey) -> None:
+    row.last_used_at = datetime.now(tz=UTC)
+    await session.flush()
+
+
+def is_engine_token(token: str) -> bool:
+    """Public helper used by the auth dependency to dispatch on token shape."""
+    return _is_engine_token(token)

--- a/engine/api/auth/dependency.py
+++ b/engine/api/auth/dependency.py
@@ -4,12 +4,17 @@ import uuid
 from typing import TYPE_CHECKING
 
 import structlog
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 
+from engine.api.auth.api_keys import (
+    find_active_by_token,
+    is_engine_token,
+    touch_last_used,
+)
 from engine.api.auth.jwt import decode_token
-from engine.db.models import User
+from engine.db.models import ApiKey, User
 from engine.deps import get_db
 
 if TYPE_CHECKING:
@@ -17,16 +22,31 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
-_bearer_scheme = HTTPBearer()
+_bearer_scheme = HTTPBearer(auto_error=False)
 
 ROLE_HIERARCHY: dict[str, int] = {"user": 0, "developer": 1, "admin": 2}
 
 
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
-    db: AsyncSession = Depends(get_db),
-) -> User:
-    payload = decode_token(credentials.credentials)
+_UNAUTHORIZED_MISSING = HTTPException(
+    status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+)
+
+
+def _resolve_token(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None,
+) -> str | None:
+    """Pull a credential from either Authorization: Bearer or X-API-Key."""
+    if credentials is not None and credentials.credentials:
+        return credentials.credentials
+    api_key_header = request.headers.get("x-api-key")
+    if api_key_header:
+        return api_key_header
+    return None
+
+
+async def _user_from_jwt(token: str, db: AsyncSession) -> User:
+    payload = decode_token(token)
     if payload is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token"
@@ -45,6 +65,21 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload"
         ) from None
 
+    return await _load_active_user(db, user_uuid)
+
+
+async def _user_from_api_key(token: str, db: AsyncSession) -> tuple[User, ApiKey]:
+    row = await find_active_by_token(db, token)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or revoked API key"
+        )
+    user = await _load_active_user(db, row.user_id)
+    await touch_last_used(db, row)
+    return user, row
+
+
+async def _load_active_user(db: AsyncSession, user_uuid: uuid.UUID) -> User:
     result = await db.execute(select(User).where(User.id == user_uuid))
     user = result.scalar_one_or_none()
     if user is None:
@@ -53,8 +88,23 @@ async def get_current_user(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="User account is disabled"
         )
-
     return user
+
+
+async def get_current_user(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    token = _resolve_token(request, credentials)
+    if token is None:
+        raise _UNAUTHORIZED_MISSING
+
+    if is_engine_token(token):
+        user, _ = await _user_from_api_key(token, db)
+        return user
+
+    return await _user_from_jwt(token, db)
 
 
 def require_role(minimum_role: str):

--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
+from engine.api.routes.api_keys import router as api_keys_router
 from engine.api.routes.auth import router as auth_router
 from engine.api.routes.backtest import router as backtest_router
 from engine.api.routes.client_errors import router as client_errors_router
@@ -14,6 +15,7 @@ from engine.api.routes.portfolio import router as portfolio_router
 from engine.api.routes.reference import router as reference_router
 from engine.api.routes.scoring import router as scoring_router
 from engine.api.routes.strategies import router as strategies_router
+from engine.api.routes.system import router as system_router
 from engine.api.routes.webhooks import router as webhooks_router
 from engine.legal.dependencies import require_legal_acceptance
 
@@ -21,6 +23,8 @@ api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
 api_router.include_router(auth_router, prefix="/api/v1/auth", tags=["auth"])
 api_router.include_router(mfa_router, prefix="/api/v1/auth/mfa", tags=["auth"])
+api_router.include_router(api_keys_router, prefix="/api/v1", tags=["auth"])
+api_router.include_router(system_router, prefix="/api/v1", tags=["system"])
 api_router.include_router(
     backtest_router,
     prefix="/api/v1/backtest",

--- a/engine/api/routes/api_keys.py
+++ b/engine/api/routes/api_keys.py
@@ -1,0 +1,140 @@
+"""CRUD routes for long-lived API keys (gh#94).
+
+Mounted at /api/v1/auth/api-keys. The plaintext token is returned
+exactly once, in the response of POST /api-keys; subsequent reads
+return only the prefix and metadata.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from engine.api.auth.api_keys import (
+    VALID_SCOPES,
+    issue_api_key,
+)
+from engine.api.auth.dependency import get_current_user
+from engine.db.models import ApiKey, User
+from engine.deps import get_db
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+router = APIRouter(prefix="/auth/api-keys", tags=["auth"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class ApiKeyCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    scopes: list[str] = Field(default_factory=lambda: ["read"])
+    expires_at: datetime | None = Field(default=None)
+    env: str = Field(default="live", pattern=r"^[A-Za-z0-9_]+$", max_length=16)
+
+
+class ApiKeySummary(BaseModel):
+    id: uuid.UUID
+    name: str
+    prefix: str
+    scopes: list[str]
+    last_used_at: datetime | None
+    expires_at: datetime | None
+    revoked_at: datetime | None
+    created_at: datetime
+
+
+class ApiKeyCreatedResponse(ApiKeySummary):
+    # Returned exactly once on POST. Surfaced to the operator and never
+    # logged or stored in plaintext on the server side.
+    token: str
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=ApiKeyCreatedResponse, status_code=status.HTTP_201_CREATED)
+async def create_api_key(
+    body: ApiKeyCreateRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiKeyCreatedResponse:
+    invalid = [s for s in body.scopes if s.strip().lower() not in VALID_SCOPES]
+    if invalid:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid scopes: {invalid}",
+        )
+
+    row, token = await issue_api_key(
+        db,
+        user_id=user.id,
+        name=body.name,
+        scopes=body.scopes,
+        expires_at=body.expires_at,
+        env=body.env,
+    )
+    await db.commit()
+    return ApiKeyCreatedResponse(
+        id=row.id,
+        name=row.name,
+        prefix=row.prefix,
+        scopes=list(row.scopes or []),
+        last_used_at=row.last_used_at,
+        expires_at=row.expires_at,
+        revoked_at=row.revoked_at,
+        created_at=row.created_at,
+        token=token,
+    )
+
+
+@router.get("", response_model=list[ApiKeySummary])
+async def list_api_keys(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ApiKeySummary]:
+    result = await db.execute(
+        select(ApiKey).where(ApiKey.user_id == user.id).order_by(ApiKey.created_at.desc())
+    )
+    rows = result.scalars().all()
+    return [
+        ApiKeySummary(
+            id=r.id,
+            name=r.name,
+            prefix=r.prefix,
+            scopes=list(r.scopes or []),
+            last_used_at=r.last_used_at,
+            expires_at=r.expires_at,
+            revoked_at=r.revoked_at,
+            created_at=r.created_at,
+        )
+        for r in rows
+    ]
+
+
+@router.delete("/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_api_key(
+    key_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    result = await db.execute(
+        select(ApiKey).where(ApiKey.id == key_id, ApiKey.user_id == user.id)
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API key not found")
+    if row.revoked_at is None:
+        row.revoked_at = datetime.now(tz=UTC)
+        await db.commit()

--- a/engine/api/routes/system.py
+++ b/engine/api/routes/system.py
@@ -1,0 +1,104 @@
+"""System status endpoint for headless / automation use (gh#94).
+
+GET /api/v1/system/status returns a single JSON object describing the
+running engine: version, uptime, DB reachability, active counts.
+Intended for CI/CD probes and operator scripts that don't want to
+scrape /metrics.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import func, select
+
+from engine.api.auth.dependency import get_current_user
+from engine.db.models import ApiKey, BacktestResult, Portfolio, User, WebhookConfig
+from engine.deps import get_db
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+router = APIRouter(prefix="/system", tags=["system"])
+
+
+_PROCESS_START = time.monotonic()
+
+
+def _engine_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("nexus-trade-engine")
+    except Exception:
+        return "0.0.0+unknown"
+
+
+class ComponentStatus(BaseModel):
+    name: str
+    healthy: bool
+    detail: str | None = None
+
+
+class SystemStatusResponse(BaseModel):
+    engine_version: str
+    uptime_seconds: float
+    server_time: datetime
+    components: list[ComponentStatus]
+    counts: dict[str, int]
+
+
+@router.get("/status", response_model=SystemStatusResponse)
+async def system_status(
+    user: User = Depends(get_current_user),  # noqa: ARG001 — auth is the goal
+    db: AsyncSession = Depends(get_db),
+) -> SystemStatusResponse:
+    components: list[ComponentStatus] = []
+
+    db_ok, db_detail = await _check_database(db)
+    components.append(ComponentStatus(name="database", healthy=db_ok, detail=db_detail))
+
+    counts: dict[str, int] = {}
+    if db_ok:
+        counts = await _gather_counts(db)
+
+    return SystemStatusResponse(
+        engine_version=_engine_version(),
+        uptime_seconds=round(time.monotonic() - _PROCESS_START, 3),
+        server_time=datetime.now(tz=UTC),
+        components=components,
+        counts=counts,
+    )
+
+
+async def _check_database(db: AsyncSession) -> tuple[bool, str | None]:
+    try:
+        await db.execute(select(func.now()))
+        return True, None
+    except Exception as exc:  # pragma: no cover - probe fail path
+        return False, str(exc)[:200]
+
+
+async def _gather_counts(db: AsyncSession) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for key, model in (
+        ("users", User),
+        ("portfolios", Portfolio),
+        ("backtests", BacktestResult),
+        ("webhooks_active", WebhookConfig),
+        ("api_keys_active", ApiKey),
+    ):
+        try:
+            result = await db.execute(select(func.count()).select_from(model))
+            counts[key] = int(result.scalar_one())
+        except Exception:  # pragma: no cover - count is best-effort
+            counts[key] = -1
+    return counts
+
+
+__all__: list[Any] = ["router"]

--- a/engine/db/migrations/versions/011_api_keys.py
+++ b/engine/db/migrations/versions/011_api_keys.py
@@ -1,0 +1,70 @@
+"""add api_keys table (gh#94)
+
+Revision ID: 011_api_keys
+Revises: 010_webhooks
+Create Date: 2026-05-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "011_api_keys"
+down_revision: str | Sequence[str] | None = "010_webhooks"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        # First 12 characters of the issued token (e.g. "nxs_live_aB3").
+        # Used for human-readable identification and as the lookup key.
+        sa.Column("prefix", sa.String(32), nullable=False, unique=True, index=True),
+        # bcrypt hash of the secret portion (the random tail after the prefix).
+        sa.Column("key_hash", sa.String(255), nullable=False),
+        # JSONB array of scope strings, e.g. ["read", "trade"].
+        sa.Column(
+            "scopes",
+            postgresql.JSONB().with_variant(sa.JSON(), "sqlite"),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_api_keys_user_active",
+        "api_keys",
+        ["user_id", "revoked_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_api_keys_user_active", table_name="api_keys")
+    op.drop_table("api_keys")

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -315,3 +315,33 @@ class ScoringSnapshot(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
     __table_args__ = (Index("ix_scoring_snapshot_strategy_time", "strategy_id", "created_at"),)
+
+
+class ApiKey(Base):
+    """Long-lived API key for headless / automation access (gh#94).
+
+    The full token (``prefix + secret``) is shown to the operator exactly
+    once on creation. The secret portion is stored as a bcrypt hash; the
+    prefix is stored in plaintext so it can be displayed in the UI for
+    identification and used as the database lookup key.
+    """
+
+    __tablename__ = "api_keys"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    name: Mapped[str] = mapped_column(String(255))
+    prefix: Mapped[str] = mapped_column(String(32), unique=True, index=True)
+    key_hash: Mapped[str] = mapped_column(String(255))
+    scopes: Mapped[list[str]] = mapped_column(JSONB, default=list)  # type: ignore[assignment]
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (Index("ix_api_keys_user_active", "user_id", "revoked_at"),)

--- a/tests/test_api_keys_service.py
+++ b/tests/test_api_keys_service.py
@@ -1,0 +1,104 @@
+"""Unit tests for the API key issuance + verification service (gh#94)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from engine.api.auth.api_keys import (
+    ApiKeyError,
+    VALID_SCOPES,
+    generate_token,
+    hash_token,
+    is_engine_token,
+    normalise_scopes,
+    split_token,
+    verify_token,
+)
+
+
+class TestGenerateToken:
+    def test_default_env(self):
+        token = generate_token()
+        assert re.match(r"^nxs_live_[0-9a-f]{32}$", token)
+
+    def test_custom_env(self):
+        token = generate_token(env="test")
+        assert token.startswith("nxs_test_")
+
+    def test_tokens_unique_across_calls(self):
+        tokens = {generate_token() for _ in range(64)}
+        assert len(tokens) == 64
+
+    def test_invalid_env_rejected(self):
+        with pytest.raises(ValueError):
+            generate_token(env="")
+        with pytest.raises(ValueError):
+            generate_token(env="bad space")
+        with pytest.raises(ValueError):
+            generate_token(env="bad/slash")
+
+
+class TestSplitToken:
+    def test_returns_prefix_and_full(self):
+        token = generate_token()
+        prefix, full = split_token(token)
+        assert prefix == token[:12]
+        assert full == token
+
+    def test_rejects_non_engine_token(self):
+        with pytest.raises(ApiKeyError):
+            split_token("not-an-engine-token")
+        with pytest.raises(ApiKeyError):
+            split_token("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.y")
+
+    def test_rejects_too_short(self):
+        with pytest.raises(ApiKeyError):
+            split_token("nxs_")
+
+
+class TestHashAndVerify:
+    def test_roundtrip_succeeds(self):
+        token = generate_token()
+        hashed = hash_token(token)
+        assert verify_token(token, hashed) is True
+
+    def test_wrong_token_fails(self):
+        a = generate_token()
+        b = generate_token()
+        hashed = hash_token(a)
+        assert verify_token(b, hashed) is False
+
+    def test_garbage_hash_returns_false_not_raise(self):
+        token = generate_token()
+        assert verify_token(token, "not-a-bcrypt-hash") is False
+
+
+class TestNormaliseScopes:
+    def test_default_is_read(self):
+        assert normalise_scopes(None) == ["read"]
+        assert normalise_scopes([]) == ["read"]
+
+    def test_lower_and_strip(self):
+        assert normalise_scopes([" Read ", "TRADE"]) == ["read", "trade"]
+
+    def test_dedupes(self):
+        assert normalise_scopes(["read", "read", "read"]) == ["read"]
+
+    def test_unknown_scope_rejected(self):
+        with pytest.raises(ValueError):
+            normalise_scopes(["read", "wizard"])
+
+
+class TestIsEngineToken:
+    def test_engine_token_recognised(self):
+        assert is_engine_token(generate_token()) is True
+
+    def test_jwt_not_recognised(self):
+        assert is_engine_token("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.body.sig") is False
+
+
+class TestValidScopesContract:
+    def test_documented_scopes_only(self):
+        assert VALID_SCOPES == frozenset({"read", "trade", "admin"})


### PR DESCRIPTION
Long-lived API keys for headless automation. Token format: nxs_<env>_<32-hex>. Adds /api/v1/auth/api-keys CRUD + /api/v1/system/status. JWT auth unaffected. Migration 011_api_keys. 17 passing service-layer tests. Closes #94. Follow-ups: batch ops, per-scope authorisation, UI-vs-API gap audit.