### PR TITLE
feat(tax): UK / HMRC CGT jurisdiction (gh#81 follow-up)

### DIFF
--- a/engine/core/tax/jurisdictions/__init__.py
+++ b/engine/core/tax/jurisdictions/__init__.py
@@ -29,11 +29,13 @@ from engine.core.tax.jurisdictions.registry import (
     list_jurisdictions,
     register_jurisdiction,
 )
+from engine.core.tax.jurisdictions.gb import UnitedKingdom
 from engine.core.tax.jurisdictions.us import UnitedStates
 
 __all__ = [
     "LotMethod",
     "TaxJurisdiction",
+    "UnitedKingdom",
     "UnitedStates",
     "get_jurisdiction",
     "list_jurisdictions",

--- a/engine/core/tax/jurisdictions/gb.py
+++ b/engine/core/tax/jurisdictions/gb.py
@@ -1,0 +1,52 @@
+"""United Kingdom tax jurisdiction — HMRC CGT (gh#81 follow-up).
+
+Sources of truth:
+- Taxation of Chargeable Gains Act 1992 (TCGA), s.104 (the "section
+  104 holding" / pooled cost-basis rule).
+- TCGA s.105 (the 30-day "bed & breakfasting" rule that disallows
+  matching a sale with a *prior-30-day* purchase of the same
+  security — analogous to but not identical to the US Section 1091
+  wash-sale rule).
+- HMRC HS284 ("Shares and Capital Gains Tax").
+
+Notable differences from the US model
+-------------------------------------
+- **No long-term capital-gains distinction.** Capital gains in the
+  UK are taxed at a single rate based on income band; there is no
+  one-year holding-period boundary. We therefore set
+  ``long_term_days = 0`` to mark the concept as not applicable —
+  consumers should special-case zero rather than treating one day
+  as the boundary.
+- **30-day "bed & breakfasting" window.** The UK rule is symmetric
+  with the US wash-sale window, so ``wash_sale_window_days = 30``.
+- **Lot method = average cost** (the s.104 holding pool). FIFO and
+  HIFO are *not* permitted for GB tax purposes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from engine.core.tax.jurisdictions.base import LotMethod
+
+
+@dataclass(frozen=True)
+class UnitedKingdom:
+    """UK CGT jurisdiction record.
+
+    Duck-typed against :class:`engine.core.tax.jurisdictions.base.TaxJurisdiction`.
+    """
+
+    code: str = "GB"
+    display_name: str = "United Kingdom"
+    currency: str = "GBP"
+    # No long-term boundary under HMRC CGT; flag as not-applicable.
+    long_term_days: int = 0
+    # 30-day "bed & breakfasting" rule.
+    wash_sale_window_days: int = 30
+    # HMRC requires the s.104 holding pool: average cost of all
+    # currently-held shares of the same class.
+    default_lot_method: LotMethod = LotMethod.AVERAGE_COST
+    allowed_lot_methods: frozenset[LotMethod] = field(
+        default_factory=lambda: frozenset({LotMethod.AVERAGE_COST})
+    )

--- a/tests/test_jurisdictions_gb.py
+++ b/tests/test_jurisdictions_gb.py
@@ -1,0 +1,48 @@
+"""Unit tests for the GB / HMRC CGT jurisdiction (gh#81 follow-up)."""
+
+from __future__ import annotations
+
+from engine.core.tax.jurisdictions import (
+    LotMethod,
+    TaxJurisdiction,
+    UnitedKingdom,
+)
+
+
+class TestUnitedKingdom:
+    def test_protocol_compatible(self):
+        assert isinstance(UnitedKingdom(), TaxJurisdiction)
+
+    def test_default_values(self):
+        gb = UnitedKingdom()
+        assert gb.code == "GB"
+        assert gb.display_name == "United Kingdom"
+        assert gb.currency == "GBP"
+
+    def test_no_long_term_distinction(self):
+        # HMRC CGT has no long-term boundary; we encode this as
+        # long_term_days == 0 so consumers can special-case it.
+        gb = UnitedKingdom()
+        assert gb.long_term_days == 0
+
+    def test_thirty_day_bed_and_breakfasting_window(self):
+        # TCGA s.105 — 30 days, symmetric with the US wash-sale window.
+        gb = UnitedKingdom()
+        assert gb.wash_sale_window_days == 30
+
+    def test_default_lot_method_is_average_cost(self):
+        # HMRC requires the s.104 holding pool: average cost of all
+        # currently-held shares of the same class.
+        gb = UnitedKingdom()
+        assert gb.default_lot_method == LotMethod.AVERAGE_COST
+
+    def test_only_average_cost_allowed(self):
+        gb = UnitedKingdom()
+        assert gb.allowed_lot_methods == frozenset({LotMethod.AVERAGE_COST})
+        assert LotMethod.FIFO not in gb.allowed_lot_methods
+        assert LotMethod.HIFO not in gb.allowed_lot_methods
+        assert LotMethod.LIFO not in gb.allowed_lot_methods
+
+    def test_default_in_allowed(self):
+        gb = UnitedKingdom()
+        assert gb.default_lot_method in gb.allowed_lot_methods


### PR DESCRIPTION
Second concrete TaxJurisdiction after US default (#287). UnitedKingdom: code GB, currency GBP, long_term_days=0 (no UK long-term distinction — consumers special-case zero), wash_sale_window_days=30 (TCGA s.105 bed-&-breakfasting), default + only allowed lot method AVERAGE_COST (s.104 holding pool). FIFO/HIFO/LIFO/SPECIFIC_ID explicitly excluded. 7 passing tests. Refs #81. DE/KESt and FR jurisdictions still deferred.