### PR TITLE
feat(tax): Schedule D summary aggregator (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -13,11 +13,21 @@ from engine.core.tax.reports.form_1099b import (
     generate_1099b_rows,
     rows_to_csv,
 )
+from engine.core.tax.reports.schedule_d import (
+    ScheduleDPartTotal,
+    ScheduleDSummary,
+    summarize_schedule_d,
+    summary_to_csv,
+)
 
 __all__ = [
     "HoldingTerm",
     "LotDisposition",
     "Schedule1099BRow",
+    "ScheduleDPartTotal",
+    "ScheduleDSummary",
     "generate_1099b_rows",
     "rows_to_csv",
+    "summarize_schedule_d",
+    "summary_to_csv",
 ]

--- a/engine/core/tax/reports/schedule_d.py
+++ b/engine/core/tax/reports/schedule_d.py
@@ -1,0 +1,166 @@
+"""US Schedule D (Form 1040) summary aggregator (gh#155).
+
+The IRS Schedule D rolls up the per-lot rows on Form 8949 into two
+totals:
+
+- Part I — Short-Term Capital Gains and Losses (lots held ≤ 1 year).
+- Part II — Long-Term Capital Gains and Losses (lots held > 1 year).
+
+Each part has its own (proceeds, cost_basis, adjustment, gain_loss)
+totals; the net of the two becomes the entry on Form 1040, Schedule 1,
+line 7. This module computes those totals from the per-lot
+:class:`Schedule1099BRow` records produced by
+:func:`engine.core.tax.reports.form_1099b.generate_1099b_rows`.
+
+Out of scope (explicit follow-ups):
+- Capital-loss carryover between tax years.
+- Section 1256 contracts (Form 6781) — different schema entirely.
+- Per-jurisdiction summaries (HMRC CGT, KESt, MiFID II) — they
+  belong in their own modules under this package.
+- AMT (alternative minimum tax) basis differences.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from decimal import Decimal
+
+from engine.core.tax.reports.form_1099b import HoldingTerm, Schedule1099BRow
+
+_TWOPLACES = Decimal("0.01")
+
+
+@dataclass(frozen=True)
+class ScheduleDPartTotal:
+    """Aggregate totals for a single Schedule D part."""
+
+    row_count: int
+    proceeds: Decimal
+    cost_basis: Decimal
+    adjustment_amount: Decimal
+    gain_loss: Decimal
+
+
+@dataclass(frozen=True)
+class ScheduleDSummary:
+    """Both parts plus the net result.
+
+    ``net_gain_loss`` equals ``short_term.gain_loss + long_term.gain_loss``.
+    """
+
+    short_term: ScheduleDPartTotal
+    long_term: ScheduleDPartTotal
+    net_gain_loss: Decimal
+
+
+def summarize_schedule_d(rows: list[Schedule1099BRow]) -> ScheduleDSummary:
+    """Aggregate ``rows`` into Schedule D Part I + Part II totals.
+
+    Money columns are quantised to two decimal places — Schedule D is
+    expressed in whole dollars on the IRS form, but engines typically
+    keep cents through the pipeline so the numbers round-trip cleanly
+    against per-fill audits.
+    """
+    short = _empty_part()
+    long_ = _empty_part()
+    for row in rows:
+        bucket = short if row.term == HoldingTerm.SHORT_TERM else long_
+        bucket["row_count"] += 1
+        bucket["proceeds"] += row.proceeds
+        bucket["cost_basis"] += row.cost_basis
+        bucket["adjustment_amount"] += row.adjustment_amount
+        bucket["gain_loss"] += row.gain_loss
+
+    short_total = _materialise(short)
+    long_total = _materialise(long_)
+    net = (short_total.gain_loss + long_total.gain_loss).quantize(_TWOPLACES)
+    return ScheduleDSummary(
+        short_term=short_total,
+        long_term=long_total,
+        net_gain_loss=net,
+    )
+
+
+def summary_to_csv(summary: ScheduleDSummary) -> str:
+    """Serialise the summary as a 4-line CSV (header + short + long + net).
+
+    Columns mirror the Schedule D form line items so a CPA can paste
+    the result straight into the IRS PDF or a tax-prep tool that
+    accepts CSV imports.
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "section",
+            "row_count",
+            "proceeds",
+            "cost_basis",
+            "adjustment_amount",
+            "gain_loss",
+        ]
+    )
+    for label, part in (
+        ("part_i_short_term", summary.short_term),
+        ("part_ii_long_term", summary.long_term),
+    ):
+        writer.writerow(
+            [
+                label,
+                part.row_count,
+                _fmt(part.proceeds),
+                _fmt(part.cost_basis),
+                _fmt(part.adjustment_amount),
+                _fmt(part.gain_loss),
+            ]
+        )
+    writer.writerow(
+        [
+            "net",
+            summary.short_term.row_count + summary.long_term.row_count,
+            "",
+            "",
+            "",
+            _fmt(summary.net_gain_loss),
+        ]
+    )
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _empty_part() -> dict[str, Decimal | int]:
+    return {
+        "row_count": 0,
+        "proceeds": Decimal("0"),
+        "cost_basis": Decimal("0"),
+        "adjustment_amount": Decimal("0"),
+        "gain_loss": Decimal("0"),
+    }
+
+
+def _materialise(part: dict) -> ScheduleDPartTotal:
+    return ScheduleDPartTotal(
+        row_count=part["row_count"],
+        proceeds=part["proceeds"].quantize(_TWOPLACES),
+        cost_basis=part["cost_basis"].quantize(_TWOPLACES),
+        adjustment_amount=part["adjustment_amount"].quantize(_TWOPLACES),
+        gain_loss=part["gain_loss"].quantize(_TWOPLACES),
+    )
+
+
+def _fmt(value: Decimal) -> str:
+    return f"{value.quantize(_TWOPLACES)}"
+
+
+__all__ = [
+    "ScheduleDPartTotal",
+    "ScheduleDSummary",
+    "summarize_schedule_d",
+    "summary_to_csv",
+]

