### PR TITLE
feat(ws): EventBus → ConnectionManager bridge (gh#7 follow-up)

### DIFF
--- a/engine/api/websocket/bridge.py
+++ b/engine/api/websocket/bridge.py
@@ -1,0 +1,167 @@
+"""EventBus → ConnectionManager bridge (gh#7 follow-up).
+
+Subscribes to domain events on the engine's :class:`EventBus` and
+forwards them to the per-user :class:`ConnectionManager` that backs
+the WebSocket route. The bridge maps an :class:`EventType` to a
+:class:`Topic` and a per-event ``user_id`` so each connection only
+sees the events it asked for *and* is entitled to.
+
+Routing rules
+-------------
+- ``order.*``        → Topic.ORDER       — requires ``user_id`` in event data.
+- ``portfolio.*``    → Topic.PORTFOLIO   — requires ``user_id`` in event data.
+- ``backtest.*``     → Topic.BACKTEST    — requires ``user_id`` in event data.
+- ``alert.*``        → Topic.ALERT       — requires ``user_id`` in event data.
+
+Events without a ``user_id`` are dropped at the bridge with a warning;
+they likely belong on a system-wide channel that ``Topic`` does not
+yet model. Adding one is a follow-up.
+
+Single-process today
+--------------------
+The bridge is in-process. Multi-replica fan-out (Redis pubsub) lives
+under the same gh#7 follow-up tracker as the manager itself.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from engine.api.websocket.manager import Topic
+
+if TYPE_CHECKING:
+    from engine.api.websocket.manager import ConnectionManager
+    from engine.events.bus import EventBus, EventType
+
+
+logger = structlog.get_logger()
+
+
+# Prefix-based mapping. The first matching prefix wins.
+_PREFIX_MAP: tuple[tuple[str, Topic], ...] = (
+    ("order.", Topic.ORDER),
+    ("portfolio.", Topic.PORTFOLIO),
+    ("backtest.", Topic.BACKTEST),
+    ("alert.", Topic.ALERT),
+)
+
+
+def topic_for_event_type(event_type: str | EventType) -> Topic | None:
+    """Return the :class:`Topic` an event type maps to, or ``None``.
+
+    ``None`` means the bridge does not route this event type. The
+    caller logs and drops it.
+    """
+    raw = event_type.value if hasattr(event_type, "value") else str(event_type)
+    for prefix, topic in _PREFIX_MAP:
+        if raw.startswith(prefix):
+            return topic
+    return None
+
+
+def extract_user_id(event_data: dict[str, Any] | None) -> uuid.UUID | None:
+    """Pull the addressee user_id from an event's ``data`` dict.
+
+    Accepts both ``"user_id"`` and ``"userId"`` for forward-
+    compatibility with frontends that pre-camelCase. Returns ``None``
+    if the value is missing or unparseable.
+    """
+    if not event_data:
+        return None
+    raw = event_data.get("user_id") or event_data.get("userId")
+    if raw is None:
+        return None
+    if isinstance(raw, uuid.UUID):
+        return raw
+    try:
+        return uuid.UUID(str(raw))
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+class EventToWebSocketBridge:
+    """Subscribes to an :class:`EventBus` and broadcasts to a
+    :class:`ConnectionManager`.
+
+    The bridge does not own the bus or the manager — it just wires
+    them. Lifespan management (start/stop) is the caller's job.
+    """
+
+    def __init__(
+        self,
+        *,
+        bus: EventBus,
+        manager: ConnectionManager,
+    ) -> None:
+        self._bus = bus
+        self._manager = manager
+        self._registered: list[EventType] = []
+        # Cache the bound method once. Each access of ``self._handle`` is
+        # a fresh wrapper object, so subscribe/unsubscribe must use the
+        # same reference for the bus's identity-based bookkeeping.
+        self._handler = self._handle
+
+    def attach(self, event_types: list[EventType]) -> None:
+        """Subscribe ``handler`` to each ``EventType`` on the bus."""
+        for et in event_types:
+            self._bus.subscribe(et, self._handler)
+            self._registered.append(et)
+
+    def detach(self) -> None:
+        """Unsubscribe from every event type previously attached."""
+        for et in self._registered:
+            try:
+                self._bus.unsubscribe(et, self._handler)
+            except Exception as exc:  # noqa: BLE001 - bus may not own state
+                logger.warning(
+                    "ws_bridge.unsubscribe_failed",
+                    event_type=getattr(et, "value", str(et)),
+                    error_type=type(exc).__name__,
+                    error_message=str(exc)[:200],
+                )
+        self._registered.clear()
+
+    async def _handle(self, payload: dict[str, Any]) -> None:
+        """Single bus-handler entry point.
+
+        ``payload`` is the dict produced by ``Event.to_dict()`` — it
+        carries ``event_type``, ``data``, ``source``, ``timestamp``.
+        """
+        et_raw = payload.get("event_type") or payload.get("type")
+        if not et_raw:
+            logger.warning("ws_bridge.event_missing_type", payload_keys=list(payload.keys()))
+            return
+        topic = topic_for_event_type(et_raw)
+        if topic is None:
+            logger.debug("ws_bridge.event_unrouted", event_type=et_raw)
+            return
+        user_id = extract_user_id(payload.get("data"))
+        if user_id is None:
+            logger.warning(
+                "ws_bridge.event_no_user_id",
+                event_type=et_raw,
+                data_keys=list((payload.get("data") or {}).keys()),
+            )
+            return
+        recipients = await self._manager.broadcast(
+            user_id=user_id,
+            topic=topic.value,
+            payload=payload,
+        )
+        logger.debug(
+            "ws_bridge.broadcast",
+            event_type=et_raw,
+            topic=topic.value,
+            user_id=str(user_id),
+            recipients=recipients,
+        )
+
+
+__all__ = [
+    "EventToWebSocketBridge",
+    "extract_user_id",
+    "topic_for_event_type",
+]

--- a/tests/test_ws_bridge.py
+++ b/tests/test_ws_bridge.py
@@ -1,0 +1,194 @@
+"""Unit tests for the EventBus → ConnectionManager bridge (gh#7 follow-up)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from engine.api.websocket.bridge import (
+    EventToWebSocketBridge,
+    extract_user_id,
+    topic_for_event_type,
+)
+from engine.api.websocket.manager import ConnectionManager, Topic
+
+
+# ---------------------------------------------------------------------------
+# topic_for_event_type
+# ---------------------------------------------------------------------------
+
+
+class TestTopicMapping:
+    def test_order_prefix(self):
+        assert topic_for_event_type("order.created") == Topic.ORDER
+        assert topic_for_event_type("order.filled") == Topic.ORDER
+
+    def test_portfolio_prefix(self):
+        assert topic_for_event_type("portfolio.updated") == Topic.PORTFOLIO
+
+    def test_backtest_prefix(self):
+        assert topic_for_event_type("backtest.completed") == Topic.BACKTEST
+
+    def test_alert_prefix(self):
+        assert topic_for_event_type("alert.triggered") == Topic.ALERT
+
+    def test_unknown_prefix_returns_none(self):
+        assert topic_for_event_type("system.heartbeat") is None
+        assert topic_for_event_type("") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_user_id
+# ---------------------------------------------------------------------------
+
+
+class TestExtractUserId:
+    def test_snake_case(self):
+        u = uuid.uuid4()
+        assert extract_user_id({"user_id": str(u)}) == u
+
+    def test_camel_case(self):
+        u = uuid.uuid4()
+        assert extract_user_id({"userId": str(u)}) == u
+
+    def test_uuid_object_passes_through(self):
+        u = uuid.uuid4()
+        assert extract_user_id({"user_id": u}) == u
+
+    def test_missing_returns_none(self):
+        assert extract_user_id({}) is None
+        assert extract_user_id(None) is None
+
+    def test_unparseable_returns_none(self):
+        assert extract_user_id({"user_id": "not-a-uuid"}) is None
+        assert extract_user_id({"user_id": 123}) is None
+
+
+# ---------------------------------------------------------------------------
+# Bridge integration with a fake bus
+# ---------------------------------------------------------------------------
+
+
+class _FakeBus:
+    """Stand-in for the real EventBus.
+
+    Only models the subscribe / unsubscribe surface the bridge uses.
+    Tests can call ``deliver`` to simulate the bus delivering a payload.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict = {}
+
+    def subscribe(self, event_type, handler) -> None:
+        self._handlers.setdefault(event_type, []).append(handler)
+
+    def unsubscribe(self, event_type, handler) -> None:
+        if event_type in self._handlers:
+            self._handlers[event_type] = [
+                h for h in self._handlers[event_type] if h is not handler
+            ]
+
+    async def deliver(self, event_type, payload) -> None:
+        for h in self._handlers.get(event_type, []):
+            await h(payload)
+
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.id = uuid.uuid4()
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeWS) and other.id == self.id
+
+
+@pytest.fixture
+async def setup():
+    bus = _FakeBus()
+    manager = ConnectionManager()
+    bridge = EventToWebSocketBridge(bus=bus, manager=manager)
+    bridge.attach(["order.filled", "portfolio.updated"])
+    return bus, manager, bridge
+
+
+class TestBridge:
+    async def test_delivers_to_subscribed_user(self, setup):
+        bus, manager, bridge = setup
+        user_id = uuid.uuid4()
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        await manager.subscribe(user_id, ws, ["order"])
+
+        await bus.deliver(
+            "order.filled",
+            {
+                "event_type": "order.filled",
+                "data": {"user_id": str(user_id), "qty": 10},
+            },
+        )
+        assert len(ws.sent) == 1
+        assert ws.sent[0]["topic"] == "order"
+        assert ws.sent[0]["data"]["event_type"] == "order.filled"
+
+    async def test_drops_event_without_user_id(self, setup):
+        bus, manager, bridge = setup
+        user_id = uuid.uuid4()
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        await manager.subscribe(user_id, ws, ["order"])
+
+        await bus.deliver(
+            "order.filled",
+            {"event_type": "order.filled", "data": {"qty": 10}},
+        )
+        assert ws.sent == []
+
+    async def test_drops_unrouted_event(self, setup):
+        bus, manager, bridge = setup
+        user_id = uuid.uuid4()
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        await manager.subscribe(user_id, ws, ["order"])
+
+        # Bridge is attached only to order.filled / portfolio.updated;
+        # delivering a different type via the bus does nothing.
+        await bus.deliver(
+            "system.heartbeat",
+            {"event_type": "system.heartbeat", "data": {"user_id": str(user_id)}},
+        )
+        assert ws.sent == []
+
+    async def test_only_subscribed_topic_receives(self, setup):
+        bus, manager, bridge = setup
+        user_id = uuid.uuid4()
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        # Subscribed to portfolio, not order.
+        await manager.subscribe(user_id, ws, ["portfolio"])
+
+        await bus.deliver(
+            "order.filled",
+            {"event_type": "order.filled", "data": {"user_id": str(user_id)}},
+        )
+        assert ws.sent == []
+
+    async def test_detach_unsubscribes(self, setup):
+        bus, manager, bridge = setup
+        user_id = uuid.uuid4()
+        ws = _FakeWS()
+        await manager.attach(user_id, ws)
+        await manager.subscribe(user_id, ws, ["order"])
+
+        bridge.detach()
+        await bus.deliver(
+            "order.filled",
+            {"event_type": "order.filled", "data": {"user_id": str(user_id)}},
+        )
+        assert ws.sent == []


### PR DESCRIPTION
Closes the explicit follow-up from PR #280. EventToWebSocketBridge subscribes to EventTypes on the bus and forwards delivered payloads to per-user ConnectionManager broadcasts. topic_for_event_type prefix-mapper (order./portfolio./backtest./alert.). extract_user_id from snake_case or camelCase. Events without user_id or unrouted prefix are dropped + logged. Caches bound-method handle so subscribe/unsubscribe see same reference. 15 passing tests. Refs #7. Multi-replica pubsub still deferred.