### PR TITLE
feat(oms): MetricsBackend instrumentation for RiskGate (gh#111)

### DIFF
--- a/engine/core/oms/risk.py
+++ b/engine/core/oms/risk.py
@@ -41,6 +41,8 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import structlog
 
+from engine.observability.metrics import MetricsBackend, get_metrics
+
 if TYPE_CHECKING:
     from engine.core.live.kill_switch import KillSwitch
     from engine.core.oms.order import Order
@@ -169,8 +171,20 @@ class MaxOrderNotional:
 class RiskGate:
     """Runs an ordered list of checks. First Reject wins."""
 
-    def __init__(self, checks: list[RiskCheck]) -> None:
+    def __init__(
+        self,
+        checks: list[RiskCheck],
+        *,
+        metrics: MetricsBackend | None = None,
+    ) -> None:
         self._checks = list(checks)
+        self._metrics = metrics
+
+    @property
+    def metrics(self) -> MetricsBackend:
+        """Resolve the metrics backend lazily so tests can swap the
+        process singleton via :func:`set_metrics` after construction."""
+        return self._metrics if self._metrics is not None else get_metrics()
 
     def evaluate(
         self,
@@ -178,16 +192,42 @@ class RiskGate:
         *,
         reference_price: Decimal | None = None,
     ) -> CheckResult:
+        metrics = self.metrics
         for check in self._checks:
+            check_name = type(check).__name__
             result = check(order, reference_price=reference_price)
             if isinstance(result, Reject):
+                metrics.counter(
+                    "oms.risk.check",
+                    tags={
+                        "check": check_name,
+                        "symbol": order.symbol,
+                        "outcome": "reject",
+                    },
+                )
+                metrics.counter(
+                    "oms.risk.rejected",
+                    tags={"check": check_name, "symbol": order.symbol},
+                )
                 logger.warning(
                     "oms.risk_rejected",
-                    check=type(check).__name__,
+                    check=check_name,
                     order_id=str(order.id),
                     symbol=order.symbol,
                     quantity=str(order.quantity),
                     reason=result.reason,
                 )
                 return result
+            metrics.counter(
+                "oms.risk.check",
+                tags={
+                    "check": check_name,
+                    "symbol": order.symbol,
+                    "outcome": "approve",
+                },
+            )
+        metrics.counter(
+            "oms.risk.approved",
+            tags={"symbol": order.symbol},
+        )
         return Approve()

--- a/tests/test_oms_risk_metrics.py
+++ b/tests/test_oms_risk_metrics.py
@@ -1,0 +1,186 @@
+"""Tests for RiskGate metrics emission (gh#111 follow-up).
+
+The gate emits three metrics through the active ``MetricsBackend``:
+
+- ``oms.risk.check`` — counter, one per individual check, tagged with
+  ``check``, ``symbol`` and ``outcome ∈ {approve, reject}``.
+- ``oms.risk.rejected`` — counter, exactly once when a check rejects
+  the order; tagged with the rejecting check's class name.
+- ``oms.risk.approved`` — counter, exactly once when every check
+  approves.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from engine.core.live.kill_switch import KillSwitch
+from engine.core.oms import Order, OrderSide, OrderType
+from engine.core.oms.risk import (
+    Approve,
+    KillSwitchCheck,
+    MaxOrderNotional,
+    MaxOrderQuantity,
+    Reject,
+    RiskGate,
+)
+from engine.observability.metrics import RecordingBackend
+
+
+def _market_buy(qty: str = "10") -> Order:
+    return Order(
+        symbol="AAPL",
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal(qty),
+    )
+
+
+def _counter_total(backend: RecordingBackend, name: str) -> float:
+    return sum(v for (n, _t), v in backend.counters.items() if n == name)
+
+
+def _counter_with(
+    backend: RecordingBackend, name: str, tags: dict[str, str]
+) -> float:
+    expected = tuple(sorted(tags.items()))
+    return sum(
+        v
+        for (n, t), v in backend.counters.items()
+        if n == name and all(item in t for item in expected)
+    )
+
+
+@pytest.fixture
+def metrics() -> RecordingBackend:
+    return RecordingBackend()
+
+
+class TestApproveAllPath:
+    def test_each_check_records_approve_then_overall_approved(self, metrics):
+        ks = KillSwitch()
+        gate = RiskGate(
+            checks=[
+                KillSwitchCheck(switch=ks),
+                MaxOrderQuantity(limit=Decimal("100")),
+            ],
+            metrics=metrics,
+        )
+
+        result = gate.evaluate(_market_buy())
+
+        assert isinstance(result, Approve)
+        assert _counter_total(metrics, "oms.risk.check") == 2
+        assert (
+            _counter_with(
+                metrics,
+                "oms.risk.check",
+                {"check": "KillSwitchCheck", "outcome": "approve"},
+            )
+            == 1
+        )
+        assert (
+            _counter_with(
+                metrics,
+                "oms.risk.check",
+                {"check": "MaxOrderQuantity", "outcome": "approve"},
+            )
+            == 1
+        )
+        assert _counter_total(metrics, "oms.risk.approved") == 1
+        assert _counter_total(metrics, "oms.risk.rejected") == 0
+
+
+class TestFirstRejectShortCircuits:
+    def test_quantity_reject_records_reject_and_skips_remaining(self, metrics):
+        ks = KillSwitch()
+        gate = RiskGate(
+            checks=[
+                MaxOrderQuantity(limit=Decimal("5")),  # rejects: order qty 10
+                KillSwitchCheck(switch=ks),  # never reached
+            ],
+            metrics=metrics,
+        )
+
+        result = gate.evaluate(_market_buy())
+
+        assert isinstance(result, Reject)
+        # Only the first check ran: one approve/reject row total.
+        assert _counter_total(metrics, "oms.risk.check") == 1
+        assert (
+            _counter_with(
+                metrics,
+                "oms.risk.check",
+                {"check": "MaxOrderQuantity", "outcome": "reject"},
+            )
+            == 1
+        )
+        assert (
+            _counter_with(
+                metrics,
+                "oms.risk.rejected",
+                {"check": "MaxOrderQuantity", "symbol": "AAPL"},
+            )
+            == 1
+        )
+        assert _counter_total(metrics, "oms.risk.approved") == 0
+
+
+class TestKillSwitchReject:
+    def test_kill_switch_engaged_records_reject(self, metrics):
+        ks = KillSwitch()
+        ks.engage(reason="manual", actor="test")
+        gate = RiskGate(
+            checks=[KillSwitchCheck(switch=ks)],
+            metrics=metrics,
+        )
+
+        result = gate.evaluate(_market_buy())
+
+        assert isinstance(result, Reject)
+        assert (
+            _counter_with(
+                metrics,
+                "oms.risk.rejected",
+                {"check": "KillSwitchCheck"},
+            )
+            == 1
+        )
+
+
+class TestNotionalCheck:
+    def test_notional_reject_carries_check_name_tag(self, metrics):
+        gate = RiskGate(
+            checks=[MaxOrderNotional(limit=Decimal("500"))],
+            metrics=metrics,
+        )
+
+        # 10 shares * $100 reference = $1000 notional > $500 limit
+        result = gate.evaluate(_market_buy(), reference_price=Decimal("100"))
+
+        assert isinstance(result, Reject)
+        assert (
+            _counter_with(
+                metrics,
+                "oms.risk.rejected",
+                {"check": "MaxOrderNotional", "symbol": "AAPL"},
+            )
+            == 1
+        )
+
+
+class TestDefaultBackend:
+    def test_resolves_get_metrics_when_not_injected(self):
+        from engine.observability.metrics import NullBackend, set_metrics
+
+        recording = RecordingBackend()
+        set_metrics(recording)
+        try:
+            ks = KillSwitch()
+            gate = RiskGate(checks=[KillSwitchCheck(switch=ks)])
+            gate.evaluate(_market_buy())
+            assert _counter_total(recording, "oms.risk.approved") == 1
+        finally:
+            set_metrics(NullBackend())


### PR DESCRIPTION
## Summary

Instrument \`RiskGate.evaluate\` with the existing \`MetricsBackend\` (gh#34) so operators can see *which* check is rejecting orders and at what rate, without parsing structlog events.

Emits:
- \`oms.risk.check\` — counter, one per individual check that runs (tags: \`check\`, \`symbol\`, \`outcome ∈ {approve, reject}\`).
- \`oms.risk.rejected\` — counter, exactly once per evaluation that rejects (tags: rejecting \`check\`, \`symbol\`).
- \`oms.risk.approved\` — counter, exactly once per evaluation when every check approves (tag: \`symbol\`).

First-Reject-wins semantics preserved: only the rejecting check records a row; later checks are not invoked, so they emit no metrics either. This matches the structlog behaviour and makes the per-check counter directly comparable to the LiveLoop \`oms.submit.outcome\` rejection paths.

Backend resolution: explicit \`metrics=\` kwarg wins; otherwise \`get_metrics()\` is consulted lazily at evaluation time so tests can swap the singleton via \`set_metrics()\` after construction.

Defaults to \`NullBackend\` → zero cost when no exporter is configured.

Refs #111. Per-symbol position caps, drawdown, margin, restricted-list, and crypto 24h caps are still deferred.

## Test plan

- [x] Approve-all path emits one \`check.approve\` per check + one \`approved\`
- [x] First Reject short-circuits — later checks emit no metrics
- [x] KillSwitchCheck reject carries \`check=KillSwitchCheck\` tag
- [x] MaxOrderNotional reject carries \`check=MaxOrderNotional\` tag
- [x] Default backend resolution via \`get_metrics()\` works when no \`metrics=\` injected