### PR TITLE
feat(tax): FR / PFU jurisdiction (gh#81 follow-up)

### DIFF
--- a/engine/core/tax/jurisdictions/__init__.py
+++ b/engine/core/tax/jurisdictions/__init__.py
@@ -30,10 +30,12 @@ from engine.core.tax.jurisdictions.registry import (
     register_jurisdiction,
 )
 from engine.core.tax.jurisdictions.de import Germany
+from engine.core.tax.jurisdictions.fr import France
 from engine.core.tax.jurisdictions.gb import UnitedKingdom
 from engine.core.tax.jurisdictions.us import UnitedStates
 
 __all__ = [
+    "France",
     "Germany",
     "LotMethod",
     "TaxJurisdiction",

--- a/engine/core/tax/jurisdictions/fr.py
+++ b/engine/core/tax/jurisdictions/fr.py
@@ -1,0 +1,52 @@
+"""France tax jurisdiction — PFU / Prélèvement Forfaitaire Unique (gh#81 follow-up).
+
+Sources of truth:
+- Code général des impôts (CGI) Article 200 A — flat-tax regime
+  ("Prélèvement Forfaitaire Unique") introduced by the 2018 finance
+  law. 30 % combined rate (12.8 % income tax + 17.2 % social
+  charges). Surcharges are operator-deployed; the engine records
+  the *base* concept.
+- CGI Article 150-0 D — FIFO ("première entrée, première sortie") is
+  mandatory for securities of the same kind held in a single account.
+- BOI-RPPM-PVBMI-20-10-30 — administrative doctrine confirming the
+  FIFO mandate and the abolition of the prior abattement-pour-durée-
+  de-détention with the PFU.
+
+Notable
+-------
+- **No long-term distinction** under the default PFU regime (the
+  prior abattement-pour-durée-de-détention applies only to taxpayers
+  who explicitly opt for the barème progressif on pre-2018 lots —
+  out of scope here). ``long_term_days = 0``.
+- **No wash-sale rule** for cash-equity sales under French tax law.
+  ``wash_sale_window_days = 0``.
+- **FIFO mandatory.** AVERAGE_COST / HIFO / LIFO / SPECIFIC_ID are
+  not permitted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from engine.core.tax.jurisdictions.base import LotMethod
+
+
+@dataclass(frozen=True)
+class France:
+    """FR / PFU jurisdiction record.
+
+    Duck-typed against :class:`engine.core.tax.jurisdictions.base.TaxJurisdiction`.
+    """
+
+    code: str = "FR"
+    display_name: str = "France"
+    currency: str = "EUR"
+    # PFU: no long-term boundary applies under the default regime.
+    long_term_days: int = 0
+    # No wash-sale rule for cash-equity sales under French tax law.
+    wash_sale_window_days: int = 0
+    # CGI Article 150-0 D mandates FIFO.
+    default_lot_method: LotMethod = LotMethod.FIFO
+    allowed_lot_methods: frozenset[LotMethod] = field(
+        default_factory=lambda: frozenset({LotMethod.FIFO})
+    )

--- a/tests/test_jurisdictions_fr.py
+++ b/tests/test_jurisdictions_fr.py
@@ -1,0 +1,45 @@
+"""Unit tests for the FR / PFU jurisdiction (gh#81 follow-up)."""
+
+from __future__ import annotations
+
+from engine.core.tax.jurisdictions import (
+    France,
+    LotMethod,
+    TaxJurisdiction,
+)
+
+
+class TestFrance:
+    def test_protocol_compatible(self):
+        assert isinstance(France(), TaxJurisdiction)
+
+    def test_default_values(self):
+        fr = France()
+        assert fr.code == "FR"
+        assert fr.display_name == "France"
+        assert fr.currency == "EUR"
+
+    def test_no_long_term_distinction(self):
+        # PFU regime since 2018 — no long-term boundary by default.
+        fr = France()
+        assert fr.long_term_days == 0
+
+    def test_no_wash_sale(self):
+        fr = France()
+        assert fr.wash_sale_window_days == 0
+
+    def test_default_lot_method_is_fifo(self):
+        # CGI Article 150-0 D mandates FIFO.
+        fr = France()
+        assert fr.default_lot_method == LotMethod.FIFO
+
+    def test_only_fifo_allowed(self):
+        fr = France()
+        assert fr.allowed_lot_methods == frozenset({LotMethod.FIFO})
+        assert LotMethod.AVERAGE_COST not in fr.allowed_lot_methods
+        assert LotMethod.HIFO not in fr.allowed_lot_methods
+        assert LotMethod.LIFO not in fr.allowed_lot_methods
+
+    def test_default_in_allowed(self):
+        fr = France()
+        assert fr.default_lot_method in fr.allowed_lot_methods


### PR DESCRIPTION
Fourth concrete TaxJurisdiction. France under PFU (2018 finance law). code FR, currency EUR, long_term_days=0 (no holding-period boundary by default), wash_sale_window_days=0, default + only allowed lot method FIFO (CGI Article 150-0 D). 7 passing tests. Refs #81. Now four jurisdictions ship: US, GB, DE, FR.