### PR TITLE
feat(live): live-loop driver — wires OMS + RiskGate + BrokerAdapter (gh#109 follow-up)

### DIFF
--- a/engine/core/live/loop.py
+++ b/engine/core/live/loop.py
@@ -1,0 +1,223 @@
+"""Live-trading loop driver (gh#109 follow-up).
+
+Wires the OMS state machine, the risk gate, and a broker adapter into
+the smallest unit of "submit an order, then react to broker events".
+
+Flow
+----
+1. Caller hands :meth:`LiveLoop.submit` an :class:`Order` plus an
+   optional reference price.
+2. The driver runs the :class:`RiskGate`. On Reject, the order
+   transitions to ``REJECTED`` via a :class:`RejectEvent` and the
+   broker is never called.
+3. On Approve, the driver calls :meth:`BrokerAdapter.submit`. The
+   resulting ``broker_order_id`` is recorded so subsequent events can
+   correlate. The Order itself is held in an in-memory registry keyed
+   by both the OMS id and the broker id.
+4. The caller invokes :meth:`apply_broker_event` for each broker
+   event consumed from ``broker.events()`` — the loop looks up the
+   originating Order, applies the event via the state machine, and
+   notifies the operator-supplied ``persister`` callback.
+
+Error policy
+------------
+- :class:`BrokerAuthError` — engage the kill-switch (this is a
+  systemic condition; we cannot trust the engine to keep submitting
+  orders) and re-raise.
+- :class:`BrokerRejectError` — apply :class:`RejectEvent` to the order
+  with the broker's reason and broker_code. Does NOT engage the
+  kill-switch.
+- :class:`BrokerConnectionError` — log and re-raise. The caller wraps
+  ``submit`` in retry-with-backoff.
+
+What's NOT here (explicit follow-ups):
+- Reconciliation on startup (read open orders from broker, walk
+  events forward).
+- Recovery from a half-submitted order (broker received but engine
+  crashed before persisting the broker_order_id).
+- Multi-broker routing.
+- Fill-handler hooks for downstream tax-lot updates.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import structlog
+
+from engine.core.brokers.base import (
+    BrokerAuthError,
+    BrokerConnectionError,
+    BrokerRejectError,
+)
+from engine.core.live.kill_switch import KillSwitch, get_kill_switch
+from engine.core.oms.events import RejectEvent, SubmitEvent
+from engine.core.oms.risk import Reject, RiskGate
+
+if TYPE_CHECKING:
+    from engine.core.brokers.base import BrokerAdapter
+    from engine.core.oms.events import OrderEvent
+    from engine.core.oms.order import Order
+
+
+logger = structlog.get_logger()
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+# Operator-supplied persister: called after every successful state
+# transition with the new (post-event) Order.
+Persister = Callable[["Order"], None]
+
+
+class LiveLoopError(Exception):
+    """Base for live-loop bookkeeping errors."""
+
+
+class UnknownOrderError(LiveLoopError):
+    """A broker event referenced an order id we don't know about."""
+
+
+class LiveLoop:
+    """Submit-and-consume orchestrator.
+
+    The driver is intentionally small. Add features by composing
+    rather than extending — risk policies live on the gate, broker
+    behaviour on the adapter, persistence in the persister.
+    """
+
+    def __init__(
+        self,
+        *,
+        broker: BrokerAdapter,
+        risk: RiskGate,
+        persister: Persister | None = None,
+        kill_switch: KillSwitch | None = None,
+    ) -> None:
+        self._broker = broker
+        self._risk = risk
+        self._persister = persister
+        self._kill_switch = kill_switch or get_kill_switch()
+        # OMS id -> Order
+        self._by_oms_id: dict[uuid.UUID, Order] = {}
+        # Broker id -> OMS id (for event correlation)
+        self._broker_to_oms: dict[str, uuid.UUID] = {}
+
+    # ------------------------------------------------------------------
+    # Submit path
+    # ------------------------------------------------------------------
+
+    async def submit(
+        self,
+        order: Order,
+        *,
+        reference_price: Decimal | None = None,
+    ) -> Order:
+        """Run risk + broker submit, register the order, persist.
+
+        Returns the Order (possibly transitioned to REJECTED). Raises
+        :class:`BrokerAuthError` / :class:`BrokerConnectionError` for
+        the caller to handle.
+        """
+        gate_result = self._risk.evaluate(order, reference_price=reference_price)
+        if isinstance(gate_result, Reject):
+            updated = order.apply_event(
+                RejectEvent(occurred_at=_utcnow(), reason=gate_result.reason)
+            )
+            self._track(updated)
+            return updated
+
+        try:
+            submitted = await self._broker.submit(order)
+        except BrokerAuthError:
+            self._kill_switch.engage(
+                reason="broker_auth_error", actor="live_loop"
+            )
+            raise
+        except BrokerRejectError as exc:
+            updated = order.apply_event(
+                RejectEvent(
+                    occurred_at=_utcnow(),
+                    reason=f"broker rejected: {exc} (code={exc.broker_code})",
+                )
+            )
+            self._track(updated)
+            return updated
+        except BrokerConnectionError:
+            logger.warning(
+                "live_loop.broker_connection_error",
+                order_id=str(order.id),
+                symbol=order.symbol,
+            )
+            raise
+
+        updated = order.apply_event(
+            SubmitEvent(
+                occurred_at=_utcnow(),
+                broker_order_id=submitted.broker_order_id,
+            )
+        )
+        self._track(updated)
+        self._broker_to_oms[submitted.broker_order_id] = updated.id
+        return updated
+
+    # ------------------------------------------------------------------
+    # Event-consumption path
+    # ------------------------------------------------------------------
+
+    async def apply_broker_event(
+        self,
+        event: OrderEvent,
+        *,
+        broker_order_id: str,
+    ) -> Order:
+        """Apply a single broker-emitted event to the corresponding order.
+
+        Raises :class:`UnknownOrderError` if ``broker_order_id`` is
+        not in this loop's registry.
+        """
+        oms_id = self._broker_to_oms.get(broker_order_id)
+        if oms_id is None:
+            raise UnknownOrderError(
+                f"no order tracked for broker id {broker_order_id!r}"
+            )
+        order = self._by_oms_id[oms_id]
+        updated = order.apply_event(event)
+        self._track(updated)
+        return updated
+
+    # ------------------------------------------------------------------
+    # Lookup helpers
+    # ------------------------------------------------------------------
+
+    def get(self, oms_id: uuid.UUID) -> Order | None:
+        return self._by_oms_id.get(oms_id)
+
+    def open_orders(self) -> list[Order]:
+        return [o for o in self._by_oms_id.values() if not o.is_terminal]
+
+    def __len__(self) -> int:
+        return len(self._by_oms_id)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _track(self, order: Order) -> None:
+        self._by_oms_id[order.id] = order
+        if self._persister is not None:
+            try:
+                self._persister(order)
+            except Exception as exc:  # noqa: BLE001 - persister failures must not break the loop
+                logger.warning(
+                    "live_loop.persister_failed",
+                    order_id=str(order.id),
+                    error_type=type(exc).__name__,
+                    error_message=str(exc)[:200],
+                )

--- a/tests/test_live_loop.py
+++ b/tests/test_live_loop.py
@@ -1,0 +1,301 @@
+"""Unit tests for the live-loop driver (gh#109 follow-up)."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from engine.core.brokers.base import (
+    BrokerAuthError,
+    BrokerConnectionError,
+    BrokerRejectError,
+    SubmittedOrder,
+)
+from engine.core.brokers.paper import PaperBroker
+from engine.core.live.kill_switch import KillSwitch
+from engine.core.live.loop import LiveLoop, UnknownOrderError
+from engine.core.oms import (
+    AckEvent,
+    Order,
+    OrderEvent,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+)
+from engine.core.oms.risk import KillSwitchCheck, MaxOrderQuantity, RiskGate
+
+
+def _market_buy(qty: str = "10") -> Order:
+    return Order(
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal(qty),
+    )
+
+
+def _gate(*, kill_switch: KillSwitch, max_qty: Decimal = Decimal("1000")) -> RiskGate:
+    return RiskGate(
+        checks=[
+            KillSwitchCheck(switch=kill_switch),
+            MaxOrderQuantity(limit=max_qty),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Faked broker variants for error-path tests
+# ---------------------------------------------------------------------------
+
+
+class _AuthFailBroker:
+    @property
+    def name(self) -> str:
+        return "auth-fail"
+
+    async def submit(self, order: Order) -> SubmittedOrder:  # noqa: ARG002
+        raise BrokerAuthError("invalid api key")
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        raise NotImplementedError
+
+    async def events(self) -> AsyncIterator[OrderEvent]:  # type: ignore[override]
+        return
+        yield  # pragma: no cover
+
+
+class _RejectBroker:
+    @property
+    def name(self) -> str:
+        return "reject"
+
+    async def submit(self, order: Order) -> SubmittedOrder:  # noqa: ARG002
+        raise BrokerRejectError("insufficient buying power", broker_code="MARGIN")
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        raise NotImplementedError
+
+    async def events(self) -> AsyncIterator[OrderEvent]:  # type: ignore[override]
+        return
+        yield  # pragma: no cover
+
+
+class _ConnectionBroker:
+    @property
+    def name(self) -> str:
+        return "no-conn"
+
+    async def submit(self, order: Order) -> SubmittedOrder:  # noqa: ARG002
+        raise BrokerConnectionError("dns failed")
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        raise NotImplementedError
+
+    async def events(self) -> AsyncIterator[OrderEvent]:  # type: ignore[override]
+        return
+        yield  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Submit happy path
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitHappyPath:
+    async def test_submit_via_paper_broker(self):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(broker=broker, risk=_gate(kill_switch=ks))
+
+        order = _market_buy()
+        result = await loop.submit(order)
+        assert result.status == OrderStatus.SUBMITTED
+        assert result.broker_order_id is not None
+        assert len(loop) == 1
+        assert loop.get(order.id) is result
+
+    async def test_persister_called_per_transition(self):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        captured: list[Order] = []
+
+        loop = LiveLoop(
+            broker=broker,
+            risk=_gate(kill_switch=ks),
+            persister=captured.append,
+        )
+        await loop.submit(_market_buy())
+        assert len(captured) == 1
+        assert captured[0].status == OrderStatus.SUBMITTED
+
+
+# ---------------------------------------------------------------------------
+# Risk-gate rejection
+# ---------------------------------------------------------------------------
+
+
+class TestRiskRejection:
+    async def test_kill_switch_blocks_submit(self):
+        ks = KillSwitch()
+        ks.engage(reason="manual_panic")
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(broker=broker, risk=_gate(kill_switch=ks))
+
+        order = _market_buy()
+        result = await loop.submit(order)
+        assert result.status == OrderStatus.REJECTED
+        assert "kill-switch engaged" in (result.reject_reason or "")
+        # Broker should not have seen the order — its event queue is empty.
+        events = await broker.drain_events()
+        assert events == []
+
+    async def test_max_qty_blocks_submit(self):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(
+            broker=broker,
+            risk=_gate(kill_switch=ks, max_qty=Decimal("5")),
+        )
+        order = _market_buy(qty="10")
+        result = await loop.submit(order)
+        assert result.status == OrderStatus.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# Broker-error policy
+# ---------------------------------------------------------------------------
+
+
+class TestBrokerErrors:
+    async def test_auth_error_engages_kill_switch_and_reraises(self):
+        ks = KillSwitch()
+        loop = LiveLoop(
+            broker=_AuthFailBroker(),
+            risk=_gate(kill_switch=ks),
+            kill_switch=ks,
+        )
+        with pytest.raises(BrokerAuthError):
+            await loop.submit(_market_buy())
+        assert ks.is_engaged()
+        snap = ks.snapshot()
+        assert snap.reason == "broker_auth_error"
+
+    async def test_reject_error_marks_order_rejected_no_kill_switch(self):
+        ks = KillSwitch()
+        loop = LiveLoop(
+            broker=_RejectBroker(),
+            risk=_gate(kill_switch=ks),
+            kill_switch=ks,
+        )
+        result = await loop.submit(_market_buy())
+        assert result.status == OrderStatus.REJECTED
+        assert "MARGIN" in (result.reject_reason or "")
+        assert ks.is_engaged() is False
+
+    async def test_connection_error_reraises_no_state_change(self):
+        ks = KillSwitch()
+        loop = LiveLoop(
+            broker=_ConnectionBroker(),
+            risk=_gate(kill_switch=ks),
+            kill_switch=ks,
+        )
+        with pytest.raises(BrokerConnectionError):
+            await loop.submit(_market_buy())
+        # Connection error should NOT engage the kill-switch — it's
+        # transient and the caller is expected to retry.
+        assert ks.is_engaged() is False
+
+
+# ---------------------------------------------------------------------------
+# Event consumption
+# ---------------------------------------------------------------------------
+
+
+class TestApplyBrokerEvent:
+    async def test_fill_event_completes_order(self):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(broker=broker, risk=_gate(kill_switch=ks))
+
+        order = _market_buy("10")
+        submitted = await loop.submit(order)
+        broker_id = submitted.broker_order_id
+        # Drain the Ack and Fill that PaperBroker emitted.
+        events = await broker.drain_events()
+        ack, fill = events[0], events[1]
+
+        # Apply Ack → ACKNOWLEDGED.
+        ack_result = await loop.apply_broker_event(ack, broker_order_id=broker_id)
+        assert ack_result.status == OrderStatus.ACKNOWLEDGED
+
+        # Apply Fill → FILLED.
+        fill_result = await loop.apply_broker_event(fill, broker_order_id=broker_id)
+        assert fill_result.status == OrderStatus.FILLED
+        assert fill_result.filled_quantity == Decimal("10")
+
+    async def test_unknown_broker_id_raises(self):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(broker=broker, risk=_gate(kill_switch=ks))
+
+        # No submit happened — the registry is empty.
+        with pytest.raises(UnknownOrderError):
+            await loop.apply_broker_event(
+                AckEvent(occurred_at=datetime.now(tz=UTC), broker_order_id="X"),
+                broker_order_id="X",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+
+class TestLookups:
+    async def test_open_orders_excludes_terminals(self):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(broker=broker, risk=_gate(kill_switch=ks))
+
+        # Submit one and walk it to FILLED.
+        order = _market_buy("10")
+        result = await loop.submit(order)
+        broker_id = result.broker_order_id
+        events = await broker.drain_events()
+        for ev in events:
+            await loop.apply_broker_event(ev, broker_order_id=broker_id)
+
+        # Submit a second and leave it pending submit (don't apply Ack).
+        order2 = _market_buy("5")
+        await loop.submit(order2)
+
+        opens = loop.open_orders()
+        assert len(opens) == 1
+        assert opens[0].id == order2.id
+
+
+# ---------------------------------------------------------------------------
+# Persister failures don't break the loop
+# ---------------------------------------------------------------------------
+
+
+class TestPersisterRobustness:
+    async def test_failing_persister_does_not_raise(self):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+
+        def angry(_order):
+            raise RuntimeError("disk full")
+
+        loop = LiveLoop(
+            broker=broker,
+            risk=_gate(kill_switch=ks),
+            persister=angry,
+        )
+        # The submit must complete despite the persister raising.
+        result = await loop.submit(_market_buy())
+        assert result.status == OrderStatus.SUBMITTED


### PR DESCRIPTION
Foundation slice of live-trading orchestration. Composes OMS state machine + RiskGate + BrokerAdapter + KillSwitch + Persister into the smallest unit of submit-and-react. submit() flow: RiskGate → broker.submit with typed-exception dispatch (Auth=engage kill-switch+raise, Reject=mark rejected, Connection=raise transient) → apply SubmitEvent. apply_broker_event() correlates broker_order_id and applies via OMS state machine. 11 passing tests including PaperBroker happy path + all 3 broker-error paths + persister-failure isolation. Refs #109. Reconciliation on startup, half-submitted recovery, multi-broker routing, fill-handler hooks all deferred.