### PR TITLE
feat(oms): MetricsBackend instrumentation for LiveLoop (gh#109/#111)

### DIFF
--- a/engine/core/live/loop.py
+++ b/engine/core/live/loop.py
@@ -57,6 +57,7 @@ from engine.core.brokers.base import (
 from engine.core.live.kill_switch import KillSwitch, get_kill_switch
 from engine.core.oms.events import RejectEvent, SubmitEvent
 from engine.core.oms.risk import Reject, RiskGate
+from engine.observability.metrics import MetricsBackend, get_metrics
 
 if TYPE_CHECKING:
     from engine.core.brokers.base import BrokerAdapter
@@ -99,15 +100,23 @@ class LiveLoop:
         risk: RiskGate,
         persister: Persister | None = None,
         kill_switch: KillSwitch | None = None,
+        metrics: MetricsBackend | None = None,
     ) -> None:
         self._broker = broker
         self._risk = risk
         self._persister = persister
         self._kill_switch = kill_switch or get_kill_switch()
+        self._metrics = metrics
         # OMS id -> Order
         self._by_oms_id: dict[uuid.UUID, Order] = {}
         # Broker id -> OMS id (for event correlation)
         self._broker_to_oms: dict[str, uuid.UUID] = {}
+
+    @property
+    def metrics(self) -> MetricsBackend:
+        """Resolve the metrics backend lazily so tests can swap the
+        process-wide singleton via :func:`set_metrics` after construction."""
+        return self._metrics if self._metrics is not None else get_metrics()
 
     # ------------------------------------------------------------------
     # Submit path
@@ -125,17 +134,29 @@ class LiveLoop:
         :class:`BrokerAuthError` / :class:`BrokerConnectionError` for
         the caller to handle.
         """
+        metrics = self.metrics
+        base_tags = {"symbol": order.symbol, "side": order.side.value}
+        metrics.counter("oms.submit.attempted", tags=base_tags)
+
         gate_result = self._risk.evaluate(order, reference_price=reference_price)
         if isinstance(gate_result, Reject):
             updated = order.apply_event(
                 RejectEvent(occurred_at=_utcnow(), reason=gate_result.reason)
             )
             self._track(updated)
+            metrics.counter(
+                "oms.submit.outcome",
+                tags={**base_tags, "outcome": "risk_rejected"},
+            )
             return updated
 
         try:
             submitted = await self._broker.submit(order)
         except BrokerAuthError:
+            metrics.counter(
+                "oms.submit.outcome",
+                tags={**base_tags, "outcome": "broker_auth_error"},
+            )
             self._kill_switch.engage(
                 reason="broker_auth_error", actor="live_loop"
             )
@@ -148,8 +169,16 @@ class LiveLoop:
                 )
             )
             self._track(updated)
+            metrics.counter(
+                "oms.submit.outcome",
+                tags={**base_tags, "outcome": "broker_rejected"},
+            )
             return updated
         except BrokerConnectionError:
+            metrics.counter(
+                "oms.submit.outcome",
+                tags={**base_tags, "outcome": "broker_connection_error"},
+            )
             logger.warning(
                 "live_loop.broker_connection_error",
                 order_id=str(order.id),
@@ -165,6 +194,10 @@ class LiveLoop:
         )
         self._track(updated)
         self._broker_to_oms[submitted.broker_order_id] = updated.id
+        metrics.counter(
+            "oms.submit.outcome",
+            tags={**base_tags, "outcome": "submitted"},
+        )
         return updated
 
     # ------------------------------------------------------------------
@@ -190,6 +223,14 @@ class LiveLoop:
         order = self._by_oms_id[oms_id]
         updated = order.apply_event(event)
         self._track(updated)
+        self.metrics.counter(
+            "oms.event.applied",
+            tags={
+                "event_type": type(event).__name__,
+                "status": updated.status.value,
+                "symbol": updated.symbol,
+            },
+        )
         return updated
 
     # ------------------------------------------------------------------
@@ -211,6 +252,10 @@ class LiveLoop:
 
     def _track(self, order: Order) -> None:
         self._by_oms_id[order.id] = order
+        self.metrics.gauge(
+            "oms.open_orders",
+            float(sum(1 for o in self._by_oms_id.values() if not o.is_terminal)),
+        )
         if self._persister is not None:
             try:
                 self._persister(order)

--- a/tests/test_live_loop_metrics.py
+++ b/tests/test_live_loop_metrics.py
@@ -1,0 +1,330 @@
+"""Tests for LiveLoop metrics emission (gh#109/#111 follow-up).
+
+The loop emits four metrics through the active ``MetricsBackend``:
+
+- ``oms.submit.attempted`` — counter, every ``submit`` call.
+- ``oms.submit.outcome`` — counter, exactly once per submit, tagged
+  with ``outcome ∈ {submitted, risk_rejected, broker_rejected,
+  broker_auth_error, broker_connection_error}``.
+- ``oms.event.applied`` — counter, every successful broker-event
+  application; tagged with the post-event ``status``.
+- ``oms.open_orders`` — gauge, set after every state change.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from engine.core.brokers.base import (
+    BrokerAuthError,
+    BrokerConnectionError,
+    BrokerRejectError,
+    SubmittedOrder,
+)
+from engine.core.brokers.paper import PaperBroker
+from engine.core.live.kill_switch import KillSwitch
+from engine.core.live.loop import LiveLoop
+from engine.core.oms import (
+    AckEvent,
+    FillEvent,
+    Order,
+    OrderEvent,
+    OrderSide,
+    OrderType,
+)
+from engine.core.oms.risk import KillSwitchCheck, MaxOrderQuantity, RiskGate
+from engine.observability.metrics import RecordingBackend
+
+
+def _market_buy(qty: str = "10") -> Order:
+    return Order(
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal(qty),
+    )
+
+
+def _gate(*, kill_switch: KillSwitch, max_qty: Decimal = Decimal("1000")) -> RiskGate:
+    return RiskGate(
+        checks=[
+            KillSwitchCheck(switch=kill_switch),
+            MaxOrderQuantity(limit=max_qty),
+        ]
+    )
+
+
+class _RejectBroker:
+    @property
+    def name(self) -> str:
+        return "reject"
+
+    async def submit(self, order: Order) -> SubmittedOrder:  # noqa: ARG002
+        raise BrokerRejectError("insufficient buying power", broker_code="MARGIN")
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        raise NotImplementedError
+
+    async def events(self) -> AsyncIterator[OrderEvent]:  # type: ignore[override]
+        return
+        yield  # pragma: no cover
+
+
+class _AuthFailBroker:
+    @property
+    def name(self) -> str:
+        return "auth-fail"
+
+    async def submit(self, order: Order) -> SubmittedOrder:  # noqa: ARG002
+        raise BrokerAuthError("invalid api key")
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        raise NotImplementedError
+
+    async def events(self) -> AsyncIterator[OrderEvent]:  # type: ignore[override]
+        return
+        yield  # pragma: no cover
+
+
+class _ConnectionBroker:
+    @property
+    def name(self) -> str:
+        return "no-conn"
+
+    async def submit(self, order: Order) -> SubmittedOrder:  # noqa: ARG002
+        raise BrokerConnectionError("dns failed")
+
+    async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
+        raise NotImplementedError
+
+    async def events(self) -> AsyncIterator[OrderEvent]:  # type: ignore[override]
+        return
+        yield  # pragma: no cover
+
+
+def _counter_total(backend: RecordingBackend, name: str) -> float:
+    return sum(v for (n, _t), v in backend.counters.items() if n == name)
+
+
+def _counter_with(
+    backend: RecordingBackend, name: str, tags: dict[str, str]
+) -> float:
+    expected = tuple(sorted(tags.items()))
+    return sum(
+        v
+        for (n, t), v in backend.counters.items()
+        if n == name and all(item in t for item in expected)
+    )
+
+
+def _gauge_value(backend: RecordingBackend, name: str) -> float | None:
+    matches = [v for (n, _t), v in backend.gauges.items() if n == name]
+    return matches[-1] if matches else None
+
+
+@pytest.fixture
+def metrics() -> RecordingBackend:
+    return RecordingBackend()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitHappyPath:
+    async def test_emits_attempted_and_submitted_outcome(self, metrics):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(
+            broker=broker, risk=_gate(kill_switch=ks), metrics=metrics
+        )
+
+        await loop.submit(_market_buy())
+
+        assert _counter_total(metrics, "oms.submit.attempted") == 1
+        assert (
+            _counter_with(
+                metrics,
+                "oms.submit.outcome",
+                {"outcome": "submitted", "symbol": "AAPL"},
+            )
+            == 1
+        )
+        # Open-order gauge moved to 1 after submit.
+        assert _gauge_value(metrics, "oms.open_orders") == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Submit rejection paths
+# ---------------------------------------------------------------------------
+
+
+class TestRiskRejected:
+    async def test_kill_switch_engaged_emits_risk_rejected(self, metrics):
+        ks = KillSwitch()
+        ks.engage(reason="manual", actor="test")
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(
+            broker=broker, risk=_gate(kill_switch=ks), metrics=metrics
+        )
+
+        await loop.submit(_market_buy())
+
+        assert (
+            _counter_with(
+                metrics,
+                "oms.submit.outcome",
+                {"outcome": "risk_rejected"},
+            )
+            == 1
+        )
+        # Rejected order is terminal -> open_orders gauge stays at 0.
+        assert _gauge_value(metrics, "oms.open_orders") == 0.0
+
+
+class TestBrokerReject:
+    async def test_broker_reject_emits_broker_rejected(self, metrics):
+        ks = KillSwitch()
+        loop = LiveLoop(
+            broker=_RejectBroker(),
+            risk=_gate(kill_switch=ks),
+            metrics=metrics,
+        )
+
+        await loop.submit(_market_buy())
+
+        assert (
+            _counter_with(
+                metrics,
+                "oms.submit.outcome",
+                {"outcome": "broker_rejected"},
+            )
+            == 1
+        )
+        assert not ks.is_engaged()
+
+
+class TestBrokerAuth:
+    async def test_auth_error_emits_outcome_then_engages_kill_switch(self, metrics):
+        ks = KillSwitch()
+        loop = LiveLoop(
+            broker=_AuthFailBroker(),
+            risk=_gate(kill_switch=ks),
+            kill_switch=ks,
+            metrics=metrics,
+        )
+
+        with pytest.raises(BrokerAuthError):
+            await loop.submit(_market_buy())
+
+        assert (
+            _counter_with(
+                metrics,
+                "oms.submit.outcome",
+                {"outcome": "broker_auth_error"},
+            )
+            == 1
+        )
+        assert ks.is_engaged()
+
+
+class TestBrokerConnection:
+    async def test_connection_error_emits_outcome_and_reraises(self, metrics):
+        ks = KillSwitch()
+        loop = LiveLoop(
+            broker=_ConnectionBroker(),
+            risk=_gate(kill_switch=ks),
+            metrics=metrics,
+        )
+
+        with pytest.raises(BrokerConnectionError):
+            await loop.submit(_market_buy())
+
+        assert (
+            _counter_with(
+                metrics,
+                "oms.submit.outcome",
+                {"outcome": "broker_connection_error"},
+            )
+            == 1
+        )
+
+
+# ---------------------------------------------------------------------------
+# Event application
+# ---------------------------------------------------------------------------
+
+
+class TestEventApplied:
+    async def test_ack_then_fill_emits_event_applied_with_status(self, metrics):
+        ks = KillSwitch()
+        broker = PaperBroker(price_for=lambda s: Decimal("100"))
+        loop = LiveLoop(
+            broker=broker, risk=_gate(kill_switch=ks), metrics=metrics
+        )
+
+        order = await loop.submit(_market_buy())
+        assert order.broker_order_id is not None
+
+        await loop.apply_broker_event(
+            AckEvent(
+                occurred_at=datetime.now(tz=UTC),
+                broker_order_id=order.broker_order_id,
+            ),
+            broker_order_id=order.broker_order_id,
+        )
+        await loop.apply_broker_event(
+            FillEvent(
+                occurred_at=datetime.now(tz=UTC),
+                fill_quantity=order.quantity,
+                fill_price=Decimal("100"),
+            ),
+            broker_order_id=order.broker_order_id,
+        )
+
+        assert _counter_total(metrics, "oms.event.applied") == 2
+        assert (
+            _counter_with(
+                metrics,
+                "oms.event.applied",
+                {"event_type": "AckEvent", "status": "acknowledged"},
+            )
+            == 1
+        )
+        assert (
+            _counter_with(
+                metrics,
+                "oms.event.applied",
+                {"event_type": "FillEvent", "status": "filled"},
+            )
+            == 1
+        )
+        # Filled is terminal -> gauge back to 0.
+        assert _gauge_value(metrics, "oms.open_orders") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Default backend resolution
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultBackend:
+    async def test_resolves_get_metrics_when_not_injected(self):
+        from engine.observability.metrics import NullBackend, set_metrics
+
+        recording = RecordingBackend()
+        set_metrics(recording)
+        try:
+            ks = KillSwitch()
+            broker = PaperBroker(price_for=lambda s: Decimal("100"))
+            loop = LiveLoop(broker=broker, risk=_gate(kill_switch=ks))
+            await loop.submit(_market_buy())
+            assert _counter_total(recording, "oms.submit.attempted") == 1
+        finally:
+            set_metrics(NullBackend())


### PR DESCRIPTION
## Summary

Instrument \`LiveLoop\` with the existing \`MetricsBackend\` (gh#34) so operators see submit health and order-lifecycle activity without parsing structlog events.

Emits:
- \`oms.submit.attempted\` — counter, every \`submit\` call (tags: \`symbol\`, \`side\`).
- \`oms.submit.outcome\` — counter, exactly once per submit. \`outcome\` tag covers all five terminal paths: \`submitted\`, \`risk_rejected\`, \`broker_rejected\`, \`broker_auth_error\`, \`broker_connection_error\`.
- \`oms.event.applied\` — counter, every successful broker-event application (tags: \`event_type\`, \`status\`, \`symbol\`).
- \`oms.open_orders\` — gauge, recomputed after every state change.

Backend resolution: explicit \`metrics=\` kwarg wins; otherwise \`get_metrics()\` is consulted lazily at emission time so tests can swap the singleton via \`set_metrics()\` after construction.

Defaults to \`NullBackend\` → zero cost when no exporter is configured.

Refs #109 and #111 — does not close. Reconciliation, multi-broker routing, and per-strategy dashboards still deferred.

## Test plan

- [x] Happy path emits \`attempted\` + \`outcome=submitted\` + open-orders gauge=1
- [x] Kill-switch engaged → \`outcome=risk_rejected\`, open-orders=0
- [x] Broker reject → \`outcome=broker_rejected\`, kill-switch NOT engaged
- [x] Broker auth → \`outcome=broker_auth_error\`, kill-switch engaged
- [x] Broker connection → \`outcome=broker_connection_error\`, exception re-raised
- [x] AckEvent + FillEvent → two \`event.applied\` rows with correct \`status\` tags
- [x] Default backend resolution via \`get_metrics()\` works when no \`metrics=\` injected