### PR TITLE
feat(tax): German KESt § 32d Abgeltungsteuer summary (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -20,6 +20,20 @@ from engine.core.tax.reports.hmrc_cgt import (
     disposals_to_csv,
     summarize_cgt,
 )
+from engine.core.tax.reports.kest import (
+    CHURCH_TAX_RATE_BAYERN_BW,
+    CHURCH_TAX_RATE_OTHER,
+    KEST_RATE,
+    SOLZ_RATE,
+    SPARER_PAUSCHBETRAG_2023,
+    SPARER_PAUSCHBETRAG_2024,
+    SPARER_PAUSCHBETRAG_JOINT_2023,
+    SPARER_PAUSCHBETRAG_JOINT_2024,
+    AssetClass,
+    KestDisposal,
+    KestSummary,
+    summarize_kest,
+)
 from engine.core.tax.reports.form_1099b import (
     HoldingTerm,
     LotDisposition,
@@ -36,13 +50,24 @@ from engine.core.tax.reports.schedule_d import (
 
 __all__ = [
     "ANNUAL_EXEMPT_AMOUNT_2024_25",
+    "CHURCH_TAX_RATE_BAYERN_BW",
+    "CHURCH_TAX_RATE_OTHER",
     "DEDUCTIBLE_CAP_DEFAULT",
     "DEDUCTIBLE_CAP_MFS",
+    "KEST_RATE",
+    "SOLZ_RATE",
+    "SPARER_PAUSCHBETRAG_2023",
+    "SPARER_PAUSCHBETRAG_2024",
+    "SPARER_PAUSCHBETRAG_JOINT_2023",
+    "SPARER_PAUSCHBETRAG_JOINT_2024",
+    "AssetClass",
     "CapitalLossApplication",
     "CapitalLossCarryover",
     "CgtDisposal",
     "CgtSummary",
     "HoldingTerm",
+    "KestDisposal",
+    "KestSummary",
     "LotDisposition",
     "Schedule1099BRow",
     "ScheduleDPartTotal",
@@ -52,6 +77,7 @@ __all__ = [
     "generate_1099b_rows",
     "rows_to_csv",
     "summarize_cgt",
+    "summarize_kest",
     "summarize_schedule_d",
     "summary_to_csv",
 ]

--- a/engine/core/tax/reports/kest.py
+++ b/engine/core/tax/reports/kest.py
@@ -1,0 +1,197 @@
+"""German Kapitalertragsteuer / Abgeltungsteuer (§ 32d EStG) summary.
+
+Computes the year-level totals a German private investor needs to
+file: gross capital gains, Sparer-Pauschbetrag (saver's lump-sum
+allowance), KESt (25 % flat capital-gains tax), Solidaritätszuschlag
+(5.5 % surcharge on the KESt), and optionally Kirchensteuer (church
+tax — 8 % in Bayern/Baden-Württemberg, 9 % elsewhere).
+
+Filing model
+------------
+The Abgeltungsteuer regime nets gains against losses *within asset
+buckets* before the allowance is applied. The most important real
+distinction is between equity (Aktien) losses, which by law can only
+offset equity gains, and "other" capital gains. Operators tag each
+disposal with an :class:`AssetClass`; the summariser nets within each
+bucket, sums the resulting net gains, applies the allowance, and
+computes the tax.
+
+What's NOT here (explicit follow-ups)
+-------------------------------------
+- Loss carry-forward (``Verlustvortrag``). Equity losses that exceed
+  equity gains carry forward indefinitely; tracking that state lives
+  in a separate carryover module (deferred — analogous to the US
+  ``carryover.py``).
+- Teilfreistellung for fund products (Investmentsteuergesetz exemption
+  rates 15 % / 30 % / 60 % / 80 %). The caller is expected to apply
+  the relevant exemption upstream and pass the post-exemption gain.
+- Quellensteuer-Anrechnung (foreign withholding tax credits).
+- Section 6 InvStG mark-to-market on funds (Vorabpauschale).
+- NV-Bescheinigung / Freistellungsauftrag handling at the broker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+# § 32d EStG flat tax + § 4 SolzG.
+KEST_RATE: Decimal = Decimal("0.25")
+SOLZ_RATE: Decimal = Decimal("0.055")  # applied on the KESt amount
+
+# Sparer-Pauschbetrag — annual allowance for capital income.
+SPARER_PAUSCHBETRAG_2023: Decimal = Decimal("1000.00")
+SPARER_PAUSCHBETRAG_JOINT_2023: Decimal = Decimal("2000.00")
+# 2024+ left unchanged at 1000/2000; constants exposed by year so
+# callers can be explicit.
+SPARER_PAUSCHBETRAG_2024: Decimal = SPARER_PAUSCHBETRAG_2023
+SPARER_PAUSCHBETRAG_JOINT_2024: Decimal = SPARER_PAUSCHBETRAG_JOINT_2023
+
+# Kirchensteuer rates (legally fixed per Bundesland).
+CHURCH_TAX_RATE_BAYERN_BW: Decimal = Decimal("0.08")
+CHURCH_TAX_RATE_OTHER: Decimal = Decimal("0.09")
+
+
+class AssetClass(str, Enum):
+    """Coarse asset bucket. ``EQUITY`` losses are ring-fenced under
+    § 20 Abs. 6 Satz 4 EStG; ``OTHER`` losses can offset any other
+    capital income."""
+
+    EQUITY = "equity"
+    OTHER = "other"
+
+
+@dataclass(frozen=True)
+class KestDisposal:
+    description: str
+    acquired: date
+    disposed: date
+    proceeds: Decimal
+    cost: Decimal
+    asset_class: AssetClass = AssetClass.EQUITY
+
+    def __post_init__(self) -> None:
+        if self.acquired > self.disposed:
+            raise ValueError(
+                f"acquired {self.acquired} is after disposed {self.disposed}"
+            )
+        if self.proceeds < 0:
+            raise ValueError("proceeds must be non-negative")
+        if self.cost < 0:
+            raise ValueError("cost must be non-negative")
+
+    @property
+    def gain_loss(self) -> Decimal:
+        return (self.proceeds - self.cost).quantize(_TWOPLACES)
+
+
+@dataclass(frozen=True)
+class KestSummary:
+    """Year-level KESt totals (EUR)."""
+
+    disposal_count: int
+    proceeds_total: Decimal
+    cost_total: Decimal
+    equity_net: Decimal  # may be negative (carry-forward eligible)
+    other_net: Decimal  # may be negative
+    taxable_income: Decimal  # after netting + allowance
+    allowance_used: Decimal
+    kest: Decimal
+    solidarity_surcharge: Decimal
+    church_tax: Decimal
+    total_tax: Decimal
+
+
+def summarize_kest(
+    disposals: list[KestDisposal],
+    *,
+    allowance: Decimal = SPARER_PAUSCHBETRAG_2024,
+    church_tax_rate: Decimal | None = None,
+) -> KestSummary:
+    """Aggregate ``disposals`` into a year-level KESt summary.
+
+    ``allowance`` defaults to the 2024 single-filer Sparer-Pauschbetrag
+    (€1,000); jointly-assessed couples pass
+    :data:`SPARER_PAUSCHBETRAG_JOINT_2024`. ``church_tax_rate`` is
+    optional; pass :data:`CHURCH_TAX_RATE_BAYERN_BW` (8 %) or
+    :data:`CHURCH_TAX_RATE_OTHER` (9 %) to include Kirchensteuer.
+
+    Equity losses are ring-fenced (§ 20 Abs. 6 Satz 4 EStG): a negative
+    equity bucket does *not* reduce a positive ``other`` bucket. The
+    summary surfaces both per-bucket nets so the operator can carry an
+    equity-only loss forward independently.
+    """
+    if allowance < 0:
+        raise ValueError("allowance must be non-negative")
+    if church_tax_rate is not None and church_tax_rate < 0:
+        raise ValueError("church_tax_rate must be non-negative")
+
+    proceeds_total = _ZERO
+    cost_total = _ZERO
+    equity = _ZERO
+    other = _ZERO
+    for d in disposals:
+        proceeds_total += d.proceeds
+        cost_total += d.cost
+        if d.asset_class == AssetClass.EQUITY:
+            equity += d.gain_loss
+        else:
+            other += d.gain_loss
+
+    equity_net = equity.quantize(_TWOPLACES)
+    other_net = other.quantize(_TWOPLACES)
+
+    # § 20 Abs. 6 Satz 4 EStG: only positive equity contributes to the
+    # current-year base. Negative equity is set aside for carry-forward.
+    taxable_equity = equity_net if equity_net > 0 else _ZERO
+    # Other-bucket losses can offset any other capital income, so they
+    # contribute their signed value (the caller may net against
+    # interest / dividends upstream).
+    base = (taxable_equity + other_net).quantize(_TWOPLACES)
+    if base < 0:
+        base = _ZERO
+
+    allowance_used = min(base, allowance).quantize(_TWOPLACES)
+    taxable_income = (base - allowance_used).quantize(_TWOPLACES)
+
+    kest = (taxable_income * KEST_RATE).quantize(_TWOPLACES)
+    solz = (kest * SOLZ_RATE).quantize(_TWOPLACES)
+    church_tax = _ZERO
+    if church_tax_rate is not None:
+        church_tax = (kest * church_tax_rate).quantize(_TWOPLACES)
+    total_tax = (kest + solz + church_tax).quantize(_TWOPLACES)
+
+    return KestSummary(
+        disposal_count=len(disposals),
+        proceeds_total=proceeds_total.quantize(_TWOPLACES),
+        cost_total=cost_total.quantize(_TWOPLACES),
+        equity_net=equity_net,
+        other_net=other_net,
+        taxable_income=taxable_income,
+        allowance_used=allowance_used,
+        kest=kest,
+        solidarity_surcharge=solz,
+        church_tax=church_tax,
+        total_tax=total_tax,
+    )
+
+
+__all__ = [
+    "CHURCH_TAX_RATE_BAYERN_BW",
+    "CHURCH_TAX_RATE_OTHER",
+    "KEST_RATE",
+    "SOLZ_RATE",
+    "SPARER_PAUSCHBETRAG_2023",
+    "SPARER_PAUSCHBETRAG_2024",
+    "SPARER_PAUSCHBETRAG_JOINT_2023",
+    "SPARER_PAUSCHBETRAG_JOINT_2024",
+    "AssetClass",
+    "KestDisposal",
+    "KestSummary",
+    "summarize_kest",
+]

--- a/tests/test_kest.py
+++ b/tests/test_kest.py
@@ -1,0 +1,228 @@
+"""Tests for the KESt § 32d summary (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    CHURCH_TAX_RATE_BAYERN_BW,
+    CHURCH_TAX_RATE_OTHER,
+    KEST_RATE,
+    SOLZ_RATE,
+    SPARER_PAUSCHBETRAG_2024,
+    SPARER_PAUSCHBETRAG_JOINT_2024,
+    AssetClass,
+    KestDisposal,
+    summarize_kest,
+)
+
+
+def _disp(
+    *,
+    proceeds: str,
+    cost: str,
+    asset_class: AssetClass = AssetClass.EQUITY,
+) -> KestDisposal:
+    return KestDisposal(
+        description="100 ABC",
+        acquired=date(2023, 6, 1),
+        disposed=date(2024, 6, 1),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+        asset_class=asset_class,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestDisposalValidation:
+    def test_acquired_after_disposed_rejected(self):
+        with pytest.raises(ValueError):
+            KestDisposal(
+                description="x",
+                acquired=date(2024, 6, 1),
+                disposed=date(2024, 5, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("80"),
+            )
+
+    def test_negative_amounts_rejected(self):
+        with pytest.raises(ValueError):
+            KestDisposal(
+                description="x",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("-1"),
+                cost=Decimal("80"),
+            )
+        with pytest.raises(ValueError):
+            KestDisposal(
+                description="x",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("-1"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    def test_empty_input_zero_summary(self):
+        s = summarize_kest([])
+
+        assert s.disposal_count == 0
+        assert s.proceeds_total == Decimal("0.00")
+        assert s.cost_total == Decimal("0.00")
+        assert s.taxable_income == Decimal("0.00")
+        assert s.kest == Decimal("0.00")
+        assert s.solidarity_surcharge == Decimal("0.00")
+        assert s.church_tax == Decimal("0.00")
+        assert s.total_tax == Decimal("0.00")
+
+
+class TestAllowance:
+    def test_gain_below_allowance_yields_no_tax(self):
+        # +500 EUR equity gain — well under the 1,000 EUR Pauschbetrag.
+        s = summarize_kest([_disp(proceeds="1500", cost="1000")])
+
+        assert s.equity_net == Decimal("500.00")
+        assert s.allowance_used == Decimal("500.00")
+        assert s.taxable_income == Decimal("0.00")
+        assert s.kest == Decimal("0.00")
+        assert s.total_tax == Decimal("0.00")
+
+    def test_gain_at_allowance_boundary_yields_no_tax(self):
+        s = summarize_kest([_disp(proceeds="2000", cost="1000")])
+
+        assert s.equity_net == Decimal("1000.00")
+        assert s.allowance_used == Decimal("1000.00")
+        assert s.taxable_income == Decimal("0.00")
+        assert s.kest == Decimal("0.00")
+
+    def test_gain_above_allowance_taxable_remainder(self):
+        # +5,000 equity gain → 4,000 taxable after 1,000 allowance.
+        # KESt = 1,000. SolZ = 55. Total = 1,055 (no church).
+        s = summarize_kest([_disp(proceeds="6000", cost="1000")])
+
+        assert s.equity_net == Decimal("5000.00")
+        assert s.allowance_used == Decimal("1000.00")
+        assert s.taxable_income == Decimal("4000.00")
+        assert s.kest == Decimal("1000.00")
+        assert s.solidarity_surcharge == Decimal("55.00")
+        assert s.church_tax == Decimal("0.00")
+        assert s.total_tax == Decimal("1055.00")
+
+    def test_joint_allowance_doubles_default(self):
+        # +1,500 equity gain. Single → 500 taxable; joint → 0 taxable.
+        single = summarize_kest([_disp(proceeds="2500", cost="1000")])
+        joint = summarize_kest(
+            [_disp(proceeds="2500", cost="1000")],
+            allowance=SPARER_PAUSCHBETRAG_JOINT_2024,
+        )
+
+        assert single.taxable_income == Decimal("500.00")
+        assert joint.taxable_income == Decimal("0.00")
+
+
+class TestEquityRingFence:
+    def test_equity_loss_does_not_offset_other_gain(self):
+        # -2,000 equity + +5,000 other = +5,000 taxable base
+        # (equity ring-fenced for carry-forward).
+        s = summarize_kest(
+            [
+                _disp(proceeds="500", cost="2500"),  # -2,000 equity
+                _disp(
+                    proceeds="6000",
+                    cost="1000",
+                    asset_class=AssetClass.OTHER,
+                ),  # +5,000 other
+            ]
+        )
+
+        assert s.equity_net == Decimal("-2000.00")
+        assert s.other_net == Decimal("5000.00")
+        # 5,000 - 1,000 allowance = 4,000 taxable.
+        assert s.taxable_income == Decimal("4000.00")
+
+    def test_equity_loss_only_keeps_total_tax_at_zero(self):
+        s = summarize_kest([_disp(proceeds="500", cost="2500")])
+
+        assert s.equity_net == Decimal("-2000.00")
+        assert s.taxable_income == Decimal("0.00")
+        assert s.total_tax == Decimal("0.00")
+        # Equity loss survives as a negative bucket for the caller to
+        # carry forward.
+        assert s.equity_net < 0
+
+    def test_other_loss_offsets_equity_gain(self):
+        # +2,000 equity + (-500) other = +1,500 base.
+        s = summarize_kest(
+            [
+                _disp(proceeds="3000", cost="1000"),  # +2,000 equity
+                _disp(
+                    proceeds="500",
+                    cost="1000",
+                    asset_class=AssetClass.OTHER,
+                ),  # -500 other
+            ]
+        )
+
+        assert s.equity_net == Decimal("2000.00")
+        assert s.other_net == Decimal("-500.00")
+        # Base = 2,000 + (-500) = 1,500; allowance fully consumes.
+        assert s.taxable_income == Decimal("500.00")
+
+
+class TestChurchTax:
+    def test_bayern_bw_8_percent_added_on_kest(self):
+        # +5,000 equity gain → 4,000 taxable, 1,000 KESt, 55 SolZ.
+        # Church 8 % of KESt = 80. Total = 1,135.
+        s = summarize_kest(
+            [_disp(proceeds="6000", cost="1000")],
+            church_tax_rate=CHURCH_TAX_RATE_BAYERN_BW,
+        )
+
+        assert s.kest == Decimal("1000.00")
+        assert s.church_tax == Decimal("80.00")
+        assert s.total_tax == Decimal("1135.00")
+
+    def test_default_other_lander_9_percent(self):
+        s = summarize_kest(
+            [_disp(proceeds="6000", cost="1000")],
+            church_tax_rate=CHURCH_TAX_RATE_OTHER,
+        )
+
+        assert s.church_tax == Decimal("90.00")
+        assert s.total_tax == Decimal("1145.00")
+
+
+class TestValidation:
+    def test_negative_allowance_rejected(self):
+        with pytest.raises(ValueError):
+            summarize_kest([], allowance=Decimal("-1"))
+
+    def test_negative_church_tax_rate_rejected(self):
+        with pytest.raises(ValueError):
+            summarize_kest([], church_tax_rate=Decimal("-0.01"))
+
+
+class TestConstants:
+    def test_kest_rate_25_percent(self):
+        assert KEST_RATE == Decimal("0.25")
+
+    def test_solz_rate_5_5_percent(self):
+        assert SOLZ_RATE == Decimal("0.055")
+
+    def test_2024_pauschbetrag_thousand_and_two_thousand(self):
+        assert SPARER_PAUSCHBETRAG_2024 == Decimal("1000.00")
+        assert SPARER_PAUSCHBETRAG_JOINT_2024 == Decimal("2000.00")


### PR DESCRIPTION
## Summary

Year-level Kapitalertragsteuer summary for a German private investor under § 32d EStG: gross capital gains, Sparer-Pauschbetrag (saver's lump-sum allowance), KESt (25 % flat rate), Solidaritätszuschlag (5.5 % on KESt), optional Kirchensteuer (8 % Bayern/Baden-Württemberg, 9 % other Länder).

API:
- \`AssetClass\` — \`EQUITY\` vs \`OTHER\`. Equity losses are ring-fenced under § 20 Abs. 6 Satz 4 EStG and do *not* offset other capital income — they survive in the per-bucket \`equity_net\` field for caller-side carry-forward.
- \`KestDisposal\` — frozen dataclass (description, acquired, disposed, proceeds, cost, asset_class). Validates date ordering + non-negative amounts. \`.gain_loss\` quantises to EUR cents.
- \`KestSummary\` — disposal_count, proceeds_total, cost_total, equity_net (signed), other_net (signed), taxable_income, allowance_used, kest, solidarity_surcharge, church_tax, total_tax.
- \`summarize_kest(disposals, *, allowance=SPARER_PAUSCHBETRAG_2024, church_tax_rate=None)\` — covers single/joint allowance and optional church tax.

Constants exposed: \`KEST_RATE\` (0.25), \`SOLZ_RATE\` (0.055), \`SPARER_PAUSCHBETRAG_{2023,2024}{,_JOINT}\`, \`CHURCH_TAX_RATE_BAYERN_BW\` (0.08), \`CHURCH_TAX_RATE_OTHER\` (0.09).

Refs #155. Verlustvortrag carry-forward state (deferred, analogous to US \`carryover.py\`), Teilfreistellung exemptions for fund products (caller applies upstream), Quellensteuer-Anrechnung foreign withholding credits, § 6 InvStG Vorabpauschale, and NV-Bescheinigung broker handling are still deferred.

## Test plan

- [x] KestDisposal rejects acquired-after-disposed + negative amounts
- [x] Empty input → all-zero summary
- [x] Gain below allowance → no tax
- [x] Gain at allowance boundary → no tax (exact-match boundary)
- [x] Gain above allowance → KESt + SolZ on remainder
- [x] Joint allowance doubles single
- [x] Equity loss does NOT offset other gain (ring-fence)
- [x] Pure equity loss preserves negative \`equity_net\` for carry-forward
- [x] Other-bucket loss DOES offset equity gain
- [x] Bayern/BW 8 % church tax computed against KESt
- [x] Other-Länder 9 % church tax computed against KESt
- [x] Negative allowance / negative church-tax rate rejected
- [x] Constants pinned (rates + 2024 allowance values)