### PR TITLE
feat(brokers): broker adapter Protocol + registry (gh#136 partial)

### DIFF
--- a/engine/core/brokers/__init__.py
+++ b/engine/core/brokers/__init__.py
@@ -1,0 +1,45 @@
+"""Broker integration surface (gh#136).
+
+Operators register a :class:`BrokerAdapter` per broker (Alpaca,
+IBKR, Binance, Kraken, Oanda, …); the live-trading loop (gh#109)
+calls :meth:`BrokerAdapter.submit` and :meth:`BrokerAdapter.cancel`
+and consumes :meth:`BrokerAdapter.events` to feed the OMS state
+machine.
+
+This module pins only the Protocol + registry. Concrete adapter
+implementations live under their own subpackages — those are the
+broker-by-broker integration tests gh#136 will exercise.
+
+Public surface:
+- :class:`BrokerAdapter` Protocol — async submit/cancel/events.
+- :class:`BrokerError` and concrete subtypes for failure modes the
+  OMS knows how to react to.
+- :func:`register_broker` / :func:`get_broker` / :func:`list_brokers`
+  — operator-facing registry.
+"""
+
+from engine.core.brokers.base import (
+    BrokerAdapter,
+    BrokerAuthError,
+    BrokerConnectionError,
+    BrokerError,
+    BrokerRejectError,
+    SubmittedOrder,
+)
+from engine.core.brokers.registry import (
+    get_broker,
+    list_brokers,
+    register_broker,
+)
+
+__all__ = [
+    "BrokerAdapter",
+    "BrokerAuthError",
+    "BrokerConnectionError",
+    "BrokerError",
+    "BrokerRejectError",
+    "SubmittedOrder",
+    "get_broker",
+    "list_brokers",
+    "register_broker",
+]

--- a/engine/core/brokers/base.py
+++ b/engine/core/brokers/base.py
@@ -1,0 +1,123 @@
+"""BrokerAdapter Protocol + error vocabulary (gh#136).
+
+The Protocol is intentionally minimal so per-broker adapters can stay
+thin and the live-loop driver can be tested against a fake. Three
+methods:
+
+- ``submit`` — send an order to the broker. Returns a
+  :class:`SubmittedOrder` with the broker's order id.
+- ``cancel`` — request cancellation of an existing broker order.
+- ``events`` — async iterator of broker events (acks, fills,
+  cancellations). The OMS converts each event to its own internal
+  event type via the live-loop driver (gh#109).
+
+Errors are typed so the loop driver can react differently to a
+permission failure vs. a network blip:
+
+- :class:`BrokerAuthError` — credentials rejected. Don't retry; surface
+  to the operator and engage the kill-switch.
+- :class:`BrokerConnectionError` — transient network / disconnect.
+  Retry with backoff.
+- :class:`BrokerRejectError` — broker accepted the request but rejected
+  the order itself (margin, restricted-list, etc.). Treat as a
+  per-order rejection; do not engage the kill-switch.
+
+Concrete adapters live under their own subpackages
+(``engine/core/brokers/alpaca/``, etc.) and are added in their own PRs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from engine.core.oms.events import OrderEvent
+    from engine.core.oms.order import Order
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class BrokerError(Exception):
+    """Base for every failure mode an adapter can surface."""
+
+
+class BrokerAuthError(BrokerError):
+    """Credentials rejected. Permanent until operator intervenes."""
+
+
+class BrokerConnectionError(BrokerError):
+    """Transient network / broker-side disconnect. Retryable."""
+
+
+class BrokerRejectError(BrokerError):
+    """Broker accepted the request but rejected the *order*.
+
+    Per-order failure (insufficient margin, restricted symbol, bad
+    price, etc.). Do not treat as a systemic problem.
+    """
+
+    def __init__(self, message: str, *, broker_code: str | None = None) -> None:
+        super().__init__(message)
+        self.broker_code = broker_code
+
+
+# ---------------------------------------------------------------------------
+# DTOs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubmittedOrder:
+    """Result of a successful :meth:`BrokerAdapter.submit` call.
+
+    The OMS uses ``broker_order_id`` to correlate subsequent broker
+    events back to the originating in-process order.
+    """
+
+    order_id: uuid.UUID            # OMS-side order id (the input)
+    broker_order_id: str           # broker's id for the same order
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class BrokerAdapter(Protocol):
+    """Per-broker integration contract."""
+
+    @property
+    def name(self) -> str:
+        """Stable lower-case identifier (e.g. ``"alpaca"``, ``"ibkr"``)."""
+        ...
+
+    async def submit(self, order: Order) -> SubmittedOrder:
+        """Send ``order`` to the broker. Raises :class:`BrokerError` on failure."""
+        ...
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        """Request cancellation. Raises :class:`BrokerError` on failure.
+
+        The broker may not honour the cancel (filled-before-cancel race);
+        in that case the next ``events`` yield carries a fill, and the
+        OMS state machine does the right thing.
+        """
+        ...
+
+    def events(self) -> AsyncIterator[OrderEvent]:
+        """Async iterator of broker-emitted OMS events.
+
+        Adapter implementations are responsible for translating
+        broker-native event shapes into ``engine.core.oms.events``
+        types (``AckEvent``, ``PartialFillEvent``, etc.). The live-
+        loop consumes this iterator and feeds each event to the
+        order's ``apply_event`` to evolve its state.
+        """
+        ...

--- a/engine/core/brokers/registry.py
+++ b/engine/core/brokers/registry.py
@@ -1,0 +1,61 @@
+"""Broker adapter registry (gh#136).
+
+Operators register a :class:`BrokerAdapter` once at startup under a
+stable name (typically the broker's slug); the live-trading loop and
+operator-facing routes look one up at runtime via configuration.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from engine.core.brokers.base import BrokerAdapter
+
+_REGISTRY: dict[str, BrokerAdapter] = {}
+_LOCK = threading.Lock()
+
+
+def register_broker(adapter: BrokerAdapter) -> None:
+    """Register ``adapter`` under its own ``name``.
+
+    Re-registering an existing name overwrites the prior entry. That
+    is intentional — operators may want to swap adapter
+    implementations at startup (e.g., paper vs. live) without
+    sub-classing.
+    """
+    if not isinstance(adapter, BrokerAdapter):
+        raise TypeError(
+            "argument must implement BrokerAdapter Protocol "
+            f"(got {type(adapter).__name__})"
+        )
+    name = adapter.name
+    if not name or not name.strip():
+        raise ValueError("broker adapter name must be non-empty")
+    if name != name.lower():
+        raise ValueError(f"broker adapter name must be lower-case (got {name!r})")
+    with _LOCK:
+        _REGISTRY[name] = adapter
+
+
+def get_broker(name: str) -> BrokerAdapter:
+    """Look up a broker adapter by name. Raises :class:`KeyError` if absent."""
+    with _LOCK:
+        try:
+            return _REGISTRY[name]
+        except KeyError as exc:
+            raise KeyError(
+                f"unknown broker: {name!r}. "
+                f"registered: {sorted(_REGISTRY.keys())}"
+            ) from exc
+
+
+def list_brokers() -> list[str]:
+    """Return registered broker names, sorted."""
+    with _LOCK:
+        return sorted(_REGISTRY.keys())
+
+
+def _reset_for_tests() -> None:
+    """Test-only: clear the registry so each test starts fresh."""
+    with _LOCK:
+        _REGISTRY.clear()

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -1,0 +1,189 @@
+"""Unit tests for the broker adapter Protocol + registry (gh#136 partial)."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+
+from engine.core.brokers import (
+    BrokerAdapter,
+    BrokerAuthError,
+    BrokerConnectionError,
+    BrokerError,
+    BrokerRejectError,
+    SubmittedOrder,
+    get_broker,
+    list_brokers,
+    register_broker,
+)
+from engine.core.brokers.registry import _reset_for_tests
+from engine.core.oms import (
+    AckEvent,
+    Order,
+    OrderEvent,
+    OrderSide,
+    OrderType,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _market_buy() -> Order:
+    return Order(
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("10"),
+    )
+
+
+class _FakeBroker:
+    """Minimal Protocol-compatible adapter."""
+
+    def __init__(self, name: str = "fake") -> None:
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def submit(self, order: Order) -> SubmittedOrder:
+        return SubmittedOrder(order_id=order.id, broker_order_id=f"BRK-{order.id}")
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        return None
+
+    async def events(self) -> AsyncIterator[OrderEvent]:  # type: ignore[override]
+        # Empty stream — sufficient for Protocol satisfaction in tests.
+        return
+        yield  # pragma: no cover - generator marker
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHierarchy:
+    def test_subtypes_inherit(self):
+        assert issubclass(BrokerAuthError, BrokerError)
+        assert issubclass(BrokerConnectionError, BrokerError)
+        assert issubclass(BrokerRejectError, BrokerError)
+
+    def test_reject_carries_broker_code(self):
+        e = BrokerRejectError("insufficient buying power", broker_code="MARGIN_001")
+        assert e.broker_code == "MARGIN_001"
+        assert "buying power" in str(e)
+
+    def test_reject_default_broker_code_none(self):
+        e = BrokerRejectError("rejected")
+        assert e.broker_code is None
+
+
+# ---------------------------------------------------------------------------
+# SubmittedOrder DTO
+# ---------------------------------------------------------------------------
+
+
+class TestSubmittedOrder:
+    def test_carries_both_ids(self):
+        oid = uuid.uuid4()
+        result = SubmittedOrder(order_id=oid, broker_order_id="BRK-1")
+        assert result.order_id == oid
+        assert result.broker_order_id == "BRK-1"
+
+
+# ---------------------------------------------------------------------------
+# Protocol contract
+# ---------------------------------------------------------------------------
+
+
+class TestProtocol:
+    def test_fake_broker_satisfies_protocol(self):
+        assert isinstance(_FakeBroker(), BrokerAdapter)
+
+    def test_incomplete_does_not_satisfy(self):
+        class Incomplete:
+            @property
+            def name(self) -> str:
+                return "x"
+
+        assert not isinstance(Incomplete(), BrokerAdapter)
+
+    async def test_fake_submit_returns_submitted_order(self):
+        adapter = _FakeBroker()
+        order = _market_buy()
+        result = await adapter.submit(order)
+        assert isinstance(result, SubmittedOrder)
+        assert result.order_id == order.id
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_register_and_lookup(self):
+        adapter = _FakeBroker(name="alpaca")
+        register_broker(adapter)
+        assert get_broker("alpaca") is adapter
+
+    def test_lookup_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_broker("zzz")
+
+    def test_list_returns_sorted(self):
+        register_broker(_FakeBroker(name="alpaca"))
+        register_broker(_FakeBroker(name="ibkr"))
+        register_broker(_FakeBroker(name="binance"))
+        assert list_brokers() == ["alpaca", "binance", "ibkr"]
+
+    def test_re_register_overwrites(self):
+        register_broker(_FakeBroker(name="alpaca"))
+        replacement = _FakeBroker(name="alpaca")
+        register_broker(replacement)
+        assert get_broker("alpaca") is replacement
+
+    def test_register_rejects_non_protocol(self):
+        with pytest.raises(TypeError):
+            register_broker("not-an-adapter")  # type: ignore[arg-type]
+
+    def test_register_rejects_empty_name(self):
+        with pytest.raises(ValueError):
+            register_broker(_FakeBroker(name=""))
+
+    def test_register_rejects_uppercase_name(self):
+        with pytest.raises(ValueError):
+            register_broker(_FakeBroker(name="ALPACA"))
+
+
+# ---------------------------------------------------------------------------
+# Sanity: an adapter can produce OMS-compatible events
+# ---------------------------------------------------------------------------
+
+
+class TestEventCompatibility:
+    def test_broker_event_is_an_order_event(self):
+        # The Protocol's events() returns AsyncIterator[OrderEvent]. As a
+        # quick sanity check that the type alias accepts the adapter's
+        # actual event shapes.
+        from datetime import UTC, datetime
+
+        ev: OrderEvent = AckEvent(
+            occurred_at=datetime.now(tz=UTC), broker_order_id="X"
+        )
+        assert isinstance(ev, AckEvent)


### PR DESCRIPTION
Foundation for per-broker integrations. Pure-Python BrokerAdapter Protocol (async submit/cancel/events) + SubmittedOrder DTO + typed error vocabulary (BrokerAuthError permanent, BrokerConnectionError retryable, BrokerRejectError per-order with broker_code) + thread-safe lower-case-keyed registry. 15 passing tests. Refs #136. Concrete adapter implementations (Alpaca/IBKR/Binance/Kraken/Oanda), sandbox integration tests, paper-trading adapter, reconnection policy all deferred.