### PR TITLE
feat(observability): Prometheus exposition formatter (gh#34)

### DIFF
--- a/engine/observability/prometheus.py
+++ b/engine/observability/prometheus.py
@@ -1,0 +1,172 @@
+"""Prometheus exposition-format renderer (gh#34 follow-up).
+
+Renders a :class:`RecordingBackend` snapshot to the Prometheus text
+exposition format (Content-Type ``text/plain; version=0.0.4``) so
+operators can wire ``/metrics`` to their pull-mode scrape target
+without adding the optional ``prometheus_client`` dependency.
+
+The formatter does *not* re-bucket histograms. Each histogram surfaces
+as ``<name>_count`` (number of observations so far) and ``<name>_sum``
+(sum of observations) — which is the strict subset of the histogram
+contract Prometheus accepts. Operators who need bucketed quantiles
+should swap in a backend that pre-buckets at observation time
+(``prometheus_client.Histogram`` is the typical choice; this scaffold
+keeps the door open for that without taking the dep here).
+
+Naming
+------
+Engine code emits dot-separated metric names (``webhook.delivered``)
+to match the rest of the codebase. Prometheus requires
+``[a-zA-Z_:][a-zA-Z0-9_:]*`` so dots are converted to underscores
+when rendering. Tag (label) values are escaped per the Prometheus
+spec: ``\\``, ``\\n``, and ``"`` are the only escapes.
+
+What this is *not*
+------------------
+- A push-gateway client. Operators choose pull vs push.
+- A registry of metric metadata (``# HELP`` / ``# TYPE`` lines are
+  emitted with placeholder doc-strings — feed-through descriptions
+  are a future enhancement once we have a metric catalog).
+- A multi-process collector. The :class:`PrometheusBackend` is a
+  single-process recorder; running multiple workers requires
+  shared-memory coordination (also deferred).
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from engine.observability.metrics import RecordingBackend
+
+
+_LABEL_ESCAPES = str.maketrans(
+    {
+        "\\": "\\\\",
+        "\n": "\\n",
+        '"': '\\"',
+    }
+)
+
+
+def _safe_metric_name(name: str) -> str:
+    """Convert dot-separated engine metric names into Prometheus-safe
+    identifiers. Replace any character outside ``[a-zA-Z0-9_:]`` with
+    ``_``. The first character must be ``[a-zA-Z_:]`` — if the input
+    starts with a digit, prefix ``_``."""
+    if not name:
+        return "_"
+    out = []
+    for ch in name:
+        if ch.isalnum() or ch in "_:":
+            out.append(ch)
+        else:
+            out.append("_")
+    if out[0].isdigit():
+        out.insert(0, "_")
+    return "".join(out)
+
+
+def _format_labels(tags: tuple[tuple[str, str], ...]) -> str:
+    """Render label set as ``{k1="v1",k2="v2"}``. Empty tags render as
+    an empty string (no braces) per the Prometheus convention for
+    label-less series."""
+    if not tags:
+        return ""
+    parts = []
+    for k, v in tags:
+        safe_k = _safe_metric_name(k)
+        safe_v = v.translate(_LABEL_ESCAPES)
+        parts.append(f'{safe_k}="{safe_v}"')
+    return "{" + ",".join(parts) + "}"
+
+
+def _format_value(value: float) -> str:
+    """Render a numeric value. Integers are emitted without a decimal
+    point so Prometheus tooling reads them cleanly; floats use Python's
+    ``repr`` which is round-trip safe."""
+    if value == int(value) and not isinstance(value, bool):
+        return str(int(value))
+    return repr(float(value))
+
+
+def render_prometheus(backend: RecordingBackend) -> str:
+    """Return the exposition-format text for ``backend``'s current
+    snapshot. The output is sorted by metric name + label set so two
+    snapshots taken with the same observations diff cleanly.
+    """
+    out = StringIO()
+
+    # Counters
+    counter_groups: dict[
+        str, list[tuple[tuple[tuple[str, str], ...], float]]
+    ] = {}
+    for (name, tags), value in backend.counters.items():
+        counter_groups.setdefault(name, []).append((tags, value))
+    for name in sorted(counter_groups):
+        prom_name = _safe_metric_name(name)
+        out.write(f"# HELP {prom_name} engine counter (gh#34)\n")
+        out.write(f"# TYPE {prom_name} counter\n")
+        for tags, value in sorted(counter_groups[name], key=lambda x: x[0]):
+            out.write(
+                f"{prom_name}{_format_labels(tags)} {_format_value(value)}\n"
+            )
+
+    # Gauges
+    gauge_groups: dict[
+        str, list[tuple[tuple[tuple[str, str], ...], float]]
+    ] = {}
+    for (name, tags), value in backend.gauges.items():
+        gauge_groups.setdefault(name, []).append((tags, value))
+    for name in sorted(gauge_groups):
+        prom_name = _safe_metric_name(name)
+        out.write(f"# HELP {prom_name} engine gauge (gh#34)\n")
+        out.write(f"# TYPE {prom_name} gauge\n")
+        for tags, value in sorted(gauge_groups[name], key=lambda x: x[0]):
+            out.write(
+                f"{prom_name}{_format_labels(tags)} {_format_value(value)}\n"
+            )
+
+    # Histograms — emit *_count and *_sum series only. No buckets.
+    histogram_groups: dict[
+        str, list[tuple[tuple[tuple[str, str], ...], list[float]]]
+    ] = {}
+    for (name, tags), values in backend.histograms.items():
+        histogram_groups.setdefault(name, []).append((tags, values))
+    for name in sorted(histogram_groups):
+        prom_name = _safe_metric_name(name)
+        out.write(
+            f"# HELP {prom_name} engine histogram (count + sum only) (gh#34)\n"
+        )
+        out.write(f"# TYPE {prom_name} summary\n")
+        for tags, observations in sorted(
+            histogram_groups[name], key=lambda x: x[0]
+        ):
+            label_text = _format_labels(tags)
+            out.write(
+                f"{prom_name}_count{label_text} {len(observations)}\n"
+            )
+            out.write(
+                f"{prom_name}_sum{label_text} "
+                f"{_format_value(sum(observations))}\n"
+            )
+
+    return out.getvalue()
+
+
+class PrometheusBackend(RecordingBackend):
+    """RecordingBackend with a :meth:`render` shortcut.
+
+    Wire this as the global metrics backend at startup, then expose
+    ``render()`` (or :func:`render_prometheus`) from a ``/metrics``
+    handler. The backend continues to record everything in memory —
+    operators are responsible for ensuring a single process owns the
+    metrics state (see module docstring for caveats)."""
+
+    def render(self) -> str:
+        return render_prometheus(self)
+
+
+__all__ = [
+    "PrometheusBackend",
+    "render_prometheus",
+]

--- a/tests/observability/test_prometheus.py
+++ b/tests/observability/test_prometheus.py
@@ -1,0 +1,215 @@
+"""Tests for the Prometheus exposition-format renderer (gh#34 follow-up)."""
+
+from __future__ import annotations
+
+from engine.observability.prometheus import (
+    PrometheusBackend,
+    _format_labels,
+    _safe_metric_name,
+    render_prometheus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (private — exercise their invariants here)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeMetricName:
+    def test_dots_become_underscores(self):
+        assert _safe_metric_name("webhook.delivered") == "webhook_delivered"
+
+    def test_keeps_underscores_and_colons(self):
+        assert _safe_metric_name("ns:metric_name") == "ns:metric_name"
+
+    def test_replaces_arbitrary_chars(self):
+        assert _safe_metric_name("foo-bar/baz") == "foo_bar_baz"
+
+    def test_prefixes_underscore_for_leading_digit(self):
+        assert _safe_metric_name("404_count").startswith("_4")
+
+    def test_empty_returns_underscore(self):
+        assert _safe_metric_name("") == "_"
+
+
+class TestFormatLabels:
+    def test_no_tags_renders_empty(self):
+        assert _format_labels(()) == ""
+
+    def test_basic_labels(self):
+        out = _format_labels((("a", "1"), ("b", "two")))
+        assert out == '{a="1",b="two"}'
+
+    def test_escapes_quote_backslash_and_newline(self):
+        out = _format_labels(
+            (("k", 'has "quote" and \\backslash and\nnewline'),)
+        )
+        assert out == '{k="has \\"quote\\" and \\\\backslash and\\nnewline"}'
+
+    def test_label_key_is_sanitised(self):
+        # A label key with a dot should become an underscored ident.
+        out = _format_labels((("event.type", "x"),))
+        assert out == '{event_type="x"}'
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCounters:
+    def test_single_counter_no_tags(self):
+        b = PrometheusBackend()
+        b.counter("webhook.delivered")
+
+        out = render_prometheus(b)
+
+        assert "# TYPE webhook_delivered counter" in out
+        assert "webhook_delivered 1" in out
+
+    def test_counter_with_tags_sorted_for_diffability(self):
+        b = PrometheusBackend()
+        b.counter("oms.submit.outcome", tags={"outcome": "submitted"})
+        b.counter("oms.submit.outcome", tags={"outcome": "rejected"})
+        b.counter("oms.submit.outcome", tags={"outcome": "submitted"})
+
+        out = render_prometheus(b)
+
+        # Two distinct label sets; the rejected line precedes submitted
+        # because the renderer sorts label tuples for stable output.
+        rejected_idx = out.index('outcome="rejected"')
+        submitted_idx = out.index('outcome="submitted"')
+        assert rejected_idx < submitted_idx
+        # Aggregated counter values rendered as integers (no .0).
+        assert 'oms_submit_outcome{outcome="submitted"} 2' in out
+        assert 'oms_submit_outcome{outcome="rejected"} 1' in out
+
+
+class TestRenderGauges:
+    def test_gauge_renders_as_float_when_fractional(self):
+        b = PrometheusBackend()
+        b.gauge("oms.open_orders", 3.5)
+
+        out = render_prometheus(b)
+
+        assert "# TYPE oms_open_orders gauge" in out
+        assert "oms_open_orders 3.5" in out
+
+    def test_gauge_integral_value_renders_without_decimal(self):
+        b = PrometheusBackend()
+        b.gauge("kill_switch.state", 1.0)
+
+        out = render_prometheus(b)
+
+        assert "kill_switch_state 1\n" in out
+
+    def test_gauge_last_write_wins(self):
+        b = PrometheusBackend()
+        b.gauge("oms.open_orders", 1.0)
+        b.gauge("oms.open_orders", 2.0)
+        b.gauge("oms.open_orders", 3.0)
+
+        out = render_prometheus(b)
+
+        # Only the most recent value should appear in the rendered text.
+        assert "oms_open_orders 3" in out
+        assert "oms_open_orders 1\n" not in out
+        assert "oms_open_orders 2\n" not in out
+
+
+class TestRenderHistograms:
+    def test_histogram_emits_count_and_sum_lines(self):
+        b = PrometheusBackend()
+        b.histogram("webhook.duration_ms", 100.0)
+        b.histogram("webhook.duration_ms", 250.0)
+        b.histogram("webhook.duration_ms", 50.0)
+
+        out = render_prometheus(b)
+
+        assert "# TYPE webhook_duration_ms summary" in out
+        assert "webhook_duration_ms_count 3" in out
+        # 100 + 250 + 50 = 400 (integral) → rendered without decimal.
+        assert "webhook_duration_ms_sum 400\n" in out
+
+    def test_histogram_with_tags(self):
+        b = PrometheusBackend()
+        b.histogram(
+            "webhook.duration_ms",
+            10.0,
+            tags={"event_type": "order.filled"},
+        )
+
+        out = render_prometheus(b)
+
+        assert (
+            'webhook_duration_ms_count{event_type="order.filled"} 1'
+            in out
+        )
+        # Sum of a single 10.0 observation is integral → no decimal.
+        assert (
+            'webhook_duration_ms_sum{event_type="order.filled"} 10\n'
+            in out
+        )
+
+
+class TestPrometheusBackend:
+    def test_render_method_matches_module_function(self):
+        b = PrometheusBackend()
+        b.counter("a.b")
+        b.gauge("c.d", 2.0)
+        b.histogram("e.f", 1.5)
+
+        assert b.render() == render_prometheus(b)
+
+    def test_subclass_is_runtime_protocol_compatible(self):
+        from engine.observability.metrics import MetricsBackend
+
+        b = PrometheusBackend()
+        assert isinstance(b, MetricsBackend)
+
+
+class TestIntegration:
+    def test_realistic_snapshot_round_trips_to_text(self):
+        # Simulate a small slice of a real run: webhook delivery + OMS
+        # lifecycle, then render.
+        b = PrometheusBackend()
+        b.counter(
+            "webhook.delivered",
+            tags={"event_type": "order.filled", "template": "discord"},
+        )
+        b.counter(
+            "webhook.attempts",
+            tags={"event_type": "order.filled", "template": "discord"},
+        )
+        b.histogram(
+            "webhook.duration_ms",
+            42.0,
+            tags={"event_type": "order.filled", "status": "200"},
+        )
+        b.gauge("oms.open_orders", 0.0)
+        b.gauge("kill_switch.state", 0.0)
+
+        out = b.render()
+
+        # Each section starts with its TYPE line and a stable order.
+        assert out.index("# TYPE kill_switch_state gauge") < out.index(
+            "# TYPE webhook_duration_ms summary"
+        )
+        # Help/type lines are exactly one per metric — no duplicates.
+        assert out.count("# TYPE webhook_delivered counter") == 1
+
+
+# ---------------------------------------------------------------------------
+# Pytest collection sanity
+# ---------------------------------------------------------------------------
+
+
+def test_renderer_is_pure_does_not_mutate_backend():
+    b = PrometheusBackend()
+    b.counter("webhook.delivered")
+
+    before = dict(b.counters)
+    render_prometheus(b)
+    after = dict(b.counters)
+
+    assert before == after


### PR DESCRIPTION
## Summary

Add a stdlib-only renderer for \`RecordingBackend\` snapshots so operators can wire \`/metrics\` to a pull-mode Prometheus scrape target without bringing in the optional \`prometheus_client\` dependency.

- \`engine.observability.prometheus.PrometheusBackend\` — \`RecordingBackend\` subclass with a \`.render()\` shortcut. Wire it as the global metrics backend at startup; expose \`render()\` from a \`/metrics\` HTTP handler.
- \`render_prometheus(backend)\` — same renderer exposed as a free function for callers that want the recorder and the renderer wired separately.

Format details:
- Engine metric names use dots (\`webhook.delivered\`); Prometheus requires \`[a-zA-Z_:][a-zA-Z0-9_:]*\` so dots become underscores in the rendered output.
- Counters and gauges render with their canonical \`# HELP\` / \`# TYPE\` lines and aggregated values.
- Histograms surface as \`<name>_count\` (observation count) and \`<name>_sum\` (sum) only — Prometheus accepts that subset of the histogram contract; bucketed quantiles need a recorder that pre-buckets at observation time and are deferred.
- Output is sorted by metric name + label tuple so two snapshots with the same observations diff cleanly.
- Label keys are sanitised the same way metric names are; label values are escaped per the Prometheus spec (\`\\\\\`, \`\\n\`, \`"\`).

Refs #34. Multi-process collector, bucketed histogram exporter, and per-metric HELP descriptions sourced from a metric catalog are deferred.

## Test plan

- [x] \`_safe_metric_name\` converts dots, replaces other non-ident chars, prefixes leading digits, handles empty
- [x] \`_format_labels\` handles empty, basic, escape characters, and key sanitisation
- [x] Counter rendering (no tags, with tags, sorted for diffability, integer-only formatting)
- [x] Gauge rendering (last-write-wins, integral vs fractional formatting)
- [x] Histogram rendering (\`*_count\` + \`*_sum\` lines with and without tags)
- [x] \`PrometheusBackend.render()\` matches \`render_prometheus()\` and satisfies the \`MetricsBackend\` Protocol
- [x] Realistic mixed snapshot renders with stable ordering and no duplicate \`# TYPE\` lines
- [x] Renderer is pure: backend state unchanged after rendering