### PR TITLE
feat(tax): jurisdiction-aware wash-sale window (gh#156 follow-up)

### DIFF
--- a/engine/core/tax/__init__.py
+++ b/engine/core/tax/__init__.py
@@ -12,6 +12,7 @@ from engine.core.tax.wash_sale import (
     TradeSide,
     WashSaleAdjustment,
     detect_wash_sales,
+    detect_wash_sales_for_jurisdiction,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "WASH_SALE_WINDOW_DAYS",
     "WashSaleAdjustment",
     "detect_wash_sales",
+    "detect_wash_sales_for_jurisdiction",
 ]

--- a/engine/core/tax/wash_sale.py
+++ b/engine/core/tax/wash_sale.py
@@ -111,6 +111,7 @@ def detect_wash_sales(
     trades: list[Trade],
     *,
     cost_basis_for: dict[str, Decimal] | None = None,
+    window_days: int = WASH_SALE_WINDOW_DAYS,
 ) -> list[WashSaleAdjustment]:
     """Return wash-sale adjustments implied by ``trades``.
 
@@ -119,9 +120,20 @@ def detect_wash_sales(
     detector falls back to using FIFO matching against earlier buys
     in ``trades`` to compute the basis.
 
+    ``window_days`` overrides the default US Section 1091 30-day
+    window. Pass the active jurisdiction's ``wash_sale_window_days``
+    for non-US tax regimes. ``window_days == 0`` short-circuits the
+    detector and returns ``[]`` — useful for jurisdictions that have
+    no wash-sale rule (DE, FR).
+
     The output is sorted by ``(sale_trade_id, replacement_trade_id)``
     so callers can diff against previous runs.
     """
+    if window_days < 0:
+        raise ValueError("window_days must be non-negative")
+    if window_days == 0:
+        return []
+
     sales = [t for t in trades if t.side == TradeSide.SELL]
 
     # FIFO state shared between basis computation and wash-sale matching.
@@ -172,7 +184,7 @@ def detect_wash_sales(
     )
 
     adjustments: list[WashSaleAdjustment] = []
-    window = timedelta(days=WASH_SALE_WINDOW_DAYS)
+    window = timedelta(days=window_days)
 
     for sale in sale_states:
         for buy in buy_states:
@@ -217,6 +229,24 @@ def detect_wash_sales(
         key=lambda a: (a.sale_trade_id, a.replacement_trade_id)
     )
     return adjustments
+
+
+def detect_wash_sales_for_jurisdiction(
+    trades: list[Trade],
+    jurisdiction,  # noqa: ANN001 - duck-typed against TaxJurisdiction Protocol
+    *,
+    cost_basis_for: dict[str, Decimal] | None = None,
+) -> list[WashSaleAdjustment]:
+    """Run :func:`detect_wash_sales` using the jurisdiction's window.
+
+    Jurisdictions with ``wash_sale_window_days == 0`` (DE, FR, etc.)
+    short-circuit to ``[]`` without scanning the trades.
+    """
+    return detect_wash_sales(
+        trades,
+        cost_basis_for=cost_basis_for,
+        window_days=jurisdiction.wash_sale_window_days,
+    )
 
 
 def _consume_fifo(lots: list[_BuyState], qty: Decimal) -> Decimal:

--- a/tests/test_wash_sale_jurisdiction.py
+++ b/tests/test_wash_sale_jurisdiction.py
@@ -1,0 +1,125 @@
+"""Tests for the jurisdiction-aware wash-sale detector (gh#156 follow-up).
+
+Covers the new ``window_days`` keyword on :func:`detect_wash_sales` and
+the :func:`detect_wash_sales_for_jurisdiction` helper that dispatches
+on a :class:`TaxJurisdiction`'s ``wash_sale_window_days``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax import (
+    Trade,
+    TradeSide,
+    detect_wash_sales,
+    detect_wash_sales_for_jurisdiction,
+)
+from engine.core.tax.jurisdictions import (
+    France,
+    Germany,
+    UnitedKingdom,
+    UnitedStates,
+)
+
+
+def _trade(
+    tid: str,
+    symbol: str,
+    side: TradeSide,
+    qty: str,
+    price: str,
+    days_offset: int,
+) -> Trade:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    return Trade(
+        trade_id=tid,
+        symbol=symbol,
+        side=side,
+        quantity=Decimal(qty),
+        price=Decimal(price),
+        when=base + timedelta(days=days_offset),
+    )
+
+
+def _loss_with_replacement(replacement_offset: int) -> list[Trade]:
+    """Buy@100, sell@80 (loss=200), buy@85 ``replacement_offset`` days later."""
+    return [
+        _trade("b1", "AAPL", TradeSide.BUY, "10", "100", 0),
+        _trade("s1", "AAPL", TradeSide.SELL, "10", "80", 5),
+        _trade("b2", "AAPL", TradeSide.BUY, "10", "85", 5 + replacement_offset),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# window_days keyword on detect_wash_sales
+# ---------------------------------------------------------------------------
+
+
+class TestWindowDaysKeyword:
+    def test_zero_window_short_circuits(self):
+        # A jurisdiction with no wash-sale rule should produce no adjustments
+        # even when the trade pattern would otherwise be a textbook wash sale.
+        trades = _loss_with_replacement(replacement_offset=5)
+        assert detect_wash_sales(trades, window_days=0) == []
+
+    def test_negative_window_rejected(self):
+        with pytest.raises(ValueError):
+            detect_wash_sales([], window_days=-1)
+
+    def test_explicit_window_narrower_than_default(self):
+        # Replacement 20 days after sale: matches default 30-day window
+        # but not a 14-day window.
+        trades = _loss_with_replacement(replacement_offset=20)
+        assert len(detect_wash_sales(trades)) == 1
+        assert detect_wash_sales(trades, window_days=14) == []
+
+    def test_explicit_window_wider_than_default(self):
+        # Replacement 40 days after sale: outside 30-day window, inside 60.
+        trades = _loss_with_replacement(replacement_offset=40)
+        assert detect_wash_sales(trades) == []
+        assert len(detect_wash_sales(trades, window_days=60)) == 1
+
+
+# ---------------------------------------------------------------------------
+# detect_wash_sales_for_jurisdiction
+# ---------------------------------------------------------------------------
+
+
+class TestForJurisdiction:
+    def test_us_runs_thirty_day_detector(self):
+        trades = _loss_with_replacement(replacement_offset=5)
+        adjustments = detect_wash_sales_for_jurisdiction(trades, UnitedStates())
+        assert len(adjustments) == 1
+        assert adjustments[0].sale_trade_id == "s1"
+        assert adjustments[0].disallowed_loss == Decimal("200.0000")
+
+    def test_gb_runs_thirty_day_detector(self):
+        # GB bed-and-breakfasting rule: same 30-day window as the US for
+        # repurchase-after-loss patterns.
+        trades = _loss_with_replacement(replacement_offset=5)
+        adjustments = detect_wash_sales_for_jurisdiction(trades, UnitedKingdom())
+        assert len(adjustments) == 1
+
+    def test_de_short_circuits(self):
+        # Germany: no wash-sale rule. Same trade pattern, no adjustments.
+        trades = _loss_with_replacement(replacement_offset=5)
+        assert detect_wash_sales_for_jurisdiction(trades, Germany()) == []
+
+    def test_fr_short_circuits(self):
+        # France: PFU regime, no wash-sale rule.
+        trades = _loss_with_replacement(replacement_offset=5)
+        assert detect_wash_sales_for_jurisdiction(trades, France()) == []
+
+    def test_threads_cost_basis_override(self):
+        # Explicit basis says the sale was break-even — even US should skip.
+        trades = _loss_with_replacement(replacement_offset=5)
+        adjustments = detect_wash_sales_for_jurisdiction(
+            trades,
+            UnitedStates(),
+            cost_basis_for={"s1": Decimal("800")},
+        )
+        assert adjustments == []


### PR DESCRIPTION
## Summary

- `detect_wash_sales(trades, *, window_days=...)` — new keyword threads the active jurisdiction's wash-sale window through the existing detector. Defaults to the US 30-day rule (`WASH_SALE_WINDOW_DAYS`).
- `window_days == 0` short-circuits to `[]` for jurisdictions with no wash-sale rule (DE, FR). Negatives raise `ValueError`.
- `detect_wash_sales_for_jurisdiction(trades, jurisdiction, *, cost_basis_for=None)` — convenience helper that reads `jurisdiction.wash_sale_window_days` and dispatches.

Pure function, no DB, no migration.

Refs #156. Does not close — "substantially identical" identification and Section 1256 mark-to-market are still deferred.

## Test plan

- [x] `tests/test_wash_sale_jurisdiction.py` — `window_days=0` returns `[]`, negative raises, narrower window suppresses match, wider window admits otherwise-out-of-window match.
- [x] Per-jurisdiction dispatch: US/GB produce adjustments, DE/FR short-circuit.
- [x] Helper threads `cost_basis_for` override correctly.
- [x] All existing wash-sale tests still pass (default 30 unchanged).