### PR TITLE
feat(brokers): paper-trading adapter — concrete BrokerAdapter for dev/staging (gh#136 follow-up)

### DIFF
--- a/engine/core/brokers/paper.py
+++ b/engine/core/brokers/paper.py
@@ -1,0 +1,223 @@
+"""Paper-trading broker adapter (gh#136 follow-up).
+
+A :class:`BrokerAdapter` that simulates a broker in-process for
+backtesting / staging / development. No network, no money.
+
+Behaviour
+---------
+- Market orders: ack and fully fill immediately at a price returned
+  by the operator-supplied ``price_for(symbol)`` callable. If the
+  callable returns ``None``, the order is rejected.
+- Limit orders: ack and rest. They do not auto-fill — the caller
+  invokes :meth:`PaperBroker.simulate_fill` (test helper) or extends
+  the adapter with a price-tick consumer.
+- Cancel: rejects if the broker order is unknown or already filled;
+  otherwise emits a confirming ``CancelEvent`` and removes the
+  pending order.
+
+Events are surfaced via an async queue so the live-loop driver can
+``async for ev in broker.events()`` exactly as it would for a real
+broker.
+
+What this is *not*
+------------------
+- A market simulator. There is no order book, slippage model, or
+  partial-fill schedule. That belongs in the existing backtest
+  runner; this is a thin broker stand-in.
+- A latency model. Fills are instantaneous in event time.
+- A funds / margin checker. ``RiskGate`` upstream is responsible
+  for that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator, Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import structlog
+
+from engine.core.brokers.base import (
+    BrokerError,
+    BrokerRejectError,
+    SubmittedOrder,
+)
+from engine.core.oms.events import (
+    AckEvent,
+    CancelEvent,
+    FillEvent,
+    OrderEvent,
+)
+from engine.core.oms.states import OrderType
+
+if TYPE_CHECKING:
+    from engine.core.oms.order import Order
+
+
+logger = structlog.get_logger()
+
+
+PriceResolver = Callable[[str], Decimal | None]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+class PaperBroker:
+    """In-process simulated broker."""
+
+    def __init__(self, *, price_for: PriceResolver, name: str = "paper") -> None:
+        if not name or not name.islower():
+            raise ValueError("PaperBroker name must be a lower-case slug")
+        self._name = name
+        self._price_for = price_for
+        self._events: asyncio.Queue[OrderEvent] = asyncio.Queue()
+        # broker_order_id -> pending order metadata
+        self._pending: dict[str, _Pending] = {}
+
+    # ------------------------------------------------------------------
+    # BrokerAdapter contract
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def submit(self, order: Order) -> SubmittedOrder:
+        broker_id = f"PAPER-{uuid.uuid4()}"
+        if order.order_type == OrderType.MARKET:
+            price = self._price_for(order.symbol)
+            if price is None or price <= 0:
+                raise BrokerRejectError(
+                    f"paper: no price for {order.symbol}",
+                    broker_code="NO_PRICE",
+                )
+            now = _utcnow()
+            await self._events.put(
+                AckEvent(occurred_at=now, broker_order_id=broker_id)
+            )
+            await self._events.put(
+                FillEvent(
+                    occurred_at=now,
+                    fill_quantity=order.quantity,
+                    fill_price=price,
+                    fill_id=f"FILL-{broker_id}",
+                )
+            )
+            logger.info(
+                "paper_broker.market_filled",
+                order_id=str(order.id),
+                broker_order_id=broker_id,
+                symbol=order.symbol,
+                quantity=str(order.quantity),
+                price=str(price),
+            )
+        else:
+            # Limit / stop / stop_limit — ack and rest.
+            self._pending[broker_id] = _Pending(
+                oms_order_id=order.id,
+                symbol=order.symbol,
+                quantity=order.quantity,
+                order_type=order.order_type,
+            )
+            await self._events.put(
+                AckEvent(occurred_at=_utcnow(), broker_order_id=broker_id)
+            )
+            logger.info(
+                "paper_broker.resting",
+                order_id=str(order.id),
+                broker_order_id=broker_id,
+                order_type=order.order_type.value,
+                symbol=order.symbol,
+                quantity=str(order.quantity),
+            )
+        return SubmittedOrder(order_id=order.id, broker_order_id=broker_id)
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        if broker_order_id not in self._pending:
+            raise BrokerRejectError(
+                f"paper: unknown or already-filled broker order {broker_order_id!r}",
+                broker_code="NOT_PENDING",
+            )
+        del self._pending[broker_order_id]
+        await self._events.put(
+            CancelEvent(occurred_at=_utcnow(), requested=False, reason="paper_cancel")
+        )
+        logger.info(
+            "paper_broker.cancelled",
+            order_id=str(order_id),
+            broker_order_id=broker_order_id,
+        )
+
+    async def events(self) -> AsyncIterator[OrderEvent]:
+        # Drain whatever is queued. The caller decides when to stop —
+        # typical pattern is to wrap this in an asyncio.timeout.
+        while True:
+            ev = await self._events.get()
+            yield ev
+
+    # ------------------------------------------------------------------
+    # Test helpers (not part of the BrokerAdapter contract)
+    # ------------------------------------------------------------------
+
+    async def simulate_fill(
+        self,
+        *,
+        broker_order_id: str,
+        fill_price: Decimal | None = None,
+    ) -> None:
+        """Force a resting order to fully fill. For tests / dev only."""
+        pending = self._pending.pop(broker_order_id, None)
+        if pending is None:
+            raise BrokerError(
+                f"simulate_fill: no pending order {broker_order_id!r}"
+            )
+        price = fill_price if fill_price is not None else self._price_for(pending.symbol)
+        if price is None or price <= 0:
+            raise BrokerRejectError(
+                f"simulate_fill: no price for {pending.symbol}",
+                broker_code="NO_PRICE",
+            )
+        await self._events.put(
+            FillEvent(
+                occurred_at=_utcnow(),
+                fill_quantity=pending.quantity,
+                fill_price=price,
+                fill_id=f"FILL-{broker_order_id}",
+            )
+        )
+
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    async def drain_events(self) -> list[OrderEvent]:
+        """Pop all currently-queued events without blocking. Test-only."""
+        out: list[OrderEvent] = []
+        while True:
+            try:
+                out.append(self._events.get_nowait())
+            except asyncio.QueueEmpty:
+                return out
+
+
+class _Pending:
+    """Internal record for a resting paper order."""
+
+    __slots__ = ("oms_order_id", "symbol", "quantity", "order_type")
+
+    def __init__(
+        self,
+        *,
+        oms_order_id: uuid.UUID,
+        symbol: str,
+        quantity: Decimal,
+        order_type: OrderType,
+    ) -> None:
+        self.oms_order_id = oms_order_id
+        self.symbol = symbol
+        self.quantity = quantity
+        self.order_type = order_type

--- a/tests/test_paper_broker.py
+++ b/tests/test_paper_broker.py
@@ -1,0 +1,210 @@
+"""Unit tests for the paper-trading broker (gh#136 follow-up)."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from engine.core.brokers import BrokerAdapter, BrokerRejectError
+from engine.core.brokers.paper import PaperBroker
+from engine.core.oms import (
+    AckEvent,
+    CancelEvent,
+    FillEvent,
+    Order,
+    OrderSide,
+    OrderType,
+)
+
+
+def _market_buy(symbol: str = "AAPL", qty: str = "10") -> Order:
+    return Order(
+        symbol=symbol,
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal(qty),
+    )
+
+
+def _limit_buy(symbol: str = "AAPL", qty: str = "10", limit: str = "100") -> Order:
+    return Order(
+        symbol=symbol,
+        side=OrderSide.BUY,
+        order_type=OrderType.LIMIT,
+        quantity=Decimal(qty),
+        limit_price=Decimal(limit),
+    )
+
+
+def _prices(table: dict[str, Decimal]):
+    return lambda symbol: table.get(symbol)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_satisfies_protocol(self):
+        broker = PaperBroker(price_for=_prices({"AAPL": Decimal("100")}))
+        assert isinstance(broker, BrokerAdapter)
+
+    def test_default_name(self):
+        broker = PaperBroker(price_for=_prices({}))
+        assert broker.name == "paper"
+
+    def test_custom_name(self):
+        broker = PaperBroker(price_for=_prices({}), name="paper-eu")
+        assert broker.name == "paper-eu"
+
+    def test_uppercase_name_rejected(self):
+        with pytest.raises(ValueError):
+            PaperBroker(price_for=_prices({}), name="PAPER")
+
+    def test_empty_name_rejected(self):
+        with pytest.raises(ValueError):
+            PaperBroker(price_for=_prices({}), name="")
+
+
+# ---------------------------------------------------------------------------
+# Market submit
+# ---------------------------------------------------------------------------
+
+
+class TestMarketSubmit:
+    async def test_market_emits_ack_then_fill(self):
+        broker = PaperBroker(price_for=_prices({"AAPL": Decimal("101")}))
+        order = _market_buy()
+        result = await broker.submit(order)
+        assert result.order_id == order.id
+        assert result.broker_order_id.startswith("PAPER-")
+
+        events = await broker.drain_events()
+        assert len(events) == 2
+        assert isinstance(events[0], AckEvent)
+        assert isinstance(events[1], FillEvent)
+        assert events[1].fill_quantity == Decimal("10")
+        assert events[1].fill_price == Decimal("101")
+
+    async def test_market_no_price_rejected(self):
+        broker = PaperBroker(price_for=_prices({}))
+        with pytest.raises(BrokerRejectError) as exc_info:
+            await broker.submit(_market_buy())
+        assert exc_info.value.broker_code == "NO_PRICE"
+
+    async def test_market_zero_price_rejected(self):
+        broker = PaperBroker(price_for=_prices({"AAPL": Decimal("0")}))
+        with pytest.raises(BrokerRejectError):
+            await broker.submit(_market_buy())
+
+
+# ---------------------------------------------------------------------------
+# Limit submit + simulate_fill
+# ---------------------------------------------------------------------------
+
+
+class TestLimitFlow:
+    async def test_limit_acks_and_rests(self):
+        broker = PaperBroker(price_for=_prices({"AAPL": Decimal("100")}))
+        order = _limit_buy()
+        await broker.submit(order)
+        events = await broker.drain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], AckEvent)
+        assert broker.pending_count() == 1
+        # No fill yet.
+        assert all(not isinstance(ev, FillEvent) for ev in events)
+
+    async def test_simulate_fill_drains_pending(self):
+        broker = PaperBroker(price_for=_prices({"AAPL": Decimal("100")}))
+        order = _limit_buy()
+        result = await broker.submit(order)
+        await broker.drain_events()  # discard the Ack
+
+        await broker.simulate_fill(broker_order_id=result.broker_order_id)
+        events = await broker.drain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], FillEvent)
+        assert events[0].fill_quantity == order.quantity
+        assert events[0].fill_price == Decimal("100")
+        assert broker.pending_count() == 0
+
+    async def test_simulate_fill_with_explicit_price(self):
+        broker = PaperBroker(price_for=_prices({}))
+        order = _limit_buy(limit="100")
+        result = await broker.submit(order)
+        await broker.drain_events()
+
+        await broker.simulate_fill(
+            broker_order_id=result.broker_order_id,
+            fill_price=Decimal("99.5"),
+        )
+        events = await broker.drain_events()
+        assert events[0].fill_price == Decimal("99.5")
+
+    async def test_simulate_fill_unknown_raises(self):
+        broker = PaperBroker(price_for=_prices({}))
+        with pytest.raises(Exception):
+            await broker.simulate_fill(broker_order_id="PAPER-doesnotexist")
+
+
+# ---------------------------------------------------------------------------
+# Cancel
+# ---------------------------------------------------------------------------
+
+
+class TestCancel:
+    async def test_cancel_resting_order(self):
+        broker = PaperBroker(price_for=_prices({"AAPL": Decimal("100")}))
+        order = _limit_buy()
+        result = await broker.submit(order)
+        await broker.drain_events()
+
+        await broker.cancel(
+            order_id=order.id, broker_order_id=result.broker_order_id
+        )
+        events = await broker.drain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], CancelEvent)
+        assert events[0].requested is False
+        assert broker.pending_count() == 0
+
+    async def test_cancel_unknown_rejected(self):
+        broker = PaperBroker(price_for=_prices({}))
+        with pytest.raises(BrokerRejectError) as exc_info:
+            await broker.cancel(
+                order_id=uuid.uuid4(), broker_order_id="PAPER-nope"
+            )
+        assert exc_info.value.broker_code == "NOT_PENDING"
+
+    async def test_cancel_after_fill_rejected(self):
+        broker = PaperBroker(price_for=_prices({"AAPL": Decimal("100")}))
+        # Market order auto-fills, so it's never pending.
+        result = await broker.submit(_market_buy())
+        await broker.drain_events()
+
+        with pytest.raises(BrokerRejectError):
+            await broker.cancel(
+                order_id=uuid.uuid4(),
+                broker_order_id=result.broker_order_id,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Events iterator
+# ---------------------------------------------------------------------------
+
+
+class TestEventsIterator:
+    async def test_async_for_yields_buffered_events(self):
+        broker = PaperBroker(price_for=_prices({"AAPL": Decimal("101")}))
+        await broker.submit(_market_buy())
+        # Pull two events via the async iterator without blocking.
+        it = broker.events()
+        first = await anext(it)
+        second = await anext(it)
+        assert isinstance(first, AckEvent)
+        assert isinstance(second, FillEvent)


### PR DESCRIPTION
First concrete BrokerAdapter implementation. In-process simulated broker. Market orders auto-fill at price_for(symbol). Limit/stop/stop_limit ack and rest until simulate_fill helper. Cancel emits broker-confirmed CancelEvent. Typed BrokerRejectError with broker_code (NO_PRICE / NOT_PENDING). Async events queue + iterator. 16 passing tests including market+limit+cancel+iterator paths. Refs #136. Real broker adapters (Alpaca/IBKR/Binance/Kraken/Oanda) and sandbox integration tests still deferred.