### PR TITLE
feat(api): /api/v1/tax/report/{code} route exposes tax dispatcher (gh#155)

### DIFF
--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -18,6 +18,7 @@ from engine.api.routes.reference import router as reference_router
 from engine.api.routes.scoring import router as scoring_router
 from engine.api.routes.strategies import router as strategies_router
 from engine.api.routes.system import router as system_router
+from engine.api.routes.tax import router as tax_router
 from engine.api.routes.webhooks import router as webhooks_router
 from engine.api.routes.websocket import router as websocket_router
 from engine.legal.dependencies import require_legal_acceptance
@@ -46,6 +47,7 @@ api_router.include_router(strategies_router, prefix="/api/v1/strategies", tags=[
 api_router.include_router(webhooks_router, prefix="/api/v1/webhooks", tags=["webhooks"])
 api_router.include_router(marketplace_router, prefix="/api/v1/marketplace", tags=["marketplace"])
 api_router.include_router(reference_router, prefix="/api/v1/reference", tags=["reference"])
+api_router.include_router(tax_router, prefix="/api/v1/tax", tags=["tax"])
 api_router.include_router(
     scoring_router,
     prefix="/api/v1/scoring",

--- a/engine/api/routes/tax.py
+++ b/engine/api/routes/tax.py
@@ -1,0 +1,131 @@
+"""Tax-report API route (gh#155).
+
+Single entrypoint that takes a list of jurisdiction-neutral disposals
+and returns the per-jurisdiction summary in JSON. The actual
+aggregation lives in :mod:`engine.core.tax.reports`; this route is a
+thin transport layer that handles auth, validation, and serialisation.
+
+Why a single endpoint
+---------------------
+The dispatcher already routes ``code`` to the right summariser. Adding
+one HTTP endpoint per jurisdiction would just duplicate the switch on
+the API surface without adding behaviour. Operators get the right
+shape of response by inspecting the ``code`` they sent.
+
+Scope
+-----
+- US / GB / DE / FR (the dispatcher's currently-supported set).
+- Auth required (every other authenticated route in the engine uses
+  the same dependency).
+- No persistence: callers re-submit the disposals they care about.
+  Operators who want to persist annual tax inputs build a separate
+  model layer on top.
+
+Out of scope (explicit follow-ups)
+----------------------------------
+- CSV download endpoint (``Accept: text/csv``) — JSON only here.
+- Per-jurisdiction carry-over state (only US implemented today).
+- Multi-currency conversion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+
+from engine.api.auth.dependency import get_current_user
+from engine.core.tax.reports import (
+    TaxableDisposal,
+    UnsupportedJurisdictionError,
+    report_for_jurisdiction,
+)
+from engine.db.models import User
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+class DisposalRequest(BaseModel):
+    """One disposal in the request payload. Money values are passed as
+    strings to preserve ``Decimal`` precision through JSON."""
+
+    description: str = Field(..., min_length=1, max_length=200)
+    acquired: date
+    disposed: date
+    proceeds: str = Field(..., description="Decimal as string")
+    cost: str = Field(..., description="Decimal as string")
+
+    @field_validator("proceeds", "cost")
+    @classmethod
+    def _is_decimal(cls, value: str) -> str:
+        try:
+            Decimal(value)
+        except Exception as exc:
+            raise ValueError(f"not a valid decimal: {value!r}") from exc
+        return value
+
+    def to_taxable(self) -> TaxableDisposal:
+        return TaxableDisposal(
+            description=self.description,
+            acquired=self.acquired,
+            disposed=self.disposed,
+            proceeds=Decimal(self.proceeds),
+            cost=Decimal(self.cost),
+        )
+
+
+class TaxReportRequest(BaseModel):
+    disposals: list[DisposalRequest] = Field(default_factory=list)
+
+
+@router.post("/report/{code}")
+async def tax_report(
+    code: str,
+    req: TaxReportRequest,
+    user: User = Depends(get_current_user),  # noqa: ARG001 - auth gate
+) -> dict[str, Any]:
+    """Return the per-jurisdiction tax summary as a JSON dict.
+
+    ``code`` matches the dispatcher's two-letter jurisdiction slug
+    (case-insensitive): US, GB, DE, FR. Anything else returns 400.
+    """
+    try:
+        disposals = [d.to_taxable() for d in req.disposals]
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        summary = report_for_jurisdiction(code, disposals)
+    except UnsupportedJurisdictionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "jurisdiction": code.upper(),
+        "summary": _to_json(summary),
+    }
+
+
+def _to_json(obj: Any) -> Any:
+    """Walk a frozen-dataclass tree and emit a JSON-safe dict.
+
+    Dataclasses are stringified field-by-field; ``Decimal`` and
+    ``date`` are turned into JSON-friendly forms; enums surface as
+    their value. Anything else falls through unchanged."""
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return {f.name: _to_json(getattr(obj, f.name)) for f in fields(obj)}
+    if isinstance(obj, Decimal):
+        return str(obj)
+    if isinstance(obj, date):
+        return obj.isoformat()
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, list | tuple):
+        return [_to_json(x) for x in obj]
+    return obj

--- a/tests/test_tax_route.py
+++ b/tests/test_tax_route.py
@@ -1,0 +1,217 @@
+"""Tests for the tax-report API route (gh#155)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from httpx import AsyncClient
+
+
+def _disposal(
+    *,
+    description: str = "100 ABC",
+    acquired: date | str = "2023-06-01",
+    disposed: date | str = "2024-06-01",
+    proceeds: str = "0",
+    cost: str = "0",
+) -> dict:
+    return {
+        "description": description,
+        "acquired": str(acquired),
+        "disposed": str(disposed),
+        "proceeds": proceeds,
+        "cost": cost,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+class TestUsRouting:
+    async def test_us_returns_schedule_d_summary_json(
+        self, client: AsyncClient
+    ):
+        # Long-term lot (>1 year) with a +5,000 gain.
+        resp = await client.post(
+            "/api/v1/tax/report/US",
+            json={
+                "disposals": [
+                    _disposal(
+                        acquired="2022-01-01",
+                        disposed="2024-06-01",
+                        proceeds="9000",
+                        cost="4000",
+                    )
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["jurisdiction"] == "US"
+        summary = body["summary"]
+        assert summary["long_term"]["row_count"] == 1
+        assert summary["long_term"]["gain_loss"] == "5000.00"
+        assert summary["short_term"]["row_count"] == 0
+
+
+class TestGbRouting:
+    async def test_gb_returns_cgt_summary_with_aea_applied(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/api/v1/tax/report/GB",
+            json={
+                "disposals": [
+                    _disposal(proceeds="15000", cost="10000"),
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["jurisdiction"] == "GB"
+        s = body["summary"]
+        assert s["net_gain"] == "5000.00"
+        assert s["annual_exempt_amount_used"] == "3000.00"
+        assert s["taxable_gain"] == "2000.00"
+
+
+class TestDeRouting:
+    async def test_de_returns_kest_summary_with_solz_breakdown(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/api/v1/tax/report/DE",
+            json={
+                "disposals": [
+                    _disposal(proceeds="6000", cost="1000"),
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        s = resp.json()["summary"]
+        assert s["taxable_income"] == "4000.00"
+        assert s["kest"] == "1000.00"
+        assert s["solidarity_surcharge"] == "55.00"
+        assert s["total_tax"] == "1055.00"
+
+
+class TestFrRouting:
+    async def test_fr_returns_pfu_summary_with_30_percent_breakdown(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/api/v1/tax/report/FR",
+            json={
+                "disposals": [
+                    _disposal(proceeds="6000", cost="5000"),
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        s = resp.json()["summary"]
+        assert s["net_gain"] == "1000.00"
+        assert s["income_tax"] == "128.00"
+        assert s["social_charges"] == "172.00"
+        assert s["total_tax"] == "300.00"
+
+
+# ---------------------------------------------------------------------------
+# Lowercase / casing
+# ---------------------------------------------------------------------------
+
+
+class TestCaseInsensitive:
+    async def test_lowercase_code_normalises_in_response(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/api/v1/tax/report/us",
+            json={"disposals": []},
+        )
+
+        assert resp.status_code == 200
+        # The route uppercases the slug for the response so callers can
+        # echo it back to the user without re-normalising.
+        assert resp.json()["jurisdiction"] == "US"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownJurisdiction:
+    async def test_unknown_code_returns_400_with_supported_list(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/api/v1/tax/report/ZZ",
+            json={"disposals": []},
+        )
+
+        assert resp.status_code == 400
+        body = resp.json()
+        # Detail surfaces the dispatcher error so the client can repair.
+        assert "ZZ" in body["detail"]
+        for code in ("US", "GB", "DE", "FR"):
+            assert code in body["detail"]
+
+
+class TestInvalidPayload:
+    async def test_non_decimal_proceeds_rejected_by_pydantic(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/api/v1/tax/report/US",
+            json={
+                "disposals": [_disposal(proceeds="abc", cost="100")],
+            },
+        )
+
+        # Pydantic returns 422 for validator failures.
+        assert resp.status_code == 422
+
+    async def test_acquired_after_disposed_rejected_at_taxable_layer(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/api/v1/tax/report/US",
+            json={
+                "disposals": [
+                    _disposal(
+                        acquired="2024-12-31",
+                        disposed="2024-01-01",
+                        proceeds="100",
+                        cost="50",
+                    )
+                ]
+            },
+        )
+
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Empty
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    @pytest.mark.parametrize("code", ["US", "GB", "DE", "FR"])
+    async def test_empty_disposals_returns_200_with_zero_summary(
+        self, client: AsyncClient, code: str
+    ):
+        resp = await client.post(
+            f"/api/v1/tax/report/{code}",
+            json={"disposals": []},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["jurisdiction"] == code


### PR DESCRIPTION
## Summary

Single HTTP entrypoint that takes a list of jurisdiction-neutral \`TaxableDisposal\` records and returns the per-jurisdiction summary in JSON. With #313 shipping the dispatcher, this PR closes the loop so a higher-layer client (frontend, CLI, MCP tool) can render any taxpayer's year via one API.

- \`POST /api/v1/tax/report/{code}\`
  - Body: \`{"disposals": [{"description", "acquired", "disposed", "proceeds", "cost"}, ...]}\` — \`proceeds\` and \`cost\` are \`Decimal\`-as-string so JSON does not lose precision.
  - Response: \`{"jurisdiction": "<UPPER>", "summary": {...}}\`.
- Auth required (matches every other authenticated route in the engine).
- Unknown jurisdiction → \`400\` with the dispatcher's error detail listing the supported codes.
- Invalid \`Decimal\` → \`422\` (Pydantic).
- Invalid date ordering (acquired > disposed) → \`400\` (TaxableDisposal validation).
- Lowercase code accepted; response always uppercases.

The handler walks the frozen-dataclass summary tree and emits a JSON-safe dict — \`Decimal\` → string, \`date\` → ISO 8601, \`Enum\` → its value.

Refs #155. CSV download (\`Accept: text/csv\`), persistence of annual tax inputs, and multi-currency conversion are still deferred.

## Test plan

- [x] US routing returns ScheduleDSummary JSON with correct long-term row
- [x] GB routing returns CgtSummary with AEA applied
- [x] DE routing returns KestSummary with KESt + SolZ breakdown
- [x] FR routing returns PfuSummary with 12.8/17.2 % breakdown
- [x] Lowercase code → response uppercases
- [x] Unknown code → 400 listing all supported codes
- [x] Non-Decimal \`proceeds\` → 422
- [x] Acquired-after-disposed → 400
- [x] Empty disposals → 200 for every supported code (parametrised)