--- a/tests/test_schedule_d.py
+++ b/tests/test_schedule_d.py
@@ -1,0 +1,228 @@
+"""Tests for the Schedule D summary aggregator (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from engine.core.tax.reports import (
+    HoldingTerm,
+    LotDisposition,
+    ScheduleDSummary,
+    generate_1099b_rows,
+    summarize_schedule_d,
+    summary_to_csv,
+)
+from engine.core.tax.reports.form_1099b import Schedule1099BRow
+
+
+def _row(
+    *,
+    proceeds: str,
+    cost_basis: str,
+    term: HoldingTerm,
+    adj: str = "0",
+    gain: str | None = None,
+) -> Schedule1099BRow:
+    proceeds_d = Decimal(proceeds)
+    basis_d = Decimal(cost_basis)
+    adj_d = Decimal(adj)
+    if gain is None:
+        gain_d = (proceeds_d - basis_d + adj_d).quantize(Decimal("0.01"))
+    else:
+        gain_d = Decimal(gain)
+    return Schedule1099BRow(
+        description="10 shares X",
+        acquired=date(2024, 1, 1),
+        sold=date(2024, 6, 1) if term == HoldingTerm.SHORT_TERM else date(2025, 6, 2),
+        proceeds=proceeds_d,
+        cost_basis=basis_d,
+        adjustment_codes="W" if adj_d > 0 else "",
+        adjustment_amount=adj_d,
+        gain_loss=gain_d,
+        term=term,
+        lot_id=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyInput:
+    def test_empty_rows_produces_zeroed_summary(self):
+        summary = summarize_schedule_d([])
+
+        assert isinstance(summary, ScheduleDSummary)
+        assert summary.short_term.row_count == 0
+        assert summary.long_term.row_count == 0
+        assert summary.short_term.gain_loss == Decimal("0.00")
+        assert summary.long_term.gain_loss == Decimal("0.00")
+        assert summary.net_gain_loss == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestAggregation:
+    def test_short_term_only_aggregates_into_part_i(self):
+        rows = [
+            _row(proceeds="100", cost_basis="80", term=HoldingTerm.SHORT_TERM),
+            _row(proceeds="50", cost_basis="60", term=HoldingTerm.SHORT_TERM),
+        ]
+
+        summary = summarize_schedule_d(rows)
+
+        assert summary.short_term.row_count == 2
+        assert summary.short_term.proceeds == Decimal("150.00")
+        assert summary.short_term.cost_basis == Decimal("140.00")
+        # Gains: +20, -10 → net +10.
+        assert summary.short_term.gain_loss == Decimal("10.00")
+        # Long-term part empty.
+        assert summary.long_term.row_count == 0
+        assert summary.long_term.gain_loss == Decimal("0.00")
+        assert summary.net_gain_loss == Decimal("10.00")
+
+    def test_long_term_only_aggregates_into_part_ii(self):
+        rows = [
+            _row(proceeds="500", cost_basis="200", term=HoldingTerm.LONG_TERM),
+            _row(proceeds="300", cost_basis="350", term=HoldingTerm.LONG_TERM),
+        ]
+
+        summary = summarize_schedule_d(rows)
+
+        assert summary.long_term.row_count == 2
+        # Gains: +300, -50 → net +250.
+        assert summary.long_term.gain_loss == Decimal("250.00")
+        assert summary.short_term.row_count == 0
+
+    def test_mixed_terms_partition_correctly(self):
+        rows = [
+            _row(proceeds="100", cost_basis="80", term=HoldingTerm.SHORT_TERM),
+            _row(proceeds="500", cost_basis="200", term=HoldingTerm.LONG_TERM),
+            _row(proceeds="50", cost_basis="60", term=HoldingTerm.SHORT_TERM),
+        ]
+
+        summary = summarize_schedule_d(rows)
+
+        assert summary.short_term.row_count == 2
+        assert summary.long_term.row_count == 1
+        # Short net: +20 -10 = +10. Long net: +300. Total: +310.
+        assert summary.short_term.gain_loss == Decimal("10.00")
+        assert summary.long_term.gain_loss == Decimal("300.00")
+        assert summary.net_gain_loss == Decimal("310.00")
+
+    def test_wash_sale_adjustment_is_summed_into_part_total(self):
+        # A short-term loss with a $40 wash-sale disallow adjusts back
+        # the loss. summarize_schedule_d trusts the per-row gain_loss,
+        # but it must also surface the adjustment column total so a CPA
+        # can reconcile the part against Form 8949 column g.
+        rows = [
+            _row(
+                proceeds="60",
+                cost_basis="100",
+                adj="40",
+                term=HoldingTerm.SHORT_TERM,
+                # 60 - 100 + 40 = 0 net loss after wash adjustment.
+                gain="0.00",
+            ),
+        ]
+
+        summary = summarize_schedule_d(rows)
+
+        assert summary.short_term.adjustment_amount == Decimal("40.00")
+        assert summary.short_term.gain_loss == Decimal("0.00")
+        assert summary.net_gain_loss == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip with the per-lot generator
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripWith1099BRows:
+    def test_summarises_rows_produced_by_generate_1099b_rows(self):
+        # Two short-term lots (held under a year) + one long-term lot.
+        dispositions = [
+            LotDisposition(
+                description="10 shares AAPL",
+                acquired=date(2024, 1, 1),
+                sold=date(2024, 6, 1),
+                proceeds=Decimal("1100"),
+                cost_basis=Decimal("1000"),
+            ),
+            LotDisposition(
+                description="5 shares AAPL",
+                acquired=date(2024, 2, 1),
+                sold=date(2024, 5, 1),
+                proceeds=Decimal("400"),
+                cost_basis=Decimal("500"),
+            ),
+            LotDisposition(
+                description="3 shares MSFT",
+                acquired=date(2022, 1, 1),
+                sold=date(2024, 6, 1),  # > 1 year held
+                proceeds=Decimal("900"),
+                cost_basis=Decimal("600"),
+            ),
+        ]
+
+        rows = generate_1099b_rows(dispositions)
+        summary = summarize_schedule_d(rows)
+
+        assert summary.short_term.row_count == 2
+        assert summary.long_term.row_count == 1
+        # Short-term net: +100 - 100 = 0. Long-term net: +300.
+        assert summary.short_term.gain_loss == Decimal("0.00")
+        assert summary.long_term.gain_loss == Decimal("300.00")
+        assert summary.net_gain_loss == Decimal("300.00")
+
+
+# ---------------------------------------------------------------------------
+# CSV serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestCsv:
+    def test_csv_header_and_three_data_rows(self):
+        rows = [
+            _row(proceeds="100", cost_basis="80", term=HoldingTerm.SHORT_TERM),
+            _row(proceeds="500", cost_basis="200", term=HoldingTerm.LONG_TERM),
+        ]
+
+        out = summary_to_csv(summarize_schedule_d(rows))
+
+        lines = out.strip().splitlines()
+        assert len(lines) == 4  # header + 3 rows
+        assert lines[0].split(",") == [
+            "section",
+            "row_count",
+            "proceeds",
+            "cost_basis",
+            "adjustment_amount",
+            "gain_loss",
+        ]
+        assert lines[1].startswith("part_i_short_term,1,100.00")
+        assert lines[2].startswith("part_ii_long_term,1,500.00")
+        # Net row leaves the per-part dollar columns blank.
+        assert lines[3].split(",") == ["net", "2", "", "", "", "320.00"]
+
+    def test_csv_quantises_to_two_decimal_places(self):
+        rows = [
+            _row(
+                proceeds="100.123",
+                cost_basis="50.456",
+                term=HoldingTerm.SHORT_TERM,
+            ),
+        ]
+
+        out = summary_to_csv(summarize_schedule_d(rows))
+
+        # Both money columns must be exactly 2 decimal places in the
+        # rendered CSV — the engine keeps cents internally but Schedule
+        # D rounds.
+        assert ",100.12," in out
+        assert ",50.46," in out


### PR DESCRIPTION
## Summary

Roll up Form 8949 per-lot rows into IRS Schedule D Part I + Part II totals. The net of the two becomes the Form 1040, Schedule 1 line 7 entry.

- \`summarize_schedule_d(rows) -> ScheduleDSummary\` — \`ScheduleDPartTotal\` for each part (\`row_count\`, \`proceeds\`, \`cost_basis\`, \`adjustment_amount\`, \`gain_loss\`) plus a \`net_gain_loss\` field.
- \`summary_to_csv(summary)\` — 4-line CSV (header + part i + part ii + net) keyed on the IRS form sections so a CPA can paste it straight into a tax-prep tool.

Money quantises to two decimal places — engines keep cents through the pipeline; Schedule D rounds to whole dollars on the IRS PDF but exporting cents lets the row tie back to the per-fill audit trail.

Refs #155. Capital-loss carryover, Section 1256 contracts (Form 6781), per-jurisdiction summaries (HMRC CGT, KESt, MiFID II), and AMT basis differences are deferred.

## Test plan

- [x] Empty input → all-zero \`ScheduleDSummary\` with quantised \`Decimal('0.00')\`
- [x] Short-term-only rows aggregate into Part I only
- [x] Long-term-only rows aggregate into Part II only
- [x] Mixed terms partition into the correct parts
- [x] Wash-sale adjustment is summed into the part \`adjustment_amount\` column
- [x] Round-trip with \`generate_1099b_rows\` produces the right per-part totals
- [x] CSV header + 3 data rows in the right order
- [x] CSV quantises money to 2 decimal places