### PR TITLE
feat(brokers): MetricsBackend instrumentation for PaperBroker (gh#136)

### DIFF
--- a/engine/core/brokers/paper.py
+++ b/engine/core/brokers/paper.py
@@ -52,6 +52,7 @@ from engine.core.oms.events import (
     OrderEvent,
 )
 from engine.core.oms.states import OrderType
+from engine.observability.metrics import MetricsBackend, get_metrics
 
 if TYPE_CHECKING:
     from engine.core.oms.order import Order
@@ -70,7 +71,13 @@ def _utcnow() -> datetime:
 class PaperBroker:
     """In-process simulated broker."""
 
-    def __init__(self, *, price_for: PriceResolver, name: str = "paper") -> None:
+    def __init__(
+        self,
+        *,
+        price_for: PriceResolver,
+        name: str = "paper",
+        metrics: MetricsBackend | None = None,
+    ) -> None:
         if not name or not name.islower():
             raise ValueError("PaperBroker name must be a lower-case slug")
         self._name = name
@@ -78,6 +85,20 @@ class PaperBroker:
         self._events: asyncio.Queue[OrderEvent] = asyncio.Queue()
         # broker_order_id -> pending order metadata
         self._pending: dict[str, _Pending] = {}
+        self._metrics = metrics
+
+    @property
+    def metrics(self) -> MetricsBackend:
+        """Resolve the metrics backend lazily so tests can swap the
+        process singleton via :func:`set_metrics` after construction."""
+        return self._metrics if self._metrics is not None else get_metrics()
+
+    def _emit_pending_gauge(self) -> None:
+        self.metrics.gauge(
+            "paper_broker.pending",
+            float(len(self._pending)),
+            tags={"broker": self._name},
+        )
 
     # ------------------------------------------------------------------
     # BrokerAdapter contract
@@ -89,9 +110,18 @@ class PaperBroker:
 
     async def submit(self, order: Order) -> SubmittedOrder:
         broker_id = f"PAPER-{uuid.uuid4()}"
+        metrics = self.metrics
+        base_tags = {
+            "broker": self._name,
+            "order_type": order.order_type.value,
+        }
         if order.order_type == OrderType.MARKET:
             price = self._price_for(order.symbol)
             if price is None or price <= 0:
+                metrics.counter(
+                    "paper_broker.submit",
+                    tags={**base_tags, "outcome": "rejected"},
+                )
                 raise BrokerRejectError(
                     f"paper: no price for {order.symbol}",
                     broker_code="NO_PRICE",
@@ -107,6 +137,10 @@ class PaperBroker:
                     fill_price=price,
                     fill_id=f"FILL-{broker_id}",
                 )
+            )
+            metrics.counter(
+                "paper_broker.submit",
+                tags={**base_tags, "outcome": "filled"},
             )
             logger.info(
                 "paper_broker.market_filled",
@@ -127,6 +161,11 @@ class PaperBroker:
             await self._events.put(
                 AckEvent(occurred_at=_utcnow(), broker_order_id=broker_id)
             )
+            metrics.counter(
+                "paper_broker.submit",
+                tags={**base_tags, "outcome": "resting"},
+            )
+            self._emit_pending_gauge()
             logger.info(
                 "paper_broker.resting",
                 order_id=str(order.id),
@@ -139,6 +178,10 @@ class PaperBroker:
 
     async def cancel(self, *, order_id: uuid.UUID, broker_order_id: str) -> None:
         if broker_order_id not in self._pending:
+            self.metrics.counter(
+                "paper_broker.cancel",
+                tags={"broker": self._name, "outcome": "unknown"},
+            )
             raise BrokerRejectError(
                 f"paper: unknown or already-filled broker order {broker_order_id!r}",
                 broker_code="NOT_PENDING",
@@ -147,6 +190,11 @@ class PaperBroker:
         await self._events.put(
             CancelEvent(occurred_at=_utcnow(), requested=False, reason="paper_cancel")
         )
+        self.metrics.counter(
+            "paper_broker.cancel",
+            tags={"broker": self._name, "outcome": "cancelled"},
+        )
+        self._emit_pending_gauge()
         logger.info(
             "paper_broker.cancelled",
             order_id=str(order_id),
@@ -171,13 +219,22 @@ class PaperBroker:
         fill_price: Decimal | None = None,
     ) -> None:
         """Force a resting order to fully fill. For tests / dev only."""
+        metrics = self.metrics
         pending = self._pending.pop(broker_order_id, None)
         if pending is None:
+            metrics.counter(
+                "paper_broker.simulate_fill",
+                tags={"broker": self._name, "outcome": "unknown"},
+            )
             raise BrokerError(
                 f"simulate_fill: no pending order {broker_order_id!r}"
             )
         price = fill_price if fill_price is not None else self._price_for(pending.symbol)
         if price is None or price <= 0:
+            metrics.counter(
+                "paper_broker.simulate_fill",
+                tags={"broker": self._name, "outcome": "no_price"},
+            )
             raise BrokerRejectError(
                 f"simulate_fill: no price for {pending.symbol}",
                 broker_code="NO_PRICE",
@@ -190,6 +247,11 @@ class PaperBroker:
                 fill_id=f"FILL-{broker_order_id}",
             )
         )
+        metrics.counter(
+            "paper_broker.simulate_fill",
+            tags={"broker": self._name, "outcome": "filled"},
+        )
+        self._emit_pending_gauge()
 
     def pending_count(self) -> int:
         return len(self._pending)

--- a/tests/test_paper_broker_metrics.py
+++ b/tests/test_paper_broker_metrics.py
@@ -1,0 +1,266 @@
+"""Tests for PaperBroker metrics emission (gh#136 follow-up).
+
+The adapter emits the following metrics through the active
+``MetricsBackend`` (all tagged with ``broker``):
+
+- ``paper_broker.submit`` — counter, exactly once per ``submit`` call.
+  ``outcome ∈ {filled, resting, rejected}`` plus ``order_type``.
+- ``paper_broker.cancel`` — counter, exactly once per ``cancel`` call.
+  ``outcome ∈ {cancelled, unknown}``.
+- ``paper_broker.simulate_fill`` — counter, exactly once per
+  ``simulate_fill`` call. ``outcome ∈ {filled, unknown, no_price}``.
+- ``paper_broker.pending`` — gauge, recomputed after every
+  state-changing operation.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from engine.core.brokers.base import BrokerError, BrokerRejectError
+from engine.core.brokers.paper import PaperBroker
+from engine.core.oms.order import Order
+from engine.core.oms.states import OrderSide, OrderType
+from engine.observability.metrics import RecordingBackend
+
+
+def _market_buy(symbol: str = "AAPL", qty: str = "10") -> Order:
+    return Order(
+        symbol=symbol,
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal(qty),
+    )
+
+
+def _limit_buy(symbol: str = "AAPL", qty: str = "10") -> Order:
+    return Order(
+        symbol=symbol,
+        side=OrderSide.BUY,
+        order_type=OrderType.LIMIT,
+        quantity=Decimal(qty),
+        limit_price=Decimal("100"),
+    )
+
+
+def _counter_total(backend: RecordingBackend, name: str) -> float:
+    return sum(v for (n, _t), v in backend.counters.items() if n == name)
+
+
+def _counter_with(
+    backend: RecordingBackend, name: str, tags: dict[str, str]
+) -> float:
+    expected = tuple(sorted(tags.items()))
+    return sum(
+        v
+        for (n, t), v in backend.counters.items()
+        if n == name and all(item in t for item in expected)
+    )
+
+
+def _gauge_with(
+    backend: RecordingBackend, name: str, tags: dict[str, str]
+) -> float | None:
+    expected = tuple(sorted(tags.items()))
+    matches = [
+        v
+        for (n, t), v in backend.gauges.items()
+        if n == name and all(item in t for item in expected)
+    ]
+    return matches[-1] if matches else None
+
+
+@pytest.fixture
+def metrics() -> RecordingBackend:
+    return RecordingBackend()
+
+
+class TestSubmitMarket:
+    async def test_market_fill_emits_filled_outcome(self, metrics):
+        broker = PaperBroker(
+            price_for=lambda _: Decimal("100"), metrics=metrics
+        )
+        await broker.submit(_market_buy())
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.submit",
+                {"outcome": "filled", "order_type": "market", "broker": "paper"},
+            )
+            == 1
+        )
+
+    async def test_market_no_price_emits_rejected_outcome(self, metrics):
+        broker = PaperBroker(price_for=lambda _: None, metrics=metrics)
+        with pytest.raises(BrokerRejectError):
+            await broker.submit(_market_buy())
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.submit",
+                {"outcome": "rejected", "order_type": "market"},
+            )
+            == 1
+        )
+
+
+class TestSubmitLimit:
+    async def test_limit_emits_resting_outcome_and_pending_gauge(self, metrics):
+        broker = PaperBroker(
+            price_for=lambda _: Decimal("100"), metrics=metrics
+        )
+        await broker.submit(_limit_buy())
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.submit",
+                {"outcome": "resting", "order_type": "limit"},
+            )
+            == 1
+        )
+        assert _gauge_with(metrics, "paper_broker.pending", {"broker": "paper"}) == 1.0
+
+    async def test_two_resting_orders_bring_pending_to_two(self, metrics):
+        broker = PaperBroker(
+            price_for=lambda _: Decimal("100"), metrics=metrics
+        )
+        await broker.submit(_limit_buy())
+        await broker.submit(_limit_buy(symbol="MSFT"))
+
+        assert _gauge_with(metrics, "paper_broker.pending", {"broker": "paper"}) == 2.0
+
+
+class TestCancel:
+    async def test_cancel_known_emits_cancelled_and_drops_pending_gauge(self, metrics):
+        broker = PaperBroker(
+            price_for=lambda _: Decimal("100"), metrics=metrics
+        )
+        result = await broker.submit(_limit_buy())
+
+        await broker.cancel(
+            order_id=result.order_id, broker_order_id=result.broker_order_id
+        )
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.cancel",
+                {"outcome": "cancelled", "broker": "paper"},
+            )
+            == 1
+        )
+        assert _gauge_with(metrics, "paper_broker.pending", {"broker": "paper"}) == 0.0
+
+    async def test_cancel_unknown_emits_unknown_outcome(self, metrics):
+        broker = PaperBroker(
+            price_for=lambda _: Decimal("100"), metrics=metrics
+        )
+
+        with pytest.raises(BrokerRejectError):
+            await broker.cancel(
+                order_id=uuid.uuid4(), broker_order_id="DOES-NOT-EXIST"
+            )
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.cancel",
+                {"outcome": "unknown"},
+            )
+            == 1
+        )
+
+
+class TestSimulateFill:
+    async def test_simulate_fill_known_emits_filled_outcome(self, metrics):
+        broker = PaperBroker(
+            price_for=lambda _: Decimal("100"), metrics=metrics
+        )
+        result = await broker.submit(_limit_buy())
+
+        await broker.simulate_fill(broker_order_id=result.broker_order_id)
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.simulate_fill",
+                {"outcome": "filled"},
+            )
+            == 1
+        )
+        assert _gauge_with(metrics, "paper_broker.pending", {"broker": "paper"}) == 0.0
+
+    async def test_simulate_fill_unknown_emits_unknown_outcome(self, metrics):
+        broker = PaperBroker(
+            price_for=lambda _: Decimal("100"), metrics=metrics
+        )
+
+        with pytest.raises(BrokerError):
+            await broker.simulate_fill(broker_order_id="DOES-NOT-EXIST")
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.simulate_fill",
+                {"outcome": "unknown"},
+            )
+            == 1
+        )
+
+    async def test_simulate_fill_no_price_emits_no_price_outcome(self, metrics):
+        # Limit submit does not call ``price_for`` (orders just rest), so
+        # a resolver returning ``None`` only fires when ``simulate_fill``
+        # asks for the fill price.
+        broker = PaperBroker(price_for=lambda _: None, metrics=metrics)
+        result = await broker.submit(_limit_buy())
+
+        with pytest.raises(BrokerRejectError):
+            await broker.simulate_fill(broker_order_id=result.broker_order_id)
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.simulate_fill",
+                {"outcome": "no_price"},
+            )
+            == 1
+        )
+
+
+class TestNameTagged:
+    async def test_custom_name_propagates_to_broker_tag(self, metrics):
+        broker = PaperBroker(
+            price_for=lambda _: Decimal("100"),
+            name="paper-staging",
+            metrics=metrics,
+        )
+        await broker.submit(_market_buy())
+
+        assert (
+            _counter_with(
+                metrics,
+                "paper_broker.submit",
+                {"broker": "paper-staging"},
+            )
+            == 1
+        )
+
+
+class TestDefaultBackend:
+    async def test_resolves_get_metrics_when_not_injected(self):
+        from engine.observability.metrics import NullBackend, set_metrics
+
+        recording = RecordingBackend()
+        set_metrics(recording)
+        try:
+            broker = PaperBroker(price_for=lambda _: Decimal("100"))
+            await broker.submit(_market_buy())
+            assert _counter_total(recording, "paper_broker.submit") == 1
+        finally:
+            set_metrics(NullBackend())


### PR DESCRIPTION
## Summary

Instrument \`PaperBroker.submit\`, \`cancel\`, and \`simulate_fill\` with the existing \`MetricsBackend\` (gh#34) so the paper broker reports the same shape of telemetry as a real broker adapter would.

Emits (every metric is tagged with \`broker\` to keep multiple paper-broker instances distinguishable):
- \`paper_broker.submit\` — counter, exactly once per \`submit\` call. \`outcome ∈ {filled, resting, rejected}\` plus \`order_type\`.
- \`paper_broker.cancel\` — counter, exactly once per \`cancel\` call. \`outcome ∈ {cancelled, unknown}\`.
- \`paper_broker.simulate_fill\` — counter, exactly once per \`simulate_fill\` call. \`outcome ∈ {filled, unknown, no_price}\`.
- \`paper_broker.pending\` — gauge, recomputed after every state-changing operation.

Backend resolution: explicit \`metrics=\` kwarg wins; otherwise \`get_metrics()\` is consulted lazily at emission time so tests can swap the singleton via \`set_metrics()\` after construction.

Defaults to \`NullBackend\` → zero cost when no exporter is configured.

Refs #136. Real broker adapters (Alpaca, IBKR, Binance) and a richer simulator (slippage, partial fills) still deferred.

## Test plan

- [x] Market fill + market no-price emit \`filled\` / \`rejected\` outcomes
- [x] Limit order emits \`resting\` outcome and bumps the pending gauge
- [x] Two resting orders bring pending gauge to 2
- [x] Cancel known emits \`cancelled\` and drops gauge to 0
- [x] Cancel unknown emits \`unknown\` outcome (and raises)
- [x] simulate_fill known/unknown/no_price emit the right outcomes
- [x] Custom \`name=\` kwarg propagates to the \`broker\` tag
- [x] Default backend resolution via \`get_metrics()\` works when no \`metrics=\` injected