### PR TITLE
feat(oms): pre-flight risk checks — kill-switch + qty + notional gates (gh#111 follow-up)

### DIFF
--- a/engine/core/oms/risk.py
+++ b/engine/core/oms/risk.py
@@ -1,0 +1,193 @@
+"""OMS pre-flight risk checks (gh#111 follow-up).
+
+A :class:`RiskGate` runs an ordered list of :class:`RiskCheck`
+implementations against an :class:`Order` *before* the OMS submits
+it to a broker. Any check that returns :class:`Reject` short-
+circuits the gate; the OMS must then transition the order via
+:class:`engine.core.oms.events.RejectEvent`.
+
+Why pre-flight
+--------------
+The state machine in :mod:`engine.core.oms.order` is correct but it
+trusts every event it sees. Risk policy is a separate concern:
+"would I send this thing to the broker at all?". Keeping it in its
+own module keeps the state machine pure and lets operators compose
+their own check chain at startup.
+
+Built-in checks
+---------------
+- :class:`KillSwitchCheck` — refuses to submit when the global
+  :func:`engine.core.live.get_kill_switch` switch is engaged.
+- :class:`MaxOrderQuantity` — refuses orders whose ``quantity``
+  exceeds an operator-configured ceiling.
+- :class:`MaxOrderNotional` — refuses orders whose ``quantity *
+  reference_price`` exceeds a notional ceiling. The reference
+  price is supplied by the caller (typically the last trade /
+  mid-quote of the symbol).
+
+What's NOT here (explicit follow-ups):
+- Per-symbol position caps (needs portfolio state).
+- Per-strategy max-drawdown (needs PnL state).
+- Buying-power / margin pre-flight (needs broker account state).
+- Restricted-list enforcement (needs compliance feed).
+- Crypto-specific 24h-trade caps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import structlog
+
+if TYPE_CHECKING:
+    from engine.core.live.kill_switch import KillSwitch
+    from engine.core.oms.order import Order
+
+
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Approve:
+    """The check approves the order; the gate continues to the next check."""
+
+
+@dataclass(frozen=True)
+class Reject:
+    """The check rejects the order. ``reason`` is surfaced to the
+    operator and to the eventual ``RejectEvent`` on the OMS."""
+
+    reason: str
+
+
+CheckResult = Approve | Reject
+
+
+@runtime_checkable
+class RiskCheck(Protocol):
+    """Anything callable with ``(Order, *, reference_price)`` is a check."""
+
+    def __call__(
+        self, order: Order, *, reference_price: Decimal | None = None
+    ) -> CheckResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Built-in checks
+# ---------------------------------------------------------------------------
+
+
+class KillSwitchCheck:
+    """Refuses to submit when the global kill-switch is engaged."""
+
+    def __init__(self, switch: KillSwitch | None = None) -> None:
+        # Late import to avoid a hard dependency for tests that pass
+        # their own switch in.
+        if switch is None:
+            from engine.core.live import get_kill_switch
+
+            switch = get_kill_switch()
+        self._switch = switch
+
+    def __call__(
+        self, order: Order, *, reference_price: Decimal | None = None
+    ) -> CheckResult:
+        if self._switch.is_engaged():
+            snap = self._switch.snapshot()
+            return Reject(
+                reason=f"kill-switch engaged: {snap.reason or 'no reason recorded'}"
+            )
+        return Approve()
+
+
+@dataclass(frozen=True)
+class MaxOrderQuantity:
+    """Refuses orders whose ``quantity`` exceeds ``limit``."""
+
+    limit: Decimal
+
+    def __post_init__(self) -> None:
+        if self.limit <= 0:
+            raise ValueError("MaxOrderQuantity.limit must be positive")
+
+    def __call__(
+        self, order: Order, *, reference_price: Decimal | None = None
+    ) -> CheckResult:
+        if order.quantity > self.limit:
+            return Reject(
+                reason=(
+                    f"order quantity {order.quantity} exceeds max {self.limit} "
+                    f"for {order.symbol}"
+                )
+            )
+        return Approve()
+
+
+@dataclass(frozen=True)
+class MaxOrderNotional:
+    """Refuses orders whose ``quantity × reference_price`` exceeds ``limit``.
+
+    The check skips silently when the caller cannot supply a
+    reference price (returns :class:`Approve`). Operators who want
+    "no price = block" should chain their own check.
+    """
+
+    limit: Decimal
+
+    def __post_init__(self) -> None:
+        if self.limit <= 0:
+            raise ValueError("MaxOrderNotional.limit must be positive")
+
+    def __call__(
+        self, order: Order, *, reference_price: Decimal | None = None
+    ) -> CheckResult:
+        if reference_price is None or reference_price <= 0:
+            return Approve()
+        notional = order.quantity * reference_price
+        if notional > self.limit:
+            return Reject(
+                reason=(
+                    f"order notional {notional} exceeds max {self.limit} "
+                    f"for {order.symbol} at price {reference_price}"
+                )
+            )
+        return Approve()
+
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+
+class RiskGate:
+    """Runs an ordered list of checks. First Reject wins."""
+
+    def __init__(self, checks: list[RiskCheck]) -> None:
+        self._checks = list(checks)
+
+    def evaluate(
+        self,
+        order: Order,
+        *,
+        reference_price: Decimal | None = None,
+    ) -> CheckResult:
+        for check in self._checks:
+            result = check(order, reference_price=reference_price)
+            if isinstance(result, Reject):
+                logger.warning(
+                    "oms.risk_rejected",
+                    check=type(check).__name__,
+                    order_id=str(order.id),
+                    symbol=order.symbol,
+                    quantity=str(order.quantity),
+                    reason=result.reason,
+                )
+                return result
+        return Approve()

--- a/tests/test_oms_risk.py
+++ b/tests/test_oms_risk.py
@@ -1,0 +1,185 @@
+"""Unit tests for OMS pre-flight risk checks (gh#111 follow-up)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from engine.core.live.kill_switch import KillSwitch
+from engine.core.oms import Order, OrderSide, OrderType
+from engine.core.oms.risk import (
+    Approve,
+    KillSwitchCheck,
+    MaxOrderNotional,
+    MaxOrderQuantity,
+    Reject,
+    RiskCheck,
+    RiskGate,
+)
+
+
+def _order(qty: str = "10", symbol: str = "AAPL") -> Order:
+    return Order(
+        symbol=symbol,
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal(qty),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class TestResultTypes:
+    def test_approve_is_truthy_via_isinstance(self):
+        assert isinstance(Approve(), Approve)
+
+    def test_reject_carries_reason(self):
+        r = Reject(reason="too big")
+        assert r.reason == "too big"
+
+
+# ---------------------------------------------------------------------------
+# MaxOrderQuantity
+# ---------------------------------------------------------------------------
+
+
+class TestMaxOrderQuantity:
+    def test_rejects_constructor_zero_limit(self):
+        with pytest.raises(ValueError):
+            MaxOrderQuantity(limit=Decimal("0"))
+
+    def test_below_limit_approves(self):
+        check = MaxOrderQuantity(limit=Decimal("100"))
+        assert isinstance(check(_order("50")), Approve)
+
+    def test_at_limit_approves(self):
+        check = MaxOrderQuantity(limit=Decimal("100"))
+        assert isinstance(check(_order("100")), Approve)
+
+    def test_above_limit_rejects(self):
+        check = MaxOrderQuantity(limit=Decimal("100"))
+        result = check(_order("101"))
+        assert isinstance(result, Reject)
+        assert "exceeds max" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# MaxOrderNotional
+# ---------------------------------------------------------------------------
+
+
+class TestMaxOrderNotional:
+    def test_rejects_constructor_zero_limit(self):
+        with pytest.raises(ValueError):
+            MaxOrderNotional(limit=Decimal("0"))
+
+    def test_no_price_approves(self):
+        check = MaxOrderNotional(limit=Decimal("1000"))
+        # qty=10, no price → can't compute notional → approve.
+        assert isinstance(check(_order("10")), Approve)
+
+    def test_zero_price_approves(self):
+        check = MaxOrderNotional(limit=Decimal("1000"))
+        assert isinstance(
+            check(_order("10"), reference_price=Decimal("0")), Approve
+        )
+
+    def test_below_limit_approves(self):
+        check = MaxOrderNotional(limit=Decimal("1000"))
+        # 10 * 50 = 500 < 1000.
+        assert isinstance(
+            check(_order("10"), reference_price=Decimal("50")), Approve
+        )
+
+    def test_above_limit_rejects(self):
+        check = MaxOrderNotional(limit=Decimal("1000"))
+        # 10 * 200 = 2000 > 1000.
+        result = check(_order("10"), reference_price=Decimal("200"))
+        assert isinstance(result, Reject)
+        assert "notional" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# KillSwitchCheck
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitchCheck:
+    def test_disengaged_approves(self):
+        ks = KillSwitch()
+        check = KillSwitchCheck(switch=ks)
+        assert isinstance(check(_order()), Approve)
+
+    def test_engaged_rejects_with_reason(self):
+        ks = KillSwitch()
+        ks.engage(reason="manual_panic")
+        check = KillSwitchCheck(switch=ks)
+        result = check(_order())
+        assert isinstance(result, Reject)
+        assert "kill-switch engaged" in result.reason
+        assert "manual_panic" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# RiskGate
+# ---------------------------------------------------------------------------
+
+
+class TestRiskGate:
+    def test_empty_chain_approves_everything(self):
+        gate = RiskGate(checks=[])
+        assert isinstance(gate.evaluate(_order()), Approve)
+
+    def test_first_reject_wins(self):
+        gate = RiskGate(
+            checks=[
+                MaxOrderQuantity(limit=Decimal("5")),
+                MaxOrderNotional(limit=Decimal("10")),
+            ]
+        )
+        # qty=10 trips MaxOrderQuantity first; MaxOrderNotional never runs.
+        result = gate.evaluate(_order("10"), reference_price=Decimal("100"))
+        assert isinstance(result, Reject)
+        assert "exceeds max 5" in result.reason
+
+    def test_all_approve_means_gate_approves(self):
+        gate = RiskGate(
+            checks=[
+                MaxOrderQuantity(limit=Decimal("100")),
+                MaxOrderNotional(limit=Decimal("10000")),
+            ]
+        )
+        result = gate.evaluate(_order("10"), reference_price=Decimal("50"))
+        assert isinstance(result, Approve)
+
+    def test_kill_switch_short_circuits_gate(self):
+        ks = KillSwitch()
+        ks.engage(reason="emergency")
+        gate = RiskGate(
+            checks=[
+                KillSwitchCheck(switch=ks),
+                # Even a permissive subsequent check shouldn't matter.
+                MaxOrderQuantity(limit=Decimal("999999")),
+            ]
+        )
+        result = gate.evaluate(_order())
+        assert isinstance(result, Reject)
+        assert "kill-switch engaged" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Protocol contract
+# ---------------------------------------------------------------------------
+
+
+class TestRiskCheckProtocol:
+    def test_lambda_satisfies_protocol(self):
+        # A bare callable with the right signature is a valid RiskCheck.
+        check = lambda order, *, reference_price=None: Approve()  # noqa: E731
+        assert isinstance(check, RiskCheck)
+        gate = RiskGate(checks=[check])
+        assert isinstance(gate.evaluate(_order()), Approve)


### PR DESCRIPTION
Closes the explicit risk-check follow-up from #285. Approve/Reject result types + RiskCheck Protocol + KillSwitchCheck (lazy-imports the global switch) + MaxOrderQuantity + MaxOrderNotional (no-price = approve, operator chains stricter) + RiskGate chain (first Reject wins, logs rejections). 18 passing tests including kill-switch short-circuit and Protocol-via-lambda. Refs #111. Position caps, max-drawdown, margin pre-flight, restricted-list, crypto 24h-caps all deferred.