### PR TITLE
feat(api): /metrics route exposes PrometheusBackend (gh#34)

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -10,6 +10,7 @@ from engine.api.routes.health import router as health_router
 from engine.api.routes.legal import router as legal_router
 from engine.api.routes.market_data import router as market_data_router
 from engine.api.routes.marketplace import router as marketplace_router
+from engine.api.routes.metrics import router as metrics_router
 from engine.api.routes.mfa import router as mfa_router
 from engine.api.routes.portfolio import router as portfolio_router
 from engine.api.routes.privacy import router as privacy_router
@@ -23,6 +24,7 @@ from engine.legal.dependencies import require_legal_acceptance
 
 api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
+api_router.include_router(metrics_router, tags=["observability"])
 api_router.include_router(auth_router, prefix="/api/v1/auth", tags=["auth"])
 api_router.include_router(mfa_router, prefix="/api/v1/auth/mfa", tags=["auth"])
 api_router.include_router(api_keys_router, prefix="/api/v1", tags=["auth"])

--- a/engine/api/routes/metrics.py
+++ b/engine/api/routes/metrics.py
@@ -1,0 +1,42 @@
+"""Prometheus-style ``/metrics`` route (gh#34 follow-up).
+
+Exposes the active :class:`MetricsBackend`'s state in Prometheus
+exposition format when the operator has wired up a
+:class:`PrometheusBackend` (or any other :class:`RecordingBackend`
+subclass). When the active backend is the default :class:`NullBackend`
+the endpoint returns a placeholder payload with HTTP 200 — Prometheus
+is happy with that, and operators can scrape unconditionally.
+
+The endpoint is intentionally unauthenticated. Operators who need to
+restrict access put a network ACL or a reverse-proxy auth check in
+front of it (the standard Prometheus pattern).
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Response
+
+from engine.observability.metrics import RecordingBackend, get_metrics
+from engine.observability.prometheus import render_prometheus
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+_PROM_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+
+@router.get("/metrics")
+async def metrics() -> Response:
+    backend = get_metrics()
+    if not isinstance(backend, RecordingBackend):
+        # NullBackend (or any other non-recording adapter) cannot be
+        # rendered. Empty body keeps Prometheus from flagging the
+        # scrape as failed; operators see the placeholder.
+        return Response(
+            content="# metrics backend does not support exposition\n",
+            media_type=_PROM_CONTENT_TYPE,
+        )
+    body = render_prometheus(backend)
+    return Response(content=body, media_type=_PROM_CONTENT_TYPE)

--- a/engine/app.py
+++ b/engine/app.py
@@ -28,7 +28,9 @@ from engine.data.providers import (
 from engine.db.session import dispose_engine, get_session_factory
 from engine.legal.sync import sync_legal_documents
 from engine.observability.logging import setup_logging
+from engine.observability.metrics import set_metrics
 from engine.observability.middleware import CorrelationIdMiddleware
+from engine.observability.prometheus import PrometheusBackend
 from engine.observability.tracing import setup_tracing
 
 if TYPE_CHECKING:
@@ -109,6 +111,11 @@ def _build_auth_registry() -> AuthProviderRegistry:
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     setup_logging()
     setup_tracing()
+    # Switch the process-wide metrics singleton to a recording backend so
+    # the /metrics route exposes real counters/gauges/histograms. Operators
+    # who want a different exporter (OTel, StatsD, etc.) call set_metrics()
+    # again after create_app() returns.
+    set_metrics(PrometheusBackend())
 
     if not settings.is_test and not settings.secret_key:
         msg = "NEXUS_SECRET_KEY must be set outside the test environment"

--- a/tests/test_metrics_route.py
+++ b/tests/test_metrics_route.py
@@ -1,0 +1,100 @@
+"""Tests for the Prometheus-style /metrics route (gh#34 follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from engine.observability.metrics import (
+    NullBackend,
+    RecordingBackend,
+    get_metrics,
+    set_metrics,
+)
+from engine.observability.prometheus import PrometheusBackend
+
+
+_PROM_PREFIX = "text/plain; version=0.0.4"
+
+
+@pytest.fixture
+def _restore_backend():
+    """Snapshot the active backend so each test can mutate the singleton
+    without polluting the others."""
+    original = get_metrics()
+    yield
+    set_metrics(original)
+
+
+class TestRecordingBackendExposed:
+    async def test_returns_text_plain_with_prom_version(
+        self, client: AsyncClient, _restore_backend
+    ):
+        backend = PrometheusBackend()
+        backend.counter("test.metric")
+        set_metrics(backend)
+
+        resp = await client.get("/metrics")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith(_PROM_PREFIX)
+        assert "test_metric" in resp.text
+        assert "# TYPE test_metric counter" in resp.text
+
+    async def test_renders_live_state_per_request(
+        self, client: AsyncClient, _restore_backend
+    ):
+        backend = PrometheusBackend()
+        set_metrics(backend)
+
+        first = await client.get("/metrics")
+        assert "test_increment" not in first.text
+
+        # Mutate state between two scrapes — the second one must reflect
+        # the new observation.
+        backend.counter("test.increment")
+        second = await client.get("/metrics")
+        assert "test_increment 1" in second.text
+
+    async def test_plain_recording_backend_also_renders(
+        self, client: AsyncClient, _restore_backend
+    ):
+        # Operators are not required to use PrometheusBackend specifically;
+        # any RecordingBackend subclass works because the route checks the
+        # Protocol-level type.
+        backend = RecordingBackend()
+        backend.gauge("recording.gauge", 7.0)
+        set_metrics(backend)
+
+        resp = await client.get("/metrics")
+
+        assert resp.status_code == 200
+        assert "recording_gauge 7" in resp.text
+
+
+class TestNullBackendPlaceholder:
+    async def test_null_backend_returns_placeholder_with_200(
+        self, client: AsyncClient, _restore_backend
+    ):
+        set_metrics(NullBackend())
+
+        resp = await client.get("/metrics")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith(_PROM_PREFIX)
+        assert "metrics backend does not support exposition" in resp.text
+
+
+class TestUnauthenticated:
+    async def test_route_does_not_require_auth(
+        self, client: AsyncClient, _restore_backend
+    ):
+        # The route does not depend on any auth dependency. Operators
+        # restrict access via reverse-proxy / network ACLs (standard
+        # Prometheus pattern). This guard exists so a careless dependency
+        # addition cannot quietly break scrapes.
+        set_metrics(PrometheusBackend())
+
+        resp = await client.get("/metrics")
+
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Closes the loop on the metrics chain shipped across PRs #262, #298, #299, #300, #301, #302, #304, #305: an HTTP endpoint that actually exposes the recorded counters/gauges/histograms in Prometheus exposition format.

- \`engine/api/routes/metrics.py\` — \`GET /metrics\` returns the active \`MetricsBackend\`'s exposition text. Recording-style backends render via \`render_prometheus()\`; \`NullBackend\` returns a 200 placeholder so scrapes never report failed even when no exporter is wired.
- \`engine/api/router.py\` — include the new router with the \`observability\` tag (no path prefix; \`/metrics\` is conventional).
- \`engine/app.py\` — switch the process metrics singleton to \`PrometheusBackend\` at lifespan startup so production scrapes return real counters/gauges/histograms by default. Operators who want a different backend (OTel, StatsD) call \`set_metrics()\` after \`create_app()\` returns.

The endpoint is intentionally unauthenticated; operators restrict access via reverse-proxy / network ACLs (the standard Prometheus pattern). Content-Type is \`text/plain; version=0.0.4; charset=utf-8\`.

Refs #34. Multi-process collector, bucketed histogram exporter, and metric-catalog HELP descriptions still deferred.

## Test plan

- [x] Recording backend renders: 200, correct content-type, expected metric line + TYPE comment
- [x] Live state per request: state mutations between scrapes show up
- [x] Plain \`RecordingBackend\` (not just \`PrometheusBackend\`) renders too
- [x] \`NullBackend\` returns the 200 placeholder
- [x] Route requires no auth dependency (regression guard)
- [x] All 226 existing observability + metrics + events tests still pass after the lifespan singleton swap