### PR TITLE
feat(tax): HMRC Capital Gains Tax summary (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -13,6 +13,13 @@ from engine.core.tax.reports.carryover import (
     CapitalLossCarryover,
     apply_carryover,
 )
+from engine.core.tax.reports.hmrc_cgt import (
+    ANNUAL_EXEMPT_AMOUNT_2024_25,
+    CgtDisposal,
+    CgtSummary,
+    disposals_to_csv,
+    summarize_cgt,
+)
 from engine.core.tax.reports.form_1099b import (
     HoldingTerm,
     LotDisposition,
@@ -28,18 +35,23 @@ from engine.core.tax.reports.schedule_d import (
 )
 
 __all__ = [
+    "ANNUAL_EXEMPT_AMOUNT_2024_25",
     "DEDUCTIBLE_CAP_DEFAULT",
     "DEDUCTIBLE_CAP_MFS",
     "CapitalLossApplication",
     "CapitalLossCarryover",
+    "CgtDisposal",
+    "CgtSummary",
     "HoldingTerm",
     "LotDisposition",
     "Schedule1099BRow",
     "ScheduleDPartTotal",
     "ScheduleDSummary",
     "apply_carryover",
+    "disposals_to_csv",
     "generate_1099b_rows",
     "rows_to_csv",
+    "summarize_cgt",
     "summarize_schedule_d",
     "summary_to_csv",
 ]

--- a/engine/core/tax/reports/hmrc_cgt.py
+++ b/engine/core/tax/reports/hmrc_cgt.py
@@ -1,0 +1,191 @@
+"""HMRC Capital Gains Tax summary (gh#155 follow-up).
+
+Aggregates per-disposal records into the totals HMRC expects on the
+Self Assessment SA108 (Capital Gains) supplement and the online
+Real-Time Transaction return.
+
+Scope
+-----
+- Per-disposal proceeds, cost, gain/loss aggregation.
+- Annual Exempt Amount (AEA) deduction (£3,000 for the 2024-25 tax
+  year; £6,000 for 2023-24; £12,300 for 2022-23 and earlier — caller
+  supplies the relevant year's allowance).
+- Net taxable gain after the AEA — what feeds into the income-band
+  rate calculation.
+
+What's NOT here (explicit follow-ups):
+- Section 104 share pooling — the engine's lot ledger is already
+  responsible for producing per-disposal records; CGT pooling rules
+  (same-day, 30-day bed-and-breakfasting, then S104 pool) are
+  applied upstream by the lot accountant.
+- Capital-loss carry-forward into future years (HMRC keeps loss
+  registration claims; the engine should mirror that with its own
+  state, deferred).
+- Income-band rate selection (10%/20% basic/higher; 18%/24% on
+  residential property). The summary surfaces the *taxable gain* so
+  the caller's tax-band module can apply the relevant rate.
+- Entrepreneur's / Investors' Relief (ER/IR) — different return.
+- Non-resident capital gains for UK property.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+# Annual Exempt Amount for the 2024-25 tax year. Operators handling
+# prior years should pass the relevant value explicitly.
+ANNUAL_EXEMPT_AMOUNT_2024_25: Decimal = Decimal("3000.00")
+
+
+@dataclass(frozen=True)
+class CgtDisposal:
+    """One disposal: a sell of an asset that triggers CGT.
+
+    HMRC expects per-disposal records on SA108 — one line per asset
+    disposal, with proceeds, cost, and gain/loss. ``acquired`` and
+    ``disposed`` capture the holding period; HMRC does not distinguish
+    short vs long term but the dates are mandatory on the return.
+    """
+
+    description: str
+    acquired: date
+    disposed: date
+    proceeds: Decimal
+    cost: Decimal  # acquisition cost + allowable expenses
+
+    def __post_init__(self) -> None:
+        if self.acquired > self.disposed:
+            raise ValueError(
+                f"acquired {self.acquired} is after disposed {self.disposed}"
+            )
+        if self.proceeds < 0:
+            raise ValueError("proceeds must be non-negative")
+        if self.cost < 0:
+            raise ValueError("cost must be non-negative")
+
+    @property
+    def gain_loss(self) -> Decimal:
+        return (self.proceeds - self.cost).quantize(_TWOPLACES)
+
+
+@dataclass(frozen=True)
+class CgtSummary:
+    """Year-level CGT totals (GBP).
+
+    - ``proceeds_total`` and ``cost_total`` are the gross totals.
+    - ``net_gain`` and ``net_loss`` are split out (HMRC reports both
+      figures separately on SA108 boxes 26 and 27).
+    - ``annual_exempt_amount_used`` is the portion of the AEA actually
+      consumed (capped at the net gain).
+    - ``taxable_gain`` is the gain after AEA — what the rate module
+      multiplies by the relevant CGT rate.
+    """
+
+    disposal_count: int
+    proceeds_total: Decimal
+    cost_total: Decimal
+    net_gain: Decimal
+    net_loss: Decimal
+    annual_exempt_amount_used: Decimal
+    taxable_gain: Decimal
+
+
+def summarize_cgt(
+    disposals: list[CgtDisposal],
+    *,
+    annual_exempt_amount: Decimal = ANNUAL_EXEMPT_AMOUNT_2024_25,
+) -> CgtSummary:
+    """Aggregate ``disposals`` into a year-level CGT summary.
+
+    ``annual_exempt_amount`` is applied only against the net gain, not
+    against the gross proceeds. If gains and losses net to a loss the
+    AEA is not consumed and carries no value into the loss for
+    carry-forward purposes (HMRC tracks loss carry-forward separately).
+    """
+    if annual_exempt_amount < 0:
+        raise ValueError("annual_exempt_amount must be non-negative")
+
+    proceeds_total = _ZERO
+    cost_total = _ZERO
+    gross_gain = _ZERO  # sum of positive disposals
+    gross_loss = _ZERO  # absolute sum of negative disposals
+    for d in disposals:
+        proceeds_total += d.proceeds
+        cost_total += d.cost
+        delta = d.gain_loss
+        if delta >= 0:
+            gross_gain += delta
+        else:
+            gross_loss += -delta
+
+    net = (gross_gain - gross_loss).quantize(_TWOPLACES)
+    if net > 0:
+        net_gain = net
+        net_loss = _ZERO
+    else:
+        net_gain = _ZERO
+        net_loss = (-net).quantize(_TWOPLACES)
+
+    aea_used = min(net_gain, annual_exempt_amount).quantize(_TWOPLACES)
+    taxable_gain = (net_gain - aea_used).quantize(_TWOPLACES)
+
+    return CgtSummary(
+        disposal_count=len(disposals),
+        proceeds_total=proceeds_total.quantize(_TWOPLACES),
+        cost_total=cost_total.quantize(_TWOPLACES),
+        net_gain=net_gain,
+        net_loss=net_loss,
+        annual_exempt_amount_used=aea_used,
+        taxable_gain=taxable_gain,
+    )
+
+
+def disposals_to_csv(disposals: list[CgtDisposal]) -> str:
+    """Serialise per-disposal records to a CSV that maps onto the SA108
+    line items so a UK-based operator can paste straight into a
+    tax-prep workflow.
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "description",
+            "acquired",
+            "disposed",
+            "proceeds",
+            "cost",
+            "gain_loss",
+        ]
+    )
+    for d in disposals:
+        writer.writerow(
+            [
+                d.description,
+                d.acquired.isoformat(),
+                d.disposed.isoformat(),
+                _fmt(d.proceeds),
+                _fmt(d.cost),
+                _fmt(d.gain_loss),
+            ]
+        )
+    return buf.getvalue()
+
+
+def _fmt(value: Decimal) -> str:
+    return f"{value.quantize(_TWOPLACES)}"
+
+
+__all__ = [
+    "ANNUAL_EXEMPT_AMOUNT_2024_25",
+    "CgtDisposal",
+    "CgtSummary",
+    "disposals_to_csv",
+    "summarize_cgt",
+]

