### PR TITLE
feat(tax): tax-report CSV download endpoint (gh#155)

### DIFF
--- a/engine/api/routes/tax.py
+++ b/engine/api/routes/tax.py
@@ -38,12 +38,14 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
 from pydantic import BaseModel, Field, field_validator
 
 from engine.api.auth.dependency import get_current_user
 from engine.core.tax.reports import (
     TaxableDisposal,
     UnsupportedJurisdictionError,
+    flatten_summary_to_csv,
     report_for_jurisdiction,
 )
 from engine.db.models import User
@@ -110,6 +112,34 @@ async def tax_report(
         "jurisdiction": code.upper(),
         "summary": _to_json(summary),
     }
+
+
+@router.post("/report/{code}/csv")
+async def tax_report_csv(
+    code: str,
+    req: TaxReportRequest,
+    user: User = Depends(get_current_user),  # noqa: ARG001 - auth gate
+) -> Response:
+    """Same dispatch as :func:`tax_report` but returns the summary as
+    a 2-row CSV (header + values). Useful for spreadsheet round-trips
+    and CPA workflows."""
+    try:
+        disposals = [d.to_taxable() for d in req.disposals]
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        summary = report_for_jurisdiction(code, disposals)
+    except UnsupportedJurisdictionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    body = flatten_summary_to_csv(summary)
+    filename = f"tax-report-{code.upper()}.csv"
+    return Response(
+        content=body,
+        media_type="text/csv; charset=utf-8",
+        headers={"content-disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 def _to_json(obj: Any) -> Any:

--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -23,6 +23,7 @@ from engine.core.tax.reports.hmrc_cgt import (
 from engine.core.tax.reports.dispatcher import (
     TaxableDisposal,
     UnsupportedJurisdictionError,
+    flatten_summary_to_csv,
     report_for_jurisdiction,
 )
 from engine.core.tax.reports.france_pfu import (
@@ -94,6 +95,7 @@ __all__ = [
     "UnsupportedJurisdictionError",
     "apply_carryover",
     "disposals_to_csv",
+    "flatten_summary_to_csv",
     "generate_1099b_rows",
     "report_for_jurisdiction",
     "rows_to_csv",

--- a/engine/core/tax/reports/dispatcher.py
+++ b/engine/core/tax/reports/dispatcher.py
@@ -30,10 +30,13 @@ Out of scope (explicit follow-ups)
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import csv
+import io
+from dataclasses import dataclass, fields, is_dataclass
 from datetime import date
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from enum import Enum
+from typing import TYPE_CHECKING, Any
 
 from engine.core.tax.reports.form_1099b import (
     LotDisposition,
@@ -167,8 +170,68 @@ def _to_fr(d: TaxableDisposal) -> PfuDisposal:
     )
 
 
+def flatten_summary_to_csv(summary: Any) -> str:
+    """Render any frozen-dataclass tax summary as a 2-row CSV.
+
+    Walks every field of ``summary``; nested dataclasses become
+    dotted column names (``short_term.gain_loss``); ``Decimal`` /
+    ``date`` / ``Enum`` values are stringified. The result is a
+    deterministic header row + one values row, suitable for a CPA
+    paste-in or a spreadsheet import.
+
+    Lists and tuples are joined with ``;`` so a single CSV cell can
+    carry them — none of the current summaries use them, but the
+    helper is forward-compatible with whatever the next jurisdiction
+    needs.
+    """
+    columns: list[str] = []
+    values: list[str] = []
+    _walk(summary, prefix="", columns=columns, values=values)
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(columns)
+    writer.writerow(values)
+    return buf.getvalue()
+
+
+def _walk(
+    obj: Any,
+    *,
+    prefix: str,
+    columns: list[str],
+    values: list[str],
+) -> None:
+    if is_dataclass(obj) and not isinstance(obj, type):
+        for f in fields(obj):
+            child = getattr(obj, f.name)
+            child_prefix = f"{prefix}{f.name}" if not prefix else f"{prefix}.{f.name}"
+            _walk(
+                child,
+                prefix=child_prefix,
+                columns=columns,
+                values=values,
+            )
+        return
+    columns.append(prefix or "value")
+    values.append(_render_scalar(obj))
+
+
+def _render_scalar(value: Any) -> str:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, list | tuple):
+        return ";".join(_render_scalar(x) for x in value)
+    return "" if value is None else str(value)
+
+
 __all__ = [
     "TaxableDisposal",
     "UnsupportedJurisdictionError",
+    "flatten_summary_to_csv",
     "report_for_jurisdiction",
 ]

--- a/tests/test_tax_route_csv.py
+++ b/tests/test_tax_route_csv.py
@@ -1,0 +1,143 @@
+"""Tests for the /tax/report/{code}.csv endpoint (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+import csv as _csv
+import io
+
+import pytest
+from httpx import AsyncClient
+
+
+_CSV_PREFIX = "text/csv"
+
+
+def _disposal(
+    *,
+    description: str = "100 ABC",
+    acquired: str = "2023-06-01",
+    disposed: str = "2024-06-01",
+    proceeds: str = "0",
+    cost: str = "0",
+) -> dict:
+    return {
+        "description": description,
+        "acquired": acquired,
+        "disposed": disposed,
+        "proceeds": proceeds,
+        "cost": cost,
+    }
+
+
+def _parse_csv(text: str) -> tuple[list[str], list[str]]:
+    rows = list(_csv.reader(io.StringIO(text)))
+    assert len(rows) == 2  # header + values
+    return rows[0], rows[1]
+
+
+class TestSuccess:
+    async def test_us_csv_includes_long_term_columns(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/v1/tax/report/US/csv",
+            json={
+                "disposals": [
+                    _disposal(
+                        acquired="2022-01-01",
+                        disposed="2024-06-01",
+                        proceeds="9000",
+                        cost="4000",
+                    )
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith(_CSV_PREFIX)
+        # Browser-friendly download; filename echoes the jurisdiction.
+        assert (
+            resp.headers["content-disposition"]
+            == 'attachment; filename="tax-report-US.csv"'
+        )
+
+        header, values = _parse_csv(resp.text)
+        idx = {col: i for i, col in enumerate(header)}
+        assert values[idx["long_term.row_count"]] == "1"
+        assert values[idx["long_term.gain_loss"]] == "5000.00"
+
+    async def test_gb_csv_includes_aea_columns(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/v1/tax/report/GB/csv",
+            json={"disposals": [_disposal(proceeds="15000", cost="10000")]},
+        )
+
+        assert resp.status_code == 200
+        header, values = _parse_csv(resp.text)
+        idx = {col: i for i, col in enumerate(header)}
+        assert values[idx["taxable_gain"]] == "2000.00"
+
+    async def test_lowercase_code_normalises_filename(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/v1/tax/report/de/csv",
+            json={"disposals": [_disposal(proceeds="6000", cost="1000")]},
+        )
+
+        assert resp.status_code == 200
+        assert (
+            resp.headers["content-disposition"]
+            == 'attachment; filename="tax-report-DE.csv"'
+        )
+
+
+class TestErrors:
+    async def test_unknown_code_returns_400(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/v1/tax/report/ZZ/csv",
+            json={"disposals": []},
+        )
+
+        assert resp.status_code == 400
+        assert "ZZ" in resp.json()["detail"]
+
+    async def test_invalid_decimal_rejected_at_pydantic(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/v1/tax/report/US/csv",
+            json={"disposals": [_disposal(proceeds="abc", cost="100")]},
+        )
+
+        assert resp.status_code == 422
+
+    async def test_acquired_after_disposed_rejected_at_taxable(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/api/v1/tax/report/US/csv",
+            json={
+                "disposals": [
+                    _disposal(
+                        acquired="2024-12-31",
+                        disposed="2024-01-01",
+                        proceeds="100",
+                        cost="50",
+                    )
+                ]
+            },
+        )
+
+        assert resp.status_code == 400
+
+
+class TestEmpty:
+    @pytest.mark.parametrize("code", ["US", "GB", "DE", "FR"])
+    async def test_empty_disposals_returns_csv_with_zero_values(
+        self, client: AsyncClient, code: str
+    ):
+        resp = await client.post(
+            f"/api/v1/tax/report/{code}/csv",
+            json={"disposals": []},
+        )
+
+        assert resp.status_code == 200
+        # Even on empty input we emit a 2-row CSV (header + zero values).
+        header, values = _parse_csv(resp.text)
+        assert len(header) > 0
+        assert len(values) == len(header)

--- a/tests/test_tax_summary_csv.py
+++ b/tests/test_tax_summary_csv.py
@@ -1,0 +1,129 @@
+"""Tests for ``flatten_summary_to_csv`` (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+import csv as _csv
+import io
+from datetime import date
+from decimal import Decimal
+
+from engine.core.tax.reports import (
+    TaxableDisposal,
+    flatten_summary_to_csv,
+    report_for_jurisdiction,
+)
+
+
+def _disp(*, proceeds: str, cost: str) -> TaxableDisposal:
+    return TaxableDisposal(
+        description="100 ABC",
+        acquired=date(2023, 6, 1),
+        disposed=date(2024, 6, 1),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+    )
+
+
+def _parse(out: str) -> tuple[list[str], list[str]]:
+    reader = _csv.reader(io.StringIO(out))
+    rows = list(reader)
+    assert len(rows) == 2, "flattener emits exactly header + values"
+    return rows[0], rows[1]
+
+
+# ---------------------------------------------------------------------------
+# Per-jurisdiction shape
+# ---------------------------------------------------------------------------
+
+
+class TestUsShape:
+    def test_us_summary_flattens_with_dotted_part_columns(self):
+        summary = report_for_jurisdiction(
+            "US",
+            [
+                TaxableDisposal(
+                    description="3 shares MSFT",
+                    acquired=date(2022, 1, 1),
+                    disposed=date(2024, 6, 1),
+                    proceeds=Decimal("9000"),
+                    cost=Decimal("4000"),
+                )
+            ],
+        )
+
+        header, values = _parse(flatten_summary_to_csv(summary))
+        # Nested ScheduleDPartTotal fields surface as dotted columns.
+        assert "short_term.row_count" in header
+        assert "short_term.gain_loss" in header
+        assert "long_term.row_count" in header
+        assert "long_term.gain_loss" in header
+        assert "net_gain_loss" in header
+
+        idx = {col: i for i, col in enumerate(header)}
+        assert values[idx["long_term.row_count"]] == "1"
+        assert values[idx["long_term.gain_loss"]] == "5000.00"
+        assert values[idx["net_gain_loss"]] == "5000.00"
+
+
+class TestGbShape:
+    def test_gb_summary_flattens_to_flat_columns(self):
+        summary = report_for_jurisdiction(
+            "GB", [_disp(proceeds="15000", cost="10000")]
+        )
+
+        header, values = _parse(flatten_summary_to_csv(summary))
+        assert {
+            "disposal_count",
+            "proceeds_total",
+            "cost_total",
+            "net_gain",
+            "net_loss",
+            "annual_exempt_amount_used",
+            "taxable_gain",
+        } <= set(header)
+
+        idx = {col: i for i, col in enumerate(header)}
+        assert values[idx["net_gain"]] == "5000.00"
+        assert values[idx["annual_exempt_amount_used"]] == "3000.00"
+        assert values[idx["taxable_gain"]] == "2000.00"
+
+
+class TestDeShape:
+    def test_de_summary_flattens_with_kest_breakdown(self):
+        summary = report_for_jurisdiction(
+            "DE", [_disp(proceeds="6000", cost="1000")]
+        )
+
+        header, values = _parse(flatten_summary_to_csv(summary))
+        idx = {col: i for i, col in enumerate(header)}
+        assert values[idx["kest"]] == "1000.00"
+        assert values[idx["solidarity_surcharge"]] == "55.00"
+        assert values[idx["total_tax"]] == "1055.00"
+
+
+class TestFrShape:
+    def test_fr_summary_flattens_with_pfu_breakdown(self):
+        summary = report_for_jurisdiction(
+            "FR", [_disp(proceeds="6000", cost="5000")]
+        )
+
+        header, values = _parse(flatten_summary_to_csv(summary))
+        idx = {col: i for i, col in enumerate(header)}
+        assert values[idx["income_tax"]] == "128.00"
+        assert values[idx["social_charges"]] == "172.00"
+        assert values[idx["total_tax"]] == "300.00"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_same_input_yields_same_csv(self):
+        summary = report_for_jurisdiction(
+            "GB", [_disp(proceeds="15000", cost="10000")]
+        )
+        a = flatten_summary_to_csv(summary)
+        b = flatten_summary_to_csv(summary)
+        assert a == b


### PR DESCRIPTION
## Summary

Adds a CSV download path to the tax-report dispatcher shipped in #313/#314. CPAs and spreadsheet workflows get a deterministic round-trip of the per-jurisdiction summary in two rows (header + values).

- \`engine.core.tax.reports.flatten_summary_to_csv(summary)\` — walks any frozen tax-summary dataclass into a flat 2-row CSV. Nested dataclasses (\`ScheduleDSummary.short_term\`, etc.) surface as dotted column names; \`Decimal\` / \`date\` / \`Enum\` values are stringified. Lists/tuples join with \`;\` for forward compatibility (no current summary uses them).
- \`POST /api/v1/tax/report/{code}/csv\` — same dispatch as \`/api/v1/tax/report/{code}\`, but returns the flattened CSV with \`text/csv; charset=utf-8\` and an \`attachment; filename="tax-report-<UPPER>.csv"\` Content-Disposition for browser downloads.

The path uses \`/csv\` as a separate path segment (not \`.csv\` extension form) so FastAPI's path parameter parsing doesn't capture the extension into the \`{code}\` parameter.

Refs #155. Annual tax-input persistence and multi-currency conversion are still deferred.

## Test plan

### Flattener (\`tests/test_tax_summary_csv.py\`)
- [x] US summary surfaces with dotted \`short_term.*\` / \`long_term.*\` columns + correct values
- [x] GB summary flattens to top-level columns including AEA usage and taxable gain
- [x] DE summary surfaces \`kest\` / \`solidarity_surcharge\` / \`total_tax\`
- [x] FR summary surfaces \`income_tax\` / \`social_charges\` / \`total_tax\`
- [x] Determinism: same input yields identical output across calls

### Route (\`tests/test_tax_route_csv.py\`)
- [x] US/GB CSVs include the right columns + values
- [x] Lowercase code normalises filename to \`tax-report-DE.csv\` etc.
- [x] Unknown code → 400 listing supported codes
- [x] Invalid Decimal → 422 (Pydantic)
- [x] Acquired-after-disposed → 400 (TaxableDisposal validation)
- [x] Empty disposals → 200 with header + zero values, parametrised across all 4 codes