### PR TITLE
feat(oms): persistence projection — OMS Order → DB row dict (gh#111 follow-up)

### DIFF
--- a/engine/core/oms/persistence.py
+++ b/engine/core/oms/persistence.py
@@ -1,0 +1,100 @@
+"""OMS → DB projection (gh#111 follow-up).
+
+Projects the immutable :class:`engine.core.oms.order.Order` state-
+machine entity into a dict shape suitable for ``Order(**d)`` against
+the existing :class:`engine.db.models.Order` ORM row.
+
+Why a projection
+----------------
+The OMS dataclass and the DB row are intentionally different
+abstractions:
+
+- The dataclass is event-sourced and immutable per state. Apply an
+  event, get a new dataclass.
+- The DB row is a snapshot indexed for portfolio queries.
+
+Keeping them at arm's length means the SM stays pure (no SQLAlchemy
+import), and the DB schema can evolve without re-shaping the SM.
+This module is the only place that knows how to map between them.
+
+Field gaps (explicit follow-ups)
+--------------------------------
+The current ORM row at ``engine/db/models.py:90`` only carries:
+``id``, ``portfolio_id``, ``symbol``, ``side``, ``order_type``,
+``quantity``, ``price``, ``status``, ``filled_at``, ``created_at``.
+
+The OMS dataclass also tracks:
+- ``filled_quantity`` and ``average_fill_price`` (partial-fill state).
+- ``broker_order_id``.
+- ``stop_price``.
+- ``reject_reason``.
+- ``updated_at``.
+
+These are dropped on projection today. Extending the ORM is a
+separate migration; this projection's contract is "fit the columns
+that exist". A follow-up will add the missing columns and remove
+the lossy projection.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from engine.core.oms.states import OrderStatus
+
+if TYPE_CHECKING:
+    import uuid
+
+    from engine.core.oms.order import Order
+
+
+# Map state-machine OrderStatus values to the loose strings the ORM's
+# ``status`` column has historically used. ``"pending"`` is the ORM's
+# default; we coerce NEW/SUBMITTED to it because the DB doesn't model
+# the broker-submission distinction yet.
+_STATUS_PROJECTION: dict[OrderStatus, str] = {
+    OrderStatus.NEW: "pending",
+    OrderStatus.SUBMITTED: "pending",
+    OrderStatus.ACKNOWLEDGED: "open",
+    OrderStatus.PARTIALLY_FILLED: "partially_filled",
+    OrderStatus.FILLED: "filled",
+    OrderStatus.CANCEL_REQUESTED: "cancel_pending",
+    OrderStatus.CANCELLED: "cancelled",
+    OrderStatus.REJECTED: "rejected",
+    OrderStatus.EXPIRED: "expired",
+}
+
+
+def to_orm_dict(order: Order, *, portfolio_id: uuid.UUID) -> dict[str, Any]:
+    """Return a dict suitable for ``Order(**d).save()``.
+
+    The OMS doesn't model portfolio ownership — the caller supplies
+    ``portfolio_id`` (typically from the strategy / order-source row
+    that originated the request).
+    """
+    status = _STATUS_PROJECTION.get(order.status, order.status.value)
+
+    # Effective price for the ORM's loose ``price`` column.
+    # Limit/stop-limit orders carry a limit_price; market orders have
+    # an average fill price once filled, otherwise None.
+    price = order.limit_price
+    if price is None and order.average_fill_price is not None:
+        price = order.average_fill_price
+
+    # filled_at is the moment the order reached a fully-filled
+    # terminal state. Use updated_at (which is the apply_event time
+    # of the FillEvent / final PartialFillEvent).
+    filled_at = order.updated_at if order.status == OrderStatus.FILLED else None
+
+    return {
+        "id": order.id,
+        "portfolio_id": portfolio_id,
+        "symbol": order.symbol,
+        "side": order.side.value,
+        "order_type": order.order_type.value,
+        "quantity": order.quantity,
+        "price": price,
+        "status": status,
+        "filled_at": filled_at,
+        "created_at": order.created_at,
+    }

--- a/tests/test_oms_persistence.py
+++ b/tests/test_oms_persistence.py
@@ -1,0 +1,258 @@
+"""Unit tests for the OMS → DB projection (gh#111 follow-up)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from engine.core.oms import (
+    AckEvent,
+    FillEvent,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    PartialFillEvent,
+    RejectEvent,
+    SubmitEvent,
+)
+from engine.core.oms.persistence import to_orm_dict
+
+
+_PID = uuid.uuid4()
+_T0 = datetime(2026, 5, 3, 12, 0, 0, tzinfo=UTC)
+
+
+def _t(seconds: int) -> datetime:
+    return _T0 + timedelta(seconds=seconds)
+
+
+def _market_buy(qty: str = "10") -> Order:
+    return Order(
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal(qty),
+    )
+
+
+def _limit_buy(qty: str = "10", limit: str = "100") -> Order:
+    return Order(
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        order_type=OrderType.LIMIT,
+        quantity=Decimal(qty),
+        limit_price=Decimal(limit),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status projection
+# ---------------------------------------------------------------------------
+
+
+class TestStatusProjection:
+    def test_new_projects_to_pending(self):
+        order = _market_buy()
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["status"] == "pending"
+
+    def test_submitted_also_pending(self):
+        order = _market_buy().apply_event(SubmitEvent(occurred_at=_t(1)))
+        d = to_orm_dict(order, portfolio_id=_PID)
+        # ORM doesn't distinguish NEW/SUBMITTED today.
+        assert d["status"] == "pending"
+
+    def test_acknowledged_open(self):
+        order = (
+            _limit_buy()
+            .apply_event(SubmitEvent(occurred_at=_t(1)))
+            .apply_event(AckEvent(occurred_at=_t(2), broker_order_id="B"))
+        )
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["status"] == "open"
+
+    def test_partially_filled_projects(self):
+        order = (
+            _market_buy("10")
+            .apply_event(SubmitEvent(occurred_at=_t(1)))
+            .apply_event(
+                PartialFillEvent(
+                    occurred_at=_t(2),
+                    fill_quantity=Decimal("4"),
+                    fill_price=Decimal("100"),
+                    fill_id="F1",
+                )
+            )
+        )
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["status"] == "partially_filled"
+
+    def test_filled(self):
+        order = (
+            _market_buy("10")
+            .apply_event(SubmitEvent(occurred_at=_t(1)))
+            .apply_event(
+                FillEvent(
+                    occurred_at=_t(2),
+                    fill_quantity=Decimal("10"),
+                    fill_price=Decimal("100"),
+                    fill_id="F1",
+                )
+            )
+        )
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["status"] == "filled"
+
+    def test_rejected(self):
+        order = (
+            _market_buy()
+            .apply_event(SubmitEvent(occurred_at=_t(1)))
+            .apply_event(RejectEvent(occurred_at=_t(2), reason="boom"))
+        )
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["status"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Price projection
+# ---------------------------------------------------------------------------
+
+
+class TestPriceProjection:
+    def test_market_unfilled_has_no_price(self):
+        order = _market_buy()
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["price"] is None
+
+    def test_limit_carries_limit_price(self):
+        order = _limit_buy(limit="123")
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["price"] == Decimal("123")
+
+    def test_market_after_fill_uses_avg_fill_price(self):
+        order = (
+            _market_buy("10")
+            .apply_event(SubmitEvent(occurred_at=_t(1)))
+            .apply_event(
+                FillEvent(
+                    occurred_at=_t(2),
+                    fill_quantity=Decimal("10"),
+                    fill_price=Decimal("101.5"),
+                    fill_id="F1",
+                )
+            )
+        )
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["price"] == Decimal("101.5")
+
+    def test_limit_filled_keeps_limit_price_not_avg(self):
+        # Limit carried at 100, filled at 99.5 (improvement). The ORM
+        # historically stores the *order* price; avg fill lives elsewhere.
+        order = (
+            _limit_buy(qty="10", limit="100")
+            .apply_event(SubmitEvent(occurred_at=_t(1)))
+            .apply_event(
+                FillEvent(
+                    occurred_at=_t(2),
+                    fill_quantity=Decimal("10"),
+                    fill_price=Decimal("99.5"),
+                    fill_id="F1",
+                )
+            )
+        )
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["price"] == Decimal("100")
+
+
+# ---------------------------------------------------------------------------
+# filled_at projection
+# ---------------------------------------------------------------------------
+
+
+class TestFilledAt:
+    def test_filled_carries_updated_at(self):
+        fill_time = _t(2)
+        order = (
+            _market_buy("10")
+            .apply_event(SubmitEvent(occurred_at=_t(1)))
+            .apply_event(
+                FillEvent(
+                    occurred_at=fill_time,
+                    fill_quantity=Decimal("10"),
+                    fill_price=Decimal("100"),
+                    fill_id="F1",
+                )
+            )
+        )
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["filled_at"] == fill_time
+
+    def test_partially_filled_has_no_filled_at(self):
+        order = (
+            _market_buy("10")
+            .apply_event(SubmitEvent(occurred_at=_t(1)))
+            .apply_event(
+                PartialFillEvent(
+                    occurred_at=_t(2),
+                    fill_quantity=Decimal("4"),
+                    fill_price=Decimal("100"),
+                    fill_id="F1",
+                )
+            )
+        )
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["filled_at"] is None
+
+    def test_unfilled_has_no_filled_at(self):
+        order = _market_buy()
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["filled_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Required ORM keys
+# ---------------------------------------------------------------------------
+
+
+class TestKeys:
+    def test_dict_has_all_orm_columns(self):
+        order = _market_buy()
+        d = to_orm_dict(order, portfolio_id=_PID)
+        expected = {
+            "id",
+            "portfolio_id",
+            "symbol",
+            "side",
+            "order_type",
+            "quantity",
+            "price",
+            "status",
+            "filled_at",
+            "created_at",
+        }
+        assert set(d.keys()) == expected
+
+    def test_strings_for_enum_columns(self):
+        order = _market_buy()
+        d = to_orm_dict(order, portfolio_id=_PID)
+        assert d["side"] == OrderSide.BUY.value
+        assert d["order_type"] == OrderType.MARKET.value
+
+    def test_caller_supplied_portfolio_id_passes_through(self):
+        order = _market_buy()
+        my_pid = uuid.uuid4()
+        d = to_orm_dict(order, portfolio_id=my_pid)
+        assert d["portfolio_id"] == my_pid
+
+    def test_status_lookup_consistency(self):
+        # Sanity: the status projection table covers every member of
+        # OrderStatus. If a new status is added without a mapping, the
+        # projection's .get() will silently fall back; this test makes
+        # the gap visible.
+        from engine.core.oms.persistence import _STATUS_PROJECTION
+
+        assert {s.value for s in OrderStatus} == {
+            s.value for s in _STATUS_PROJECTION
+        }


### PR DESCRIPTION
Closes persistence-projection follow-up from #285. Pure projection from immutable OMS Order to engine/db/models.py Order ORM dict. Status projection table covers all 9 OrderStatus values (drift-detection test). Price column resolution: limit_price for limit/stop_limit, avg_fill_price for filled markets, None otherwise. filled_at populated only on FILLED status. Caller supplies portfolio_id (OMS doesn't model portfolio ownership). 17 passing tests. Refs #111. Field gaps (filled_quantity, broker_order_id, stop_price, reject_reason, updated_at) deferred to ORM-extension migration.