### PR TITLE
feat(observability): HttpMetricsMiddleware for per-request metrics (gh#34)

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -27,6 +27,7 @@ from engine.data.providers import (
 )
 from engine.db.session import dispose_engine, get_session_factory
 from engine.legal.sync import sync_legal_documents
+from engine.observability.http_metrics import HttpMetricsMiddleware
 from engine.observability.logging import setup_logging
 from engine.observability.metrics import set_metrics
 from engine.observability.middleware import CorrelationIdMiddleware
@@ -182,6 +183,11 @@ def create_app() -> FastAPI:
     # log-bombing limits the per-route Pydantic models impose.
     app.add_middleware(BodySizeLimitMiddleware, max_bytes=1_048_576)
     app.add_middleware(CorrelationIdMiddleware)
+    # Stack order matters — HttpMetricsMiddleware is added last so it
+    # wraps everything else and times the full request lifecycle. The
+    # /metrics route itself is included so operators can monitor scrape
+    # latency.
+    app.add_middleware(HttpMetricsMiddleware)
 
     app.include_router(api_router)
 

--- a/engine/observability/http_metrics.py
+++ b/engine/observability/http_metrics.py
@@ -1,0 +1,106 @@
+"""ASGI middleware that emits per-request HTTP metrics (gh#34).
+
+Three metrics per request, all routed through the active
+:class:`MetricsBackend` (NullBackend → zero cost):
+
+- ``http.request.count`` counter — exactly once per terminated request.
+- ``http.request.duration_ms`` histogram — wall-time the request spent
+  inside the application, measured from the moment the middleware
+  receives the scope to the moment ``http.response.start`` is sent.
+- ``http.request.in_flight`` gauge — set on every state change so the
+  scrape always sees a fresh value.
+
+All metrics are tagged by ``method`` and ``status_class`` (``2xx``,
+``3xx``, ``4xx``, ``5xx``, ``1xx``, ``unknown``). The full path is *not*
+used as a label: in a typical FastAPI app it carries ids that explode
+the time-series cardinality. Operators who need per-route latency
+should layer a route-aware exporter on top (deferred).
+
+The middleware is a raw ASGI implementation so streaming responses and
+``BackgroundTasks`` keep the timing measurement honest. It writes the
+status code only on the first ``http.response.start`` message, which is
+all Starlette will send.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from engine.observability.metrics import MetricsBackend, get_metrics
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+def _status_class(status: int | None) -> str:
+    if status is None:
+        return "unknown"
+    if 100 <= status < 200:
+        return "1xx"
+    if 200 <= status < 300:
+        return "2xx"
+    if 300 <= status < 400:
+        return "3xx"
+    if 400 <= status < 500:
+        return "4xx"
+    if 500 <= status < 600:
+        return "5xx"
+    return "unknown"
+
+
+class HttpMetricsMiddleware:
+    """Wraps the downstream app, recording counters + histogram + gauge."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        metrics: MetricsBackend | None = None,
+    ) -> None:
+        self.app = app
+        self._metrics = metrics
+        self._in_flight = 0
+
+    @property
+    def metrics(self) -> MetricsBackend:
+        """Resolve the metrics backend lazily so tests can swap the
+        process-wide singleton via :func:`set_metrics` after construction."""
+        return self._metrics if self._metrics is not None else get_metrics()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "UNKNOWN")
+        metrics = self.metrics
+        self._in_flight += 1
+        metrics.gauge("http.request.in_flight", float(self._in_flight))
+
+        start = time.monotonic()
+        status_holder: dict[str, int] = {}
+
+        async def send_wrapper(message: Message) -> None:
+            if (
+                message["type"] == "http.response.start"
+                and "status" not in status_holder
+            ):
+                status_holder["status"] = int(message.get("status", 0))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+            tags = {
+                "method": method,
+                "status_class": _status_class(status_holder.get("status")),
+            }
+            metrics.counter("http.request.count", tags=tags)
+            metrics.histogram("http.request.duration_ms", elapsed_ms, tags=tags)
+            self._in_flight -= 1
+            metrics.gauge("http.request.in_flight", float(self._in_flight))
+
+
+__all__ = ["HttpMetricsMiddleware"]

