### PR TITLE
feat(tax): multi-jurisdiction tax-report dispatcher (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -20,6 +20,11 @@ from engine.core.tax.reports.hmrc_cgt import (
     disposals_to_csv,
     summarize_cgt,
 )
+from engine.core.tax.reports.dispatcher import (
+    TaxableDisposal,
+    UnsupportedJurisdictionError,
+    report_for_jurisdiction,
+)
 from engine.core.tax.reports.france_pfu import (
     PFU_INCOME_TAX_RATE,
     PFU_SOCIAL_CHARGES_RATE,
@@ -85,9 +90,12 @@ __all__ = [
     "Schedule1099BRow",
     "ScheduleDPartTotal",
     "ScheduleDSummary",
+    "TaxableDisposal",
+    "UnsupportedJurisdictionError",
     "apply_carryover",
     "disposals_to_csv",
     "generate_1099b_rows",
+    "report_for_jurisdiction",
     "rows_to_csv",
     "summarize_cgt",
     "summarize_kest",

--- a/engine/core/tax/reports/dispatcher.py
+++ b/engine/core/tax/reports/dispatcher.py
@@ -1,0 +1,174 @@
+"""Multi-jurisdiction tax-report dispatcher (gh#155 follow-up).
+
+A neutral :class:`TaxableDisposal` record describes a single sale event
+in jurisdiction-agnostic form. :func:`report_for_jurisdiction` routes
+the list of disposals to the right per-jurisdiction summariser:
+
+- ``US`` → :class:`engine.core.tax.reports.ScheduleDSummary`
+  (per-lot Form 8949 rows + Schedule D Part I/II totals).
+- ``GB`` → :class:`engine.core.tax.reports.CgtSummary` (SA108).
+- ``DE`` → :class:`engine.core.tax.reports.KestSummary` (§ 32d EStG).
+- ``FR`` → :class:`engine.core.tax.reports.PfuSummary`
+  (CGI Article 200 A flat tax).
+
+The dispatcher is intentionally thin: each jurisdiction already owns
+its own summariser; this is just a single entry point so a higher
+layer (API endpoint, CLI exporter) can pick "render this taxpayer's
+year" without growing per-jurisdiction switches inside its own code.
+
+Out of scope (explicit follow-ups)
+----------------------------------
+- Carry-over state. Each jurisdiction's carry-over bookkeeping lives
+  in its own module (only the US one is implemented today, see
+  ``carryover.py``).
+- ``KestDisposal.asset_class`` is hard-defaulted to ``EQUITY`` from a
+  neutral disposal. Callers who need to feed in non-equity gains
+  build the per-jurisdiction record set themselves.
+- Per-jurisdiction CSV / report formatters that do not exist yet
+  (1256, MiFID II, etc.) — pick them up as separate issues.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from engine.core.tax.reports.form_1099b import (
+    LotDisposition,
+    generate_1099b_rows,
+)
+from engine.core.tax.reports.france_pfu import PfuDisposal, summarize_pfu
+from engine.core.tax.reports.hmrc_cgt import CgtDisposal, summarize_cgt
+from engine.core.tax.reports.kest import (
+    AssetClass,
+    KestDisposal,
+    summarize_kest,
+)
+from engine.core.tax.reports.schedule_d import summarize_schedule_d
+
+if TYPE_CHECKING:
+    from engine.core.tax.reports.france_pfu import PfuSummary
+    from engine.core.tax.reports.hmrc_cgt import CgtSummary
+    from engine.core.tax.reports.kest import KestSummary
+    from engine.core.tax.reports.schedule_d import ScheduleDSummary
+
+JurisdictionSummary = (
+    "ScheduleDSummary | CgtSummary | KestSummary | PfuSummary"
+)
+
+_TWOPLACES = Decimal("0.01")
+
+
+@dataclass(frozen=True)
+class TaxableDisposal:
+    """Jurisdiction-neutral sale-event record.
+
+    Mirrors the smallest set of fields every supported jurisdiction
+    needs: a description (broker label / symbol), the acquisition and
+    disposition dates, and the proceeds + cost in the *jurisdiction's*
+    currency. Multi-currency conversion is the caller's responsibility.
+    """
+
+    description: str
+    acquired: date
+    disposed: date
+    proceeds: Decimal
+    cost: Decimal
+
+    def __post_init__(self) -> None:
+        if self.acquired > self.disposed:
+            raise ValueError(
+                f"acquired {self.acquired} is after disposed {self.disposed}"
+            )
+        if self.proceeds < 0:
+            raise ValueError("proceeds must be non-negative")
+        if self.cost < 0:
+            raise ValueError("cost must be non-negative")
+
+    @property
+    def gain_loss(self) -> Decimal:
+        return (self.proceeds - self.cost).quantize(_TWOPLACES)
+
+
+class UnsupportedJurisdictionError(ValueError):
+    """Raised when ``code`` does not match any supported jurisdiction."""
+
+
+def report_for_jurisdiction(
+    code: str,
+    disposals: list[TaxableDisposal],
+):
+    """Dispatch ``disposals`` to the right per-jurisdiction summariser.
+
+    ``code`` is the jurisdiction's two-letter slug (case-insensitive):
+    ``US``, ``GB``, ``DE``, ``FR``. Anything else raises
+    :class:`UnsupportedJurisdictionError` listing the supported codes.
+    """
+    norm = code.upper()
+    if norm == "US":
+        rows = generate_1099b_rows([_to_us(d) for d in disposals])
+        return summarize_schedule_d(rows)
+    if norm == "GB":
+        return summarize_cgt([_to_gb(d) for d in disposals])
+    if norm == "DE":
+        return summarize_kest([_to_de(d) for d in disposals])
+    if norm == "FR":
+        return summarize_pfu([_to_fr(d) for d in disposals])
+    raise UnsupportedJurisdictionError(
+        f"unknown jurisdiction {code!r}; supported: US, GB, DE, FR"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-jurisdiction adapters
+# ---------------------------------------------------------------------------
+
+
+def _to_us(d: TaxableDisposal) -> LotDisposition:
+    return LotDisposition(
+        description=d.description,
+        acquired=d.acquired,
+        sold=d.disposed,
+        proceeds=d.proceeds,
+        cost_basis=d.cost,
+    )
+
+
+def _to_gb(d: TaxableDisposal) -> CgtDisposal:
+    return CgtDisposal(
+        description=d.description,
+        acquired=d.acquired,
+        disposed=d.disposed,
+        proceeds=d.proceeds,
+        cost=d.cost,
+    )
+
+
+def _to_de(d: TaxableDisposal) -> KestDisposal:
+    return KestDisposal(
+        description=d.description,
+        acquired=d.acquired,
+        disposed=d.disposed,
+        proceeds=d.proceeds,
+        cost=d.cost,
+        asset_class=AssetClass.EQUITY,
+    )
+
+
+def _to_fr(d: TaxableDisposal) -> PfuDisposal:
+    return PfuDisposal(
+        description=d.description,
+        acquired=d.acquired,
+        disposed=d.disposed,
+        proceeds=d.proceeds,
+        cost=d.cost,
+    )
+
+
+__all__ = [
+    "TaxableDisposal",
+    "UnsupportedJurisdictionError",
+    "report_for_jurisdiction",
+]

--- a/tests/test_tax_dispatcher.py
+++ b/tests/test_tax_dispatcher.py
@@ -1,0 +1,180 @@
+"""Tests for the multi-jurisdiction tax-report dispatcher (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    CgtSummary,
+    KestSummary,
+    PfuSummary,
+    ScheduleDSummary,
+    TaxableDisposal,
+    UnsupportedJurisdictionError,
+    report_for_jurisdiction,
+)
+
+
+def _disp(*, proceeds: str, cost: str) -> TaxableDisposal:
+    return TaxableDisposal(
+        description="100 ABC",
+        acquired=date(2023, 6, 1),
+        disposed=date(2024, 6, 1),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TaxableDisposal validation
+# ---------------------------------------------------------------------------
+
+
+class TestTaxableDisposalValidation:
+    def test_acquired_after_disposed_rejected(self):
+        with pytest.raises(ValueError):
+            TaxableDisposal(
+                description="x",
+                acquired=date(2024, 6, 1),
+                disposed=date(2024, 5, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("80"),
+            )
+
+    def test_negative_proceeds_rejected(self):
+        with pytest.raises(ValueError):
+            TaxableDisposal(
+                description="x",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("-1"),
+                cost=Decimal("80"),
+            )
+
+    def test_negative_cost_rejected(self):
+        with pytest.raises(ValueError):
+            TaxableDisposal(
+                description="x",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("-1"),
+            )
+
+    def test_gain_loss_property_quantises(self):
+        d = TaxableDisposal(
+            description="x",
+            acquired=date(2024, 1, 1),
+            disposed=date(2024, 6, 1),
+            proceeds=Decimal("100.123"),
+            cost=Decimal("50.456"),
+        )
+        assert d.gain_loss == Decimal("49.67")
+
+
+# ---------------------------------------------------------------------------
+# Per-jurisdiction routing
+# ---------------------------------------------------------------------------
+
+
+class TestUsRouting:
+    def test_us_returns_schedule_d_summary(self):
+        # Disposal is held > 1 year → long-term; +5,000 net gain.
+        result = report_for_jurisdiction(
+            "US",
+            [
+                TaxableDisposal(
+                    description="3 shares MSFT",
+                    acquired=date(2022, 1, 1),
+                    disposed=date(2024, 6, 1),
+                    proceeds=Decimal("9000"),
+                    cost=Decimal("4000"),
+                )
+            ],
+        )
+
+        assert isinstance(result, ScheduleDSummary)
+        assert result.long_term.row_count == 1
+        assert result.long_term.gain_loss == Decimal("5000.00")
+
+    def test_lowercase_code_accepted(self):
+        result = report_for_jurisdiction("us", [_disp(proceeds="200", cost="100")])
+        assert isinstance(result, ScheduleDSummary)
+
+
+class TestGbRouting:
+    def test_gb_returns_cgt_summary_with_aea_applied(self):
+        # +£5,000 gain → £3,000 AEA (2024-25), £2,000 taxable.
+        result = report_for_jurisdiction(
+            "GB", [_disp(proceeds="15000", cost="10000")]
+        )
+
+        assert isinstance(result, CgtSummary)
+        assert result.net_gain == Decimal("5000.00")
+        assert result.annual_exempt_amount_used == Decimal("3000.00")
+        assert result.taxable_gain == Decimal("2000.00")
+
+
+class TestDeRouting:
+    def test_de_returns_kest_summary_routed_to_equity_bucket(self):
+        # +5,000 EUR equity → 1,000 EUR allowance, 4,000 EUR taxable.
+        # KESt = 1,000; SolZ = 55; total = 1,055.
+        result = report_for_jurisdiction(
+            "DE", [_disp(proceeds="6000", cost="1000")]
+        )
+
+        assert isinstance(result, KestSummary)
+        assert result.equity_net == Decimal("5000.00")
+        assert result.taxable_income == Decimal("4000.00")
+        assert result.kest == Decimal("1000.00")
+        assert result.total_tax == Decimal("1055.00")
+
+
+class TestFrRouting:
+    def test_fr_returns_pfu_summary(self):
+        # +1,000 EUR gain → 30 % flat tax = 300.
+        result = report_for_jurisdiction(
+            "FR", [_disp(proceeds="6000", cost="5000")]
+        )
+
+        assert isinstance(result, PfuSummary)
+        assert result.net_gain == Decimal("1000.00")
+        assert result.income_tax == Decimal("128.00")
+        assert result.social_charges == Decimal("172.00")
+        assert result.total_tax == Decimal("300.00")
+
+
+# ---------------------------------------------------------------------------
+# Unknown jurisdiction
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownJurisdiction:
+    def test_unknown_code_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedJurisdictionError) as exc_info:
+            report_for_jurisdiction("ZZ", [])
+
+        # Error lists the supported codes so a CLI user can self-correct.
+        msg = str(exc_info.value)
+        assert "US" in msg
+        assert "GB" in msg
+        assert "DE" in msg
+        assert "FR" in msg
+
+
+# ---------------------------------------------------------------------------
+# Empty input through every code
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDisposalsPerJurisdiction:
+    @pytest.mark.parametrize("code", ["US", "GB", "DE", "FR"])
+    def test_empty_input_returns_typed_summary_with_zero_totals(self, code):
+        result = report_for_jurisdiction(code, [])
+
+        # Each jurisdiction returns its own summary type even when the
+        # disposal list is empty — the dispatcher never returns None.
+        assert result is not None


### PR DESCRIPTION
## Summary

Single entry-point that routes neutral \`TaxableDisposal\` records to the right per-jurisdiction summariser. With #308 (Schedule D), #309 (US carryover), #310 (HMRC CGT), #311 (KESt § 32d), and #312 (France PFU) all merged, this PR closes the loop so a higher layer (API endpoint / CLI exporter) can pick "render this taxpayer's year" without growing per-jurisdiction switches inside its own code.

API:
- \`TaxableDisposal\` — frozen dataclass with the smallest set of fields every supported jurisdiction needs (description, acquired, disposed, proceeds, cost). Validates date ordering + non-negative amounts; \`.gain_loss\` quantises to two decimals.
- \`report_for_jurisdiction(code, disposals)\` — case-insensitive code routing:
  - \`US\` → \`ScheduleDSummary\`
  - \`GB\` → \`CgtSummary\`
  - \`DE\` → \`KestSummary\`
  - \`FR\` → \`PfuSummary\`
  Anything else raises \`UnsupportedJurisdictionError\` listing the supported codes.
- \`UnsupportedJurisdictionError\` — \`ValueError\` subclass.

Refs #155. Per-jurisdiction carry-over state (only US implemented today), \`KestDisposal.asset_class\` hard-defaults to \`EQUITY\` (callers needing non-equity build per-jurisdiction records themselves), and per-jurisdiction CSV/report formatters not yet shipped (1256, MiFID II, etc.) are still deferred.

## Test plan

- [x] TaxableDisposal validation (date ordering, non-negative amounts, \`.gain_loss\` quantising)
- [x] US routing → ScheduleDSummary with correct long-term row + lowercase code accepted
- [x] GB routing → CgtSummary with AEA applied
- [x] DE routing → KestSummary with equity bucket + KESt + SolZ totals
- [x] FR routing → PfuSummary with 12.8 % + 17.2 % breakdown
- [x] Unknown code raises \`UnsupportedJurisdictionError\` listing all supported slugs
- [x] Empty input returns a typed summary (never \`None\`) for every supported code