### PR TITLE
feat(tax): capital-loss carryover under IRS § 1212(b) (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -6,6 +6,13 @@ explicit follow-ups — each adds its own row schema and serialiser
 under this package.
 """
 
+from engine.core.tax.reports.carryover import (
+    DEDUCTIBLE_CAP_DEFAULT,
+    DEDUCTIBLE_CAP_MFS,
+    CapitalLossApplication,
+    CapitalLossCarryover,
+    apply_carryover,
+)
 from engine.core.tax.reports.form_1099b import (
     HoldingTerm,
     LotDisposition,
@@ -21,11 +28,16 @@ from engine.core.tax.reports.schedule_d import (
 )
 
 __all__ = [
+    "DEDUCTIBLE_CAP_DEFAULT",
+    "DEDUCTIBLE_CAP_MFS",
+    "CapitalLossApplication",
+    "CapitalLossCarryover",
     "HoldingTerm",
     "LotDisposition",
     "Schedule1099BRow",
     "ScheduleDPartTotal",
     "ScheduleDSummary",
+    "apply_carryover",
     "generate_1099b_rows",
     "rows_to_csv",
     "summarize_schedule_d",

--- a/engine/core/tax/reports/carryover.py
+++ b/engine/core/tax/reports/carryover.py
@@ -1,0 +1,164 @@
+"""US capital-loss carryover (gh#155 follow-up).
+
+Applies IRS § 1212(b) carryover rules to a single tax year's
+Schedule D result:
+
+1. The taxpayer first nets short-term gain/loss against long-term
+   gain/loss within the same year (already done by
+   :func:`engine.core.tax.reports.schedule_d.summarize_schedule_d`).
+2. If the resulting net is a loss, up to ``deductible_cap`` of it can
+   be deducted against ordinary income in the current year (default
+   $3,000; $1,500 if Married Filing Separately).
+3. The unused balance carries over to the next year, splitting back
+   into short-term and long-term components — short-term losses
+   absorb the deduction first, then long-term losses.
+
+This module computes the next-year carryover and the current-year
+deductible amount; it does not file the form. Operators are expected
+to feed the prior-year carryover (if any) back into next year's
+Schedule D run before computing the new summary.
+
+What's NOT here (explicit follow-ups):
+- Loss harvesting recommendations (different problem entirely).
+- Section 1244 small-business stock loss handling.
+- Joint vs. Married-Filing-Separately filing-status switches mid-year.
+- Carryback (only forward carryover applies under § 1212(b) for
+  individuals; § 1212(a) corporate carrybacks are out of scope).
+- AMT carryover differences.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from engine.core.tax.reports.schedule_d import ScheduleDSummary
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+# IRS § 1211(b) annual deduction caps.
+DEDUCTIBLE_CAP_DEFAULT: Decimal = Decimal("3000.00")
+DEDUCTIBLE_CAP_MFS: Decimal = Decimal("1500.00")
+
+
+@dataclass(frozen=True)
+class CapitalLossCarryover:
+    """A two-bucket carryover record. Both fields are *non-negative*
+    (loss amounts) — gains do not carry over. ``zero()`` is the
+    identity for the first year a taxpayer files."""
+
+    short_term: Decimal = _ZERO
+    long_term: Decimal = _ZERO
+
+    @classmethod
+    def zero(cls) -> CapitalLossCarryover:
+        return cls(short_term=_ZERO, long_term=_ZERO)
+
+    @property
+    def total(self) -> Decimal:
+        return (self.short_term + self.long_term).quantize(_TWOPLACES)
+
+
+@dataclass(frozen=True)
+class CapitalLossApplication:
+    """Result of running :func:`apply_carryover` for one tax year.
+
+    - ``current_year_deduction`` is the (positive) amount that lands on
+      Form 1040 Schedule 1 line 7 as a loss against ordinary income.
+      Capped at ``deductible_cap`` and at the absolute net loss.
+    - ``next_year_carryover`` is what the taxpayer carries forward.
+      Both legs are non-negative; either or both may be zero.
+    """
+
+    current_year_deduction: Decimal
+    next_year_carryover: CapitalLossCarryover
+
+
+def apply_carryover(
+    summary: ScheduleDSummary,
+    prior: CapitalLossCarryover | None = None,
+    *,
+    deductible_cap: Decimal = DEDUCTIBLE_CAP_DEFAULT,
+) -> CapitalLossApplication:
+    """Return the current-year deduction and next-year carryover.
+
+    Algorithm (matches the IRS Capital Loss Carryover Worksheet):
+
+    1. Add the prior-year carryover into the current-year per-leg
+       gain/loss so prior losses get a fresh shot at offsetting any
+       new gains.
+    2. Net short-term against long-term as the IRS does.
+    3. If the combined result is non-negative there is no loss to
+       deduct or carry over; deduction = 0, next-year carryover = 0.
+    4. If it is a loss, the current-year deduction is
+       ``min(abs(loss), deductible_cap)``. Anything above the cap
+       carries to next year.
+    5. The carryover is split back into short-term first, then
+       long-term, mirroring the form's Schedule D Part I / Part II
+       split.
+    """
+    if deductible_cap <= 0:
+        raise ValueError("deductible_cap must be positive")
+
+    prior = prior or CapitalLossCarryover.zero()
+    if prior.short_term < 0 or prior.long_term < 0:
+        raise ValueError(
+            "prior carryover legs must be non-negative loss amounts"
+        )
+
+    # Apply prior-year losses to this year's per-leg result.
+    short_net = summary.short_term.gain_loss - prior.short_term
+    long_net = summary.long_term.gain_loss - prior.long_term
+
+    combined = (short_net + long_net).quantize(_TWOPLACES)
+    if combined >= 0:
+        return CapitalLossApplication(
+            current_year_deduction=_ZERO,
+            next_year_carryover=CapitalLossCarryover.zero(),
+        )
+
+    total_loss = -combined  # positive amount
+    deduction = min(total_loss, deductible_cap).quantize(_TWOPLACES)
+    remaining = (total_loss - deduction).quantize(_TWOPLACES)
+
+    # Split the remaining loss back into short-term and long-term
+    # buckets. Pull the deduction off short-term first (if it was a
+    # loss), matching the IRS form's Schedule D ordering.
+    short_loss = -short_net if short_net < 0 else _ZERO
+    long_loss = -long_net if long_net < 0 else _ZERO
+
+    if short_loss + long_loss == total_loss:
+        # Both legs are losses (or one is zero). Apply the deduction
+        # to the short-term leg first, then the long-term leg.
+        next_short = max(_ZERO, short_loss - deduction).quantize(_TWOPLACES)
+        absorbed_by_short = short_loss - next_short
+        deduction_after_short = (deduction - absorbed_by_short).quantize(
+            _TWOPLACES
+        )
+        next_long = max(_ZERO, long_loss - deduction_after_short).quantize(
+            _TWOPLACES
+        )
+    else:
+        # One leg is a gain that already absorbed part of the other
+        # leg's loss. ``remaining`` lives entirely on whichever leg is
+        # still in loss after netting.
+        next_short = remaining if short_net < 0 else _ZERO
+        next_long = remaining if long_net < 0 else _ZERO
+
+    return CapitalLossApplication(
+        current_year_deduction=deduction,
+        next_year_carryover=CapitalLossCarryover(
+            short_term=next_short.quantize(_TWOPLACES),
+            long_term=next_long.quantize(_TWOPLACES),
+        ),
+    )
+
+
+__all__ = [
+    "CapitalLossApplication",
+    "CapitalLossCarryover",
+    "DEDUCTIBLE_CAP_DEFAULT",
+    "DEDUCTIBLE_CAP_MFS",
+    "apply_carryover",
+]

--- a/tests/test_capital_loss_carryover.py
+++ b/tests/test_capital_loss_carryover.py
@@ -1,0 +1,219 @@
+"""Tests for the capital-loss carryover (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    DEDUCTIBLE_CAP_DEFAULT,
+    DEDUCTIBLE_CAP_MFS,
+    CapitalLossApplication,
+    CapitalLossCarryover,
+    ScheduleDPartTotal,
+    ScheduleDSummary,
+    apply_carryover,
+)
+
+
+def _summary(short: str, long_: str) -> ScheduleDSummary:
+    short_total = ScheduleDPartTotal(
+        row_count=1,
+        proceeds=Decimal("0.00"),
+        cost_basis=Decimal("0.00"),
+        adjustment_amount=Decimal("0.00"),
+        gain_loss=Decimal(short).quantize(Decimal("0.01")),
+    )
+    long_total = ScheduleDPartTotal(
+        row_count=1,
+        proceeds=Decimal("0.00"),
+        cost_basis=Decimal("0.00"),
+        adjustment_amount=Decimal("0.00"),
+        gain_loss=Decimal(long_).quantize(Decimal("0.01")),
+    )
+    net = (short_total.gain_loss + long_total.gain_loss).quantize(Decimal("0.01"))
+    return ScheduleDSummary(
+        short_term=short_total,
+        long_term=long_total,
+        net_gain_loss=net,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity / no-op cases
+# ---------------------------------------------------------------------------
+
+
+class TestCarryoverConstructors:
+    def test_zero_constructor_returns_both_legs_at_zero(self):
+        c = CapitalLossCarryover.zero()
+        assert c.short_term == Decimal("0.00")
+        assert c.long_term == Decimal("0.00")
+        assert c.total == Decimal("0.00")
+
+    def test_total_quantises_to_two_decimals(self):
+        c = CapitalLossCarryover(
+            short_term=Decimal("100.123"), long_term=Decimal("50.456")
+        )
+        assert c.total == Decimal("150.58")
+
+
+class TestNoLossNoCarryover:
+    def test_pure_gain_year_yields_zero_deduction_and_no_carry(self):
+        result = apply_carryover(_summary(short="500", long_="1000"))
+
+        assert isinstance(result, CapitalLossApplication)
+        assert result.current_year_deduction == Decimal("0.00")
+        assert result.next_year_carryover == CapitalLossCarryover.zero()
+
+    def test_short_loss_offset_by_long_gain_yields_no_deduction(self):
+        # -500 short + 800 long = +300 net → no loss.
+        result = apply_carryover(_summary(short="-500", long_="800"))
+
+        assert result.current_year_deduction == Decimal("0.00")
+        assert result.next_year_carryover.total == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Loss within the cap
+# ---------------------------------------------------------------------------
+
+
+class TestLossWithinCap:
+    def test_small_loss_fully_deducted_no_carry(self):
+        # -1500 short, 0 long → $1,500 deduction, no carry.
+        result = apply_carryover(_summary(short="-1500", long_="0"))
+
+        assert result.current_year_deduction == Decimal("1500.00")
+        assert result.next_year_carryover == CapitalLossCarryover.zero()
+
+
+# ---------------------------------------------------------------------------
+# Loss above the cap → carryover
+# ---------------------------------------------------------------------------
+
+
+class TestLossAboveCap:
+    def test_short_only_loss_caps_at_default_3000_then_carries(self):
+        # -10,000 short, 0 long → $3,000 deduction, $7,000 short carry.
+        result = apply_carryover(_summary(short="-10000", long_="0"))
+
+        assert result.current_year_deduction == Decimal("3000.00")
+        assert result.next_year_carryover.short_term == Decimal("7000.00")
+        assert result.next_year_carryover.long_term == Decimal("0.00")
+
+    def test_long_only_loss_caps_then_carries_to_long_bucket(self):
+        # -10,000 long, 0 short → $3,000 deduction, $7,000 long carry.
+        result = apply_carryover(_summary(short="0", long_="-10000"))
+
+        assert result.current_year_deduction == Decimal("3000.00")
+        assert result.next_year_carryover.short_term == Decimal("0.00")
+        assert result.next_year_carryover.long_term == Decimal("7000.00")
+
+    def test_both_legs_loss_deduction_pulled_off_short_first(self):
+        # -2,000 short + -5,000 long = -7,000 net. $3,000 deduction
+        # absorbs the entire $2,000 short loss + $1,000 of long loss.
+        # Carry: 0 short + 4,000 long.
+        result = apply_carryover(_summary(short="-2000", long_="-5000"))
+
+        assert result.current_year_deduction == Decimal("3000.00")
+        assert result.next_year_carryover.short_term == Decimal("0.00")
+        assert result.next_year_carryover.long_term == Decimal("4000.00")
+
+    def test_short_loss_offset_then_remainder_carries(self):
+        # -8,000 short + 2,000 long = -6,000 net.
+        # The $2,000 long gain offsets $2,000 of short loss intra-year.
+        # Remaining short loss: $6,000. $3,000 deducted → $3,000 carry.
+        result = apply_carryover(_summary(short="-8000", long_="2000"))
+
+        assert result.current_year_deduction == Decimal("3000.00")
+        # The residual lives entirely on the short-term leg.
+        assert result.next_year_carryover.short_term == Decimal("3000.00")
+        assert result.next_year_carryover.long_term == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Prior-year carryover applied to current year
+# ---------------------------------------------------------------------------
+
+
+class TestPriorYearCarryover:
+    def test_prior_loss_offsets_current_gain_no_new_carry(self):
+        # Prior: $4,000 short carry. Current: +5,000 long.
+        # Prior absorbs into short leg: short_net = 0 - 4000 = -4000.
+        # Combined: -4000 + 5000 = +1000 → no loss this year, no carry.
+        prior = CapitalLossCarryover(
+            short_term=Decimal("4000"), long_term=Decimal("0")
+        )
+        result = apply_carryover(_summary(short="0", long_="5000"), prior)
+
+        assert result.current_year_deduction == Decimal("0.00")
+        assert result.next_year_carryover == CapitalLossCarryover.zero()
+
+    def test_prior_loss_plus_current_loss_compounds_carryover(self):
+        # Prior: $2,000 short carry. Current: -1,000 short, 0 long.
+        # Combined short loss: 3,000. $3,000 deducted, no carryover.
+        prior = CapitalLossCarryover(
+            short_term=Decimal("2000"), long_term=Decimal("0")
+        )
+        result = apply_carryover(_summary(short="-1000", long_="0"), prior)
+
+        assert result.current_year_deduction == Decimal("3000.00")
+        assert result.next_year_carryover == CapitalLossCarryover.zero()
+
+    def test_prior_loss_plus_current_loss_above_cap_carries_remainder(self):
+        # Prior: $5,000 short. Current: -3,000 short. Combined = -8,000
+        # short. $3,000 deducted → $5,000 short carry.
+        prior = CapitalLossCarryover(
+            short_term=Decimal("5000"), long_term=Decimal("0")
+        )
+        result = apply_carryover(_summary(short="-3000", long_="0"), prior)
+
+        assert result.current_year_deduction == Decimal("3000.00")
+        assert result.next_year_carryover.short_term == Decimal("5000.00")
+        assert result.next_year_carryover.long_term == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# MFS cap
+# ---------------------------------------------------------------------------
+
+
+class TestMfsCap:
+    def test_mfs_cap_halves_the_default_deduction(self):
+        # Big loss with the MFS cap → only $1,500 deductible.
+        result = apply_carryover(
+            _summary(short="-10000", long_="0"),
+            deductible_cap=DEDUCTIBLE_CAP_MFS,
+        )
+
+        assert result.current_year_deduction == Decimal("1500.00")
+        assert result.next_year_carryover.short_term == Decimal("8500.00")
+
+    def test_default_cap_is_three_thousand(self):
+        assert DEDUCTIBLE_CAP_DEFAULT == Decimal("3000.00")
+        assert DEDUCTIBLE_CAP_MFS == Decimal("1500.00")
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_negative_prior_short_term_rejected(self):
+        with pytest.raises(ValueError):
+            apply_carryover(
+                _summary(short="0", long_="0"),
+                CapitalLossCarryover(
+                    short_term=Decimal("-1"), long_term=Decimal("0")
+                ),
+            )
+
+    def test_zero_or_negative_cap_rejected(self):
+        with pytest.raises(ValueError):
+            apply_carryover(
+                _summary(short="-100", long_="0"),
+                deductible_cap=Decimal("0"),
+            )


### PR DESCRIPTION
## Summary

Apply IRS § 1212(b) carryover rules to a single tax year's Schedule D result. The annual deduction (default \$3,000; \$1,500 if Married Filing Separately) is taken against ordinary income; anything above the cap carries forward into next year split back into short-term and long-term legs.

API:
- \`CapitalLossCarryover\` — frozen dataclass; both legs are *non-negative* loss amounts. \`.zero()\` for first-year filers; \`.total\` for the sum.
- \`CapitalLossApplication\` — \`current_year_deduction\` (the dollar amount on Form 1040 Schedule 1 line 7) + \`next_year_carryover\`.
- \`apply_carryover(summary, prior=None, *, deductible_cap=...)\` — single entrypoint covering: pure-gain years, within-cap losses, above-cap losses, prior-year carryover applied to current year, and MFS cap.

Algorithm matches the IRS Capital Loss Carryover Worksheet:
1. Add the prior-year carryover into the current-year per-leg gain/loss so prior losses get a fresh shot at offsetting gains.
2. Net short-term against long-term as the IRS does.
3. If the combined result is non-negative → no deduction, no carryover.
4. If a loss → \`min(abs(loss), deductible_cap)\` is the current-year deduction; the remainder carries.
5. The deduction pulls off the short-term leg first, then the long-term leg, mirroring the form's Schedule D ordering.

Refs #155. Loss-harvesting recommendations, Section 1244 small-business stock, mid-year filing-status switches, corporate carryback under § 1212(a), and AMT carryover differences are still deferred.

## Test plan

- [x] \`zero()\` constructor + \`total\` quantises to two decimals
- [x] Pure-gain year → \$0 deduction, \$0 carryover
- [x] Short loss offset by long gain → no deduction
- [x] Within-cap loss fully deducted, no carry
- [x] Short-only loss above cap → \$3,000 deduction + short carry
- [x] Long-only loss above cap → \$3,000 deduction + long carry
- [x] Both-leg losses pull deduction off short first
- [x] Mixed sign legs route the residual to the correct bucket
- [x] Prior loss offsets current gain → no new carry
- [x] Prior + current loss compounds and may eliminate carry
- [x] Prior + current loss above cap → preserved short-term carry
- [x] MFS cap halves the deduction
- [x] Negative prior leg + zero/negative cap rejected