### PR TITLE
feat(oms): order state machine + event types (gh#111 partial)

### DIFF
--- a/engine/core/oms/__init__.py
+++ b/engine/core/oms/__init__.py
@@ -1,0 +1,54 @@
+"""Order Management System (gh#111).
+
+Today this exposes the core order state machine and the event types
+that drive transitions. Broker wiring, persistence, risk checks, and
+the live execution loop (gh#109) consume these primitives but live
+in their own modules so the state machine can be unit-tested in
+isolation.
+
+Public surface:
+
+- :class:`OrderSide`, :class:`OrderType`, :class:`OrderStatus` — the
+  vocabulary brokers expect plus the lifecycle states the engine
+  models.
+- :class:`Order` — single in-flight or terminal order. Immutable
+  per state — :meth:`Order.apply_event` returns a *new* Order.
+- :class:`OrderEvent` and friends — strongly-typed transitions.
+- :func:`is_terminal` — convenience predicate for the end states.
+- :data:`VALID_TRANSITIONS` — exposed so tests / monitoring can
+  validate broker-emitted events before applying them.
+"""
+
+from engine.core.oms.events import (
+    AckEvent,
+    CancelEvent,
+    FillEvent,
+    OrderEvent,
+    PartialFillEvent,
+    RejectEvent,
+    SubmitEvent,
+)
+from engine.core.oms.order import Order
+from engine.core.oms.states import (
+    VALID_TRANSITIONS,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    is_terminal,
+)
+
+__all__ = [
+    "AckEvent",
+    "CancelEvent",
+    "FillEvent",
+    "Order",
+    "OrderEvent",
+    "OrderSide",
+    "OrderStatus",
+    "OrderType",
+    "PartialFillEvent",
+    "RejectEvent",
+    "SubmitEvent",
+    "VALID_TRANSITIONS",
+    "is_terminal",
+]

--- a/engine/core/oms/events.py
+++ b/engine/core/oms/events.py
@@ -1,0 +1,96 @@
+"""OMS event types (gh#111).
+
+Each event represents one external (broker-emitted or operator-issued)
+fact about an order. Events are frozen dataclasses so they serialise
+cleanly to JSON and survive a database round-trip without bespoke
+wiring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class _BaseEvent:
+    occurred_at: datetime
+
+
+@dataclass(frozen=True)
+class SubmitEvent(_BaseEvent):
+    """Engine sent the order to the broker."""
+
+    broker_order_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AckEvent(_BaseEvent):
+    """Broker accepted the order; it's resting on the book."""
+
+    broker_order_id: str = ""
+
+
+@dataclass(frozen=True)
+class PartialFillEvent(_BaseEvent):
+    """Some quantity filled; more remains."""
+
+    fill_quantity: Decimal = Decimal("0")
+    fill_price: Decimal = Decimal("0")
+    fill_id: str = ""
+
+
+@dataclass(frozen=True)
+class FillEvent(_BaseEvent):
+    """Final fill — order is fully filled."""
+
+    fill_quantity: Decimal = Decimal("0")
+    fill_price: Decimal = Decimal("0")
+    fill_id: str = ""
+
+
+@dataclass(frozen=True)
+class CancelEvent(_BaseEvent):
+    """Either we requested the cancel (``requested=True``) or the
+    broker confirmed it (``requested=False``). The OMS uses the flag
+    to distinguish ``CANCEL_REQUESTED`` from ``CANCELLED``."""
+
+    requested: bool = False
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class RejectEvent(_BaseEvent):
+    """Broker rejected the order (or a cancel attempt)."""
+
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ExpireEvent(_BaseEvent):
+    """Broker expired the order (TIF reached)."""
+
+
+# Algebraic-data-type alias — every concrete event in the system.
+OrderEvent = (
+    SubmitEvent
+    | AckEvent
+    | PartialFillEvent
+    | FillEvent
+    | CancelEvent
+    | RejectEvent
+    | ExpireEvent
+)
+
+
+__all__ = [
+    "AckEvent",
+    "CancelEvent",
+    "ExpireEvent",
+    "FillEvent",
+    "OrderEvent",
+    "PartialFillEvent",
+    "RejectEvent",
+    "SubmitEvent",
+]

--- a/engine/core/oms/order.py
+++ b/engine/core/oms/order.py
@@ -1,0 +1,209 @@
+"""Order entity + state-machine application (gh#111).
+
+The :class:`Order` is **immutable per state**. ``apply_event`` returns
+a new Order; the old one is left untouched so callers can keep a
+history without copying.
+
+The OMS does *not* persist Orders here — that's the caller's job.
+This module just owns the rules of how an Order's status, filled
+quantity, average fill price, and broker id evolve as events arrive.
+
+Note: ``engine/db/models.py`` defines a SQLAlchemy ``Order`` row for
+persisted state. That is a different abstraction — the row is the
+*projection* of an event-sourced :class:`Order` into a snapshot the
+DB can index. Keep them at arm's length.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from engine.core.oms.events import (
+    AckEvent,
+    CancelEvent,
+    ExpireEvent,
+    FillEvent,
+    OrderEvent,
+    PartialFillEvent,
+    RejectEvent,
+    SubmitEvent,
+)
+from engine.core.oms.states import (
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    can_transition,
+    is_terminal,
+)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+class OMSError(Exception):
+    """Base for OMS rule violations."""
+
+
+class IllegalTransitionError(OMSError):
+    """Raised when an event would move the order to a status that the
+    state machine forbids from the current status."""
+
+
+class OverFillError(OMSError):
+    """Raised when applying a fill would exceed the order's quantity."""
+
+
+@dataclass(frozen=True)
+class Order:
+    """In-flight or terminal order.
+
+    Fields with sensible defaults are populated by the engine when it
+    mints the order; broker-controlled fields are populated by events.
+    """
+
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    symbol: str = ""
+    side: OrderSide = OrderSide.BUY
+    order_type: OrderType = OrderType.MARKET
+    quantity: Decimal = Decimal("0")
+    limit_price: Decimal | None = None
+    stop_price: Decimal | None = None
+    status: OrderStatus = OrderStatus.NEW
+    filled_quantity: Decimal = Decimal("0")
+    average_fill_price: Decimal | None = None
+    broker_order_id: str | None = None
+    reject_reason: str | None = None
+    created_at: datetime = field(default_factory=_utcnow)
+    updated_at: datetime = field(default_factory=_utcnow)
+
+    def __post_init__(self) -> None:
+        if self.quantity <= 0:
+            raise ValueError("quantity must be positive")
+        if self.order_type in (OrderType.LIMIT, OrderType.STOP_LIMIT):
+            if self.limit_price is None or self.limit_price <= 0:
+                raise ValueError(
+                    f"{self.order_type.value} order requires positive limit_price"
+                )
+        if self.order_type in (OrderType.STOP, OrderType.STOP_LIMIT):
+            if self.stop_price is None or self.stop_price <= 0:
+                raise ValueError(
+                    f"{self.order_type.value} order requires positive stop_price"
+                )
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def remaining_quantity(self) -> Decimal:
+        return self.quantity - self.filled_quantity
+
+    @property
+    def is_terminal(self) -> bool:
+        return is_terminal(self.status)
+
+    # ------------------------------------------------------------------
+    # State-machine application
+    # ------------------------------------------------------------------
+
+    def apply_event(self, event: OrderEvent) -> Order:
+        """Return a new Order reflecting ``event``.
+
+        Raises :class:`IllegalTransitionError` if ``event`` is not
+        valid from the current status, or :class:`OverFillError` if a
+        fill would exceed the order's total quantity.
+        """
+        if isinstance(event, SubmitEvent):
+            return self._with_status(
+                OrderStatus.SUBMITTED,
+                event,
+                broker_order_id=event.broker_order_id or self.broker_order_id,
+            )
+        if isinstance(event, AckEvent):
+            return self._with_status(
+                OrderStatus.ACKNOWLEDGED,
+                event,
+                broker_order_id=event.broker_order_id or self.broker_order_id,
+            )
+        if isinstance(event, PartialFillEvent):
+            new_filled = self.filled_quantity + event.fill_quantity
+            self._guard_fill(new_filled)
+            new_status = (
+                OrderStatus.FILLED
+                if new_filled == self.quantity
+                else OrderStatus.PARTIALLY_FILLED
+            )
+            return self._with_status(
+                new_status,
+                event,
+                filled_quantity=new_filled,
+                average_fill_price=self._next_avg(event.fill_quantity, event.fill_price),
+            )
+        if isinstance(event, FillEvent):
+            new_filled = self.filled_quantity + event.fill_quantity
+            self._guard_fill(new_filled)
+            if new_filled != self.quantity:
+                raise OverFillError(
+                    f"FillEvent leaves {new_filled} filled of {self.quantity}; "
+                    "use PartialFillEvent for non-final fills"
+                )
+            return self._with_status(
+                OrderStatus.FILLED,
+                event,
+                filled_quantity=new_filled,
+                average_fill_price=self._next_avg(event.fill_quantity, event.fill_price),
+            )
+        if isinstance(event, CancelEvent):
+            target = (
+                OrderStatus.CANCEL_REQUESTED if event.requested else OrderStatus.CANCELLED
+            )
+            return self._with_status(target, event)
+        if isinstance(event, RejectEvent):
+            return self._with_status(
+                OrderStatus.REJECTED, event, reject_reason=event.reason
+            )
+        if isinstance(event, ExpireEvent):
+            return self._with_status(OrderStatus.EXPIRED, event)
+        raise TypeError(f"unknown event type: {type(event).__name__}")
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _with_status(
+        self,
+        new_status: OrderStatus,
+        event: OrderEvent,
+        **changes,
+    ) -> Order:
+        if not can_transition(self.status, new_status):
+            raise IllegalTransitionError(
+                f"{self.status.value} -> {new_status.value} is not a legal transition "
+                f"(via {type(event).__name__})"
+            )
+        return replace(
+            self,
+            status=new_status,
+            updated_at=event.occurred_at,
+            **changes,
+        )
+
+    def _guard_fill(self, new_filled: Decimal) -> None:
+        if new_filled > self.quantity:
+            raise OverFillError(
+                f"fill would push filled_quantity to {new_filled}, "
+                f"exceeding order quantity {self.quantity}"
+            )
+
+    def _next_avg(self, fill_qty: Decimal, fill_price: Decimal) -> Decimal:
+        """Volume-weighted average fill price after this partial / final fill."""
+        prior_qty = self.filled_quantity
+        prior_avg = self.average_fill_price or Decimal("0")
+        new_qty = prior_qty + fill_qty
+        if new_qty == 0:
+            return Decimal("0")
+        return ((prior_avg * prior_qty) + (fill_price * fill_qty)) / new_qty

--- a/engine/core/oms/states.py
+++ b/engine/core/oms/states.py
@@ -1,0 +1,107 @@
+"""Order vocabulary + lifecycle transitions (gh#111).
+
+Lifecycle
+---------
+Initial state: ``NEW`` (the engine has minted an Order; nothing has
+been told to the broker yet).
+
+Normal flow: ``NEW → SUBMITTED → ACKNOWLEDGED → PARTIALLY_FILLED* → FILLED``.
+Terminal at ``FILLED``, ``CANCELLED``, ``REJECTED``, ``EXPIRED``.
+
+States and transitions are documented as ``VALID_TRANSITIONS`` so
+both the OMS itself *and* monitoring code can validate broker-emitted
+events without re-reading the implementation.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class OrderSide(str, Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+class OrderType(str, Enum):
+    MARKET = "market"
+    LIMIT = "limit"
+    STOP = "stop"
+    STOP_LIMIT = "stop_limit"
+
+
+class OrderStatus(str, Enum):
+    NEW = "new"  # minted in the engine; not yet sent to broker
+    SUBMITTED = "submitted"  # sent to broker, waiting for ack
+    ACKNOWLEDGED = "acknowledged"  # broker accepted; resting on the book
+    PARTIALLY_FILLED = "partially_filled"
+    FILLED = "filled"
+    CANCEL_REQUESTED = "cancel_requested"  # we asked to cancel; awaiting confirmation
+    CANCELLED = "cancelled"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+
+
+_TERMINAL: frozenset[OrderStatus] = frozenset(
+    {OrderStatus.FILLED, OrderStatus.CANCELLED, OrderStatus.REJECTED, OrderStatus.EXPIRED}
+)
+
+
+def is_terminal(status: OrderStatus) -> bool:
+    return status in _TERMINAL
+
+
+# Allowed forward transitions. Reverse transitions are intentionally
+# excluded — once an order has been ``CANCELLED`` it does not become
+# ``ACKNOWLEDGED`` again. If you need to retry, mint a new order.
+VALID_TRANSITIONS: dict[OrderStatus, frozenset[OrderStatus]] = {
+    OrderStatus.NEW: frozenset(
+        {OrderStatus.SUBMITTED, OrderStatus.REJECTED, OrderStatus.CANCELLED}
+    ),
+    OrderStatus.SUBMITTED: frozenset(
+        {
+            OrderStatus.ACKNOWLEDGED,
+            OrderStatus.PARTIALLY_FILLED,
+            OrderStatus.FILLED,
+            OrderStatus.REJECTED,
+            OrderStatus.CANCEL_REQUESTED,
+            OrderStatus.CANCELLED,
+            OrderStatus.EXPIRED,
+        }
+    ),
+    OrderStatus.ACKNOWLEDGED: frozenset(
+        {
+            OrderStatus.PARTIALLY_FILLED,
+            OrderStatus.FILLED,
+            OrderStatus.CANCEL_REQUESTED,
+            OrderStatus.CANCELLED,
+            OrderStatus.EXPIRED,
+            OrderStatus.REJECTED,
+        }
+    ),
+    OrderStatus.PARTIALLY_FILLED: frozenset(
+        {
+            OrderStatus.PARTIALLY_FILLED,  # repeated partial fills
+            OrderStatus.FILLED,
+            OrderStatus.CANCEL_REQUESTED,
+            OrderStatus.CANCELLED,
+            OrderStatus.EXPIRED,
+        }
+    ),
+    OrderStatus.CANCEL_REQUESTED: frozenset(
+        {
+            OrderStatus.CANCELLED,
+            OrderStatus.PARTIALLY_FILLED,  # broker filled before cancel landed
+            OrderStatus.FILLED,            # broker fully filled before cancel landed
+            OrderStatus.REJECTED,          # cancel itself rejected; back in flight
+        }
+    ),
+    OrderStatus.FILLED: frozenset(),
+    OrderStatus.CANCELLED: frozenset(),
+    OrderStatus.REJECTED: frozenset(),
+    OrderStatus.EXPIRED: frozenset(),
+}
+
+
+def can_transition(from_status: OrderStatus, to_status: OrderStatus) -> bool:
+    return to_status in VALID_TRANSITIONS.get(from_status, frozenset())

--- a/tests/test_oms.py
+++ b/tests/test_oms.py
@@ -1,0 +1,308 @@
+"""Unit tests for the OMS state machine (gh#111)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from engine.core.oms import (
+    VALID_TRANSITIONS,
+    AckEvent,
+    CancelEvent,
+    FillEvent,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    PartialFillEvent,
+    RejectEvent,
+    SubmitEvent,
+    is_terminal,
+)
+from engine.core.oms.events import ExpireEvent
+from engine.core.oms.order import IllegalTransitionError, OverFillError
+from engine.core.oms.states import can_transition
+
+
+_T0 = datetime(2026, 5, 3, 12, 0, 0, tzinfo=UTC)
+
+
+def _t(seconds: int) -> datetime:
+    return _T0 + timedelta(seconds=seconds)
+
+
+def _market_buy(qty: str = "10") -> Order:
+    return Order(
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal(qty),
+    )
+
+
+def _limit_buy(qty: str = "10", limit: str = "100") -> Order:
+    return Order(
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        order_type=OrderType.LIMIT,
+        quantity=Decimal(qty),
+        limit_price=Decimal(limit),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Order construction
+# ---------------------------------------------------------------------------
+
+
+class TestOrderConstruction:
+    def test_zero_quantity_rejected(self):
+        with pytest.raises(ValueError):
+            Order(symbol="AAPL", quantity=Decimal("0"), order_type=OrderType.MARKET)
+
+    def test_limit_without_price_rejected(self):
+        with pytest.raises(ValueError):
+            Order(symbol="AAPL", quantity=Decimal("1"), order_type=OrderType.LIMIT)
+
+    def test_stop_without_stop_price_rejected(self):
+        with pytest.raises(ValueError):
+            Order(symbol="AAPL", quantity=Decimal("1"), order_type=OrderType.STOP)
+
+    def test_initial_status_is_new(self):
+        o = _market_buy()
+        assert o.status == OrderStatus.NEW
+        assert o.filled_quantity == Decimal("0")
+        assert o.is_terminal is False
+
+
+# ---------------------------------------------------------------------------
+# Transition table contract
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionTable:
+    def test_terminal_states_are_dead_ends(self):
+        for terminal in (
+            OrderStatus.FILLED,
+            OrderStatus.CANCELLED,
+            OrderStatus.REJECTED,
+            OrderStatus.EXPIRED,
+        ):
+            assert is_terminal(terminal)
+            assert VALID_TRANSITIONS[terminal] == frozenset()
+
+    def test_all_states_present_in_table(self):
+        for s in OrderStatus:
+            assert s in VALID_TRANSITIONS
+
+    def test_can_transition_helper(self):
+        assert can_transition(OrderStatus.NEW, OrderStatus.SUBMITTED)
+        assert not can_transition(OrderStatus.FILLED, OrderStatus.SUBMITTED)
+        assert not can_transition(OrderStatus.CANCELLED, OrderStatus.NEW)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_submit_ack_fully_fill(self):
+        o = _market_buy("10")
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1), broker_order_id="B1"))
+        assert o.status == OrderStatus.SUBMITTED
+        assert o.broker_order_id == "B1"
+
+        o = o.apply_event(AckEvent(occurred_at=_t(2), broker_order_id="B1"))
+        assert o.status == OrderStatus.ACKNOWLEDGED
+
+        o = o.apply_event(
+            FillEvent(
+                occurred_at=_t(3),
+                fill_quantity=Decimal("10"),
+                fill_price=Decimal("100"),
+                fill_id="F1",
+            )
+        )
+        assert o.status == OrderStatus.FILLED
+        assert o.filled_quantity == Decimal("10")
+        assert o.average_fill_price == Decimal("100")
+        assert o.is_terminal
+
+    def test_partial_then_full_fills(self):
+        o = _market_buy("10")
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        o = o.apply_event(AckEvent(occurred_at=_t(2), broker_order_id="B1"))
+        o = o.apply_event(
+            PartialFillEvent(
+                occurred_at=_t(3),
+                fill_quantity=Decimal("4"),
+                fill_price=Decimal("100"),
+                fill_id="F1",
+            )
+        )
+        assert o.status == OrderStatus.PARTIALLY_FILLED
+        assert o.filled_quantity == Decimal("4")
+        assert o.average_fill_price == Decimal("100")
+
+        o = o.apply_event(
+            PartialFillEvent(
+                occurred_at=_t(4),
+                fill_quantity=Decimal("6"),
+                fill_price=Decimal("101"),
+                fill_id="F2",
+            )
+        )
+        assert o.status == OrderStatus.FILLED
+        assert o.filled_quantity == Decimal("10")
+        # VWAP: (4*100 + 6*101) / 10 = 100.6
+        assert o.average_fill_price == Decimal("100.6")
+
+    def test_partial_fill_at_full_quantity_marks_filled(self):
+        o = _market_buy("10")
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        o = o.apply_event(AckEvent(occurred_at=_t(2), broker_order_id="B1"))
+        o = o.apply_event(
+            PartialFillEvent(
+                occurred_at=_t(3),
+                fill_quantity=Decimal("10"),
+                fill_price=Decimal("100"),
+                fill_id="F1",
+            )
+        )
+        # Even though it came as a PartialFillEvent, the quantity reaches
+        # the order total → status becomes FILLED.
+        assert o.status == OrderStatus.FILLED
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+
+class TestCancel:
+    def test_cancel_request_then_confirm(self):
+        o = _limit_buy("10", "100")
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        o = o.apply_event(AckEvent(occurred_at=_t(2), broker_order_id="B1"))
+        o = o.apply_event(CancelEvent(occurred_at=_t(3), requested=True))
+        assert o.status == OrderStatus.CANCEL_REQUESTED
+        o = o.apply_event(CancelEvent(occurred_at=_t(4), requested=False))
+        assert o.status == OrderStatus.CANCELLED
+        assert o.is_terminal
+
+    def test_cancel_lost_race_to_fill(self):
+        # Cancel requested, but broker filled before the cancel landed.
+        o = _limit_buy("10", "100")
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        o = o.apply_event(AckEvent(occurred_at=_t(2), broker_order_id="B1"))
+        o = o.apply_event(CancelEvent(occurred_at=_t(3), requested=True))
+        assert o.status == OrderStatus.CANCEL_REQUESTED
+        o = o.apply_event(
+            FillEvent(
+                occurred_at=_t(4),
+                fill_quantity=Decimal("10"),
+                fill_price=Decimal("100"),
+                fill_id="F1",
+            )
+        )
+        assert o.status == OrderStatus.FILLED
+
+
+# ---------------------------------------------------------------------------
+# Rejection / expiry
+# ---------------------------------------------------------------------------
+
+
+class TestRejectExpire:
+    def test_reject_from_submitted(self):
+        o = _market_buy()
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        o = o.apply_event(RejectEvent(occurred_at=_t(2), reason="insufficient_funds"))
+        assert o.status == OrderStatus.REJECTED
+        assert o.reject_reason == "insufficient_funds"
+        assert o.is_terminal
+
+    def test_expire_from_ack(self):
+        o = _limit_buy()
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        o = o.apply_event(AckEvent(occurred_at=_t(2), broker_order_id="B1"))
+        o = o.apply_event(ExpireEvent(occurred_at=_t(3)))
+        assert o.status == OrderStatus.EXPIRED
+        assert o.is_terminal
+
+
+# ---------------------------------------------------------------------------
+# Illegal transitions / over-fills
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_illegal_transition_raises(self):
+        o = _market_buy()
+        # NEW -> ACKNOWLEDGED is not allowed; must go through SUBMITTED.
+        with pytest.raises(IllegalTransitionError):
+            o.apply_event(AckEvent(occurred_at=_t(1), broker_order_id="B1"))
+
+    def test_terminal_state_rejects_further_events(self):
+        o = _market_buy()
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        o = o.apply_event(
+            FillEvent(
+                occurred_at=_t(2),
+                fill_quantity=Decimal("10"),
+                fill_price=Decimal("100"),
+                fill_id="F1",
+            )
+        )
+        with pytest.raises(IllegalTransitionError):
+            o.apply_event(CancelEvent(occurred_at=_t(3)))
+
+    def test_overfill_raises(self):
+        o = _market_buy("10")
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        with pytest.raises(OverFillError):
+            o.apply_event(
+                PartialFillEvent(
+                    occurred_at=_t(2),
+                    fill_quantity=Decimal("11"),
+                    fill_price=Decimal("100"),
+                    fill_id="F1",
+                )
+            )
+
+    def test_fill_event_must_complete_order(self):
+        o = _market_buy("10")
+        o = o.apply_event(SubmitEvent(occurred_at=_t(1)))
+        # FillEvent for less than the full remaining is rejected — caller
+        # should use PartialFillEvent.
+        with pytest.raises(OverFillError):
+            o.apply_event(
+                FillEvent(
+                    occurred_at=_t(2),
+                    fill_quantity=Decimal("5"),
+                    fill_price=Decimal("100"),
+                    fill_id="F1",
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+class TestImmutability:
+    def test_apply_event_returns_new_order(self):
+        o1 = _market_buy()
+        o2 = o1.apply_event(SubmitEvent(occurred_at=_t(1)))
+        assert o1 is not o2
+        assert o1.status == OrderStatus.NEW
+        assert o2.status == OrderStatus.SUBMITTED
+
+    def test_order_is_frozen(self):
+        o = _market_buy()
+        with pytest.raises(Exception):
+            o.status = OrderStatus.SUBMITTED  # type: ignore[misc]


### PR DESCRIPTION
First slice of OMS. Pure-Python frozen-dataclass Order with apply_event returning new instance. OrderSide/OrderType/OrderStatus enums + VALID_TRANSITIONS table + is_terminal/can_transition helpers. Events: Submit/Ack/PartialFill/Fill/Cancel/Reject/Expire. VWAP fill price. Cancel-lost-race-to-fill supported. IllegalTransition + OverFill errors. 20 passing tests. Refs #111. Broker adapters, live loop driver, persistence projection, risk checks all deferred.