### PR TITLE
feat(live): kill-switch primitive — safety floor for live trading (gh#109 partial)

### DIFF
--- a/engine/core/live/__init__.py
+++ b/engine/core/live/__init__.py
@@ -1,0 +1,15 @@
+"""Live trading primitives (gh#109).
+
+Today this exposes the kill-switch — the safety floor every live
+trading deployment must check before submitting an order. Live-loop
+orchestration, reconciliation, and recovery are tracked as follow-ups
+under the same issue and consume this primitive.
+"""
+
+from engine.core.live.kill_switch import (
+    KillSwitch,
+    KillSwitchState,
+    get_kill_switch,
+)
+
+__all__ = ["KillSwitch", "KillSwitchState", "get_kill_switch"]

--- a/engine/core/live/kill_switch.py
+++ b/engine/core/live/kill_switch.py
@@ -1,0 +1,231 @@
+"""Live trading kill-switch (gh#109).
+
+The kill-switch is the safety floor: any code path that submits an
+order to a broker must check it first. When engaged, the engine must
+stop generating new orders, attempt to cancel resting orders, and
+emit a structured event that surfaces in the runbooks.
+
+Design choices
+--------------
+- One process-singleton :func:`get_kill_switch` so domain code and
+  routes get the same view without threading the instance through
+  the DI graph.
+- :meth:`engage` is *idempotent* — calling it twice with the same
+  reason is a no-op. This matches operator behaviour ("smash the
+  red button" should not race with itself).
+- :meth:`disengage` requires an explicit ``confirmation`` token so
+  that an accidental call doesn't restart trading. The token is
+  documented in the runbook.
+- Observers are notified on every transition. Failures inside an
+  observer are logged but do not block the transition — the switch
+  must always work, even if downstream notification breaks.
+
+What's *not* here (explicit follow-ups):
+- Persistence — the switch does not survive a restart. The live
+  trading loop should re-read its state from a known-good source
+  on boot (config, DB, or a heartbeat row).
+- Auto-engage triggers (max-loss, drawdown, broker-disconnect).
+  Those policies belong in the live-trading orchestration loop and
+  call :meth:`engage` when their thresholds trip.
+- Per-strategy / per-symbol gates. Today's switch is global; future
+  work can add a hierarchical version backed by the same primitive.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+# Documented disengage token. Operators are expected to type this
+# explicitly so a stray script can't toggle the switch off.
+_DISENGAGE_TOKEN: str = "I_UNDERSTAND_THE_RISK"
+
+
+class KillSwitchState(str, Enum):
+    DISENGAGED = "disengaged"  # trading allowed
+    ENGAGED = "engaged"        # trading blocked
+
+
+@dataclass(frozen=True)
+class KillSwitchSnapshot:
+    """Read-only view of the switch — useful for logs / API responses."""
+
+    state: KillSwitchState
+    engaged_at: datetime | None
+    reason: str | None
+    actor: str | None
+
+
+Observer = Callable[[KillSwitchSnapshot], None]
+
+
+class KillSwitchError(Exception):
+    """Raised on disengage attempts without the proper confirmation."""
+
+
+class KillSwitch:
+    """Process-wide on/off switch for live order submission."""
+
+    def __init__(self) -> None:
+        self._state = KillSwitchState.DISENGAGED
+        self._engaged_at: datetime | None = None
+        self._reason: str | None = None
+        self._actor: str | None = None
+        self._lock = threading.Lock()
+        self._observers: list[Observer] = []
+
+    # ------------------------------------------------------------------
+    # State
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> KillSwitchState:
+        return self._state
+
+    def is_engaged(self) -> bool:
+        return self._state == KillSwitchState.ENGAGED
+
+    def snapshot(self) -> KillSwitchSnapshot:
+        with self._lock:
+            return KillSwitchSnapshot(
+                state=self._state,
+                engaged_at=self._engaged_at,
+                reason=self._reason,
+                actor=self._actor,
+            )
+
+    # ------------------------------------------------------------------
+    # Transitions
+    # ------------------------------------------------------------------
+
+    def engage(self, *, reason: str, actor: str = "system") -> bool:
+        """Engage the switch. Returns True if state changed.
+
+        Idempotent: a second call with no state change returns False
+        and does not bump the engaged_at timestamp.
+        """
+        if not reason or not reason.strip():
+            raise ValueError("kill-switch engage requires a non-empty reason")
+        with self._lock:
+            if self._state == KillSwitchState.ENGAGED:
+                logger.warning(
+                    "kill_switch.engage_noop",
+                    existing_reason=self._reason,
+                    new_reason=reason,
+                    actor=actor,
+                )
+                return False
+            self._state = KillSwitchState.ENGAGED
+            self._engaged_at = datetime.now(tz=UTC)
+            self._reason = reason
+            self._actor = actor
+            snap = KillSwitchSnapshot(
+                state=self._state,
+                engaged_at=self._engaged_at,
+                reason=self._reason,
+                actor=self._actor,
+            )
+        logger.error(
+            "kill_switch.engaged",
+            reason=reason,
+            actor=actor,
+            engaged_at=snap.engaged_at.isoformat() if snap.engaged_at else None,
+        )
+        self._notify(snap)
+        return True
+
+    def disengage(self, *, confirmation: str, actor: str = "operator") -> bool:
+        """Disengage the switch. Returns True if state changed.
+
+        Requires ``confirmation == _DISENGAGE_TOKEN``. The token is
+        deliberately wordy and documented in the runbook so an
+        accidental call cannot restart trading.
+        """
+        if confirmation != _DISENGAGE_TOKEN:
+            raise KillSwitchError(
+                "disengage requires confirmation token "
+                f"{_DISENGAGE_TOKEN!r} (see runbook)"
+            )
+        with self._lock:
+            if self._state == KillSwitchState.DISENGAGED:
+                return False
+            prior_reason = self._reason
+            self._state = KillSwitchState.DISENGAGED
+            self._engaged_at = None
+            self._reason = None
+            self._actor = actor
+            snap = KillSwitchSnapshot(
+                state=self._state,
+                engaged_at=self._engaged_at,
+                reason=self._reason,
+                actor=self._actor,
+            )
+        logger.warning(
+            "kill_switch.disengaged",
+            actor=actor,
+            prior_reason=prior_reason,
+        )
+        self._notify(snap)
+        return True
+
+    # ------------------------------------------------------------------
+    # Observers
+    # ------------------------------------------------------------------
+
+    def add_observer(self, observer: Observer) -> None:
+        with self._lock:
+            self._observers.append(observer)
+
+    def remove_observer(self, observer: Observer) -> None:
+        with self._lock:
+            try:
+                self._observers.remove(observer)
+            except ValueError:
+                pass
+
+    def _notify(self, snap: KillSwitchSnapshot) -> None:
+        with self._lock:
+            observers = list(self._observers)
+        for obs in observers:
+            try:
+                obs(snap)
+            except Exception as exc:  # noqa: BLE001 - observer is untrusted
+                logger.warning(
+                    "kill_switch.observer_failed",
+                    observer=getattr(obs, "__name__", repr(obs)),
+                    error_type=type(exc).__name__,
+                    error_message=str(exc)[:200],
+                )
+
+
+# ---------------------------------------------------------------------------
+# Process singleton
+# ---------------------------------------------------------------------------
+
+
+_INSTANCE: KillSwitch | None = None
+_INSTANCE_LOCK = threading.Lock()
+
+
+def get_kill_switch() -> KillSwitch:
+    global _INSTANCE  # noqa: PLW0603 - process-wide singleton
+    if _INSTANCE is None:
+        with _INSTANCE_LOCK:
+            if _INSTANCE is None:
+                _INSTANCE = KillSwitch()
+    return _INSTANCE
+
+
+def _reset_for_tests() -> None:
+    """Test-only: clear the singleton so each test starts fresh."""
+    global _INSTANCE  # noqa: PLW0603
+    with _INSTANCE_LOCK:
+        _INSTANCE = None

--- a/tests/test_kill_switch.py
+++ b/tests/test_kill_switch.py
@@ -1,0 +1,168 @@
+"""Unit tests for the live-trading kill-switch (gh#109)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.live import KillSwitch, KillSwitchState, get_kill_switch
+from engine.core.live.kill_switch import (
+    _DISENGAGE_TOKEN,
+    KillSwitchError,
+    _reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestInitial:
+    def test_starts_disengaged(self):
+        ks = KillSwitch()
+        assert ks.state == KillSwitchState.DISENGAGED
+        assert ks.is_engaged() is False
+        snap = ks.snapshot()
+        assert snap.engaged_at is None
+        assert snap.reason is None
+        assert snap.actor is None
+
+
+# ---------------------------------------------------------------------------
+# Engage
+# ---------------------------------------------------------------------------
+
+
+class TestEngage:
+    def test_engage_changes_state(self):
+        ks = KillSwitch()
+        changed = ks.engage(reason="test", actor="sysop")
+        assert changed is True
+        assert ks.is_engaged()
+        snap = ks.snapshot()
+        assert snap.reason == "test"
+        assert snap.actor == "sysop"
+        assert snap.engaged_at is not None
+
+    def test_engage_is_idempotent(self):
+        ks = KillSwitch()
+        ks.engage(reason="first")
+        first_snap = ks.snapshot()
+        changed = ks.engage(reason="second")
+        assert changed is False
+        # State unchanged: original reason + timestamp preserved.
+        snap = ks.snapshot()
+        assert snap.reason == "first"
+        assert snap.engaged_at == first_snap.engaged_at
+
+    def test_engage_requires_reason(self):
+        ks = KillSwitch()
+        with pytest.raises(ValueError):
+            ks.engage(reason="")
+        with pytest.raises(ValueError):
+            ks.engage(reason="   ")
+
+
+# ---------------------------------------------------------------------------
+# Disengage
+# ---------------------------------------------------------------------------
+
+
+class TestDisengage:
+    def test_disengage_with_token(self):
+        ks = KillSwitch()
+        ks.engage(reason="test")
+        changed = ks.disengage(confirmation=_DISENGAGE_TOKEN)
+        assert changed is True
+        assert ks.is_engaged() is False
+        snap = ks.snapshot()
+        assert snap.reason is None
+        assert snap.engaged_at is None
+
+    def test_disengage_without_token_raises(self):
+        ks = KillSwitch()
+        ks.engage(reason="test")
+        with pytest.raises(KillSwitchError):
+            ks.disengage(confirmation="please")
+        # Switch still engaged.
+        assert ks.is_engaged()
+
+    def test_disengage_when_already_disengaged_is_noop(self):
+        ks = KillSwitch()
+        changed = ks.disengage(confirmation=_DISENGAGE_TOKEN)
+        assert changed is False
+
+
+# ---------------------------------------------------------------------------
+# Observers
+# ---------------------------------------------------------------------------
+
+
+class TestObservers:
+    def test_observer_called_on_engage_and_disengage(self):
+        ks = KillSwitch()
+        events: list[KillSwitchState] = []
+
+        def cb(snap):
+            events.append(snap.state)
+
+        ks.add_observer(cb)
+        ks.engage(reason="test")
+        ks.disengage(confirmation=_DISENGAGE_TOKEN)
+        assert events == [KillSwitchState.ENGAGED, KillSwitchState.DISENGAGED]
+
+    def test_observer_failure_does_not_block_transition(self):
+        ks = KillSwitch()
+
+        def angry(snap):
+            raise RuntimeError("nope")
+
+        ks.add_observer(angry)
+        # The transition still completes despite the observer raising.
+        assert ks.engage(reason="test") is True
+        assert ks.is_engaged()
+
+    def test_remove_observer(self):
+        ks = KillSwitch()
+        seen: list = []
+
+        def cb(snap):
+            seen.append(snap)
+
+        ks.add_observer(cb)
+        ks.remove_observer(cb)
+        ks.engage(reason="test")
+        assert seen == []
+
+    def test_idempotent_engage_does_not_notify(self):
+        ks = KillSwitch()
+        seen: list = []
+        ks.add_observer(seen.append)
+        ks.engage(reason="first")
+        ks.engage(reason="second")  # no-op
+        assert len(seen) == 1
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    def test_get_kill_switch_idempotent(self):
+        a = get_kill_switch()
+        b = get_kill_switch()
+        assert a is b
+
+    def test_singleton_state_persists_across_calls(self):
+        a = get_kill_switch()
+        a.engage(reason="boom")
+        b = get_kill_switch()
+        assert b.is_engaged()


### PR DESCRIPTION
Foundation slice of live-trading orchestration. Process-wide thread-safe KillSwitch with engage/disengage/snapshot/observers. Idempotent engage. disengage requires explicit 'I_UNDERSTAND_THE_RISK' token. Observer failures don't block state transitions. Singleton accessor. 13 passing tests. Refs #109. Persistence, auto-engage triggers, per-strategy gates, full orchestration loop with reconciliation/recovery all deferred.