--- a/tests/test_hmrc_cgt.py
+++ b/tests/test_hmrc_cgt.py
@@ -1,0 +1,208 @@
+"""Tests for the HMRC CGT summary (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    ANNUAL_EXEMPT_AMOUNT_2024_25,
+    CgtDisposal,
+    CgtSummary,
+    disposals_to_csv,
+    summarize_cgt,
+)
+
+
+def _disp(*, proceeds: str, cost: str) -> CgtDisposal:
+    return CgtDisposal(
+        description="100 ABC.L",
+        acquired=date(2023, 4, 6),
+        disposed=date(2024, 4, 5),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Disposal validation
+# ---------------------------------------------------------------------------
+
+
+class TestDisposalValidation:
+    def test_acquired_after_disposed_rejected(self):
+        with pytest.raises(ValueError):
+            CgtDisposal(
+                description="x",
+                acquired=date(2024, 6, 1),
+                disposed=date(2024, 5, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("80"),
+            )
+
+    def test_negative_proceeds_rejected(self):
+        with pytest.raises(ValueError):
+            CgtDisposal(
+                description="x",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("-1"),
+                cost=Decimal("80"),
+            )
+
+    def test_negative_cost_rejected(self):
+        with pytest.raises(ValueError):
+            CgtDisposal(
+                description="x",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("-1"),
+            )
+
+    def test_gain_loss_property_quantises(self):
+        d = CgtDisposal(
+            description="x",
+            acquired=date(2024, 1, 1),
+            disposed=date(2024, 6, 1),
+            proceeds=Decimal("100.123"),
+            cost=Decimal("50.456"),
+        )
+        assert d.gain_loss == Decimal("49.67")
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    def test_empty_disposals_zero_summary(self):
+        s = summarize_cgt([])
+
+        assert isinstance(s, CgtSummary)
+        assert s.disposal_count == 0
+        assert s.proceeds_total == Decimal("0.00")
+        assert s.cost_total == Decimal("0.00")
+        assert s.net_gain == Decimal("0.00")
+        assert s.net_loss == Decimal("0.00")
+        assert s.annual_exempt_amount_used == Decimal("0.00")
+        assert s.taxable_gain == Decimal("0.00")
+
+
+class TestNetGainBelowAea:
+    def test_aea_consumes_entire_gain_no_taxable(self):
+        # £2,000 gain — well under the 2024-25 £3,000 AEA → no tax due.
+        s = summarize_cgt([_disp(proceeds="12000", cost="10000")])
+
+        assert s.net_gain == Decimal("2000.00")
+        assert s.net_loss == Decimal("0.00")
+        assert s.annual_exempt_amount_used == Decimal("2000.00")
+        assert s.taxable_gain == Decimal("0.00")
+
+
+class TestNetGainAboveAea:
+    def test_aea_caps_then_remainder_is_taxable(self):
+        # £10,000 gain → £3,000 AEA, £7,000 taxable.
+        s = summarize_cgt([_disp(proceeds="20000", cost="10000")])
+
+        assert s.net_gain == Decimal("10000.00")
+        assert s.annual_exempt_amount_used == Decimal("3000.00")
+        assert s.taxable_gain == Decimal("7000.00")
+
+    def test_multiple_gains_aggregate(self):
+        s = summarize_cgt(
+            [
+                _disp(proceeds="10000", cost="5000"),
+                _disp(proceeds="8000", cost="6000"),
+            ]
+        )
+
+        # Gross gain: 5000 + 2000 = 7000.
+        assert s.disposal_count == 2
+        assert s.net_gain == Decimal("7000.00")
+        assert s.annual_exempt_amount_used == Decimal("3000.00")
+        assert s.taxable_gain == Decimal("4000.00")
+
+
+class TestNetLoss:
+    def test_pure_loss_year_no_aea_consumed_no_taxable(self):
+        s = summarize_cgt([_disp(proceeds="500", cost="2000")])
+
+        assert s.net_gain == Decimal("0.00")
+        assert s.net_loss == Decimal("1500.00")
+        # AEA not consumed when there is no net gain.
+        assert s.annual_exempt_amount_used == Decimal("0.00")
+        assert s.taxable_gain == Decimal("0.00")
+
+    def test_gains_offset_by_larger_losses_yields_loss(self):
+        # +2,000 gain - 5,000 loss = -3,000 net.
+        s = summarize_cgt(
+            [
+                _disp(proceeds="7000", cost="5000"),
+                _disp(proceeds="1000", cost="6000"),
+            ]
+        )
+
+        assert s.net_gain == Decimal("0.00")
+        assert s.net_loss == Decimal("3000.00")
+        assert s.annual_exempt_amount_used == Decimal("0.00")
+        assert s.taxable_gain == Decimal("0.00")
+
+
+class TestCustomAea:
+    def test_prior_year_aea_passed_in_explicitly(self):
+        # 2022-23 AEA was £12,300 — gain of £10,000 falls fully under it.
+        s = summarize_cgt(
+            [_disp(proceeds="20000", cost="10000")],
+            annual_exempt_amount=Decimal("12300"),
+        )
+
+        assert s.net_gain == Decimal("10000.00")
+        assert s.annual_exempt_amount_used == Decimal("10000.00")
+        assert s.taxable_gain == Decimal("0.00")
+
+    def test_negative_aea_rejected(self):
+        with pytest.raises(ValueError):
+            summarize_cgt([], annual_exempt_amount=Decimal("-1"))
+
+
+class TestConstants:
+    def test_2024_25_aea_is_three_thousand(self):
+        assert ANNUAL_EXEMPT_AMOUNT_2024_25 == Decimal("3000.00")
+
+
+# ---------------------------------------------------------------------------
+# CSV serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestCsv:
+    def test_csv_header_and_row_per_disposal(self):
+        disposals = [
+            CgtDisposal(
+                description="100 ABC.L",
+                acquired=date(2024, 1, 5),
+                disposed=date(2024, 6, 30),
+                proceeds=Decimal("1500"),
+                cost=Decimal("1000"),
+            ),
+        ]
+
+        out = disposals_to_csv(disposals)
+        lines = out.strip().splitlines()
+        assert lines[0].split(",") == [
+            "description",
+            "acquired",
+            "disposed",
+            "proceeds",
+            "cost",
+            "gain_loss",
+        ]
+        # Dates ISO 8601, money quantised to two decimals.
+        assert "2024-01-05" in lines[1]
+        assert "2024-06-30" in lines[1]
+        assert ",1500.00," in lines[1]
+        assert lines[1].endswith(",500.00")


### PR DESCRIPTION
## Summary

Aggregate per-disposal records into the totals HMRC expects on the Self Assessment SA108 (Capital Gains) supplement and the Real-Time Transaction return.

API:
- \`CgtDisposal\` — frozen dataclass (description, acquired, disposed, proceeds, cost). Validates date ordering + non-negative amounts. \`.gain_loss\` quantises to GBP pence.
- \`CgtSummary\` — disposal_count, proceeds_total, cost_total, net_gain, net_loss, annual_exempt_amount_used, taxable_gain.
- \`summarize_cgt(disposals, *, annual_exempt_amount=...)\` — defaults to the 2024-25 AEA (£3,000); operators handling prior years pass the relevant value (£6,000 for 2023-24, £12,300 for 2022-23 and earlier).
- \`disposals_to_csv(disposals)\` — SA108-shaped per-disposal CSV.

The AEA is applied only against the net gain. Loss years do not consume the AEA (HMRC tracks loss carry-forward separately, deferred).

Refs #155. Section 104 share pooling (lot accountant upstream), loss carry-forward state, income-band rate selection (10%/20%/18%/24%), ER/IR, and non-resident UK property are still deferred.

## Test plan

- [x] CgtDisposal rejects acquired-after-disposed, negative proceeds/cost
- [x] \`.gain_loss\` quantises to two decimals
- [x] Empty input → all-zero CgtSummary
- [x] Net gain below AEA → AEA fully consumes it, no taxable gain
- [x] Net gain above AEA → AEA caps, remainder taxable
- [x] Multiple gains aggregate correctly
- [x] Pure loss year → no AEA consumed, no taxable gain
- [x] Mixed gains + larger losses still net to a loss
- [x] Custom AEA (prior years) applied correctly
- [x] Negative AEA rejected
- [x] CSV header + ISO 8601 dates + 2-decimal money formatting