### PR TITLE
feat(privacy): GDPR/CCPA DSR foundation — export + deletion lifecycle (gh#157)

### DIFF
--- a/docs/legal/processors.md
+++ b/docs/legal/processors.md
@@ -1,0 +1,71 @@
+# Sub-processor inventory
+
+Operators of Nexus Trade Engine are responsible for keeping their own
+sub-processor inventory current. This file is the **template** for
+that inventory and the canonical list of categories every privacy
+policy needs to reference.
+
+> Update this file in your fork — do not point your customers at the
+> upstream repo. The upstream cannot warrant who you have engaged.
+
+## What goes here
+
+For every external service that processes user data:
+
+- **Service** — vendor name and the specific product.
+- **Role** — controller / processor / sub-processor.
+- **Purpose** — *why* the data goes there (storage, market data,
+  notifications, observability, etc.).
+- **Data categories** — which fields it touches.
+- **Region(s)** — physical processing location and any cross-region
+  transfers (relevant for GDPR Chapter V).
+- **DPA** — link to the vendor's data-processing addendum.
+
+## Categories every operator should review
+
+Even if you delete every row below, ask whether you're using:
+
+| Category | Examples |
+|----------|----------|
+| Hosting & compute | AWS / GCP / Azure / Hetzner / on-prem |
+| Database & storage | RDS / Cloud SQL / Crunchy / Neon / Supabase / S3 / GCS |
+| Cache / queue | ElastiCache / Memorystore / Upstash |
+| Email | SES / Postmark / SendGrid / Mailgun |
+| Notifications | Slack / Discord / Telegram / Twilio (SMS) |
+| Market data | Polygon / IEX / Alpaca / Binance / Tradier |
+| Brokers | Alpaca / IBKR / Binance / Kraken / Oanda |
+| Auth IdPs | Google / GitHub / Auth0 / Okta / Keycloak |
+| Observability | Sentry / Datadog / Grafana Cloud / New Relic |
+| Container registry | GHCR (default) / ECR / GAR |
+| CDN / WAF | Cloudflare / Fastly |
+| Backup storage | S3 with versioning / B2 / GCS — see [`backup-and-recovery.md`](../operations/backup-and-recovery.md) |
+
+## Template
+
+```markdown
+### <Service name>
+
+- **Role:** <controller | processor | sub-processor>
+- **Purpose:** <one-sentence why>
+- **Data categories:** <e.g., user email, IP address, request metadata>
+- **Region:** <e.g., eu-central-1 / us-east-1>
+- **DPA:** <URL>
+- **Notes:** <special arrangements, expiry, contact for incidents>
+```
+
+## Inventory (fill in)
+
+> **This is the part you have to fill in for your deployment.**
+
+### <None — fill in before going live>
+
+The upstream repository ships with no sub-processors. Your privacy
+policy must replace this section with the real list before you accept
+EU or California user data.
+
+## Related
+
+- [`SECURITY.md`](../../SECURITY.md) — vulnerability disclosure.
+- [`docs/operations/backup-and-recovery.md`](../operations/backup-and-recovery.md)
+  — your backup destination is itself a sub-processor.
+- gh#157 — GDPR/CCPA DSR handling, which this inventory underpins.

--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -12,6 +12,7 @@ from engine.api.routes.market_data import router as market_data_router
 from engine.api.routes.marketplace import router as marketplace_router
 from engine.api.routes.mfa import router as mfa_router
 from engine.api.routes.portfolio import router as portfolio_router
+from engine.api.routes.privacy import router as privacy_router
 from engine.api.routes.reference import router as reference_router
 from engine.api.routes.scoring import router as scoring_router
 from engine.api.routes.strategies import router as strategies_router
@@ -25,6 +26,7 @@ api_router.include_router(auth_router, prefix="/api/v1/auth", tags=["auth"])
 api_router.include_router(mfa_router, prefix="/api/v1/auth/mfa", tags=["auth"])
 api_router.include_router(api_keys_router, prefix="/api/v1", tags=["auth"])
 api_router.include_router(system_router, prefix="/api/v1", tags=["system"])
+api_router.include_router(privacy_router, prefix="/api/v1", tags=["privacy"])
 api_router.include_router(
     backtest_router,
     prefix="/api/v1/backtest",

--- a/engine/api/routes/privacy.py
+++ b/engine/api/routes/privacy.py
@@ -1,0 +1,176 @@
+"""Privacy / DSR routes — GDPR & CCPA (gh#157).
+
+Mounted at /api/v1/privacy. Endpoints:
+
+- POST /export             — synchronous export of the caller's data
+- POST /delete             — initiate account deletion (30-day grace)
+- POST /delete/cancel      — cancel deletion during the grace window
+- GET  /delete/status      — pending? + remaining grace
+- GET  /requests           — list the caller's DSR history
+- GET  /kinds              — allow-list of DSR kinds (for clients)
+
+Out of scope for this PR (explicit follow-ups):
+- Async tarball + signed download URLs.
+- Consent management (per-purpose).
+- Admin-side DSR tooling for requests received outside the product.
+- Restriction / objection flags.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from engine.api.auth.dependency import get_current_user
+from engine.db.models import User
+from engine.deps import get_db
+from engine.privacy import (
+    DSR_KINDS,
+    cancel_deletion,
+    collect_user_data,
+    is_pending_deletion,
+    list_user_requests,
+    record_request,
+    request_deletion,
+)
+from engine.privacy.deletion import DeletionError
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+router = APIRouter(prefix="/privacy", tags=["privacy"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class DSRRequestSummary(BaseModel):
+    id: uuid.UUID
+    kind: str
+    status: str
+    note: str | None
+    sla_due_at: datetime
+    completed_at: datetime | None
+    cancelled_at: datetime | None
+    created_at: datetime
+
+
+class DSRListResponse(BaseModel):
+    requests: list[DSRRequestSummary]
+
+
+class ExportResponse(BaseModel):
+    request: DSRRequestSummary
+    data: dict[str, Any]
+
+
+class DeletionRequestBody(BaseModel):
+    note: str | None = Field(default=None, max_length=4000)
+
+
+class DeletionStatusResponse(BaseModel):
+    pending: bool
+    sla_due_at: datetime | None
+    request: DSRRequestSummary | None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _serialise(req) -> DSRRequestSummary:
+    return DSRRequestSummary(
+        id=req.id,
+        kind=req.kind,
+        status=req.status,
+        note=req.note,
+        sla_due_at=req.sla_due_at,
+        completed_at=req.completed_at,
+        cancelled_at=req.cancelled_at,
+        created_at=req.created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.post("/export", response_model=ExportResponse)
+async def export_my_data(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ExportResponse:
+    request = await record_request(db, user_id=user.id, kind="export")
+    data = await collect_user_data(db, user.id)
+    request.status = "completed"
+    request.completed_at = datetime.now(tz=UTC)
+    await db.commit()
+    return ExportResponse(request=_serialise(request), data=data)
+
+
+@router.post(
+    "/delete",
+    response_model=DeletionStatusResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def request_account_deletion(
+    body: DeletionRequestBody,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DeletionStatusResponse:
+    try:
+        req = await request_deletion(db, user_id=user.id, note=body.note)
+    except DeletionError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    await db.commit()
+    return DeletionStatusResponse(
+        pending=True, sla_due_at=req.sla_due_at, request=_serialise(req)
+    )
+
+
+@router.post("/delete/cancel", response_model=DeletionStatusResponse)
+async def cancel_account_deletion(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DeletionStatusResponse:
+    try:
+        req = await cancel_deletion(db, user_id=user.id)
+    except DeletionError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    await db.commit()
+    return DeletionStatusResponse(
+        pending=False, sla_due_at=None, request=_serialise(req)
+    )
+
+
+@router.get("/delete/status", response_model=DeletionStatusResponse)
+async def deletion_status(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DeletionStatusResponse:
+    pending, sla_due_at = await is_pending_deletion(db, user.id)
+    return DeletionStatusResponse(pending=pending, sla_due_at=sla_due_at, request=None)
+
+
+@router.get("/requests", response_model=DSRListResponse)
+async def my_dsr_history(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DSRListResponse:
+    rows = await list_user_requests(db, user.id)
+    return DSRListResponse(requests=[_serialise(r) for r in rows])
+
+
+@router.get("/kinds")
+async def supported_kinds() -> dict[str, list[str]]:
+    """OpenAPI clients can validate ``kind`` against this allow-list."""
+    return {"kinds": sorted(DSR_KINDS)}

--- a/engine/db/migrations/versions/012_dsr_requests.py
+++ b/engine/db/migrations/versions/012_dsr_requests.py
@@ -1,0 +1,78 @@
+"""add dsr_requests table for GDPR/CCPA DSR tracking (gh#157)
+
+Revision ID: 012_dsr_requests
+Revises: 011_api_keys
+Create Date: 2026-05-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "012_dsr_requests"
+down_revision: str | Sequence[str] | None = "011_api_keys"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dsr_requests",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        # Type of request: "export" (Art. 15 / 20), "delete" (Art. 17),
+        # "rectify" (Art. 16), "restrict" (Art. 18), "object" (Art. 21).
+        sa.Column("kind", sa.String(32), nullable=False),
+        # Lifecycle: "pending" -> "in_progress" -> ("completed" | "failed" | "cancelled")
+        sa.Column(
+            "status",
+            sa.String(32),
+            nullable=False,
+            server_default="pending",
+        ),
+        # Free-form note from the user or the operator who recorded the request.
+        sa.Column("note", sa.Text(), nullable=True),
+        # Operator-attached metadata (e.g., evidence of identity verification,
+        # outbound legal correspondence reference). JSONB for forward compat.
+        sa.Column(
+            "details",
+            postgresql.JSONB().with_variant(sa.JSON(), "sqlite"),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        # GDPR Art. 12: respond within one month. Operator can shorten.
+        sa.Column("sla_due_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_dsr_requests_user_kind_status",
+        "dsr_requests",
+        ["user_id", "kind", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_dsr_requests_user_kind_status", table_name="dsr_requests")
+    op.drop_table("dsr_requests")

--- a/engine/db/models.py
+++ b/engine/db/models.py
@@ -317,6 +317,34 @@ class ScoringSnapshot(Base):
     __table_args__ = (Index("ix_scoring_snapshot_strategy_time", "strategy_id", "created_at"),)
 
 
+class DSRequest(Base):
+    """GDPR / CCPA data-subject request audit row (gh#157).
+
+    One row per export / delete / rectify / restrict / object request.
+    Tracks lifecycle and the SLA timer (1 month under GDPR Art. 12).
+    """
+
+    __tablename__ = "dsr_requests"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    kind: Mapped[str] = mapped_column(String(32))  # export | delete | rectify | restrict | object
+    status: Mapped[str] = mapped_column(String(32), default="pending")
+    note: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    details: Mapped[dict] = mapped_column(JSONB, default=dict)  # type: ignore[assignment]
+    sla_due_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cancelled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (Index("ix_dsr_requests_user_kind_status", "user_id", "kind", "status"),)
+
+
 class ApiKey(Base):
     """Long-lived API key for headless / automation access (gh#94).
 

--- a/engine/privacy/__init__.py
+++ b/engine/privacy/__init__.py
@@ -1,0 +1,40 @@
+"""Privacy / DSR (data-subject request) handling — GDPR & CCPA (gh#157).
+
+Public surface intentionally minimal — see the submodules for details:
+
+- :mod:`engine.privacy.dsr`       — registry: record, list, transition status.
+- :mod:`engine.privacy.export`    — Art. 15 / 20: collect a user's data.
+- :mod:`engine.privacy.deletion`  — Art. 17: initiate / cancel / grace window.
+
+Async tarball generation, signed download URLs, and consent management
+are explicit follow-ups; see ``docs/legal/processors.md`` and the
+follow-up notes in the gh#157 PR.
+"""
+
+from engine.privacy.deletion import (
+    DELETION_GRACE_DAYS,
+    cancel_deletion,
+    is_pending_deletion,
+    request_deletion,
+)
+from engine.privacy.dsr import (
+    DSR_KINDS,
+    DSR_TERMINAL_STATUSES,
+    SLA_DEFAULT_DAYS,
+    list_user_requests,
+    record_request,
+)
+from engine.privacy.export import collect_user_data
+
+__all__ = [
+    "DELETION_GRACE_DAYS",
+    "DSR_KINDS",
+    "DSR_TERMINAL_STATUSES",
+    "SLA_DEFAULT_DAYS",
+    "cancel_deletion",
+    "collect_user_data",
+    "is_pending_deletion",
+    "list_user_requests",
+    "record_request",
+    "request_deletion",
+]

--- a/engine/privacy/deletion.py
+++ b/engine/privacy/deletion.py
@@ -1,0 +1,125 @@
+"""Account deletion lifecycle — GDPR Art. 17 right to erasure (gh#157).
+
+Deletion is **not** an immediate hard-delete. The flow is:
+
+1. ``request_deletion`` — records a DSRequest of kind ``delete``,
+   status ``pending``. The user account stays usable during a
+   grace period (30 days by default) so accidental deletions can
+   be undone.
+2. The user can call ``cancel_deletion`` at any time during the
+   grace window. The DSR row transitions to ``cancelled``.
+3. After ``DELETION_GRACE_DAYS``, an offline operator job (not in
+   this PR) consumes the still-pending row and performs the
+   audit-chain-preserving anonymization described in the spec.
+
+The actual purge / anonymization is intentionally out of scope here:
+it touches every domain table and needs careful audit-chain handling.
+This module only owns the *intent* and the timer.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from engine.db.models import DSRequest
+from engine.privacy.dsr import record_request, transition
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+DELETION_GRACE_DAYS: int = 30
+
+
+class DeletionError(Exception):
+    """Raised on invalid deletion-flow transitions (e.g., double request)."""
+
+
+async def request_deletion(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    note: str | None = None,
+) -> DSRequest:
+    """Initiate the deletion grace period for ``user_id``.
+
+    Refuses if the user already has an active (pending or in_progress)
+    deletion request — operators should cancel that first.
+    """
+    existing = await _find_active_deletion(session, user_id)
+    if existing is not None:
+        raise DeletionError(
+            f"user already has an active deletion request ({existing.id})"
+        )
+    return await record_request(
+        session,
+        user_id=user_id,
+        kind="delete",
+        note=note,
+        details={"grace_days": DELETION_GRACE_DAYS},
+        sla_days=DELETION_GRACE_DAYS,
+    )
+
+
+async def cancel_deletion(session: AsyncSession, *, user_id: uuid.UUID) -> DSRequest:
+    """Cancel the active deletion request for ``user_id``.
+
+    Returns the cancelled row. Raises if there is nothing to cancel.
+    """
+    existing = await _find_active_deletion(session, user_id)
+    if existing is None:
+        raise DeletionError("no active deletion request to cancel")
+    return await transition(session, existing, status="cancelled")
+
+
+async def is_pending_deletion(
+    session: AsyncSession, user_id: uuid.UUID
+) -> tuple[bool, datetime | None]:
+    """Return ``(pending?, sla_due_at)`` for the user.
+
+    Useful for UI surfaces and middleware that want to warn / restrict.
+    """
+    row = await _find_active_deletion(session, user_id)
+    if row is None:
+        return False, None
+    return True, row.sla_due_at
+
+
+async def is_due_for_purge(
+    session: AsyncSession, user_id: uuid.UUID
+) -> bool:
+    """Return True iff a pending deletion's grace window has elapsed.
+
+    The actual purge job is not in this module; this is the predicate
+    that job will consume.
+    """
+    row = await _find_active_deletion(session, user_id)
+    if row is None:
+        return False
+    return row.sla_due_at <= datetime.now(tz=UTC)
+
+
+async def _find_active_deletion(
+    session: AsyncSession, user_id: uuid.UUID
+) -> DSRequest | None:
+    result = await session.execute(
+        select(DSRequest)
+        .where(
+            DSRequest.user_id == user_id,
+            DSRequest.kind == "delete",
+            DSRequest.status.in_(("pending", "in_progress")),
+        )
+        .order_by(DSRequest.created_at.desc())
+    )
+    return result.scalars().first()
+
+
+def remaining_grace(now: datetime, sla_due_at: datetime) -> timedelta:
+    """Helper for UI countdown displays."""
+    delta = sla_due_at - now
+    return delta if delta.total_seconds() > 0 else timedelta(0)

--- a/engine/privacy/dsr.py
+++ b/engine/privacy/dsr.py
@@ -1,0 +1,96 @@
+"""DSR registry — recording and listing data-subject requests (gh#157).
+
+A DSRequest row is the audit trail for every privacy request the engine
+handles. The registry is intentionally simple: record on intake, list
+per-user, transition status as work progresses.
+
+GDPR Art. 12 obliges responding within one month of receipt; the SLA
+timer is set on insert and never extended. Operators who need to extend
+must add a note and either complete or fail the request before the new
+deadline.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from engine.db.models import DSRequest
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+DSR_KINDS: frozenset[str] = frozenset(
+    {"export", "delete", "rectify", "restrict", "object"}
+)
+
+DSR_TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {"completed", "failed", "cancelled"}
+)
+
+SLA_DEFAULT_DAYS: int = 30
+
+
+async def record_request(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    kind: str,
+    note: str | None = None,
+    details: dict | None = None,
+    sla_days: int = SLA_DEFAULT_DAYS,
+) -> DSRequest:
+    """Record a fresh DSR. Returns the new row (caller commits)."""
+    if kind not in DSR_KINDS:
+        raise ValueError(f"unknown DSR kind: {kind!r}")
+    if sla_days <= 0:
+        raise ValueError("sla_days must be positive")
+
+    row = DSRequest(
+        user_id=user_id,
+        kind=kind,
+        status="pending",
+        note=note,
+        details=details or {},
+        sla_due_at=datetime.now(tz=UTC) + timedelta(days=sla_days),
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def list_user_requests(
+    session: AsyncSession, user_id: uuid.UUID
+) -> list[DSRequest]:
+    result = await session.execute(
+        select(DSRequest)
+        .where(DSRequest.user_id == user_id)
+        .order_by(DSRequest.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def transition(
+    session: AsyncSession,
+    request: DSRequest,
+    *,
+    status: str,
+) -> DSRequest:
+    """Move a request to a new status. Idempotent on terminal states."""
+    if status not in {"pending", "in_progress", *DSR_TERMINAL_STATUSES}:
+        raise ValueError(f"unknown DSR status: {status!r}")
+    if request.status in DSR_TERMINAL_STATUSES and request.status == status:
+        return request
+    request.status = status
+    now = datetime.now(tz=UTC)
+    if status == "completed":
+        request.completed_at = now
+    elif status == "cancelled":
+        request.cancelled_at = now
+    await session.flush()
+    return request

--- a/engine/privacy/export.py
+++ b/engine/privacy/export.py
@@ -1,0 +1,132 @@
+"""Data export collector — GDPR Art. 15 / 20 right of access & portability (gh#157).
+
+Builds a single in-memory dict of everything the engine knows about a
+user, ready to be JSON-serialised for download.
+
+What this module does *not* do (explicit follow-ups):
+- Async generation. Today's ``collect_user_data`` runs in the request.
+  For users with thousands of fills, the operator will want this in a
+  TaskIQ job with a signed-URL download.
+- Tarball / CSV side-by-side packaging. JSON is the canonical export
+  format here. The packaging step is a follow-up.
+- Field redaction. The export is for the user; nothing is masked.
+
+Sensitive fields that we deliberately *exclude*:
+- ``users.password_hash`` — bcrypt hash, no value to the user.
+- ``users.mfa_secret_encrypted`` — no value to the user; would defeat
+  the purpose of MFA storage if exported.
+- ``users.mfa_backup_codes`` — same reasoning.
+- ``api_keys.key_hash`` — secret material the engine never re-derives.
+- ``webhook_configs.signing_secret`` — same.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+
+from engine.db.models import (
+    ApiKey,
+    BacktestResult,
+    DSRequest,
+    LegalAcceptance,
+    Portfolio,
+    User,
+    WebhookConfig,
+)
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+_PII_DENYLIST: frozenset[str] = frozenset(
+    {
+        "password_hash",
+        "mfa_secret_encrypted",
+        "mfa_backup_codes",
+    }
+)
+
+_API_KEY_DENYLIST: frozenset[str] = frozenset({"key_hash"})
+
+
+async def collect_user_data(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+) -> dict[str, Any]:
+    """Return a JSON-serialisable dict of everything we know about ``user_id``.
+
+    Raises ``LookupError`` if the user does not exist.
+    """
+    user = (
+        await session.execute(select(User).where(User.id == user_id))
+    ).scalar_one_or_none()
+    if user is None:
+        raise LookupError(f"user not found: {user_id}")
+
+    portfolios = (
+        await session.execute(select(Portfolio).where(Portfolio.user_id == user_id))
+    ).scalars().all()
+    backtests = (
+        await session.execute(select(BacktestResult).where(BacktestResult.user_id == user_id))
+    ).scalars().all()
+    webhooks = (
+        await session.execute(select(WebhookConfig).where(WebhookConfig.user_id == user_id))
+    ).scalars().all()
+    api_keys = (
+        await session.execute(select(ApiKey).where(ApiKey.user_id == user_id))
+    ).scalars().all()
+    dsr_rows = (
+        await session.execute(select(DSRequest).where(DSRequest.user_id == user_id))
+    ).scalars().all()
+    legal_rows = (
+        await session.execute(
+            select(LegalAcceptance).where(LegalAcceptance.user_id == user_id)
+        )
+    ).scalars().all()
+
+    return {
+        "schema_version": 1,
+        "exported_at": datetime.now(tz=UTC).isoformat(),
+        "user_id": str(user_id),
+        "user": _row_to_dict(user, deny=_PII_DENYLIST),
+        "portfolios": [_row_to_dict(p) for p in portfolios],
+        "backtests": [_row_to_dict(b) for b in backtests],
+        "webhooks": [_row_to_dict(w, deny=frozenset({"signing_secret"})) for w in webhooks],
+        "api_keys": [_row_to_dict(k, deny=_API_KEY_DENYLIST) for k in api_keys],
+        "dsr_history": [_row_to_dict(d) for d in dsr_rows],
+        "legal_acceptances": [_row_to_dict(la) for la in legal_rows],
+    }
+
+
+def _row_to_dict(row: Any, *, deny: frozenset[str] = frozenset()) -> dict[str, Any]:
+    """Best-effort SQLAlchemy row -> JSON-friendly dict.
+
+    Skips columns in ``deny``. Stringifies non-JSON-native types
+    (UUID, datetime, Decimal). The export schema version is bumped if
+    this representation changes in a non-backwards-compatible way.
+    """
+    out: dict[str, Any] = {}
+    for column in row.__table__.columns:
+        name = column.name
+        if name in deny:
+            continue
+        value = getattr(row, name, None)
+        out[name] = _jsonify(value)
+    return out
+
+
+def _jsonify(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_jsonify(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonify(v) for k, v in value.items()}
+    return str(value)

--- a/tests/test_privacy_dsr.py
+++ b/tests/test_privacy_dsr.py
@@ -1,0 +1,46 @@
+"""Unit tests for the DSR registry constants and helpers — gh#157."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from engine.privacy.deletion import DELETION_GRACE_DAYS, remaining_grace
+from engine.privacy.dsr import DSR_KINDS, DSR_TERMINAL_STATUSES, SLA_DEFAULT_DAYS
+
+
+class TestRegistryConstants:
+    def test_documented_kinds(self):
+        assert DSR_KINDS == frozenset(
+            {"export", "delete", "rectify", "restrict", "object"}
+        )
+
+    def test_terminal_statuses(self):
+        assert DSR_TERMINAL_STATUSES == frozenset(
+            {"completed", "failed", "cancelled"}
+        )
+
+    def test_gdpr_one_month_default(self):
+        # GDPR Art. 12 obliges responding within one month. Default must
+        # be at least 30 days.
+        assert SLA_DEFAULT_DAYS == 30
+
+
+class TestDeletionConstants:
+    def test_grace_thirty_days(self):
+        assert DELETION_GRACE_DAYS == 30
+
+
+class TestRemainingGrace:
+    def test_in_window_returns_positive(self):
+        now = datetime(2026, 5, 3, tzinfo=UTC)
+        due = now + timedelta(days=10)
+        assert remaining_grace(now, due) == timedelta(days=10)
+
+    def test_past_due_returns_zero(self):
+        now = datetime(2026, 5, 3, tzinfo=UTC)
+        due = now - timedelta(days=1)
+        assert remaining_grace(now, due) == timedelta(0)
+
+    def test_exact_due_returns_zero(self):
+        now = datetime(2026, 5, 3, tzinfo=UTC)
+        assert remaining_grace(now, now) == timedelta(0)

--- a/tests/test_privacy_export.py
+++ b/tests/test_privacy_export.py
@@ -1,0 +1,70 @@
+"""Unit tests for the export collector — gh#157."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from engine.privacy.export import _jsonify, _row_to_dict
+
+
+class _FakeColumn:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeTable:
+    def __init__(self, columns: list[str]) -> None:
+        self.columns = [_FakeColumn(c) for c in columns]
+
+
+class _FakeRow:
+    def __init__(self, **fields) -> None:
+        self.__table__ = _FakeTable(list(fields.keys()))
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+
+class TestJsonify:
+    def test_primitives_pass_through(self):
+        assert _jsonify(None) is None
+        assert _jsonify(True) is True
+        assert _jsonify(1) == 1
+        assert _jsonify(1.5) == 1.5
+        assert _jsonify("x") == "x"
+
+    def test_datetime_iso(self):
+        dt = datetime(2026, 5, 3, 12, 0, 0, tzinfo=UTC)
+        assert _jsonify(dt).startswith("2026-05-03T12:00:00")
+
+    def test_list_recurses(self):
+        out = _jsonify([1, "x", None])
+        assert out == [1, "x", None]
+
+    def test_dict_recurses_with_str_keys(self):
+        out = _jsonify({1: "v"})
+        assert out == {"1": "v"}
+
+    def test_unknown_falls_back_to_str(self):
+        class _Foo:
+            def __str__(self) -> str:
+                return "FOO"
+
+        assert _jsonify(_Foo()) == "FOO"
+
+
+class TestRowToDict:
+    def test_includes_all_columns(self):
+        row = _FakeRow(id="abc", name="Alice", password_hash="secret")
+        out = _row_to_dict(row)
+        assert out == {"id": "abc", "name": "Alice", "password_hash": "secret"}
+
+    def test_deny_list_excludes_columns(self):
+        row = _FakeRow(id="abc", name="Alice", password_hash="secret")
+        out = _row_to_dict(row, deny=frozenset({"password_hash"}))
+        assert "password_hash" not in out
+        assert out == {"id": "abc", "name": "Alice"}
+
+    def test_datetime_serialised(self):
+        row = _FakeRow(created_at=datetime(2026, 5, 3, tzinfo=UTC))
+        out = _row_to_dict(row)
+        assert out["created_at"].startswith("2026-05-03")


### PR DESCRIPTION
Foundation for data-subject requests under GDPR Art. 15/17/20 and CCPA. Export + account-deletion lifecycle land here; consent management, async tarball delivery, and audit-chain anonymization are follow-ups. New dsr_requests table (migration 012). Service layer in engine/privacy/. /api/v1/privacy/{export,delete,delete/cancel,delete/status,requests,kinds}. Sub-processor inventory template. 15 passing unit tests. Refs #157.