### PR TITLE
fix(events): rename event= structlog kwarg in EventBus to event_type=

### DIFF
--- a/engine/events/bus.py
+++ b/engine/events/bus.py
@@ -136,7 +136,11 @@ class EventBus:
         if event_type not in self._handlers:
             self._handlers[event_type] = []
         self._handlers[event_type].append(handler)
-        logger.debug("event_bus.subscribed", event=event_type.value, handler=handler.__name__)
+        logger.debug(
+            "event_bus.subscribed",
+            event_type=event_type.value,
+            handler=handler.__name__,
+        )
 
     def unsubscribe(self, event_type: EventType, handler: EventHandler):
         if event_type in self._handlers:
@@ -166,7 +170,11 @@ class EventBus:
                     tags=event_tags,
                 )
                 metrics.counter("event_bus.handler_error", tags=event_tags)
-                logger.error("event_bus.handler_error", event=event.event_type.value, error=str(e))
+                logger.error(
+                    "event_bus.handler_error",
+                    event_type=event.event_type.value,
+                    error=str(e),
+                )
 
         # Redis pub/sub for cross-process consumers
         if self._redis:

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -2,17 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
-
-import pytest
-
 from engine.events.bus import Event, EventBus, EventType
-
-
-@pytest.fixture(autouse=True)
-def _patch_bus_logger():
-    with patch("engine.events.bus.logger", MagicMock()):
-        yield
 
 
 def _make_handler(results: list):
@@ -130,6 +120,30 @@ class TestEmit:
         assert len(results) == 1
         assert results[0]["data"]["msg"] == "hello"
         assert results[0]["source"] == "test"
+
+
+class TestStructlogKwargRegression:
+    """Regression: structlog reserves the ``event`` kwarg for the
+    positional event-name argument. Earlier the bus passed
+    ``event=event_type.value`` to the logger and that raised TypeError
+    whenever the configured wrapper actually processed the call (e.g.
+    debug at NOTSET filtering). The field is now ``event_type=`` so
+    subscribe / publish cannot raise from this clash."""
+
+    async def test_subscribe_does_not_raise_with_default_structlog(self):
+        bus = EventBus()
+        bus.subscribe(EventType.ORDER_CREATED, _make_handler([]))
+
+    async def test_publish_does_not_raise_when_handler_errors(self):
+        bus = EventBus()
+
+        async def boom(_):
+            raise RuntimeError("nope")
+
+        bus.subscribe(EventType.STRATEGY_ERROR, boom)
+        # Must NOT raise — handler errors are logged via event_type=,
+        # never propagated.
+        await bus.publish(Event(EventType.STRATEGY_ERROR))
 
 
 class TestEventSerialization:

--- a/tests/test_event_bus_metrics.py
+++ b/tests/test_event_bus_metrics.py
@@ -15,22 +15,12 @@ The bus emits the following metrics through the active
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from engine.events.bus import Event, EventBus, EventType
 from engine.observability.metrics import RecordingBackend
-
-
-@pytest.fixture(autouse=True)
-def _patch_bus_logger():
-    """Bypass an unrelated structlog kwarg clash in ``bus.subscribe``'s
-    ``logger.debug(..., event=...)`` call. The metric assertions are the
-    point of this file; logging behaviour is covered by
-    ``tests/test_event_bus.py`` (which uses the same workaround)."""
-    with patch("engine.events.bus.logger", MagicMock()):
-        yield
 
 
 def _counter_total(backend: RecordingBackend, name: str) -> float:


### PR DESCRIPTION
## Summary

structlog reserves \`event\` as the positional event-name argument on its bound-logger methods. \`engine/events/bus.py\` passed \`event=event_type.value\` as a kwarg to \`logger.debug\` / \`logger.error\`, which raised \`TypeError("got multiple values for argument 'event'")\` whenever the configured wrapper actually processed the call.

The clash was masked everywhere by an autouse \`patch("engine.events.bus.logger", MagicMock())\` fixture in \`tests/test_event_bus.py\` — and copied into \`tests/test_event_bus_metrics.py\` (gh#302) — so the bug never surfaced in CI but would have raised at runtime for any operator running with structlog at NOTSET filtering or below.

Changes:
- Rename the structlog field to \`event_type=\` in both call sites.
- Drop the autouse logger patch from both test files.
- Add two regression tests that exercise \`subscribe\` and \`publish\` (with a failing handler) under the default structlog config — they would have failed before this fix.

The structlog field name is now consistent with the rest of the codebase (webhook + OMS metrics use \`event_type\` everywhere).

## Test plan

- [x] \`subscribe\` no longer raises under default structlog config
- [x] \`publish\` with a failing handler no longer raises (the handler-error log path used to raise too)
- [x] All existing event-bus + webhook + metrics tests still pass after dropping the logger patch