### PR TITLE
feat(tax): pluggable tax-jurisdiction engine + US default (gh#81 partial)

### DIFF
--- a/engine/core/tax/jurisdictions/__init__.py
+++ b/engine/core/tax/jurisdictions/__init__.py
@@ -1,0 +1,41 @@
+"""Configurable tax jurisdictions (gh#81).
+
+A *jurisdiction* is the set of rules a country (or a sub-region of
+one) applies to capital-gains accounting. Each jurisdiction declares:
+
+- Lot-selection method (FIFO, LIFO, average cost, …).
+- Long-term holding-period boundary (in days).
+- Wash-sale window (in days, or 0 if the rule does not apply).
+- Currency.
+
+The :class:`TaxJurisdiction` Protocol pins the contract; the
+registry lets operators register their own implementations under a
+stable string key and look one up at runtime via configuration.
+
+Out of scope (explicit follow-ups):
+- Per-jurisdiction report generators (1099-B already lives in
+  :mod:`engine.core.tax.reports`; MiFID II / HMRC CGT / KESt are
+  tracked under gh#155).
+- Per-jurisdiction wash-sale variants. Today the detector at
+  :mod:`engine.core.tax.wash_sale` is US-shaped; non-US
+  jurisdictions can ignore it by setting wash_sale_window_days = 0.
+- Mark-to-market regimes (Section 1256, KESt §32d).
+- Income-vs-capital classification heuristics.
+"""
+
+from engine.core.tax.jurisdictions.base import LotMethod, TaxJurisdiction
+from engine.core.tax.jurisdictions.registry import (
+    get_jurisdiction,
+    list_jurisdictions,
+    register_jurisdiction,
+)
+from engine.core.tax.jurisdictions.us import UnitedStates
+
+__all__ = [
+    "LotMethod",
+    "TaxJurisdiction",
+    "UnitedStates",
+    "get_jurisdiction",
+    "list_jurisdictions",
+    "register_jurisdiction",
+]

--- a/engine/core/tax/jurisdictions/base.py
+++ b/engine/core/tax/jurisdictions/base.py
@@ -1,0 +1,78 @@
+"""Tax-jurisdiction Protocol + supporting enums (gh#81)."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+
+class LotMethod(str, Enum):
+    """Lot-selection method (which lot does a sale consume?).
+
+    - FIFO: oldest lot first. US default.
+    - LIFO: newest lot first. Permitted in some jurisdictions.
+    - HIFO: highest-cost first. Permitted as "specific identification" in
+      the US when the broker / operator can substantiate the choice.
+    - AVERAGE_COST: weighted-average per security. Required for some
+      mutual-fund-only accounts; permitted in many EU jurisdictions.
+    - SPECIFIC_ID: caller picks the lot per disposition.
+    """
+
+    FIFO = "fifo"
+    LIFO = "lifo"
+    HIFO = "hifo"
+    AVERAGE_COST = "average_cost"
+    SPECIFIC_ID = "specific_id"
+
+
+@runtime_checkable
+class TaxJurisdiction(Protocol):
+    """Contract every jurisdiction implements.
+
+    The Protocol is intentionally narrow — it only carries the
+    *configurable* knobs the rest of the engine reads. Computation
+    lives in the modules that consume the jurisdiction
+    (``wash_sale.py``, ``reports/form_1099b.py``, …) so the same
+    jurisdiction record can be persisted, serialised, or swapped at
+    runtime without re-shaping its API.
+    """
+
+    @property
+    def code(self) -> str:
+        """ISO 3166-1 alpha-2 code (e.g. ``"US"``, ``"GB"``, ``"DE"``).
+
+        Sub-regions append a hyphen and the ISO 3166-2 sub-code
+        (e.g. ``"US-CA"`` for California-specific overrides).
+        """
+        ...
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable name."""
+        ...
+
+    @property
+    def currency(self) -> str:
+        """ISO 4217 currency code (e.g. ``"USD"``, ``"EUR"``)."""
+        ...
+
+    @property
+    def long_term_days(self) -> int:
+        """Holding-period boundary for long-term treatment (days)."""
+        ...
+
+    @property
+    def wash_sale_window_days(self) -> int:
+        """Wash-sale window in days; ``0`` if the rule does not apply."""
+        ...
+
+    @property
+    def default_lot_method(self) -> LotMethod:
+        """Lot-selection method applied when the operator hasn't
+        explicitly specified one for a given account."""
+        ...
+
+    @property
+    def allowed_lot_methods(self) -> frozenset[LotMethod]:
+        """Lot-selection methods this jurisdiction permits."""
+        ...

--- a/engine/core/tax/jurisdictions/registry.py
+++ b/engine/core/tax/jurisdictions/registry.py
@@ -1,0 +1,59 @@
+"""Tax-jurisdiction registry (gh#81).
+
+Operators register a :class:`TaxJurisdiction` implementation under a
+stable string key (typically the ISO code) and look one up at runtime
+via configuration. Replaces hard-coded references to a single
+jurisdiction throughout the engine.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from engine.core.tax.jurisdictions.base import TaxJurisdiction
+
+_REGISTRY: dict[str, TaxJurisdiction] = {}
+_LOCK = threading.Lock()
+
+
+def register_jurisdiction(jurisdiction: TaxJurisdiction) -> None:
+    """Register ``jurisdiction`` under its own ``code``.
+
+    Re-registering an existing code overwrites the prior entry. That
+    is intentional — operators may want to tweak a built-in
+    jurisdiction at startup without subclassing.
+    """
+    if not isinstance(jurisdiction, TaxJurisdiction):
+        raise TypeError(
+            "argument must implement TaxJurisdiction Protocol "
+            f"(got {type(jurisdiction).__name__})"
+        )
+    code = jurisdiction.code
+    if not code or not code.strip():
+        raise ValueError("jurisdiction code must be non-empty")
+    with _LOCK:
+        _REGISTRY[code] = jurisdiction
+
+
+def get_jurisdiction(code: str) -> TaxJurisdiction:
+    """Look up a jurisdiction by code. Raises :class:`KeyError` if absent."""
+    with _LOCK:
+        try:
+            return _REGISTRY[code]
+        except KeyError as exc:
+            raise KeyError(
+                f"unknown tax jurisdiction: {code!r}. "
+                f"registered: {sorted(_REGISTRY.keys())}"
+            ) from exc
+
+
+def list_jurisdictions() -> list[str]:
+    """Return registered jurisdiction codes, sorted."""
+    with _LOCK:
+        return sorted(_REGISTRY.keys())
+
+
+def _reset_for_tests() -> None:
+    """Test-only: clear the registry so each test starts fresh."""
+    with _LOCK:
+        _REGISTRY.clear()

--- a/engine/core/tax/jurisdictions/us.py
+++ b/engine/core/tax/jurisdictions/us.py
@@ -1,0 +1,43 @@
+"""United States tax jurisdiction (gh#81).
+
+Sources of truth:
+- 26 U.S.C. § 1222 (long-term boundary: more than 1 year held).
+- 26 U.S.C. § 1091 (wash-sale window: ±30 days around loss sale).
+- IRS Pub. 550, "Investment Income and Expenses" (lot-selection
+  defaults; default is FIFO when the broker / operator hasn't
+  documented specific identification).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from engine.core.tax.jurisdictions.base import LotMethod
+
+
+@dataclass(frozen=True)
+class UnitedStates:
+    """US federal tax-jurisdiction record.
+
+    Duck-typed against the :class:`TaxJurisdiction` Protocol.
+    Operator overrides for specific accounts (e.g. mutual-fund-only
+    accounts that mandate average cost) live on the account, not on
+    the jurisdiction.
+    """
+
+    code: str = "US"
+    display_name: str = "United States"
+    currency: str = "USD"
+    long_term_days: int = 365
+    wash_sale_window_days: int = 30
+    default_lot_method: LotMethod = LotMethod.FIFO
+    allowed_lot_methods: frozenset[LotMethod] = field(
+        default_factory=lambda: frozenset(
+            {
+                LotMethod.FIFO,
+                LotMethod.HIFO,
+                LotMethod.SPECIFIC_ID,
+                LotMethod.AVERAGE_COST,  # mutual-fund-only accounts
+            }
+        )
+    )

--- a/tests/test_jurisdictions.py
+++ b/tests/test_jurisdictions.py
@@ -1,0 +1,128 @@
+"""Unit tests for the tax-jurisdiction engine (gh#81)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from engine.core.tax.jurisdictions import (
+    LotMethod,
+    TaxJurisdiction,
+    UnitedStates,
+    get_jurisdiction,
+    list_jurisdictions,
+    register_jurisdiction,
+)
+from engine.core.tax.jurisdictions.registry import _reset_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make(code_value: str, name: str) -> TaxJurisdiction:
+    @dataclass(frozen=True)
+    class _J:
+        code: str = code_value
+        display_name: str = name
+        currency: str = "EUR"
+        long_term_days: int = 365
+        wash_sale_window_days: int = 0
+        default_lot_method: LotMethod = LotMethod.FIFO
+        allowed_lot_methods: frozenset[LotMethod] = field(
+            default_factory=lambda: frozenset({LotMethod.FIFO, LotMethod.AVERAGE_COST})
+        )
+
+    return _J()
+
+
+# ---------------------------------------------------------------------------
+# UnitedStates record
+# ---------------------------------------------------------------------------
+
+
+class TestUnitedStates:
+    def test_protocol_compatible(self):
+        us = UnitedStates()
+        assert isinstance(us, TaxJurisdiction)
+
+    def test_default_values(self):
+        us = UnitedStates()
+        assert us.code == "US"
+        assert us.currency == "USD"
+        assert us.long_term_days == 365
+        assert us.wash_sale_window_days == 30
+        assert us.default_lot_method == LotMethod.FIFO
+
+    def test_default_lot_method_in_allowed_set(self):
+        us = UnitedStates()
+        assert us.default_lot_method in us.allowed_lot_methods
+
+    def test_lifo_not_allowed(self):
+        # IRS Pub. 550 — LIFO is not a permitted default for non-mutual-fund
+        # securities accounts. The model reflects that.
+        us = UnitedStates()
+        assert LotMethod.LIFO not in us.allowed_lot_methods
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_register_and_lookup(self):
+        us = UnitedStates()
+        register_jurisdiction(us)
+        assert get_jurisdiction("US") is us
+
+    def test_lookup_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_jurisdiction("ZZ")
+
+    def test_list_returns_sorted(self):
+        register_jurisdiction(UnitedStates())
+        register_jurisdiction(_make("GB", "United Kingdom"))
+        register_jurisdiction(_make("DE", "Germany"))
+        assert list_jurisdictions() == ["DE", "GB", "US"]
+
+    def test_re_register_overwrites(self):
+        register_jurisdiction(UnitedStates(long_term_days=999))
+        register_jurisdiction(UnitedStates())
+        assert get_jurisdiction("US").long_term_days == 365
+
+    def test_register_rejects_non_protocol(self):
+        with pytest.raises(TypeError):
+            register_jurisdiction("not-a-jurisdiction")  # type: ignore[arg-type]
+
+    def test_register_rejects_empty_code(self):
+        bad = _make("", "Empty code")
+        with pytest.raises(ValueError):
+            register_jurisdiction(bad)
+
+
+# ---------------------------------------------------------------------------
+# Protocol contract
+# ---------------------------------------------------------------------------
+
+
+class TestProtocol:
+    def test_custom_implementation_satisfies_protocol(self):
+        custom = _make("FR", "France")
+        assert isinstance(custom, TaxJurisdiction)
+
+    def test_missing_field_does_not_satisfy_protocol(self):
+        @dataclass(frozen=True)
+        class Incomplete:
+            code: str = "XX"
+
+        assert not isinstance(Incomplete(), TaxJurisdiction)


### PR DESCRIPTION
Foundation for multi-jurisdiction tax accounting. LotMethod enum (FIFO/LIFO/HIFO/AVERAGE_COST/SPECIFIC_ID) + runtime-checkable TaxJurisdiction Protocol + thread-safe registry + UnitedStates dataclass (Section 1222 long-term, Section 1091 wash-sale, FIFO default, LIFO excluded per IRS Pub. 550). 12 passing tests. Refs #81. Other jurisdictions (GB/DE/FR), sub-region overrides, mark-to-market regimes, per-jurisdiction report generators all deferred.