--- a/tests/test_http_metrics_middleware.py
+++ b/tests/test_http_metrics_middleware.py
@@ -1,0 +1,246 @@
+"""Tests for HttpMetricsMiddleware (gh#34 follow-up).
+
+The middleware wraps the FastAPI app and emits three metrics through
+the active ``MetricsBackend``:
+
+- ``http.request.count`` counter, exactly once per terminated request.
+- ``http.request.duration_ms`` histogram, one observation per request.
+- ``http.request.in_flight`` gauge, set on each state change.
+
+Tags: ``method`` and ``status_class`` (``2xx``/``3xx``/``4xx``/``5xx``/
+``1xx``/``unknown``). The full path is intentionally not labelled.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from engine.observability.http_metrics import (
+    HttpMetricsMiddleware,
+    _status_class,
+)
+from engine.observability.metrics import RecordingBackend
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _ok(_: Request) -> Response:
+    return JSONResponse({"ok": True})
+
+
+async def _server_error(_: Request) -> Response:
+    return JSONResponse({"err": "boom"}, status_code=500)
+
+
+async def _redirect(_: Request) -> Response:
+    return Response(status_code=302, headers={"location": "/elsewhere"})
+
+
+def _app(metrics: RecordingBackend) -> Starlette:
+    app = Starlette(
+        routes=[
+            Route("/ok", _ok, methods=["GET"]),
+            Route("/boom", _server_error, methods=["GET"]),
+            Route("/redirect", _redirect, methods=["GET"]),
+            Route("/post", _ok, methods=["POST"]),
+        ]
+    )
+    return HttpMetricsMiddleware(app, metrics=metrics)
+
+
+def _counter_total(backend: RecordingBackend, name: str) -> float:
+    return sum(v for (n, _t), v in backend.counters.items() if n == name)
+
+
+def _counter_with(
+    backend: RecordingBackend, name: str, tags: dict[str, str]
+) -> float:
+    expected = tuple(sorted(tags.items()))
+    return sum(
+        v
+        for (n, t), v in backend.counters.items()
+        if n == name and all(item in t for item in expected)
+    )
+
+
+def _histogram_count(
+    backend: RecordingBackend, name: str, tags: dict[str, str]
+) -> int:
+    expected = tuple(sorted(tags.items()))
+    return sum(
+        len(v)
+        for (n, t), v in backend.histograms.items()
+        if n == name and all(item in t for item in expected)
+    )
+
+
+def _last_gauge(backend: RecordingBackend, name: str) -> float | None:
+    matches = [v for (n, _t), v in backend.gauges.items() if n == name]
+    return matches[-1] if matches else None
+
+
+@pytest.fixture
+def metrics() -> RecordingBackend:
+    return RecordingBackend()
+
+
+# ---------------------------------------------------------------------------
+# Status-class helper
+# ---------------------------------------------------------------------------
+
+
+class TestStatusClass:
+    def test_buckets(self):
+        assert _status_class(100) == "1xx"
+        assert _status_class(200) == "2xx"
+        assert _status_class(299) == "2xx"
+        assert _status_class(302) == "3xx"
+        assert _status_class(404) == "4xx"
+        assert _status_class(500) == "5xx"
+        assert _status_class(599) == "5xx"
+        assert _status_class(None) == "unknown"
+        assert _status_class(700) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Per-request metrics
+# ---------------------------------------------------------------------------
+
+
+class TestRequestMetrics:
+    async def test_2xx_get_records_count_and_histogram(self, metrics):
+        transport = ASGITransport(app=_app(metrics))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            r = await c.get("/ok")
+
+        assert r.status_code == 200
+        assert (
+            _counter_with(
+                metrics,
+                "http.request.count",
+                {"method": "GET", "status_class": "2xx"},
+            )
+            == 1
+        )
+        assert (
+            _histogram_count(
+                metrics,
+                "http.request.duration_ms",
+                {"method": "GET", "status_class": "2xx"},
+            )
+            == 1
+        )
+
+    async def test_500_records_5xx_status_class(self, metrics):
+        transport = ASGITransport(app=_app(metrics))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            r = await c.get("/boom")
+
+        assert r.status_code == 500
+        assert (
+            _counter_with(
+                metrics,
+                "http.request.count",
+                {"method": "GET", "status_class": "5xx"},
+            )
+            == 1
+        )
+
+    async def test_302_records_3xx_status_class(self, metrics):
+        transport = ASGITransport(app=_app(metrics))
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            follow_redirects=False,
+        ) as c:
+            r = await c.get("/redirect")
+
+        assert r.status_code == 302
+        assert (
+            _counter_with(
+                metrics,
+                "http.request.count",
+                {"method": "GET", "status_class": "3xx"},
+            )
+            == 1
+        )
+
+    async def test_method_tag_propagates(self, metrics):
+        transport = ASGITransport(app=_app(metrics))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            await c.post("/post", json={})
+
+        assert (
+            _counter_with(
+                metrics,
+                "http.request.count",
+                {"method": "POST"},
+            )
+            == 1
+        )
+
+
+class TestInFlightGauge:
+    async def test_returns_to_zero_after_request(self, metrics):
+        transport = ASGITransport(app=_app(metrics))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            await c.get("/ok")
+
+        # Last write is the post-request decrement back to 0.
+        assert _last_gauge(metrics, "http.request.in_flight") == 0.0
+
+    async def test_three_serial_requests_all_settle_at_zero(self, metrics):
+        transport = ASGITransport(app=_app(metrics))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            for _ in range(3):
+                await c.get("/ok")
+
+        assert _counter_total(metrics, "http.request.count") == 3
+        assert _last_gauge(metrics, "http.request.in_flight") == 0.0
+
+
+class TestNonHttpScopePassthrough:
+    async def test_lifespan_scope_is_passed_through_unchanged(self, metrics):
+        # Build a tiny app that responds to a lifespan scope. The
+        # middleware must not record metrics for it.
+        async def lifespan_only_app(scope, receive, send):  # noqa: ARG001
+            assert scope["type"] == "lifespan"
+            msg = await receive()
+            assert msg["type"] == "lifespan.startup"
+            await send({"type": "lifespan.startup.complete"})
+            msg = await receive()
+            assert msg["type"] == "lifespan.shutdown"
+            await send({"type": "lifespan.shutdown.complete"})
+
+        wrapped = HttpMetricsMiddleware(lifespan_only_app, metrics=metrics)
+
+        # Drive the lifespan dance manually.
+        sent: list[dict] = []
+        events = iter(
+            [
+                {"type": "lifespan.startup"},
+                {"type": "lifespan.shutdown"},
+            ]
+        )
+
+        async def receive():
+            return next(events)
+
+        async def send(message):
+            sent.append(message)
+
+        await wrapped({"type": "lifespan"}, receive, send)
+
+        assert _counter_total(metrics, "http.request.count") == 0
+        assert sent == [
+            {"type": "lifespan.startup.complete"},
+            {"type": "lifespan.shutdown.complete"},
+        ]


### PR DESCRIPTION
## Summary

Raw ASGI middleware that emits per-request HTTP metrics through the active \`MetricsBackend\`. With #306 already shipping the \`/metrics\` route + \`PrometheusBackend\` lifespan wiring, this PR fills in the actual request-level signal operators need to dashboard the API.

Emits:
- \`http.request.count\` — counter, exactly once per terminated request.
- \`http.request.duration_ms\` — histogram, one observation per request.
- \`http.request.in_flight\` — gauge, set on each state change so scrapes always see a fresh value.

Tags: \`method\` and \`status_class\` (\`1xx\`/\`2xx\`/\`3xx\`/\`4xx\`/\`5xx\`/\`unknown\`). The full path is intentionally **not** a label — FastAPI route ids would explode time-series cardinality. Operators who need per-route latency layer a route-aware exporter on top (deferred).

The middleware is wired in \`create_app()\` *after* \`CorrelationIdMiddleware\`, so it sits at the outermost layer of the stack and times the full request lifecycle including every other middleware. The \`/metrics\` route itself is timed too — operators can monitor their own scrape latency.

Backend resolution: explicit \`metrics=\` kwarg wins; otherwise \`get_metrics()\` is consulted lazily at request time so tests can swap the singleton via \`set_metrics()\` after construction.

Defaults to \`NullBackend\` → zero cost when no exporter is configured.

Refs #34. Per-route labels and bucketed histograms still deferred.

## Test plan

- [x] \`_status_class\` covers all bucket boundaries + None + out-of-range
- [x] 2xx GET records count + histogram with the right tags
- [x] 500 records \`status_class=5xx\`
- [x] 302 records \`status_class=3xx\` (redirects must not be silently 200)
- [x] \`method\` tag propagates for non-GET (POST tested)
- [x] \`in_flight\` gauge returns to 0 after a request
- [x] Three serial requests all settle the gauge to 0 and bump count to 3
- [x] Lifespan scope is passed through unchanged with no metrics emitted