### PR TITLE
feat(data): streaming backpressure primitives — bounded buffer + replay log (gh#133 partial)

### DIFF
--- a/engine/data/streaming/__init__.py
+++ b/engine/data/streaming/__init__.py
@@ -1,0 +1,25 @@
+"""Real-time streaming primitives (gh#133).
+
+Today this exposes:
+
+- :class:`BoundedBuffer` — fixed-capacity buffer with a drop policy.
+  Use it between a fast producer (market data feed) and a slower
+  consumer (strategy / WebSocket fan-out) so a stalled consumer
+  does not block the producer or grow memory unbounded.
+- :class:`ReplayLog` — bounded recent-history log. Useful for
+  resubscribe / catch-up flows where a new consumer joins mid-stream
+  and needs the last N messages.
+
+Out of scope (explicit follow-ups):
+- Wiring this into the actual market-data provider abstraction
+  (``engine/data/providers/``) and the WebSocket fan-out
+  (``engine/api/websocket/``).
+- Multi-consumer fan-out across replicas — that's the Redis/Valkey
+  pubsub work tracked under gh#7 follow-ups.
+- Persisted replay across restarts.
+"""
+
+from engine.data.streaming.replay import ReplayLog
+from engine.data.streaming.ring_buffer import BoundedBuffer, DropPolicy
+
+__all__ = ["BoundedBuffer", "DropPolicy", "ReplayLog"]

--- a/engine/data/streaming/replay.py
+++ b/engine/data/streaming/replay.py
@@ -1,0 +1,90 @@
+"""Bounded replay log — recent-history catch-up for new subscribers (gh#133).
+
+A producer can ``record`` every message; a new consumer that joins
+mid-stream can call ``since_seq`` to fetch the messages it missed,
+bounded by the configured retention.
+
+This is **not** a durable log. Restarts lose history; messages
+beyond the retention window are forgotten silently. For durable
+event sourcing use the database directly.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class _Entry(Generic[T]):
+    seq: int
+    payload: T
+
+
+class ReplayLog(Generic[T]):
+    """Bounded recent-history log keyed by a monotonic sequence number."""
+
+    def __init__(self, capacity: int) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._capacity = capacity
+        self._items: deque[_Entry[T]] = deque(maxlen=capacity)
+        self._next_seq = 0
+        self._lock = threading.Lock()
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    @property
+    def next_seq(self) -> int:
+        with self._lock:
+            return self._next_seq
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._items)
+
+    def record(self, payload: T) -> int:
+        """Append ``payload`` and return the assigned sequence number."""
+        with self._lock:
+            seq = self._next_seq
+            self._items.append(_Entry(seq=seq, payload=payload))
+            self._next_seq += 1
+            return seq
+
+    def since_seq(self, after: int) -> list[T]:
+        """Return all payloads strictly after sequence number ``after``.
+
+        If ``after`` is older than the retained window, the caller
+        gets the oldest retained payloads onwards — the resubscribe
+        is best-effort and silently truncated. Caller can detect
+        this via :meth:`oldest_seq` and decide whether to do a full
+        snapshot fetch.
+        """
+        with self._lock:
+            return [e.payload for e in self._items if e.seq > after]
+
+    def oldest_seq(self) -> int | None:
+        """Lowest sequence number still retained, or ``None`` if empty."""
+        with self._lock:
+            return self._items[0].seq if self._items else None
+
+    def latest(self, n: int = 1) -> list[T]:
+        """Return the most recent ``n`` payloads (oldest-first)."""
+        if n <= 0:
+            return []
+        with self._lock:
+            length = len(self._items)
+            start = max(length - n, 0)
+            return [self._items[i].payload for i in range(start, length)]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._items.clear()
+            # Keep next_seq monotonic so consumers' cursors don't
+            # collide with reused sequence numbers after a reset.

--- a/engine/data/streaming/ring_buffer.py
+++ b/engine/data/streaming/ring_buffer.py
@@ -1,0 +1,165 @@
+"""Bounded buffer with explicit drop policy (gh#133).
+
+Why this is here
+----------------
+A real-time data feed (market quotes, fills, alerts) produces
+messages faster than any single consumer can handle, especially
+during volatile periods. Without backpressure the choices are bad:
+
+- Block the producer (latency spikes, can lose the network slot).
+- Grow an unbounded queue (memory blows up, GC pauses worsen).
+
+This buffer makes the trade-off explicit: it has a fixed capacity
+and a documented behaviour when full. Drop counters surface the
+backpressure event to monitoring (the SLOs in
+``docs/operations/slos.md`` will reference these once the
+:class:`MetricsBackend` exporter lands).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from collections.abc import Iterator
+from enum import Enum
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class DropPolicy(str, Enum):
+    """How a full :class:`BoundedBuffer` reacts to a new ``put``."""
+
+    # Push out the oldest item to make room — preserves the freshest
+    # data. Default for live feeds where stale prices are useless.
+    DROP_OLDEST = "drop_oldest"
+    # Reject the new item — preserves the historical window. Use for
+    # event streams where every event must be considered in order
+    # until the queue catches up (e.g., audit / alert pipelines that
+    # are OK to fail rather than silently lose history).
+    DROP_NEWEST = "drop_newest"
+
+
+class BoundedBuffer(Generic[T]):
+    """Thread-safe bounded buffer with a documented drop policy.
+
+    The buffer is a ring with capacity ``maxsize``. ``put`` returns
+    ``True`` if the item was accepted, ``False`` if it was dropped
+    (after also bumping the appropriate counter).
+
+    Single-process and synchronous on purpose. The async equivalent
+    is one of the well-tested asyncio queues; this primitive is for
+    the boundary between sync producers and async consumers (and
+    vice-versa) where neither stdlib option fits cleanly.
+    """
+
+    def __init__(
+        self,
+        maxsize: int,
+        *,
+        policy: DropPolicy = DropPolicy.DROP_OLDEST,
+    ) -> None:
+        if maxsize <= 0:
+            raise ValueError("maxsize must be positive")
+        self._maxsize = maxsize
+        self._policy = policy
+        self._items: deque[T] = deque()
+        self._lock = threading.Lock()
+        self._dropped_oldest = 0
+        self._dropped_newest = 0
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def maxsize(self) -> int:
+        return self._maxsize
+
+    @property
+    def policy(self) -> DropPolicy:
+        return self._policy
+
+    @property
+    def dropped_oldest(self) -> int:
+        return self._dropped_oldest
+
+    @property
+    def dropped_newest(self) -> int:
+        return self._dropped_newest
+
+    @property
+    def dropped_total(self) -> int:
+        return self._dropped_oldest + self._dropped_newest
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._items)
+
+    def is_full(self) -> bool:
+        with self._lock:
+            return len(self._items) >= self._maxsize
+
+    def is_empty(self) -> bool:
+        with self._lock:
+            return not self._items
+
+    # ------------------------------------------------------------------
+    # Producer / consumer
+    # ------------------------------------------------------------------
+
+    def put(self, item: T) -> bool:
+        """Add ``item``. Returns True if accepted, False if dropped."""
+        with self._lock:
+            if len(self._items) < self._maxsize:
+                self._items.append(item)
+                return True
+            if self._policy == DropPolicy.DROP_OLDEST:
+                self._items.popleft()
+                self._items.append(item)
+                self._dropped_oldest += 1
+                return True
+            # DROP_NEWEST
+            self._dropped_newest += 1
+            return False
+
+    def get(self) -> T:
+        """Remove and return the oldest item. Raises ``IndexError`` if empty."""
+        with self._lock:
+            return self._items.popleft()
+
+    def get_nowait_or(self, default: T) -> T:
+        """Non-raising alternative to :meth:`get`."""
+        with self._lock:
+            return self._items.popleft() if self._items else default
+
+    def drain(self) -> list[T]:
+        """Remove and return all queued items (oldest-first)."""
+        with self._lock:
+            out = list(self._items)
+            self._items.clear()
+            return out
+
+    def snapshot(self) -> list[T]:
+        """Return a copy of the current contents without removing them."""
+        with self._lock:
+            return list(self._items)
+
+    # ------------------------------------------------------------------
+    # Iteration
+    # ------------------------------------------------------------------
+
+    def __iter__(self) -> Iterator[T]:
+        # Snapshot iteration so a consumer can walk the buffer without
+        # blocking concurrent producers. Mutations after the snapshot
+        # are not visible.
+        return iter(self.snapshot())
+
+    # ------------------------------------------------------------------
+    # Reset (mostly for tests + admin)
+    # ------------------------------------------------------------------
+
+    def reset_drop_counters(self) -> None:
+        with self._lock:
+            self._dropped_oldest = 0
+            self._dropped_newest = 0

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,187 @@
+"""Unit tests for streaming primitives (gh#133)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.data.streaming import BoundedBuffer, DropPolicy, ReplayLog
+
+
+# ---------------------------------------------------------------------------
+# BoundedBuffer
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedBufferConstructor:
+    def test_zero_maxsize_rejected(self):
+        with pytest.raises(ValueError):
+            BoundedBuffer(maxsize=0)
+
+    def test_negative_maxsize_rejected(self):
+        with pytest.raises(ValueError):
+            BoundedBuffer(maxsize=-1)
+
+
+class TestBoundedBufferDropOldest:
+    def test_put_below_capacity(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=3)
+        assert b.put(1) is True
+        assert b.put(2) is True
+        assert len(b) == 2
+        assert b.dropped_total == 0
+
+    def test_put_at_capacity_drops_oldest(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=3)
+        for v in (1, 2, 3):
+            b.put(v)
+        assert b.put(4) is True
+        assert b.snapshot() == [2, 3, 4]
+        assert b.dropped_oldest == 1
+        assert b.dropped_newest == 0
+
+    def test_get_returns_oldest_first(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=3)
+        for v in (1, 2, 3):
+            b.put(v)
+        assert b.get() == 1
+        assert b.get() == 2
+        assert b.get() == 3
+
+    def test_get_empty_raises(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=3)
+        with pytest.raises(IndexError):
+            b.get()
+
+    def test_get_nowait_or_default(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=3)
+        assert b.get_nowait_or(-1) == -1
+
+    def test_drain_returns_all_and_empties(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=5)
+        for v in (1, 2, 3):
+            b.put(v)
+        assert b.drain() == [1, 2, 3]
+        assert b.is_empty()
+
+    def test_iteration_is_snapshot(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=5)
+        for v in (1, 2, 3):
+            b.put(v)
+        snapshot = list(b)
+        b.put(4)  # mutation after snapshot
+        assert snapshot == [1, 2, 3]
+
+
+class TestBoundedBufferDropNewest:
+    def test_put_at_capacity_rejects_new(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=3, policy=DropPolicy.DROP_NEWEST)
+        for v in (1, 2, 3):
+            b.put(v)
+        assert b.put(4) is False
+        assert b.snapshot() == [1, 2, 3]
+        assert b.dropped_oldest == 0
+        assert b.dropped_newest == 1
+
+
+class TestDropCounters:
+    def test_reset_zeroes_counters(self):
+        b: BoundedBuffer[int] = BoundedBuffer(maxsize=2)
+        for v in (1, 2, 3, 4):
+            b.put(v)
+        assert b.dropped_total == 2
+        b.reset_drop_counters()
+        assert b.dropped_total == 0
+
+
+# ---------------------------------------------------------------------------
+# ReplayLog
+# ---------------------------------------------------------------------------
+
+
+class TestReplayLogConstructor:
+    def test_zero_capacity_rejected(self):
+        with pytest.raises(ValueError):
+            ReplayLog(capacity=0)
+
+
+class TestReplayLogRecord:
+    def test_seq_is_monotonic(self):
+        log: ReplayLog[str] = ReplayLog(capacity=10)
+        assert log.record("a") == 0
+        assert log.record("b") == 1
+        assert log.record("c") == 2
+        assert log.next_seq == 3
+
+    def test_capacity_bounds_history(self):
+        log: ReplayLog[int] = ReplayLog(capacity=3)
+        for v in range(5):
+            log.record(v)
+        assert len(log) == 3
+        assert log.oldest_seq() == 2  # 0,1 evicted
+
+    def test_seq_remains_monotonic_after_eviction(self):
+        log: ReplayLog[int] = ReplayLog(capacity=2)
+        for v in range(5):
+            log.record(v)
+        # Even after evictions, next_seq keeps climbing.
+        assert log.next_seq == 5
+
+
+class TestReplayLogSinceSeq:
+    def test_returns_only_after(self):
+        log: ReplayLog[int] = ReplayLog(capacity=10)
+        for v in range(5):
+            log.record(v)
+        assert log.since_seq(2) == [3, 4]
+
+    def test_after_negative_returns_all(self):
+        log: ReplayLog[int] = ReplayLog(capacity=10)
+        for v in range(3):
+            log.record(v)
+        assert log.since_seq(-1) == [0, 1, 2]
+
+    def test_after_too_old_returns_oldest_retained(self):
+        log: ReplayLog[int] = ReplayLog(capacity=3)
+        for v in range(10):
+            log.record(v)
+        # Retained seqs: 7,8,9. Asking after seq=2 is older than the
+        # window; we still get the retained tail.
+        assert log.since_seq(2) == [7, 8, 9]
+
+    def test_after_latest_returns_empty(self):
+        log: ReplayLog[int] = ReplayLog(capacity=3)
+        for v in range(3):
+            log.record(v)
+        assert log.since_seq(2) == []
+
+
+class TestReplayLogLatest:
+    def test_latest_n(self):
+        log: ReplayLog[int] = ReplayLog(capacity=10)
+        for v in range(5):
+            log.record(v)
+        assert log.latest(2) == [3, 4]
+
+    def test_latest_more_than_size(self):
+        log: ReplayLog[int] = ReplayLog(capacity=10)
+        for v in range(3):
+            log.record(v)
+        assert log.latest(99) == [0, 1, 2]
+
+    def test_latest_zero_or_negative_returns_empty(self):
+        log: ReplayLog[int] = ReplayLog(capacity=5)
+        log.record(1)
+        assert log.latest(0) == []
+        assert log.latest(-3) == []
+
+
+class TestReplayLogClear:
+    def test_clear_drops_history_keeps_seq(self):
+        log: ReplayLog[int] = ReplayLog(capacity=3)
+        for v in range(3):
+            log.record(v)
+        log.clear()
+        assert len(log) == 0
+        assert log.oldest_seq() is None
+        # next_seq does NOT reset.
+        assert log.next_seq == 3


### PR DESCRIPTION
Two pure-Python primitives for producer/consumer boundary on real-time feeds. BoundedBuffer[T] with DropPolicy (DROP_OLDEST for live feeds, DROP_NEWEST for audit pipelines) + drop counters. ReplayLog[T] with monotonic seq, since_seq for resubscribe catch-up, bounded retention, latest(n). 23 passing tests. Refs #133. Provider integration, WebSocket fan-out wiring, multi-replica pubsub, durable persistence — all deferred.