### PR TITLE
feat(tax): France PFU (Prélèvement Forfaitaire Unique) summary (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -20,6 +20,14 @@ from engine.core.tax.reports.hmrc_cgt import (
     disposals_to_csv,
     summarize_cgt,
 )
+from engine.core.tax.reports.france_pfu import (
+    PFU_INCOME_TAX_RATE,
+    PFU_SOCIAL_CHARGES_RATE,
+    PFU_TOTAL_RATE,
+    PfuDisposal,
+    PfuSummary,
+    summarize_pfu,
+)
 from engine.core.tax.reports.kest import (
     CHURCH_TAX_RATE_BAYERN_BW,
     CHURCH_TAX_RATE_OTHER,
@@ -55,6 +63,11 @@ __all__ = [
     "DEDUCTIBLE_CAP_DEFAULT",
     "DEDUCTIBLE_CAP_MFS",
     "KEST_RATE",
+    "PFU_INCOME_TAX_RATE",
+    "PFU_SOCIAL_CHARGES_RATE",
+    "PFU_TOTAL_RATE",
+    "PfuDisposal",
+    "PfuSummary",
     "SOLZ_RATE",
     "SPARER_PAUSCHBETRAG_2023",
     "SPARER_PAUSCHBETRAG_2024",
@@ -78,6 +91,7 @@ __all__ = [
     "rows_to_csv",
     "summarize_cgt",
     "summarize_kest",
+    "summarize_pfu",
     "summarize_schedule_d",
     "summary_to_csv",
 ]

--- a/engine/core/tax/reports/france_pfu.py
+++ b/engine/core/tax/reports/france_pfu.py
@@ -1,0 +1,147 @@
+"""France Prélèvement Forfaitaire Unique (PFU / flat tax) summary.
+
+Computes the year-level totals a French resident files for capital
+gains on stocks and similar securities under the PFU regime introduced
+by the Loi de finances pour 2018 (CGI Article 200 A). The flat 30 %
+total breaks down as:
+
+- 12.8 % impôt sur le revenu (income-tax fraction).
+- 17.2 % prélèvements sociaux (CSG / CRDS / contribution de
+  solidarité — collectively "social levies").
+
+What's NOT here (explicit follow-ups)
+-------------------------------------
+- *Barème progressif* election. The taxpayer may opt to apply the
+  progressive income-tax scale instead of the flat 12.8 % component
+  (CGI Art. 200 A 2). The election is global and separate from the
+  social-levy component. Operators who need that path build it on
+  top of this summary's pre-tax ``net_gain``.
+- *Capital-loss carry-forward*. Net losses on stock disposals carry
+  forward 10 years against future stock gains (CGI Art. 150-0 D 11).
+  Tracking that state belongs in a separate carryover module
+  (analogous to the US ``carryover.py``) and is deferred.
+- *Abattement pour durée de détention*. Available under the legacy
+  pre-PFU regime (CGI Art. 150-0 D 1 quater) only when the barème
+  progressif is elected on shares acquired before 2018 — out of
+  scope for the default flat-tax path here.
+- *Plus-values immobilières* (real-estate gains under CGI Art. 150 U)
+  — different schema and rates entirely.
+- *PEA-eligible holdings*. PEAs have their own exemption schedule
+  (CGI Art. 157 5° bis) — the caller is expected to filter those
+  before passing disposals to this summariser.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+# Loi de finances pour 2018 — Article 200 A CGI.
+PFU_INCOME_TAX_RATE: Decimal = Decimal("0.128")
+PFU_SOCIAL_CHARGES_RATE: Decimal = Decimal("0.172")
+# Sanity check — the two components must add to the famous 30 %.
+PFU_TOTAL_RATE: Decimal = PFU_INCOME_TAX_RATE + PFU_SOCIAL_CHARGES_RATE
+
+
+@dataclass(frozen=True)
+class PfuDisposal:
+    """One taxable disposal under the PFU regime.
+
+    The PFU is symbol-agnostic at this layer — operators may pre-filter
+    PEA-eligible holdings or non-PFU instruments upstream.
+    """
+
+    description: str
+    acquired: date
+    disposed: date
+    proceeds: Decimal
+    cost: Decimal
+
+    def __post_init__(self) -> None:
+        if self.acquired > self.disposed:
+            raise ValueError(
+                f"acquired {self.acquired} is after disposed {self.disposed}"
+            )
+        if self.proceeds < 0:
+            raise ValueError("proceeds must be non-negative")
+        if self.cost < 0:
+            raise ValueError("cost must be non-negative")
+
+    @property
+    def gain_loss(self) -> Decimal:
+        return (self.proceeds - self.cost).quantize(_TWOPLACES)
+
+
+@dataclass(frozen=True)
+class PfuSummary:
+    """Year-level PFU totals (EUR)."""
+
+    disposal_count: int
+    proceeds_total: Decimal
+    cost_total: Decimal
+    net_gain: Decimal
+    net_loss: Decimal
+    taxable_gain: Decimal  # equals net_gain (no allowance under PFU)
+    income_tax: Decimal  # 12.8 % component
+    social_charges: Decimal  # 17.2 % component
+    total_tax: Decimal
+
+
+def summarize_pfu(disposals: list[PfuDisposal]) -> PfuSummary:
+    """Aggregate ``disposals`` into a year-level PFU summary.
+
+    Loss years emit zero tax: net losses are not refundable and the
+    PFU regime has no annual allowance. Operators are expected to
+    track the net-loss bucket separately for the 10-year carry-forward
+    against future stock gains.
+    """
+    proceeds_total = _ZERO
+    cost_total = _ZERO
+    gross_gain = _ZERO
+    gross_loss = _ZERO
+    for d in disposals:
+        proceeds_total += d.proceeds
+        cost_total += d.cost
+        delta = d.gain_loss
+        if delta >= 0:
+            gross_gain += delta
+        else:
+            gross_loss += -delta
+
+    net = (gross_gain - gross_loss).quantize(_TWOPLACES)
+    if net > 0:
+        net_gain = net
+        net_loss = _ZERO
+    else:
+        net_gain = _ZERO
+        net_loss = (-net).quantize(_TWOPLACES)
+
+    income_tax = (net_gain * PFU_INCOME_TAX_RATE).quantize(_TWOPLACES)
+    social_charges = (net_gain * PFU_SOCIAL_CHARGES_RATE).quantize(_TWOPLACES)
+    total_tax = (income_tax + social_charges).quantize(_TWOPLACES)
+
+    return PfuSummary(
+        disposal_count=len(disposals),
+        proceeds_total=proceeds_total.quantize(_TWOPLACES),
+        cost_total=cost_total.quantize(_TWOPLACES),
+        net_gain=net_gain,
+        net_loss=net_loss,
+        taxable_gain=net_gain,
+        income_tax=income_tax,
+        social_charges=social_charges,
+        total_tax=total_tax,
+    )
+
+
+__all__ = [
+    "PFU_INCOME_TAX_RATE",
+    "PFU_SOCIAL_CHARGES_RATE",
+    "PFU_TOTAL_RATE",
+    "PfuDisposal",
+    "PfuSummary",
+    "summarize_pfu",
+]

--- a/tests/test_france_pfu.py
+++ b/tests/test_france_pfu.py
@@ -1,0 +1,169 @@
+"""Tests for the France PFU summary (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    PFU_INCOME_TAX_RATE,
+    PFU_SOCIAL_CHARGES_RATE,
+    PFU_TOTAL_RATE,
+    PfuDisposal,
+    PfuSummary,
+    summarize_pfu,
+)
+
+
+def _disp(*, proceeds: str, cost: str) -> PfuDisposal:
+    return PfuDisposal(
+        description="100 ABC.PA",
+        acquired=date(2023, 6, 1),
+        disposed=date(2024, 6, 1),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestDisposalValidation:
+    def test_acquired_after_disposed_rejected(self):
+        with pytest.raises(ValueError):
+            PfuDisposal(
+                description="x",
+                acquired=date(2024, 6, 1),
+                disposed=date(2024, 5, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("80"),
+            )
+
+    def test_negative_proceeds_rejected(self):
+        with pytest.raises(ValueError):
+            PfuDisposal(
+                description="x",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("-1"),
+                cost=Decimal("80"),
+            )
+
+    def test_negative_cost_rejected(self):
+        with pytest.raises(ValueError):
+            PfuDisposal(
+                description="x",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("-1"),
+            )
+
+    def test_gain_loss_property_quantises(self):
+        d = PfuDisposal(
+            description="x",
+            acquired=date(2024, 1, 1),
+            disposed=date(2024, 6, 1),
+            proceeds=Decimal("100.123"),
+            cost=Decimal("50.456"),
+        )
+        assert d.gain_loss == Decimal("49.67")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_components_sum_to_thirty_percent(self):
+        assert PFU_INCOME_TAX_RATE == Decimal("0.128")
+        assert PFU_SOCIAL_CHARGES_RATE == Decimal("0.172")
+        assert PFU_TOTAL_RATE == Decimal("0.300")
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    def test_empty_input_zero_summary(self):
+        s = summarize_pfu([])
+
+        assert isinstance(s, PfuSummary)
+        assert s.disposal_count == 0
+        assert s.net_gain == Decimal("0.00")
+        assert s.net_loss == Decimal("0.00")
+        assert s.taxable_gain == Decimal("0.00")
+        assert s.income_tax == Decimal("0.00")
+        assert s.social_charges == Decimal("0.00")
+        assert s.total_tax == Decimal("0.00")
+
+
+class TestNetGain:
+    def test_pure_gain_taxed_at_thirty_percent_split(self):
+        # +10,000 gain → 1,280 income tax + 1,720 social = 3,000.
+        s = summarize_pfu([_disp(proceeds="20000", cost="10000")])
+
+        assert s.net_gain == Decimal("10000.00")
+        assert s.taxable_gain == Decimal("10000.00")
+        assert s.income_tax == Decimal("1280.00")
+        assert s.social_charges == Decimal("1720.00")
+        assert s.total_tax == Decimal("3000.00")
+
+    def test_multiple_gains_aggregate(self):
+        s = summarize_pfu(
+            [
+                _disp(proceeds="6000", cost="5000"),  # +1,000
+                _disp(proceeds="9000", cost="6000"),  # +3,000
+            ]
+        )
+
+        assert s.disposal_count == 2
+        assert s.net_gain == Decimal("4000.00")
+        assert s.income_tax == Decimal("512.00")  # 4,000 * 0.128
+        assert s.social_charges == Decimal("688.00")  # 4,000 * 0.172
+        assert s.total_tax == Decimal("1200.00")
+
+    def test_gain_offset_intra_year_then_taxed_on_net(self):
+        # +5,000 gain - 2,000 loss = +3,000 net.
+        s = summarize_pfu(
+            [
+                _disp(proceeds="10000", cost="5000"),
+                _disp(proceeds="3000", cost="5000"),
+            ]
+        )
+
+        assert s.net_gain == Decimal("3000.00")
+        assert s.income_tax == Decimal("384.00")
+        assert s.social_charges == Decimal("516.00")
+        assert s.total_tax == Decimal("900.00")
+
+
+class TestNetLoss:
+    def test_pure_loss_year_emits_zero_tax(self):
+        s = summarize_pfu([_disp(proceeds="500", cost="2000")])
+
+        assert s.net_gain == Decimal("0.00")
+        assert s.net_loss == Decimal("1500.00")
+        assert s.taxable_gain == Decimal("0.00")
+        assert s.total_tax == Decimal("0.00")
+
+    def test_gains_offset_by_larger_losses_yields_loss_no_refund(self):
+        s = summarize_pfu(
+            [
+                _disp(proceeds="6000", cost="4000"),  # +2,000
+                _disp(proceeds="500", cost="6000"),  # -5,500
+            ]
+        )
+
+        assert s.net_gain == Decimal("0.00")
+        assert s.net_loss == Decimal("3500.00")
+        assert s.income_tax == Decimal("0.00")
+        assert s.social_charges == Decimal("0.00")
+        assert s.total_tax == Decimal("0.00")


### PR DESCRIPTION
## Summary

Year-level PFU summary for a French resident under CGI Article 200 A: the famous flat 30 % on capital gains, broken down as 12.8 % impôt sur le revenu + 17.2 % prélèvements sociaux.

API:
- \`PfuDisposal\` — frozen dataclass (description, acquired, disposed, proceeds, cost). Validates date ordering + non-negative amounts. \`.gain_loss\` quantises to EUR cents.
- \`PfuSummary\` — disposal_count, proceeds_total, cost_total, net_gain, net_loss, taxable_gain, income_tax, social_charges, total_tax.
- \`summarize_pfu(disposals)\` — net gains/losses across the year. Loss years emit zero tax (no refund, no allowance under PFU).

Constants exposed: \`PFU_INCOME_TAX_RATE\` (0.128), \`PFU_SOCIAL_CHARGES_RATE\` (0.172), \`PFU_TOTAL_RATE\` (0.300).

Refs #155. *Barème progressif* election (CGI Art. 200 A 2), 10-year capital-loss carry-forward (CGI Art. 150-0 D 11), *abattement pour durée de détention* (CGI Art. 150-0 D 1 quater), *plus-values immobilières* (CGI Art. 150 U), and PEA-eligible holdings (CGI Art. 157 5° bis) are still deferred.

## Test plan

- [x] PfuDisposal rejects acquired-after-disposed + negative amounts; \`.gain_loss\` quantises
- [x] Constants sum to 0.300
- [x] Empty input → all-zero summary
- [x] Pure gain year taxed 12.8 % + 17.2 % = 30 %
- [x] Multiple gains aggregate correctly
- [x] Intra-year loss offsets gain before taxing the net
- [x] Pure loss year → zero tax (no refund)
- [x] Mixed signs that net to a loss → zero tax