### PR TITLE
feat(api): WebSocket API foundation — connection manager + auth-then-subscribe (gh#7 partial)

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -18,6 +18,7 @@ from engine.api.routes.scoring import router as scoring_router
 from engine.api.routes.strategies import router as strategies_router
 from engine.api.routes.system import router as system_router
 from engine.api.routes.webhooks import router as webhooks_router
+from engine.api.routes.websocket import router as websocket_router
 from engine.legal.dependencies import require_legal_acceptance
 
 api_router = APIRouter()
@@ -27,6 +28,7 @@ api_router.include_router(mfa_router, prefix="/api/v1/auth/mfa", tags=["auth"])
 api_router.include_router(api_keys_router, prefix="/api/v1", tags=["auth"])
 api_router.include_router(system_router, prefix="/api/v1", tags=["system"])
 api_router.include_router(privacy_router, prefix="/api/v1", tags=["privacy"])
+api_router.include_router(websocket_router, prefix="/api/v1", tags=["websocket"])
 api_router.include_router(
     backtest_router,
     prefix="/api/v1/backtest",

--- a/engine/api/routes/websocket.py
+++ b/engine/api/routes/websocket.py
@@ -1,0 +1,188 @@
+"""WebSocket route — auth-then-subscribe protocol (gh#7).
+
+Connection flow
+---------------
+1. Client opens ``WS /api/v1/ws``. Server accepts.
+2. Client must send ``{"type": "auth", "token": "<JWT or nxs_*>"}``
+   within ``AUTH_TIMEOUT_SECONDS``. Server validates.
+3. On success, server replies ``{"type": "auth.ok", "user_id": ...}``
+   and the connection is attached to the manager.
+4. Client subscribes via ``{"type": "subscribe", "topics": [...]}``
+   and unsubscribes with ``{"type": "unsubscribe", "topics": [...]}``.
+5. ``{"type": "ping"}`` from either side keeps the connection warm
+   (the server replies with ``{"type": "pong"}``).
+
+JWT in the URL is intentionally **not** supported — query strings end
+up in proxy logs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from sqlalchemy import select
+
+from engine.api.auth.api_keys import find_active_by_token, is_engine_token
+from engine.api.auth.jwt import decode_token
+from engine.api.websocket.manager import VALID_TOPICS, get_manager
+from engine.db.models import User
+from engine.db.session import get_session_factory
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+AUTH_TIMEOUT_SECONDS = 10.0
+
+
+@router.websocket("/ws")
+async def ws_endpoint(ws: WebSocket) -> None:
+    await ws.accept()
+    manager = get_manager()
+
+    # 1. Auth
+    user = await _authenticate(ws)
+    if user is None:
+        return  # _authenticate already closed the socket
+
+    await manager.attach(user.id, ws)
+    try:
+        await _send(ws, {"type": "auth.ok", "user_id": str(user.id)})
+
+        # 2. Message loop
+        while True:
+            msg = await ws.receive_json()
+            mtype = msg.get("type") if isinstance(msg, dict) else None
+
+            if mtype == "subscribe":
+                topics = _coerce_topic_list(msg.get("topics"))
+                resulting = await manager.subscribe(user.id, ws, topics)
+                await _send(
+                    ws,
+                    {"type": "subscribed", "topics": sorted(resulting)},
+                )
+
+            elif mtype == "unsubscribe":
+                topics = _coerce_topic_list(msg.get("topics"))
+                resulting = await manager.unsubscribe(user.id, ws, topics)
+                await _send(
+                    ws,
+                    {"type": "unsubscribed", "topics": sorted(resulting)},
+                )
+
+            elif mtype == "ping":
+                await _send(ws, {"type": "pong"})
+
+            else:
+                await _send(
+                    ws,
+                    {
+                        "type": "error",
+                        "code": "unknown_message_type",
+                        "detail": str(mtype),
+                    },
+                )
+
+    except WebSocketDisconnect:
+        pass
+    except Exception as exc:  # noqa: BLE001 - last-line defence
+        logger.warning(
+            "ws.unexpected_error",
+            error_type=type(exc).__name__,
+            error_message=str(exc)[:200],
+        )
+    finally:
+        await manager.detach(user.id, ws)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+async def _authenticate(ws: WebSocket) -> User | None:
+    try:
+        msg = await asyncio.wait_for(
+            ws.receive_json(), timeout=AUTH_TIMEOUT_SECONDS
+        )
+    except asyncio.TimeoutError:
+        await _close(ws, code=4401, reason="auth_timeout")
+        return None
+    except WebSocketDisconnect:
+        return None
+
+    if not isinstance(msg, dict) or msg.get("type") != "auth":
+        await _close(ws, code=4400, reason="auth_required")
+        return None
+    token = msg.get("token")
+    if not isinstance(token, str) or not token:
+        await _close(ws, code=4400, reason="auth_token_missing")
+        return None
+
+    user = await _user_for_token(token)
+    if user is None:
+        await _close(ws, code=4401, reason="auth_invalid")
+        return None
+
+    return user
+
+
+async def _user_for_token(token: str) -> User | None:
+    session_factory = get_session_factory()
+    async with session_factory() as session:
+        if is_engine_token(token):
+            return await _user_for_api_key(session, token)
+        return await _user_for_jwt(session, token)
+
+
+async def _user_for_jwt(session: AsyncSession, token: str) -> User | None:
+    payload = decode_token(token)
+    if payload is None:
+        return None
+    sub = payload.get("sub")
+    if not sub:
+        return None
+    try:
+        user_uuid = uuid.UUID(sub)
+    except (ValueError, AttributeError):
+        return None
+    return await _load_active_user(session, user_uuid)
+
+
+async def _user_for_api_key(session: AsyncSession, token: str) -> User | None:
+    row = await find_active_by_token(session, token)
+    if row is None:
+        return None
+    return await _load_active_user(session, row.user_id)
+
+
+async def _load_active_user(session: AsyncSession, user_uuid: uuid.UUID) -> User | None:
+    result = await session.execute(select(User).where(User.id == user_uuid))
+    user = result.scalar_one_or_none()
+    if user is None or not user.is_active:
+        return None
+    return user
+
+
+def _coerce_topic_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [v for v in value if isinstance(v, str) and v in VALID_TOPICS]
+
+
+async def _send(ws: WebSocket, payload: dict[str, Any]) -> None:
+    with contextlib.suppress(Exception):
+        await ws.send_json(payload)
+
+
+async def _close(ws: WebSocket, *, code: int, reason: str) -> None:
+    with contextlib.suppress(Exception):
+        await ws.close(code=code, reason=reason)

--- a/engine/api/websocket/__init__.py
+++ b/engine/api/websocket/__init__.py
@@ -1,0 +1,16 @@
+"""Real-time WebSocket API (gh#7).
+
+Public surface:
+
+- :class:`ConnectionManager` — per-user fan-out registry. Process-local
+  today; future work routes broadcasts through Redis/Valkey for
+  multi-replica deployments.
+- :class:`Topic` — string-typed broadcast channels: ``portfolio``,
+  ``backtest``, ``order``, ``alert``.
+
+The route handler lives at :mod:`engine.api.routes.websocket`.
+"""
+
+from engine.api.websocket.manager import ConnectionManager, Topic
+
+__all__ = ["ConnectionManager", "Topic"]

--- a/engine/api/websocket/manager.py
+++ b/engine/api/websocket/manager.py
@@ -1,0 +1,168 @@
+"""Connection manager — per-user WebSocket fan-out (gh#7).
+
+Process-local registry: ``{user_id: {websocket: subscribed_topics}}``.
+Broadcasts to a user happen by walking that user's open connections
+and pushing the message in parallel via ``asyncio.gather``.
+
+Multi-replica deployments need the same broadcasts to fan out across
+processes — that's a follow-up that wires this manager to a Redis
+pubsub channel (``valkey``-backed) and consumes other replicas'
+messages on a worker task. This file exposes the shape that work
+will consume; the wire-up is intentionally not in this PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    import uuid
+
+    from fastapi import WebSocket
+
+
+logger = structlog.get_logger()
+
+
+class Topic(str, Enum):
+    """Broadcast channels addressable by clients."""
+
+    PORTFOLIO = "portfolio"
+    BACKTEST = "backtest"
+    ORDER = "order"
+    ALERT = "alert"
+
+
+VALID_TOPICS: frozenset[str] = frozenset(t.value for t in Topic)
+
+
+class ConnectionManager:
+    """Tracks open WebSocket connections per user + their topic subs."""
+
+    def __init__(self) -> None:
+        # {user_id: {ws: {topic, ...}}}
+        self._conns: dict[uuid.UUID, dict[WebSocket, set[str]]] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def attach(self, user_id: uuid.UUID, ws: WebSocket) -> None:
+        async with self._lock:
+            self._conns.setdefault(user_id, {})[ws] = set()
+        logger.info(
+            "ws.attached",
+            user_id=str(user_id),
+            user_open_connections=self.user_connection_count(user_id),
+        )
+
+    async def detach(self, user_id: uuid.UUID, ws: WebSocket) -> None:
+        async with self._lock:
+            user_conns = self._conns.get(user_id)
+            if user_conns is None:
+                return
+            user_conns.pop(ws, None)
+            if not user_conns:
+                self._conns.pop(user_id, None)
+        logger.info(
+            "ws.detached",
+            user_id=str(user_id),
+            user_open_connections=self.user_connection_count(user_id),
+        )
+
+    # ------------------------------------------------------------------
+    # Subscriptions
+    # ------------------------------------------------------------------
+
+    async def subscribe(
+        self, user_id: uuid.UUID, ws: WebSocket, topics: list[str]
+    ) -> set[str]:
+        """Add ``topics`` to this connection's subscription set.
+
+        Unknown topics are silently dropped — the route handler is
+        responsible for validating and reporting back if it wants to.
+        Returns the resulting subscription set.
+        """
+        valid = {t for t in topics if t in VALID_TOPICS}
+        async with self._lock:
+            user_conns = self._conns.get(user_id)
+            if user_conns is None or ws not in user_conns:
+                return set()
+            user_conns[ws] |= valid
+            return set(user_conns[ws])
+
+    async def unsubscribe(
+        self, user_id: uuid.UUID, ws: WebSocket, topics: list[str]
+    ) -> set[str]:
+        async with self._lock:
+            user_conns = self._conns.get(user_id)
+            if user_conns is None or ws not in user_conns:
+                return set()
+            user_conns[ws] -= set(topics)
+            return set(user_conns[ws])
+
+    # ------------------------------------------------------------------
+    # Broadcast
+    # ------------------------------------------------------------------
+
+    async def broadcast(
+        self,
+        *,
+        user_id: uuid.UUID,
+        topic: str,
+        payload: dict[str, Any],
+    ) -> int:
+        """Push ``payload`` to every connection of ``user_id`` subscribed to ``topic``.
+
+        Returns the number of recipients. Best-effort: a send that
+        fails is logged and the connection is left for the route
+        handler's normal disconnect path to clean up.
+        """
+        if topic not in VALID_TOPICS:
+            logger.warning("ws.broadcast_unknown_topic", topic=topic)
+            return 0
+        message = {"topic": topic, "data": payload}
+
+        async with self._lock:
+            user_conns = self._conns.get(user_id)
+            if not user_conns:
+                return 0
+            recipients = [ws for ws, topics in user_conns.items() if topic in topics]
+
+        if not recipients:
+            return 0
+
+        async def _send(ws: WebSocket) -> None:
+            with contextlib.suppress(Exception):
+                await ws.send_json(message)
+
+        await asyncio.gather(*(_send(ws) for ws in recipients))
+        return len(recipients)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def user_connection_count(self, user_id: uuid.UUID) -> int:
+        return len(self._conns.get(user_id, {}))
+
+    def total_connections(self) -> int:
+        return sum(len(v) for v in self._conns.values())
+
+
+# Process-singleton accessor — keeps the manager outside the FastAPI
+# DI graph so domain code (event listeners) can import it cheaply.
+_MANAGER: ConnectionManager | None = None
+
+
+def get_manager() -> ConnectionManager:
+    global _MANAGER  # noqa: PLW0603 - process-wide singleton
+    if _MANAGER is None:
+        _MANAGER = ConnectionManager()
+    return _MANAGER

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -1,0 +1,172 @@
+"""Unit tests for the WebSocket connection manager (gh#7)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from engine.api.websocket.manager import (
+    VALID_TOPICS,
+    ConnectionManager,
+    Topic,
+    get_manager,
+)
+
+
+class _FakeWS:
+    """Minimal WebSocket stand-in. Captures every send_json call."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.sent: list[dict] = []
+        self.fail = fail
+        self.id = uuid.uuid4()
+
+    async def send_json(self, payload: dict) -> None:
+        if self.fail:
+            raise RuntimeError("simulated send failure")
+        self.sent.append(payload)
+
+    # Required so ConnectionManager can use it as a dict key.
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeWS) and other.id == self.id
+
+
+@pytest.fixture
+def manager() -> ConnectionManager:
+    return ConnectionManager()
+
+
+@pytest.fixture
+def user_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+class TestTopicEnum:
+    def test_valid_topics_match_enum(self):
+        assert VALID_TOPICS == frozenset(t.value for t in Topic)
+
+    def test_documented_topics(self):
+        assert VALID_TOPICS == frozenset({"portfolio", "backtest", "order", "alert"})
+
+
+class TestAttachDetach:
+    async def test_attach_increments_count(self, manager, user_id):
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        assert manager.user_connection_count(user_id) == 1
+        assert manager.total_connections() == 1
+
+    async def test_detach_zeroes_count(self, manager, user_id):
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        await manager.detach(user_id, ws)
+        assert manager.user_connection_count(user_id) == 0
+        assert manager.total_connections() == 0
+
+    async def test_detach_unknown_is_noop(self, manager, user_id):
+        await manager.detach(user_id, _FakeWS())
+        assert manager.total_connections() == 0
+
+    async def test_two_users_isolated(self, manager):
+        u1, u2 = uuid.uuid4(), uuid.uuid4()
+        ws1, ws2 = _FakeWS(), _FakeWS()
+        await manager.attach(u1, ws1)
+        await manager.attach(u2, ws2)
+        assert manager.user_connection_count(u1) == 1
+        assert manager.user_connection_count(u2) == 1
+        assert manager.total_connections() == 2
+
+
+class TestSubscribe:
+    async def test_subscribe_filters_invalid(self, manager, user_id):
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        result = await manager.subscribe(user_id, ws, ["portfolio", "wizard"])
+        assert result == {"portfolio"}
+
+    async def test_subscribe_accumulates(self, manager, user_id):
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        await manager.subscribe(user_id, ws, ["portfolio"])
+        result = await manager.subscribe(user_id, ws, ["backtest"])
+        assert result == {"portfolio", "backtest"}
+
+    async def test_unsubscribe_removes(self, manager, user_id):
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        await manager.subscribe(user_id, ws, ["portfolio", "backtest"])
+        result = await manager.unsubscribe(user_id, ws, ["portfolio"])
+        assert result == {"backtest"}
+
+    async def test_subscribe_unattached_returns_empty(self, manager, user_id):
+        ws = _FakeWS()  # never attached
+        result = await manager.subscribe(user_id, ws, ["portfolio"])
+        assert result == set()
+
+
+class TestBroadcast:
+    async def test_only_subscribed_recipients(self, manager, user_id):
+        a, b = _FakeWS(), _FakeWS()
+        await manager.attach(user_id, a)
+        await manager.attach(user_id, b)
+        await manager.subscribe(user_id, a, ["portfolio"])
+        await manager.subscribe(user_id, b, ["alert"])
+        n = await manager.broadcast(
+            user_id=user_id, topic="portfolio", payload={"v": 1}
+        )
+        assert n == 1
+        assert a.sent == [{"topic": "portfolio", "data": {"v": 1}}]
+        assert b.sent == []
+
+    async def test_unknown_topic_yields_zero(self, manager, user_id):
+        a = _FakeWS()
+        await manager.attach(user_id, a)
+        await manager.subscribe(user_id, a, ["portfolio"])
+        n = await manager.broadcast(
+            user_id=user_id, topic="wizard", payload={"v": 1}
+        )
+        assert n == 0
+        assert a.sent == []
+
+    async def test_no_recipients_returns_zero(self, manager, user_id):
+        a = _FakeWS()
+        await manager.attach(user_id, a)
+        # No subscriptions at all.
+        n = await manager.broadcast(
+            user_id=user_id, topic="portfolio", payload={"v": 1}
+        )
+        assert n == 0
+        assert a.sent == []
+
+    async def test_send_failure_does_not_break_others(self, manager, user_id):
+        good = _FakeWS()
+        bad = _FakeWS(fail=True)
+        await manager.attach(user_id, good)
+        await manager.attach(user_id, bad)
+        await manager.subscribe(user_id, good, ["portfolio"])
+        await manager.subscribe(user_id, bad, ["portfolio"])
+        n = await manager.broadcast(
+            user_id=user_id, topic="portfolio", payload={"v": 7}
+        )
+        # Both were recipients — broadcast counts them; only the working
+        # one received.
+        assert n == 2
+        assert good.sent == [{"topic": "portfolio", "data": {"v": 7}}]
+        assert bad.sent == []  # failed silently
+
+    async def test_broadcast_to_unknown_user_returns_zero(self, manager):
+        n = await manager.broadcast(
+            user_id=uuid.uuid4(), topic="portfolio", payload={"v": 1}
+        )
+        assert n == 0
+
+
+class TestSingleton:
+    def test_get_manager_is_idempotent(self):
+        a = get_manager()
+        b = get_manager()
+        assert a is b


### PR DESCRIPTION
First slice of real-time WebSocket surface. ConnectionManager (per-user fan-out, asyncio.gather broadcast, best-effort send) + Topic enum (portfolio/backtest/order/alert). /api/v1/ws endpoint with auth-then-subscribe protocol: client sends {type:auth,token:...} within 10s, then subscribe/unsubscribe/ping. Accepts JWT or engine API key. Close codes 4400/4401. 16 passing manager tests. Refs #7. Follow-ups: EventBus bridge, Redis/Valkey multi-replica fan-out, backpressure, frontend client.