### PR TITLE
feat(live): MetricsBackend instrumentation for KillSwitch (gh#109)

### DIFF
--- a/engine/core/live/kill_switch.py
+++ b/engine/core/live/kill_switch.py
@@ -41,6 +41,8 @@ from enum import Enum
 
 import structlog
 
+from engine.observability.metrics import MetricsBackend, get_metrics
+
 logger = structlog.get_logger()
 
 
@@ -74,13 +76,20 @@ class KillSwitchError(Exception):
 class KillSwitch:
     """Process-wide on/off switch for live order submission."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, metrics: MetricsBackend | None = None) -> None:
         self._state = KillSwitchState.DISENGAGED
         self._engaged_at: datetime | None = None
         self._reason: str | None = None
         self._actor: str | None = None
         self._lock = threading.Lock()
         self._observers: list[Observer] = []
+        self._metrics = metrics
+
+    @property
+    def metrics(self) -> MetricsBackend:
+        """Resolve the metrics backend lazily so tests can swap the
+        process-wide singleton via :func:`set_metrics` after construction."""
+        return self._metrics if self._metrics is not None else get_metrics()
 
     # ------------------------------------------------------------------
     # State
@@ -122,6 +131,9 @@ class KillSwitch:
                     new_reason=reason,
                     actor=actor,
                 )
+                self.metrics.counter(
+                    "kill_switch.engage_noop", tags={"actor": actor}
+                )
                 return False
             self._state = KillSwitchState.ENGAGED
             self._engaged_at = datetime.now(tz=UTC)
@@ -139,6 +151,9 @@ class KillSwitch:
             actor=actor,
             engaged_at=snap.engaged_at.isoformat() if snap.engaged_at else None,
         )
+        metrics = self.metrics
+        metrics.counter("kill_switch.engaged", tags={"actor": actor})
+        metrics.gauge("kill_switch.state", 1.0)
         self._notify(snap)
         return True
 
@@ -173,6 +188,9 @@ class KillSwitch:
             actor=actor,
             prior_reason=prior_reason,
         )
+        metrics = self.metrics
+        metrics.counter("kill_switch.disengaged", tags={"actor": actor})
+        metrics.gauge("kill_switch.state", 0.0)
         self._notify(snap)
         return True
 

--- a/tests/test_kill_switch_metrics.py
+++ b/tests/test_kill_switch_metrics.py
@@ -1,0 +1,144 @@
+"""Tests for KillSwitch metrics emission (gh#109 follow-up).
+
+The switch emits the following metrics through the active
+``MetricsBackend``:
+
+- ``kill_switch.engaged`` — counter, exactly once per real engage
+  transition (idempotent re-engages do not increment it).
+- ``kill_switch.engage_noop`` — counter, on each idempotent re-engage.
+- ``kill_switch.disengaged`` — counter, exactly once per real
+  disengage transition.
+- ``kill_switch.state`` — gauge, 1.0 while engaged, 0.0 while
+  disengaged.
+
+All counters are tagged with ``actor``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.live.kill_switch import KillSwitch
+from engine.observability.metrics import RecordingBackend
+
+
+_DISENGAGE_TOKEN = "I_UNDERSTAND_THE_RISK"
+
+
+def _counter_total(backend: RecordingBackend, name: str) -> float:
+    return sum(v for (n, _t), v in backend.counters.items() if n == name)
+
+
+def _counter_with(
+    backend: RecordingBackend, name: str, tags: dict[str, str]
+) -> float:
+    expected = tuple(sorted(tags.items()))
+    return sum(
+        v
+        for (n, t), v in backend.counters.items()
+        if n == name and all(item in t for item in expected)
+    )
+
+
+def _gauge_value(backend: RecordingBackend, name: str) -> float | None:
+    matches = [v for (n, _t), v in backend.gauges.items() if n == name]
+    return matches[-1] if matches else None
+
+
+@pytest.fixture
+def metrics() -> RecordingBackend:
+    return RecordingBackend()
+
+
+class TestEngageMetrics:
+    def test_first_engage_increments_counter_and_sets_state_gauge(self, metrics):
+        ks = KillSwitch(metrics=metrics)
+
+        changed = ks.engage(reason="manual", actor="operator")
+
+        assert changed is True
+        assert (
+            _counter_with(
+                metrics, "kill_switch.engaged", {"actor": "operator"}
+            )
+            == 1
+        )
+        assert _counter_total(metrics, "kill_switch.engage_noop") == 0
+        assert _gauge_value(metrics, "kill_switch.state") == 1.0
+
+    def test_repeat_engage_records_engage_noop_only(self, metrics):
+        ks = KillSwitch(metrics=metrics)
+        ks.engage(reason="manual", actor="operator")
+        ks.engage(reason="manual", actor="live_loop")  # already engaged
+
+        # Real engagements: still exactly one.
+        assert _counter_total(metrics, "kill_switch.engaged") == 1
+        # Noop bumped under the second actor.
+        assert (
+            _counter_with(
+                metrics, "kill_switch.engage_noop", {"actor": "live_loop"}
+            )
+            == 1
+        )
+        # Gauge stayed at 1.
+        assert _gauge_value(metrics, "kill_switch.state") == 1.0
+
+
+class TestDisengageMetrics:
+    def test_real_disengage_increments_counter_and_clears_state(self, metrics):
+        ks = KillSwitch(metrics=metrics)
+        ks.engage(reason="manual", actor="operator")
+
+        changed = ks.disengage(
+            confirmation=_DISENGAGE_TOKEN, actor="operator"
+        )
+
+        assert changed is True
+        assert (
+            _counter_with(
+                metrics, "kill_switch.disengaged", {"actor": "operator"}
+            )
+            == 1
+        )
+        assert _gauge_value(metrics, "kill_switch.state") == 0.0
+
+    def test_disengage_when_already_disengaged_emits_nothing(self, metrics):
+        ks = KillSwitch(metrics=metrics)
+
+        changed = ks.disengage(
+            confirmation=_DISENGAGE_TOKEN, actor="operator"
+        )
+
+        assert changed is False
+        assert _counter_total(metrics, "kill_switch.disengaged") == 0
+        # Never engaged → gauge was never set.
+        assert _gauge_value(metrics, "kill_switch.state") is None
+
+
+class TestRoundTrip:
+    def test_engage_disengage_engage_records_two_engaged_two_state_writes(
+        self, metrics
+    ):
+        ks = KillSwitch(metrics=metrics)
+        ks.engage(reason="r1", actor="op")
+        ks.disengage(confirmation=_DISENGAGE_TOKEN, actor="op")
+        ks.engage(reason="r2", actor="op")
+
+        assert _counter_total(metrics, "kill_switch.engaged") == 2
+        assert _counter_total(metrics, "kill_switch.disengaged") == 1
+        # Final state gauge reflects the engaged status.
+        assert _gauge_value(metrics, "kill_switch.state") == 1.0
+
+
+class TestDefaultBackend:
+    def test_resolves_get_metrics_when_not_injected(self):
+        from engine.observability.metrics import NullBackend, set_metrics
+
+        recording = RecordingBackend()
+        set_metrics(recording)
+        try:
+            ks = KillSwitch()
+            ks.engage(reason="manual", actor="operator")
+            assert _counter_total(recording, "kill_switch.engaged") == 1
+        finally:
+            set_metrics(NullBackend())


### PR DESCRIPTION
## Summary

Instrument \`KillSwitch.engage\` and \`disengage\` with the existing \`MetricsBackend\` (gh#34) so operators can wire the safety floor directly into their dashboards and pagers.

Emits:
- \`kill_switch.engaged\` — counter, exactly once per real engage transition (tag: \`actor\`).
- \`kill_switch.engage_noop\` — counter, on each idempotent re-engage when the switch was already engaged (tag: \`actor\`). Distinguishes "operator hit the button twice" from "two distinct triggers fired".
- \`kill_switch.disengaged\` — counter, exactly once per real disengage transition (tag: \`actor\`).
- \`kill_switch.state\` — gauge, \`1.0\` while engaged, \`0.0\` while disengaged. Gives a single binary signal for runbooks.

Idempotent behaviour preserved: a second engage call while already engaged still returns \`False\` and emits *only* \`engage_noop\` (not \`engaged\`); a disengage call while already disengaged emits nothing.

Backend resolution: explicit \`metrics=\` kwarg wins; otherwise \`get_metrics()\` is consulted lazily at transition time so tests can swap the singleton via \`set_metrics()\` after construction.

Defaults to \`NullBackend\` → zero cost when no exporter is configured.

Refs #109. Persistence, auto-engage triggers, and per-strategy gates still deferred.

## Test plan

- [x] First engage increments \`engaged\` counter and sets state gauge to 1.0
- [x] Repeat engage records \`engage_noop\` only — \`engaged\` counter does NOT bump, gauge stays at 1.0
- [x] Real disengage increments \`disengaged\` and clears the state gauge to 0.0
- [x] Disengage while already disengaged emits no metrics
- [x] Round-trip (engage → disengage → engage) records 2× engaged + 1× disengaged + final gauge=1.0
- [x] Default backend resolution via \`get_metrics()\` works when no \`metrics=\` injected