### PR TITLE
feat(tax): German Verlustvortrag carry-forward under § 20 Abs. 6 EStG (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -48,6 +48,11 @@ from engine.core.tax.reports.kest import (
     KestSummary,
     summarize_kest,
 )
+from engine.core.tax.reports.kest_carryover import (
+    KestApplication,
+    KestCarryover,
+    apply_kest_carryover,
+)
 from engine.core.tax.reports.form_1099b import (
     HoldingTerm,
     LotDisposition,
@@ -85,6 +90,8 @@ __all__ = [
     "CgtDisposal",
     "CgtSummary",
     "HoldingTerm",
+    "KestApplication",
+    "KestCarryover",
     "KestDisposal",
     "KestSummary",
     "LotDisposition",
@@ -94,6 +101,7 @@ __all__ = [
     "TaxableDisposal",
     "UnsupportedJurisdictionError",
     "apply_carryover",
+    "apply_kest_carryover",
     "disposals_to_csv",
     "flatten_summary_to_csv",
     "generate_1099b_rows",

--- a/engine/core/tax/reports/kest_carryover.py
+++ b/engine/core/tax/reports/kest_carryover.py
@@ -1,0 +1,210 @@
+"""German Verlustvortrag carry-forward (§ 20 Abs. 6 EStG).
+
+Companion to :mod:`engine.core.tax.reports.kest`. Handles the
+multi-year capital-loss carry-forward state German private investors
+maintain under § 20 Abs. 6 EStG: net losses survive into future years
+and offset future capital income, with the equity ring-fence
+preserved across years.
+
+Two buckets, both non-negative loss amounts:
+
+- ``equity`` — losses that may *only* offset future equity gains
+  (§ 20 Abs. 6 Satz 4 EStG).
+- ``other`` — losses against any other capital income (interest,
+  dividends, non-equity gains).
+
+Algorithm
+---------
+1. Apply the prior carryover into the current-year per-bucket
+   gain/loss totals (treating prior losses as a deduction against
+   gains).
+2. Net intra-year per the existing :func:`summarize_kest` rules: only
+   positive equity contributes to the taxable base; the ``other``
+   bucket contributes signed.
+3. The combined base goes through allowance + KESt + SolZ + optional
+   church tax via :func:`summarize_kest`.
+4. Whatever remains as a *loss* on either bucket carries forward into
+   the next year's :class:`KestCarryover`.
+
+Out of scope (explicit follow-ups)
+----------------------------------
+- Mindestgewinnbesteuerung. Applies only to corporate income tax
+  (§ 10d EStG / § 8 KStG), not § 32d EStG. Documented for posterity.
+- Carryback. § 20 Abs. 6 forbids carryback for capital income; only
+  forward carryover applies.
+- Spousal Verlustverrechnung (joint filers may net losses across
+  spouses) — modelled by the caller upstream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from engine.core.tax.reports.kest import (
+    SPARER_PAUSCHBETRAG_2024,
+    AssetClass,
+    KestDisposal,
+    KestSummary,
+    summarize_kest,
+)
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+
+@dataclass(frozen=True)
+class KestCarryover:
+    """Two-bucket carryover record. Both legs are non-negative loss
+    amounts — gains do not carry over."""
+
+    equity: Decimal = _ZERO
+    other: Decimal = _ZERO
+
+    @classmethod
+    def zero(cls) -> KestCarryover:
+        return cls(equity=_ZERO, other=_ZERO)
+
+    @property
+    def total(self) -> Decimal:
+        return (self.equity + self.other).quantize(_TWOPLACES)
+
+
+@dataclass(frozen=True)
+class KestApplication:
+    """Result of running :func:`apply_kest_carryover` for one tax year.
+
+    ``summary`` is the standard :class:`KestSummary` produced after the
+    prior carryover was applied. ``next_year_carryover`` is the
+    carryover the taxpayer brings into the following year.
+    """
+
+    summary: KestSummary
+    next_year_carryover: KestCarryover
+
+
+def apply_kest_carryover(
+    disposals: list[KestDisposal],
+    prior: KestCarryover | None = None,
+    *,
+    allowance: Decimal = SPARER_PAUSCHBETRAG_2024,
+    church_tax_rate: Decimal | None = None,
+) -> KestApplication:
+    """Apply ``prior`` losses to ``disposals``, then compute the year's
+    KESt summary and the carryover that survives into next year.
+
+    The prior carryover is applied at the per-bucket level *before*
+    intra-year netting so that prior losses get a fresh shot at
+    offsetting any new gains. The ring-fence rule still holds: prior
+    equity losses can only reduce equity gains; prior ``other`` losses
+    can only reduce the ``other`` bucket.
+    """
+    prior = prior or KestCarryover.zero()
+    if prior.equity < 0 or prior.other < 0:
+        raise ValueError(
+            "prior carryover legs must be non-negative loss amounts"
+        )
+
+    # Sum current-year per-bucket gain/loss without going through the
+    # full summariser yet — we need the per-bucket numbers to apply
+    # the prior carryover surgically.
+    eq = _ZERO
+    other = _ZERO
+    for d in disposals:
+        delta = d.gain_loss
+        if d.asset_class == AssetClass.EQUITY:
+            eq += delta
+        else:
+            other += delta
+
+    eq_after_prior = (eq - prior.equity).quantize(_TWOPLACES)
+    other_after_prior = (other - prior.other).quantize(_TWOPLACES)
+
+    # Build a synthetic per-bucket disposal list so summarize_kest can
+    # still own the allowance + tax computations.
+    summary = summarize_kest(
+        _synthesize(eq_after_prior, other_after_prior),
+        allowance=allowance,
+        church_tax_rate=church_tax_rate,
+    )
+
+    next_carry = KestCarryover(
+        equity=(-eq_after_prior).quantize(_TWOPLACES)
+        if eq_after_prior < 0
+        else _ZERO,
+        other=(-other_after_prior).quantize(_TWOPLACES)
+        if other_after_prior < 0
+        else _ZERO,
+    )
+
+    return KestApplication(
+        summary=_with_disposal_count(summary, len(disposals)),
+        next_year_carryover=next_carry,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _synthesize(
+    equity_net: Decimal, other_net: Decimal
+) -> list[KestDisposal]:
+    """Build the smallest set of synthetic disposals that reproduce the
+    given per-bucket nets. Used so :func:`summarize_kest` can still own
+    the allowance + tax computations."""
+    out: list[KestDisposal] = []
+    if equity_net != 0:
+        proceeds = equity_net if equity_net > 0 else _ZERO
+        cost = -equity_net if equity_net < 0 else _ZERO
+        out.append(
+            KestDisposal(
+                description="(carry-adjusted equity bucket)",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 12, 31),
+                proceeds=proceeds,
+                cost=cost,
+                asset_class=AssetClass.EQUITY,
+            )
+        )
+    if other_net != 0:
+        proceeds = other_net if other_net > 0 else _ZERO
+        cost = -other_net if other_net < 0 else _ZERO
+        out.append(
+            KestDisposal(
+                description="(carry-adjusted other bucket)",
+                acquired=date(2024, 1, 1),
+                disposed=date(2024, 12, 31),
+                proceeds=proceeds,
+                cost=cost,
+                asset_class=AssetClass.OTHER,
+            )
+        )
+    return out
+
+
+def _with_disposal_count(summary: KestSummary, count: int) -> KestSummary:
+    """Replace the synthesised disposal count with the real one. The
+    summary is otherwise identical."""
+    return KestSummary(
+        disposal_count=count,
+        proceeds_total=summary.proceeds_total,
+        cost_total=summary.cost_total,
+        equity_net=summary.equity_net,
+        other_net=summary.other_net,
+        taxable_income=summary.taxable_income,
+        allowance_used=summary.allowance_used,
+        kest=summary.kest,
+        solidarity_surcharge=summary.solidarity_surcharge,
+        church_tax=summary.church_tax,
+        total_tax=summary.total_tax,
+    )
+
+
+__all__ = [
+    "KestApplication",
+    "KestCarryover",
+    "apply_kest_carryover",
+]

--- a/tests/test_kest_carryover.py
+++ b/tests/test_kest_carryover.py
@@ -1,0 +1,261 @@
+"""Tests for the German Verlustvortrag carry-forward (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    AssetClass,
+    KestApplication,
+    KestCarryover,
+    KestDisposal,
+    apply_kest_carryover,
+)
+
+
+def _disp(
+    *,
+    proceeds: str,
+    cost: str,
+    asset_class: AssetClass = AssetClass.EQUITY,
+) -> KestDisposal:
+    return KestDisposal(
+        description="100 ABC",
+        acquired=date(2023, 6, 1),
+        disposed=date(2024, 6, 1),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+        asset_class=asset_class,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+class TestCarryoverConstructor:
+    def test_zero_constructor_returns_both_legs_at_zero(self):
+        c = KestCarryover.zero()
+        assert c.equity == Decimal("0.00")
+        assert c.other == Decimal("0.00")
+        assert c.total == Decimal("0.00")
+
+    def test_total_quantises_to_two_decimals(self):
+        c = KestCarryover(equity=Decimal("100.123"), other=Decimal("50.456"))
+        assert c.total == Decimal("150.58")
+
+
+# ---------------------------------------------------------------------------
+# No prior carry — straight passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestNoPrior:
+    def test_pure_gain_year_yields_no_next_year_carry(self):
+        result = apply_kest_carryover([_disp(proceeds="6000", cost="1000")])
+
+        assert isinstance(result, KestApplication)
+        assert result.summary.equity_net == Decimal("5000.00")
+        assert result.summary.taxable_income == Decimal("4000.00")
+        assert result.next_year_carryover == KestCarryover.zero()
+
+    def test_pure_equity_loss_year_carries_only_equity_bucket(self):
+        result = apply_kest_carryover([_disp(proceeds="500", cost="2500")])
+
+        assert result.summary.equity_net == Decimal("-2000.00")
+        assert result.summary.total_tax == Decimal("0.00")
+        assert result.next_year_carryover.equity == Decimal("2000.00")
+        assert result.next_year_carryover.other == Decimal("0.00")
+
+    def test_pure_other_loss_year_carries_only_other_bucket(self):
+        result = apply_kest_carryover(
+            [
+                _disp(
+                    proceeds="500",
+                    cost="2500",
+                    asset_class=AssetClass.OTHER,
+                )
+            ]
+        )
+
+        assert result.summary.other_net == Decimal("-2000.00")
+        assert result.summary.total_tax == Decimal("0.00")
+        assert result.next_year_carryover.other == Decimal("2000.00")
+        assert result.next_year_carryover.equity == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Prior loss applied to current year
+# ---------------------------------------------------------------------------
+
+
+class TestPriorEquityCarry:
+    def test_prior_equity_loss_offsets_current_equity_gain(self):
+        # Prior 4,000 EUR equity loss + +5,000 EUR current equity gain
+        # → 1,000 net equity. Below allowance → no tax, no carry.
+        prior = KestCarryover(
+            equity=Decimal("4000"), other=Decimal("0")
+        )
+        result = apply_kest_carryover(
+            [_disp(proceeds="6000", cost="1000")], prior
+        )
+
+        assert result.summary.equity_net == Decimal("1000.00")
+        assert result.summary.taxable_income == Decimal("0.00")
+        assert result.summary.total_tax == Decimal("0.00")
+        assert result.next_year_carryover == KestCarryover.zero()
+
+    def test_prior_equity_loss_above_current_gain_carries_remainder(self):
+        # Prior 8,000 + current +5,000 = -3,000 still on equity bucket.
+        prior = KestCarryover(
+            equity=Decimal("8000"), other=Decimal("0")
+        )
+        result = apply_kest_carryover(
+            [_disp(proceeds="6000", cost="1000")], prior
+        )
+
+        assert result.summary.equity_net == Decimal("-3000.00")
+        assert result.summary.total_tax == Decimal("0.00")
+        assert result.next_year_carryover.equity == Decimal("3000.00")
+
+    def test_prior_equity_loss_does_not_offset_other_gain(self):
+        # Prior 10,000 equity carry + only "other" gain this year.
+        # Equity ring-fence: prior equity does not reduce other base.
+        prior = KestCarryover(
+            equity=Decimal("10000"), other=Decimal("0")
+        )
+        result = apply_kest_carryover(
+            [
+                _disp(
+                    proceeds="6000",
+                    cost="1000",
+                    asset_class=AssetClass.OTHER,
+                )
+            ],
+            prior,
+        )
+
+        # Other bucket: +5,000; equity bucket after prior: -10,000.
+        # Taxable: 5,000 - 1,000 allowance = 4,000.
+        assert result.summary.equity_net == Decimal("-10000.00")
+        assert result.summary.other_net == Decimal("5000.00")
+        assert result.summary.taxable_income == Decimal("4000.00")
+        # Equity loss survives untouched.
+        assert result.next_year_carryover.equity == Decimal("10000.00")
+
+
+class TestPriorOtherCarry:
+    def test_prior_other_loss_offsets_current_other_gain(self):
+        prior = KestCarryover(
+            equity=Decimal("0"), other=Decimal("3000")
+        )
+        result = apply_kest_carryover(
+            [
+                _disp(
+                    proceeds="5000",
+                    cost="1000",
+                    asset_class=AssetClass.OTHER,
+                )
+            ],
+            prior,
+        )
+
+        # Other after prior: 4,000 - 3,000 = +1,000.
+        # Allowance fully consumes; no tax, no carry.
+        assert result.summary.other_net == Decimal("1000.00")
+        assert result.summary.taxable_income == Decimal("0.00")
+        assert result.next_year_carryover == KestCarryover.zero()
+
+    def test_prior_other_loss_above_current_other_gain_carries_remainder(self):
+        prior = KestCarryover(
+            equity=Decimal("0"), other=Decimal("5000")
+        )
+        result = apply_kest_carryover(
+            [
+                _disp(
+                    proceeds="2000",
+                    cost="1000",
+                    asset_class=AssetClass.OTHER,
+                )
+            ],
+            prior,
+        )
+
+        # Other after prior: 1,000 - 5,000 = -4,000.
+        assert result.next_year_carryover.other == Decimal("4000.00")
+        assert result.next_year_carryover.equity == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Compound prior + current losses
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundLosses:
+    def test_prior_loss_plus_current_loss_compounds_carryover(self):
+        prior = KestCarryover(
+            equity=Decimal("2000"), other=Decimal("1000")
+        )
+        result = apply_kest_carryover(
+            [
+                _disp(proceeds="500", cost="1500"),  # -1,000 equity
+                _disp(
+                    proceeds="200",
+                    cost="700",
+                    asset_class=AssetClass.OTHER,
+                ),  # -500 other
+            ],
+            prior,
+        )
+
+        # equity_after = -1,000 - 2,000 = -3,000.
+        # other_after = -500 - 1,000 = -1,500.
+        assert result.next_year_carryover.equity == Decimal("3000.00")
+        assert result.next_year_carryover.other == Decimal("1500.00")
+        assert result.summary.total_tax == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Disposal count preserved
+# ---------------------------------------------------------------------------
+
+
+class TestDisposalCount:
+    def test_summary_disposal_count_matches_input_not_synthetic(self):
+        # Even after the synthetic per-bucket disposals are fed through
+        # summarize_kest, the surfaced count is the real input length.
+        disposals = [
+            _disp(proceeds="6000", cost="1000"),
+            _disp(proceeds="3000", cost="2000"),
+        ]
+        result = apply_kest_carryover(disposals)
+        assert result.summary.disposal_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_negative_prior_equity_rejected(self):
+        with pytest.raises(ValueError):
+            apply_kest_carryover(
+                [],
+                KestCarryover(
+                    equity=Decimal("-1"), other=Decimal("0")
+                ),
+            )
+
+    def test_negative_prior_other_rejected(self):
+        with pytest.raises(ValueError):
+            apply_kest_carryover(
+                [],
+                KestCarryover(
+                    equity=Decimal("0"), other=Decimal("-1")
+                ),
+            )


### PR DESCRIPTION
## Summary

Two-bucket § 20 Abs. 6 EStG capital-loss carryover that preserves the equity ring-fence across years. Companion to \`kest.py\` and analogous to the US \`carryover.py\` shipped in #309.

API:
- \`KestCarryover\` — frozen dataclass with \`equity\` + \`other\` legs (both *non-negative* loss amounts). \`zero()\` constructor for first-year filers; \`total\` property for the sum.
- \`KestApplication\` — \`summary\` (KestSummary for the current year) + \`next_year_carryover\` (KestCarryover for the year after).
- \`apply_kest_carryover(disposals, prior=None, *, allowance, church_tax_rate)\` — applies prior losses surgically to the matching bucket *before* intra-year netting, then routes through \`summarize_kest\` for the allowance + KESt + SolZ + church-tax computation, and surfaces the losses that survive.

Equity ring-fence is enforced both intra-year (via \`summarize_kest\`) and across years: prior equity losses can only offset future equity gains; a year with only "other" gains leaves the equity carry untouched.

Synthetic per-bucket disposals are fed through \`summarize_kest\` so the existing summariser keeps owning the tax math; the resulting \`KestSummary.disposal_count\` is restored to the real input length.

Refs #155. Mindestgewinnbesteuerung (corporate income tax only — § 10d EStG / § 8 KStG), carryback (forbidden under § 20 Abs. 6), and spousal Verlustverrechnung are still deferred.

## Test plan

- [x] Constructor: \`zero()\` returns both legs at 0.00; \`total\` quantises to two decimals
- [x] No prior + pure-gain year → no carryover
- [x] No prior + pure-equity-loss year → equity-only carry; total tax 0
- [x] No prior + pure-other-loss year → other-only carry; total tax 0
- [x] Prior equity carry offsets current equity gain (no remainder, no tax)
- [x] Prior equity carry above current gain → residual carries forward
- [x] Prior equity carry does NOT offset current other gain (ring-fence)
- [x] Prior other carry offsets current other gain
- [x] Prior other carry above current other gain → residual carries forward
- [x] Compound prior + current losses on both buckets compound carryover
- [x] \`disposal_count\` preserved despite synthetic per-bucket reduction
- [x] Negative prior equity / other rejected