### PR TITLE
feat(tax): HMRC CGT loss carry-forward (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -13,6 +13,11 @@ from engine.core.tax.reports.carryover import (
     CapitalLossCarryover,
     apply_carryover,
 )
+from engine.core.tax.reports.cgt_carryover import (
+    CgtApplication,
+    CgtCarryover,
+    apply_cgt_carryover,
+)
 from engine.core.tax.reports.hmrc_cgt import (
     ANNUAL_EXEMPT_AMOUNT_2024_25,
     CgtDisposal,
@@ -87,6 +92,8 @@ __all__ = [
     "AssetClass",
     "CapitalLossApplication",
     "CapitalLossCarryover",
+    "CgtApplication",
+    "CgtCarryover",
     "CgtDisposal",
     "CgtSummary",
     "HoldingTerm",
@@ -101,6 +108,7 @@ __all__ = [
     "TaxableDisposal",
     "UnsupportedJurisdictionError",
     "apply_carryover",
+    "apply_cgt_carryover",
     "apply_kest_carryover",
     "disposals_to_csv",
     "flatten_summary_to_csv",

--- a/engine/core/tax/reports/cgt_carryover.py
+++ b/engine/core/tax/reports/cgt_carryover.py
@@ -1,0 +1,136 @@
+"""HMRC CGT loss carry-forward.
+
+Companion to :mod:`engine.core.tax.reports.hmrc_cgt`. Allowable
+capital losses that exceed in-year gains carry forward indefinitely
+(no time limit on use, but the loss itself must be *claimed* within
+four years of the end of the tax year in which it arose — that
+claim-window state lives outside this module).
+
+HMRC's order of operations
+--------------------------
+1. Net same-year gains and losses inside :func:`summarize_cgt`.
+2. Apply the Annual Exempt Amount (AEA) to the in-year *net gain*.
+3. Apply any prior-year carry-forward loss to the *taxable gain after
+   the AEA*. Carry-forward losses cannot reduce a year's gains below
+   the AEA — that allowance survives in full when there is enough
+   gain to absorb it.
+4. Anything left of the prior loss after step 3 carries forward into
+   the next tax year. Same-year net losses also push into the
+   carryover so the taxpayer can use them later.
+
+What's NOT here (explicit follow-ups)
+-------------------------------------
+- The four-year *claim* window for in-year losses. HMRC requires the
+  loss to be reported on a Self Assessment return within four years
+  of the tax-year end; tracking that deadline is a separate workflow
+  on the operator side.
+- Clogged losses (TCGA 1992 s.18 — connected-party transactions),
+  pre-1996 losses, and other ring-fenced loss types.
+- Allowable losses on residential property (different rate but same
+  carry-forward mechanics — caller can model them separately).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from engine.core.tax.reports.hmrc_cgt import (
+    ANNUAL_EXEMPT_AMOUNT_2024_25,
+    CgtDisposal,
+    CgtSummary,
+    summarize_cgt,
+)
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+
+@dataclass(frozen=True)
+class CgtCarryover:
+    """Single-bucket loss carryover (GBP). UK CGT does not ring-fence
+    losses by asset class for individuals."""
+
+    loss: Decimal = _ZERO
+
+    @classmethod
+    def zero(cls) -> CgtCarryover:
+        return cls(loss=_ZERO)
+
+
+@dataclass(frozen=True)
+class CgtApplication:
+    """Result of running :func:`apply_cgt_carryover` for one tax year.
+
+    - ``summary`` — the in-year :class:`CgtSummary` produced by
+      :func:`summarize_cgt`. Carry-forward absorption is reflected in
+      ``carryover_loss_used`` and ``taxable_gain_after_carryover``.
+    - ``carryover_loss_used`` — amount of prior loss consumed by this
+      year's taxable gain (zero if the year's taxable gain was zero).
+    - ``taxable_gain_after_carryover`` — taxable gain net of both AEA
+      and the prior carryover.
+    - ``next_year_carryover`` — what carries to the following year.
+    """
+
+    summary: CgtSummary
+    carryover_loss_used: Decimal
+    taxable_gain_after_carryover: Decimal
+    next_year_carryover: CgtCarryover
+
+
+def apply_cgt_carryover(
+    disposals: list[CgtDisposal],
+    prior: CgtCarryover | None = None,
+    *,
+    annual_exempt_amount: Decimal = ANNUAL_EXEMPT_AMOUNT_2024_25,
+) -> CgtApplication:
+    """Apply the prior-year loss to ``disposals``'s net gain *after*
+    the AEA, then surface the remaining carryover.
+
+    Same-year net losses push into ``next_year_carryover`` on top of
+    whatever prior loss survives the year's taxable gain.
+    """
+    if annual_exempt_amount < 0:
+        raise ValueError("annual_exempt_amount must be non-negative")
+    prior = prior or CgtCarryover.zero()
+    if prior.loss < 0:
+        raise ValueError("prior carryover loss must be non-negative")
+
+    summary = summarize_cgt(
+        disposals, annual_exempt_amount=annual_exempt_amount
+    )
+
+    # Step 3: prior loss applied AFTER the AEA. ``taxable_gain`` is
+    # already post-AEA per summarize_cgt.
+    used = min(prior.loss, summary.taxable_gain).quantize(_TWOPLACES)
+    remaining_prior = (prior.loss - used).quantize(_TWOPLACES)
+    taxable_after = (summary.taxable_gain - used).quantize(_TWOPLACES)
+
+    # Same-year net loss compounds with whatever prior loss survived.
+    next_loss = (remaining_prior + summary.net_loss).quantize(_TWOPLACES)
+
+    return CgtApplication(
+        summary=summary,
+        carryover_loss_used=used,
+        taxable_gain_after_carryover=taxable_after,
+        next_year_carryover=CgtCarryover(loss=next_loss),
+    )
+
+
+def roll_forward(prior: CgtCarryover) -> CgtCarryover:
+    """Return the prior carryover unchanged (zero current activity).
+
+    Convenience for audit workflows that need to roll a prior loss
+    forward without computing a year's worth of disposals.
+    """
+    if prior.loss < 0:
+        raise ValueError("prior carryover loss must be non-negative")
+    return CgtCarryover(loss=prior.loss.quantize(_TWOPLACES))
+
+
+__all__ = [
+    "CgtApplication",
+    "CgtCarryover",
+    "apply_cgt_carryover",
+    "roll_forward",
+]

--- a/tests/test_cgt_carryover.py
+++ b/tests/test_cgt_carryover.py
@@ -1,0 +1,189 @@
+"""Tests for the HMRC CGT loss carry-forward (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    CgtApplication,
+    CgtCarryover,
+    CgtDisposal,
+    apply_cgt_carryover,
+)
+from engine.core.tax.reports.cgt_carryover import roll_forward
+
+
+def _disp(*, proceeds: str, cost: str) -> CgtDisposal:
+    return CgtDisposal(
+        description="100 ABC.L",
+        acquired=date(2023, 4, 6),
+        disposed=date(2024, 4, 5),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor / no-op
+# ---------------------------------------------------------------------------
+
+
+class TestCarryoverConstructor:
+    def test_zero_constructor_returns_zero_loss(self):
+        assert CgtCarryover.zero().loss == Decimal("0.00")
+
+    def test_roll_forward_preserves_loss(self):
+        c = CgtCarryover(loss=Decimal("123.456"))
+        assert roll_forward(c).loss == Decimal("123.46")
+
+    def test_roll_forward_rejects_negative_loss(self):
+        with pytest.raises(ValueError):
+            roll_forward(CgtCarryover(loss=Decimal("-1")))
+
+
+# ---------------------------------------------------------------------------
+# No prior — same-year mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestNoPrior:
+    def test_pure_gain_below_aea_no_taxable_no_carry(self):
+        result = apply_cgt_carryover(
+            [_disp(proceeds="12000", cost="10000")]
+        )
+
+        assert isinstance(result, CgtApplication)
+        assert result.summary.net_gain == Decimal("2000.00")
+        assert result.summary.taxable_gain == Decimal("0.00")
+        assert result.taxable_gain_after_carryover == Decimal("0.00")
+        assert result.carryover_loss_used == Decimal("0.00")
+        assert result.next_year_carryover == CgtCarryover.zero()
+
+    def test_pure_gain_above_aea_taxable_no_carry(self):
+        # +£10,000 gain → £3,000 AEA, £7,000 taxable.
+        result = apply_cgt_carryover(
+            [_disp(proceeds="20000", cost="10000")]
+        )
+
+        assert result.summary.taxable_gain == Decimal("7000.00")
+        assert result.taxable_gain_after_carryover == Decimal("7000.00")
+        assert result.next_year_carryover.loss == Decimal("0.00")
+
+    def test_pure_loss_year_carries_forward(self):
+        result = apply_cgt_carryover(
+            [_disp(proceeds="500", cost="2000")]
+        )
+
+        assert result.summary.net_loss == Decimal("1500.00")
+        assert result.taxable_gain_after_carryover == Decimal("0.00")
+        assert result.next_year_carryover.loss == Decimal("1500.00")
+
+
+# ---------------------------------------------------------------------------
+# Prior loss applied to current taxable gain
+# ---------------------------------------------------------------------------
+
+
+class TestPriorLossAfterAea:
+    def test_prior_loss_does_not_eat_into_aea(self):
+        # +£2,000 gain, all under AEA. Prior £5,000 loss should not be
+        # consumed; AEA absorbs the whole gain.
+        prior = CgtCarryover(loss=Decimal("5000"))
+        result = apply_cgt_carryover(
+            [_disp(proceeds="12000", cost="10000")], prior
+        )
+
+        assert result.summary.taxable_gain == Decimal("0.00")
+        assert result.carryover_loss_used == Decimal("0.00")
+        assert result.next_year_carryover.loss == Decimal("5000.00")
+
+    def test_prior_loss_offsets_taxable_gain_above_aea(self):
+        # +£10,000 gain → £7,000 taxable post-AEA.
+        # Prior £4,000 loss → £3,000 taxable; £0 prior left.
+        prior = CgtCarryover(loss=Decimal("4000"))
+        result = apply_cgt_carryover(
+            [_disp(proceeds="20000", cost="10000")], prior
+        )
+
+        assert result.summary.taxable_gain == Decimal("7000.00")
+        assert result.carryover_loss_used == Decimal("4000.00")
+        assert result.taxable_gain_after_carryover == Decimal("3000.00")
+        assert result.next_year_carryover.loss == Decimal("0.00")
+
+    def test_prior_loss_above_taxable_gain_carries_remainder(self):
+        # +£10,000 gain → £7,000 taxable. Prior £15,000 loss absorbs
+        # the £7,000 taxable; £8,000 prior left for next year.
+        prior = CgtCarryover(loss=Decimal("15000"))
+        result = apply_cgt_carryover(
+            [_disp(proceeds="20000", cost="10000")], prior
+        )
+
+        assert result.carryover_loss_used == Decimal("7000.00")
+        assert result.taxable_gain_after_carryover == Decimal("0.00")
+        assert result.next_year_carryover.loss == Decimal("8000.00")
+
+
+# ---------------------------------------------------------------------------
+# Compounding losses
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundLosses:
+    def test_prior_plus_current_loss_compounds_carryover(self):
+        # Prior £2,000 + current -£1,500 = £3,500 carryover.
+        prior = CgtCarryover(loss=Decimal("2000"))
+        result = apply_cgt_carryover(
+            [_disp(proceeds="500", cost="2000")], prior
+        )
+
+        assert result.summary.net_loss == Decimal("1500.00")
+        assert result.next_year_carryover.loss == Decimal("3500.00")
+
+    def test_year_with_no_disposals_preserves_prior_intact(self):
+        prior = CgtCarryover(loss=Decimal("4321.99"))
+        result = apply_cgt_carryover([], prior)
+
+        assert result.summary.disposal_count == 0
+        assert result.next_year_carryover.loss == Decimal("4321.99")
+        assert result.carryover_loss_used == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Custom AEA
+# ---------------------------------------------------------------------------
+
+
+class TestCustomAea:
+    def test_prior_year_aea_consumed_first(self):
+        # 2022-23 AEA was £12,300. +£10,000 gain → 0 taxable.
+        # Prior loss should not be touched.
+        prior = CgtCarryover(loss=Decimal("4000"))
+        result = apply_cgt_carryover(
+            [_disp(proceeds="20000", cost="10000")],
+            prior,
+            annual_exempt_amount=Decimal("12300"),
+        )
+
+        assert result.summary.taxable_gain == Decimal("0.00")
+        assert result.carryover_loss_used == Decimal("0.00")
+        assert result.next_year_carryover.loss == Decimal("4000.00")
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_negative_aea_rejected(self):
+        with pytest.raises(ValueError):
+            apply_cgt_carryover([], annual_exempt_amount=Decimal("-1"))
+
+    def test_negative_prior_loss_rejected(self):
+        with pytest.raises(ValueError):
+            apply_cgt_carryover(
+                [], CgtCarryover(loss=Decimal("-0.01"))
+            )


### PR DESCRIPTION
## Summary

Single-bucket UK CGT carry-forward (TCGA 1992 mechanics): allowable losses that exceed in-year gains carry forward indefinitely and offset future taxable gains **after** the AEA is exhausted. Crucial HMRC rule: carry-forward losses cannot reduce a year's gains below the AEA — that allowance survives in full when there is enough gain to absorb it.

API:
- \`CgtCarryover\` — frozen dataclass; non-negative \`loss\` field; \`zero()\` constructor for first-year filers.
- \`CgtApplication\` — in-year \`CgtSummary\` + \`carryover_loss_used\` + \`taxable_gain_after_carryover\` + \`next_year_carryover\`.
- \`apply_cgt_carryover(disposals, prior=None, *, annual_exempt_amount=...)\` — routes through \`summarize_cgt\` then applies the prior loss to the post-AEA taxable gain.
- \`roll_forward(prior)\` — convenience for audit workflows that need to preserve a prior loss across years with no disposals.

Same-year net losses compound on top of any surviving prior loss.

Refs #155. The 4-year *claim* window for in-year losses (HMRC requires the loss to be reported on Self Assessment within four years of tax-year end), clogged losses (TCGA 1992 s.18 connected-party), pre-1996 losses, and residential-property loss buckets are deferred.

## Test plan

### Constructor / no-op
- [x] \`zero()\` returns \`loss=0.00\`
- [x] \`roll_forward\` quantises the loss to two decimals
- [x] \`roll_forward\` rejects negative loss

### No prior — same-year mechanics
- [x] Pure gain below AEA → 0 taxable, no carry
- [x] Pure gain above AEA → £7,000 taxable, no carry
- [x] Pure loss year carries forward unchanged

### Prior loss applied AFTER AEA
- [x] Prior £5,000 loss + £2,000 gain (under AEA) → loss untouched
- [x] Prior £4,000 loss + £7,000 post-AEA taxable → £3,000 taxable, 0 prior left
- [x] Prior £15,000 loss + £7,000 post-AEA taxable → 0 taxable, £8,000 prior carries

### Compounding
- [x] Prior + same-year loss compounds carryover
- [x] Year with no disposals preserves prior intact

### Custom AEA + validation
- [x] Prior-year £12,300 AEA consumed first; prior loss untouched
- [x] Negative AEA rejected
- [x] Negative prior loss rejected