### PR TITLE
feat(tax): wash-sale detector — IRS Section 1091 (gh#156 partial)

### DIFF
--- a/engine/core/tax/__init__.py
+++ b/engine/core/tax/__init__.py
@@ -1,0 +1,23 @@
+"""Tax engine — runtime rules and adjustments (gh#156 onwards).
+
+Public surface intentionally minimal. Today this exposes the wash-sale
+detector; future work adds the configurable jurisdiction engine
+(gh#81), the regulatory report generator (gh#155), and runtime
+enforcement that integrates with the live order pipeline.
+"""
+
+from engine.core.tax.wash_sale import (
+    WASH_SALE_WINDOW_DAYS,
+    Trade,
+    TradeSide,
+    WashSaleAdjustment,
+    detect_wash_sales,
+)
+
+__all__ = [
+    "Trade",
+    "TradeSide",
+    "WASH_SALE_WINDOW_DAYS",
+    "WashSaleAdjustment",
+    "detect_wash_sales",
+]

--- a/engine/core/tax/wash_sale.py
+++ b/engine/core/tax/wash_sale.py
@@ -1,0 +1,242 @@
+"""US IRS Section 1091 wash-sale detector (gh#156).
+
+A "wash sale" is a sale of a security at a loss when the same (or a
+substantially identical) security is bought within a ±30-day window
+around the sale. The disallowed loss is added to the cost basis of
+the replacement shares; the holding period of the replacement
+inherits from the lot that was sold.
+
+This module is intentionally a *pure function* over a stream of
+trades. It does not read the database. The caller passes a list of
+:class:`Trade` records (sourced from fills, lot movements, or a
+backtest); the detector returns a list of
+:class:`WashSaleAdjustment` records that the caller can persist or
+report on.
+
+Scope
+-----
+- "Substantially identical" is implemented as exact symbol match.
+  Real-world identification (options, ETF/ETF substitutes,
+  reorganisations) is a follow-up that lives behind a configurable
+  hook.
+- Lot selection is FIFO within the same symbol when the caller does
+  not supply per-sale cost basis.
+- Mark-to-market trades (Section 1256 contracts) are out of scope.
+- Cross-account / cross-portfolio aggregation is out of scope (the
+  caller decides what set of trades to feed in).
+
+Reference: 26 U.S.C. § 1091; IRS Pub. 550, "Investment Income and
+Expenses".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal
+from enum import Enum
+
+WASH_SALE_WINDOW_DAYS: int = 30
+
+
+class TradeSide(str, Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+@dataclass(frozen=True)
+class Trade:
+    """One executed trade in a single security.
+
+    ``trade_id`` is opaque; the caller maps it back to whatever
+    persistence layer it uses. ``quantity`` and ``price`` are
+    ``Decimal`` so basis arithmetic stays exact.
+    """
+
+    trade_id: str
+    symbol: str
+    side: TradeSide
+    quantity: Decimal
+    price: Decimal
+    when: datetime
+
+    def __post_init__(self) -> None:
+        if self.quantity <= 0:
+            raise ValueError(f"trade {self.trade_id!r}: quantity must be positive")
+        if self.price < 0:
+            raise ValueError(f"trade {self.trade_id!r}: price must be non-negative")
+
+    @property
+    def gross(self) -> Decimal:
+        return self.quantity * self.price
+
+
+@dataclass(frozen=True)
+class WashSaleAdjustment:
+    """One disallowed-loss adjustment.
+
+    The caller adds ``disallowed_loss`` to the cost basis of
+    ``replacement_trade_id``'s lot. ``matched_quantity`` is the
+    number of shares the replacement absorbed from the loss sale —
+    the disallowed-loss amount is already prorated to that quantity.
+    """
+
+    sale_trade_id: str
+    replacement_trade_id: str
+    symbol: str
+    matched_quantity: Decimal
+    disallowed_loss: Decimal
+
+
+@dataclass
+class _BuyState:
+    """Mutable buy-side accounting carried across the scan."""
+
+    trade: Trade
+    available_qty: Decimal
+
+
+@dataclass
+class _SaleState:
+    """Mutable sale-side accounting carried across the scan."""
+
+    trade: Trade
+    cost_basis: Decimal
+    total_loss: Decimal  # full loss at sale time, fixed
+    remaining_qty: Decimal
+    remaining_loss: Decimal  # always non-negative; only loss sales tracked
+
+
+def detect_wash_sales(
+    trades: list[Trade],
+    *,
+    cost_basis_for: dict[str, Decimal] | None = None,
+) -> list[WashSaleAdjustment]:
+    """Return wash-sale adjustments implied by ``trades``.
+
+    ``cost_basis_for`` is an optional ``trade_id -> total cost basis``
+    map for sale trades. If a sale's ``trade_id`` is missing, the
+    detector falls back to using FIFO matching against earlier buys
+    in ``trades`` to compute the basis.
+
+    The output is sorted by ``(sale_trade_id, replacement_trade_id)``
+    so callers can diff against previous runs.
+    """
+    sales = [t for t in trades if t.side == TradeSide.SELL]
+
+    # FIFO state shared between basis computation and wash-sale matching.
+    # After basis consumption, lots' ``available_qty`` reflects shares
+    # still held — those (and only those) can be wash-sale replacements.
+    fifo_lots: dict[str, list[_BuyState]] = {}
+    cost_basis_for = dict(cost_basis_for or {})
+    for trade in sorted(trades, key=lambda t: t.when):
+        if trade.side == TradeSide.BUY:
+            fifo_lots.setdefault(trade.symbol, []).append(
+                _BuyState(trade=trade, available_qty=trade.quantity)
+            )
+        else:
+            consumed_basis = _consume_fifo(
+                fifo_lots.get(trade.symbol, []), trade.quantity
+            )
+            if trade.trade_id not in cost_basis_for:
+                cost_basis_for[trade.trade_id] = consumed_basis
+
+    # Build sale states; only sales at a loss matter.
+    sale_states: list[_SaleState] = []
+    for s in sales:
+        basis = cost_basis_for.get(s.trade_id, Decimal("0"))
+        loss = basis - s.gross  # positive = loss
+        if loss <= 0:
+            continue
+        sale_states.append(
+            _SaleState(
+                trade=s,
+                cost_basis=basis,
+                total_loss=loss,
+                remaining_qty=s.quantity,
+                remaining_loss=loss,
+            )
+        )
+    sale_states.sort(key=lambda s: s.trade.when)
+
+    # Wash-sale candidates = lots with surviving ``available_qty``.
+    # Order by time so earlier replacements consume the loss first.
+    buy_states = sorted(
+        (
+            lot
+            for lots in fifo_lots.values()
+            for lot in lots
+            if lot.available_qty > 0
+        ),
+        key=lambda b: b.trade.when,
+    )
+
+    adjustments: list[WashSaleAdjustment] = []
+    window = timedelta(days=WASH_SALE_WINDOW_DAYS)
+
+    for sale in sale_states:
+        for buy in buy_states:
+            if buy.available_qty <= 0:
+                continue
+            if buy.trade.symbol != sale.trade.symbol:
+                continue
+            if abs(buy.trade.when - sale.trade.when) > window:
+                continue
+            if buy.trade.trade_id == sale.trade.trade_id:
+                # Defensive: a single trade should never be both buy
+                # and sale, but if the caller passed bad data don't
+                # match it against itself.
+                continue
+
+            matched = min(sale.remaining_qty, buy.available_qty)
+            if matched <= 0:
+                continue
+            # Prorate the FULL loss by matched_qty / sale.qty so multiple
+            # replacements consume the loss linearly (not exponentially).
+            disallowed = (
+                sale.total_loss * (matched / sale.trade.quantity)
+            ).quantize(Decimal("0.0001"))
+            adjustments.append(
+                WashSaleAdjustment(
+                    sale_trade_id=sale.trade.trade_id,
+                    replacement_trade_id=buy.trade.trade_id,
+                    symbol=sale.trade.symbol,
+                    matched_quantity=matched,
+                    disallowed_loss=disallowed,
+                )
+            )
+
+            sale.remaining_qty -= matched
+            sale.remaining_loss -= disallowed
+            buy.available_qty -= matched
+
+            if sale.remaining_qty <= 0 or sale.remaining_loss <= 0:
+                break
+
+    adjustments.sort(
+        key=lambda a: (a.sale_trade_id, a.replacement_trade_id)
+    )
+    return adjustments
+
+
+def _consume_fifo(lots: list[_BuyState], qty: Decimal) -> Decimal:
+    """FIFO-consume ``qty`` shares from ``lots`` and return cost basis.
+
+    Mutates ``lots`` so that subsequent calls see the reduced
+    availability. If ``lots`` doesn't have enough, the missing portion
+    contributes zero basis. Real systems should reject that case
+    upstream — this is just a fallback so the detector doesn't crash
+    on partial inputs.
+    """
+    remaining = qty
+    basis = Decimal("0")
+    for lot in lots:
+        if remaining <= 0:
+            break
+        take = min(lot.available_qty, remaining)
+        if take <= 0:
+            continue
+        basis += take * lot.trade.price
+        lot.available_qty -= take
+        remaining -= take
+    return basis

--- a/tests/test_wash_sale.py
+++ b/tests/test_wash_sale.py
@@ -1,0 +1,210 @@
+"""Unit tests for the wash-sale detector — gh#156."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax import (
+    WASH_SALE_WINDOW_DAYS,
+    Trade,
+    TradeSide,
+    detect_wash_sales,
+)
+
+
+def _trade(
+    tid: str,
+    symbol: str,
+    side: TradeSide,
+    qty: str,
+    price: str,
+    days_offset: int,
+) -> Trade:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    return Trade(
+        trade_id=tid,
+        symbol=symbol,
+        side=side,
+        quantity=Decimal(qty),
+        price=Decimal(price),
+        when=base + timedelta(days=days_offset),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trade validation
+# ---------------------------------------------------------------------------
+
+
+class TestTrade:
+    def test_zero_quantity_rejected(self):
+        with pytest.raises(ValueError):
+            Trade(
+                trade_id="t1",
+                symbol="AAPL",
+                side=TradeSide.BUY,
+                quantity=Decimal("0"),
+                price=Decimal("100"),
+                when=datetime(2026, 5, 1, tzinfo=UTC),
+            )
+
+    def test_negative_price_rejected(self):
+        with pytest.raises(ValueError):
+            Trade(
+                trade_id="t1",
+                symbol="AAPL",
+                side=TradeSide.BUY,
+                quantity=Decimal("10"),
+                price=Decimal("-1"),
+                when=datetime(2026, 5, 1, tzinfo=UTC),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Constant
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_window_is_thirty_days(self):
+        # IRS Section 1091 — 30 days each side. The detector tolerates
+        # exactly +/- WASH_SALE_WINDOW_DAYS as a match.
+        assert WASH_SALE_WINDOW_DAYS == 30
+
+
+# ---------------------------------------------------------------------------
+# Detector behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestNoMatch:
+    def test_gain_sale_not_a_wash_sale(self):
+        # Buy at 100, sell at 120 — gain, no wash sale possible.
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "120", 5),
+            _trade("b2", "AAPL", TradeSide.BUY, "10", "121", 10),
+        ]
+        assert detect_wash_sales(trades) == []
+
+    def test_loss_with_no_replacement_is_not_wash(self):
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 5),
+        ]
+        assert detect_wash_sales(trades) == []
+
+    def test_replacement_outside_window_does_not_match(self):
+        # Buy 0, sell 5 (loss), buy again at day 36 — outside 30-day window.
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 5),
+            _trade("b2", "AAPL", TradeSide.BUY, "10", "85", 36),
+        ]
+        assert detect_wash_sales(trades) == []
+
+    def test_different_symbol_does_not_match(self):
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 5),
+            _trade("b2", "MSFT", TradeSide.BUY, "10", "80", 10),
+        ]
+        assert detect_wash_sales(trades) == []
+
+
+class TestSimpleMatch:
+    def test_replacement_after_loss_within_window(self):
+        # Buy 10@100, sell 10@80 (loss=200), re-buy 10@85 within 30 days.
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 5),
+            _trade("b2", "AAPL", TradeSide.BUY, "10", "85", 10),
+        ]
+        adjustments = detect_wash_sales(trades)
+        assert len(adjustments) == 1
+        adj = adjustments[0]
+        assert adj.sale_trade_id == "s1"
+        assert adj.replacement_trade_id == "b2"
+        assert adj.symbol == "AAPL"
+        assert adj.matched_quantity == Decimal("10")
+        # Full loss is disallowed because replacement qty == sale qty.
+        assert adj.disallowed_loss == Decimal("200.0000")
+
+
+class TestPartialMatch:
+    def test_replacement_smaller_than_sale_partial_disallow(self):
+        # Buy 10@100, sell 10@80 (loss=200), replacement 4 shares only.
+        # Disallowed loss is prorated: 200 * (4/10) = 80.
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 5),
+            _trade("b2", "AAPL", TradeSide.BUY, "4", "85", 10),
+        ]
+        adjustments = detect_wash_sales(trades)
+        assert len(adjustments) == 1
+        adj = adjustments[0]
+        assert adj.matched_quantity == Decimal("4")
+        assert adj.disallowed_loss == Decimal("80.0000")
+
+    def test_two_replacements_consume_loss_in_order(self):
+        # Sale qty 10, two later buys of 6 and 5. Should match all 10.
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 5),
+            _trade("b2", "AAPL", TradeSide.BUY, "6", "85", 10),
+            _trade("b3", "AAPL", TradeSide.BUY, "5", "85", 12),
+        ]
+        adjustments = detect_wash_sales(trades)
+        # Two adjustments: 6 shares to b2, 4 shares to b3.
+        replacements = {a.replacement_trade_id: a.matched_quantity for a in adjustments}
+        assert replacements == {"b2": Decimal("6"), "b3": Decimal("4")}
+        # Loss totals 200; split should add to 200 (within rounding).
+        total = sum((a.disallowed_loss for a in adjustments), Decimal("0"))
+        assert total == Decimal("200.0000")
+
+
+class TestExactBoundary:
+    def test_buy_exactly_thirty_days_after_matches(self):
+        # The window is inclusive at the boundary.
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 0),
+            _trade("b2", "AAPL", TradeSide.BUY, "10", "85", WASH_SALE_WINDOW_DAYS),
+        ]
+        adjustments = detect_wash_sales(trades)
+        assert len(adjustments) == 1
+        assert adjustments[0].replacement_trade_id == "b2"
+
+    def test_buy_thirty_one_days_after_does_not_match(self):
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 0),
+            _trade(
+                "b2",
+                "AAPL",
+                TradeSide.BUY,
+                "10",
+                "85",
+                WASH_SALE_WINDOW_DAYS + 1,
+            ),
+        ]
+        assert detect_wash_sales(trades) == []
+
+
+class TestExplicitBasis:
+    def test_basis_map_overrides_fifo(self):
+        # Same shape as the simple match, but explicit cost basis says
+        # the sale was at break-even (no loss). Detector must skip.
+        trades = [
+            _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+            _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 5),
+            _trade("b2", "AAPL", TradeSide.BUY, "10", "85", 10),
+        ]
+        # Sale gross = 800. If basis = 800, loss = 0.
+        adjustments = detect_wash_sales(
+            trades, cost_basis_for={"s1": Decimal("800")}
+        )
+        assert adjustments == []


### PR DESCRIPTION
Pure-Python detector for US wash-sale violations. Trade + WashSaleAdjustment + detect_wash_sales. FIFO-shares basis state with wash-sale matching so basis-establishing buys are correctly excluded as replacements. Linear loss proration across multiple replacements. 13 passing tests covering boundary, partial, multi-replacement, gain-sale, out-of-window, different-symbol, explicit-basis cases. Refs #156. Persistence, jurisdiction engine, substantially-identical beyond symbol, Section 1256 — all deferred.