### PR TITLE
feat(tax): DE / KESt jurisdiction (gh#81 follow-up)

### DIFF
--- a/engine/core/tax/jurisdictions/__init__.py
+++ b/engine/core/tax/jurisdictions/__init__.py
@@ -29,10 +29,12 @@ from engine.core.tax.jurisdictions.registry import (
     list_jurisdictions,
     register_jurisdiction,
 )
+from engine.core.tax.jurisdictions.de import Germany
 from engine.core.tax.jurisdictions.gb import UnitedKingdom
 from engine.core.tax.jurisdictions.us import UnitedStates
 
 __all__ = [
+    "Germany",
     "LotMethod",
     "TaxJurisdiction",
     "UnitedKingdom",

--- a/engine/core/tax/jurisdictions/de.py
+++ b/engine/core/tax/jurisdictions/de.py
@@ -1,0 +1,53 @@
+"""Germany tax jurisdiction — KESt / Abgeltungsteuer (gh#81 follow-up).
+
+Sources of truth:
+- EStG § 20 (income from capital assets) — defines the categories
+  taxed under the flat-rate Abgeltungsteuer regime.
+- EStG § 32d — flat 25% withholding rate (plus 5.5% solidarity
+  surcharge, plus 8/9% church tax where applicable). The engine
+  records the *base* rate; surcharge handling is operator-deployed.
+- BMF letter 18.01.2016 (income from capital assets) — confirms
+  FIFO as the mandatory lot-selection method for shares held in a
+  domestic securities account.
+
+Notable differences from the US and UK models
+---------------------------------------------
+- **No long-term / short-term distinction.** The Abgeltungsteuer
+  reform (2009) abolished the prior Spekulationsfrist for newly-
+  acquired shares. ``long_term_days = 0`` flags the concept as
+  not applicable.
+- **No wash-sale rule for shares.** Germany has no equivalent of
+  the US Section 1091 rule for cash-equity sales (a separate rule
+  applies to certain derivatives — out of scope for this slice).
+  ``wash_sale_window_days = 0``.
+- **FIFO is mandatory.** §20 EStG and the BMF letter both require
+  FIFO. AVERAGE_COST / HIFO / SPECIFIC_ID are not permitted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from engine.core.tax.jurisdictions.base import LotMethod
+
+
+@dataclass(frozen=True)
+class Germany:
+    """DE / KESt jurisdiction record.
+
+    Duck-typed against :class:`engine.core.tax.jurisdictions.base.TaxJurisdiction`.
+    """
+
+    code: str = "DE"
+    display_name: str = "Germany"
+    currency: str = "EUR"
+    # Abgeltungsteuer reform abolished the holding-period boundary
+    # for newly-acquired shares (2009). Flag as not-applicable.
+    long_term_days: int = 0
+    # No wash-sale rule for cash-equity sales under German tax law.
+    wash_sale_window_days: int = 0
+    # §20 EStG + BMF letter 18.01.2016 mandate FIFO.
+    default_lot_method: LotMethod = LotMethod.FIFO
+    allowed_lot_methods: frozenset[LotMethod] = field(
+        default_factory=lambda: frozenset({LotMethod.FIFO})
+    )

--- a/tests/test_jurisdictions_de.py
+++ b/tests/test_jurisdictions_de.py
@@ -1,0 +1,47 @@
+"""Unit tests for the DE / KESt jurisdiction (gh#81 follow-up)."""
+
+from __future__ import annotations
+
+from engine.core.tax.jurisdictions import (
+    Germany,
+    LotMethod,
+    TaxJurisdiction,
+)
+
+
+class TestGermany:
+    def test_protocol_compatible(self):
+        assert isinstance(Germany(), TaxJurisdiction)
+
+    def test_default_values(self):
+        de = Germany()
+        assert de.code == "DE"
+        assert de.display_name == "Germany"
+        assert de.currency == "EUR"
+
+    def test_no_long_term_distinction(self):
+        # Abgeltungsteuer reform (2009) abolished the holding-period
+        # boundary. Encoded as 0.
+        de = Germany()
+        assert de.long_term_days == 0
+
+    def test_no_wash_sale(self):
+        # No equivalent of US Section 1091 for cash-equity sales.
+        de = Germany()
+        assert de.wash_sale_window_days == 0
+
+    def test_default_lot_method_is_fifo(self):
+        # §20 EStG + BMF letter 18.01.2016 mandate FIFO.
+        de = Germany()
+        assert de.default_lot_method == LotMethod.FIFO
+
+    def test_only_fifo_allowed(self):
+        de = Germany()
+        assert de.allowed_lot_methods == frozenset({LotMethod.FIFO})
+        assert LotMethod.AVERAGE_COST not in de.allowed_lot_methods
+        assert LotMethod.HIFO not in de.allowed_lot_methods
+        assert LotMethod.LIFO not in de.allowed_lot_methods
+
+    def test_default_in_allowed(self):
+        de = Germany()
+        assert de.default_lot_method in de.allowed_lot_methods


### PR DESCRIPTION
Third concrete TaxJurisdiction after US (#287) and GB (#294). Germany: code DE, currency EUR, long_term_days=0 (Abgeltungsteuer 2009 reform), wash_sale_window_days=0 (no Section-1091 equivalent for cash equities), default + only allowed lot method FIFO (§20 EStG + BMF letter 18.01.2016). 7 passing tests. Refs #81. FR jurisdiction still deferred.