### PR TITLE
feat(tax): France PFU 10-year loss carry-forward (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -39,6 +39,12 @@ from engine.core.tax.reports.france_pfu import (
     PfuSummary,
     summarize_pfu,
 )
+from engine.core.tax.reports.pfu_carryover import (
+    PfuApplication,
+    PfuCarryover,
+    PfuLossVintage,
+    apply_pfu_carryover,
+)
 from engine.core.tax.reports.kest import (
     CHURCH_TAX_RATE_BAYERN_BW,
     CHURCH_TAX_RATE_OTHER,
@@ -82,7 +88,10 @@ __all__ = [
     "PFU_INCOME_TAX_RATE",
     "PFU_SOCIAL_CHARGES_RATE",
     "PFU_TOTAL_RATE",
+    "PfuApplication",
+    "PfuCarryover",
     "PfuDisposal",
+    "PfuLossVintage",
     "PfuSummary",
     "SOLZ_RATE",
     "SPARER_PAUSCHBETRAG_2023",
@@ -110,6 +119,7 @@ __all__ = [
     "apply_carryover",
     "apply_cgt_carryover",
     "apply_kest_carryover",
+    "apply_pfu_carryover",
     "disposals_to_csv",
     "flatten_summary_to_csv",
     "generate_1099b_rows",

--- a/engine/core/tax/reports/pfu_carryover.py
+++ b/engine/core/tax/reports/pfu_carryover.py
@@ -1,0 +1,203 @@
+"""France PFU loss carry-forward (CGI Article 150-0 D 11).
+
+Companion to :mod:`engine.core.tax.reports.france_pfu`. Net capital
+losses on stock disposals carry forward for *ten years* and may be
+used to offset future stock gains. After ten years, the loss expires.
+
+Vintage tracking
+----------------
+French law dates losses by their tax year of origin: a 2024 loss is
+usable in 2024–2034 inclusive, then expires. The carryover record
+therefore tracks loss *vintages* (year + amount), not a single
+aggregate balance like the US/UK forms. When a future year nets a
+gain, the *oldest* unexpired vintage absorbs first (FIFO) — that
+matches how every French tax-prep tool models the box-2DC ordering.
+
+Algorithm per year (tax year ``Y``)
+-----------------------------------
+1. Net the year's disposals via :func:`summarize_pfu`.
+2. Drop any vintage with ``Y - vintage.year >= 10`` — these have
+   expired (10-year window).
+3. If the year netted a *gain*: walk vintages oldest-first and
+   absorb up to the gain. Surviving vintages stay; the gain net of
+   absorbed losses becomes the taxable base; PFU is recomputed.
+4. If the year netted a *loss*: append it as a new vintage tagged
+   with ``Y``.
+
+Out of scope (explicit follow-ups)
+----------------------------------
+- *Barème progressif* election. The taxpayer may opt for the
+  progressive scale (CGI Art. 200 A 2); loss carry-forward mechanics
+  are identical, but rate computation differs — out of scope here.
+- Loss segmentation by asset type (PEA, dérivés / SOFICA, etc.).
+  Filter upstream.
+- *Plus-values immobilières* — different regime entirely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from engine.core.tax.reports.france_pfu import (
+    PFU_INCOME_TAX_RATE,
+    PFU_SOCIAL_CHARGES_RATE,
+    PfuDisposal,
+    PfuSummary,
+    summarize_pfu,
+)
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+CARRY_FORWARD_YEARS: int = 10
+
+
+@dataclass(frozen=True)
+class PfuLossVintage:
+    """One vintage of carry-forward loss, dated by its origin year."""
+
+    year: int
+    amount: Decimal  # positive loss amount
+
+    def __post_init__(self) -> None:
+        if self.amount < 0:
+            raise ValueError("vintage amount must be non-negative")
+
+
+@dataclass(frozen=True)
+class PfuCarryover:
+    """Multi-vintage loss carryover record. ``vintages`` is sorted
+    oldest-first (caller is responsible — :func:`normalised` does it
+    for you)."""
+
+    vintages: tuple[PfuLossVintage, ...] = ()
+
+    @classmethod
+    def zero(cls) -> PfuCarryover:
+        return cls(vintages=())
+
+    @property
+    def total(self) -> Decimal:
+        return sum(
+            (v.amount for v in self.vintages), _ZERO
+        ).quantize(_TWOPLACES)
+
+
+def normalised(carryover: PfuCarryover) -> PfuCarryover:
+    """Return a carryover with vintages sorted oldest-first and any
+    zero-amount vintages dropped."""
+    sorted_vs = tuple(
+        sorted(
+            (v for v in carryover.vintages if v.amount > 0),
+            key=lambda v: v.year,
+        )
+    )
+    return PfuCarryover(vintages=sorted_vs)
+
+
+@dataclass(frozen=True)
+class PfuApplication:
+    """Result of running :func:`apply_pfu_carryover` for one tax year.
+
+    - ``summary`` — base :class:`PfuSummary` for ``disposals`` (no
+      carry consumption).
+    - ``loss_used`` — total prior loss amount absorbed against the
+      year's net gain.
+    - ``taxable_gain_after_carryover`` — the year's taxable gain net
+      of the absorbed prior loss.
+    - ``income_tax_after_carryover`` and
+      ``social_charges_after_carryover`` — recomputed at the PFU
+      breakdown rates (12.8 % + 17.2 %) on the post-carryover base.
+    - ``total_tax_after_carryover`` — sum of the two.
+    - ``next_year_carryover`` — vintages that survive into the next
+      tax year. Expired vintages are already dropped.
+    - ``expired`` — vintages dropped this year because they hit the
+      10-year wall. Useful for audit / UI display.
+    """
+
+    summary: PfuSummary
+    loss_used: Decimal
+    taxable_gain_after_carryover: Decimal
+    income_tax_after_carryover: Decimal
+    social_charges_after_carryover: Decimal
+    total_tax_after_carryover: Decimal
+    next_year_carryover: PfuCarryover
+    expired: tuple[PfuLossVintage, ...]
+
+
+def apply_pfu_carryover(
+    disposals: list[PfuDisposal],
+    prior: PfuCarryover | None = None,
+    *,
+    current_year: int,
+) -> PfuApplication:
+    """Apply ``prior`` losses (FIFO by vintage) to ``disposals``'s net
+    gain, then return the new tax basis and the surviving carryover.
+    """
+    prior = normalised(prior or PfuCarryover.zero())
+    summary = summarize_pfu(disposals)
+
+    # Drop vintages older than the 10-year window.
+    fresh_vintages: list[PfuLossVintage] = []
+    expired_vintages: list[PfuLossVintage] = []
+    for v in prior.vintages:
+        if current_year - v.year >= CARRY_FORWARD_YEARS:
+            expired_vintages.append(v)
+        else:
+            fresh_vintages.append(v)
+
+    loss_used = _ZERO
+    surviving = list(fresh_vintages)
+    if summary.net_gain > 0:
+        # Absorb oldest-first, FIFO by vintage year.
+        remaining_gain = summary.net_gain
+        new_surviving: list[PfuLossVintage] = []
+        for v in surviving:
+            if remaining_gain <= 0:
+                new_surviving.append(v)
+                continue
+            take = min(remaining_gain, v.amount).quantize(_TWOPLACES)
+            loss_used += take
+            remaining_after = (v.amount - take).quantize(_TWOPLACES)
+            if remaining_after > 0:
+                new_surviving.append(
+                    PfuLossVintage(year=v.year, amount=remaining_after)
+                )
+            remaining_gain = (remaining_gain - take).quantize(_TWOPLACES)
+        surviving = new_surviving
+    elif summary.net_loss > 0:
+        # Tag the year's loss as a new vintage.
+        surviving.append(
+            PfuLossVintage(
+                year=current_year, amount=summary.net_loss
+            )
+        )
+
+    taxable_after = (summary.net_gain - loss_used).quantize(_TWOPLACES)
+    income_tax = (taxable_after * PFU_INCOME_TAX_RATE).quantize(_TWOPLACES)
+    social = (taxable_after * PFU_SOCIAL_CHARGES_RATE).quantize(_TWOPLACES)
+    total = (income_tax + social).quantize(_TWOPLACES)
+
+    return PfuApplication(
+        summary=summary,
+        loss_used=loss_used.quantize(_TWOPLACES),
+        taxable_gain_after_carryover=taxable_after,
+        income_tax_after_carryover=income_tax,
+        social_charges_after_carryover=social,
+        total_tax_after_carryover=total,
+        next_year_carryover=normalised(
+            PfuCarryover(vintages=tuple(surviving))
+        ),
+        expired=tuple(expired_vintages),
+    )
+
+
+__all__ = [
+    "CARRY_FORWARD_YEARS",
+    "PfuApplication",
+    "PfuCarryover",
+    "PfuLossVintage",
+    "apply_pfu_carryover",
+    "normalised",
+]

--- a/tests/test_pfu_carryover.py
+++ b/tests/test_pfu_carryover.py
@@ -1,0 +1,251 @@
+"""Tests for the France PFU 10-year loss carry-forward (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    PfuApplication,
+    PfuCarryover,
+    PfuDisposal,
+    PfuLossVintage,
+    apply_pfu_carryover,
+)
+from engine.core.tax.reports.pfu_carryover import (
+    CARRY_FORWARD_YEARS,
+    normalised,
+)
+
+
+def _disp(*, proceeds: str, cost: str) -> PfuDisposal:
+    return PfuDisposal(
+        description="100 ABC.PA",
+        acquired=date(2023, 6, 1),
+        disposed=date(2024, 6, 1),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vintage / Carryover constructors
+# ---------------------------------------------------------------------------
+
+
+class TestVintage:
+    def test_negative_amount_rejected(self):
+        with pytest.raises(ValueError):
+            PfuLossVintage(year=2024, amount=Decimal("-1"))
+
+    def test_zero_amount_allowed(self):
+        # The dataclass itself permits zero; ``normalised`` later drops
+        # zero vintages so they don't pollute the carryover.
+        v = PfuLossVintage(year=2024, amount=Decimal("0"))
+        assert v.amount == Decimal("0")
+
+
+class TestCarryoverConstructor:
+    def test_zero_returns_empty_tuple(self):
+        c = PfuCarryover.zero()
+        assert c.vintages == ()
+        assert c.total == Decimal("0.00")
+
+    def test_total_sums_vintages(self):
+        c = PfuCarryover(
+            vintages=(
+                PfuLossVintage(year=2024, amount=Decimal("1000")),
+                PfuLossVintage(year=2023, amount=Decimal("500.5")),
+            )
+        )
+        assert c.total == Decimal("1500.50")
+
+
+class TestNormalised:
+    def test_sorts_oldest_first_and_drops_zero_amounts(self):
+        c = PfuCarryover(
+            vintages=(
+                PfuLossVintage(year=2024, amount=Decimal("100")),
+                PfuLossVintage(year=2022, amount=Decimal("200")),
+                PfuLossVintage(year=2023, amount=Decimal("0")),
+            )
+        )
+        out = normalised(c)
+        assert [v.year for v in out.vintages] == [2022, 2024]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_ten_year_window(self):
+        assert CARRY_FORWARD_YEARS == 10
+
+
+# ---------------------------------------------------------------------------
+# No prior — same-year mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestNoPrior:
+    def test_pure_gain_year_no_carry_just_pfu(self):
+        result = apply_pfu_carryover(
+            [_disp(proceeds="6000", cost="5000")],
+            current_year=2024,
+        )
+        assert isinstance(result, PfuApplication)
+        assert result.summary.net_gain == Decimal("1000.00")
+        assert result.taxable_gain_after_carryover == Decimal("1000.00")
+        assert result.income_tax_after_carryover == Decimal("128.00")
+        assert result.social_charges_after_carryover == Decimal("172.00")
+        assert result.total_tax_after_carryover == Decimal("300.00")
+        assert result.next_year_carryover == PfuCarryover.zero()
+
+    def test_pure_loss_year_creates_new_vintage(self):
+        result = apply_pfu_carryover(
+            [_disp(proceeds="500", cost="2000")],
+            current_year=2024,
+        )
+        assert result.summary.net_loss == Decimal("1500.00")
+        assert result.total_tax_after_carryover == Decimal("0.00")
+        assert len(result.next_year_carryover.vintages) == 1
+        v = result.next_year_carryover.vintages[0]
+        assert v.year == 2024
+        assert v.amount == Decimal("1500.00")
+
+
+# ---------------------------------------------------------------------------
+# Prior loss applied FIFO
+# ---------------------------------------------------------------------------
+
+
+class TestFifo:
+    def test_oldest_vintage_absorbs_first(self):
+        prior = PfuCarryover(
+            vintages=(
+                PfuLossVintage(year=2017, amount=Decimal("400")),
+                PfuLossVintage(year=2020, amount=Decimal("300")),
+            )
+        )
+        # +500 EUR gain, prior 700 EUR. 2017 vintage absorbs 400 first,
+        # then 100 from 2020. 2020 carries 200 forward.
+        result = apply_pfu_carryover(
+            [_disp(proceeds="1500", cost="1000")],
+            prior,
+            current_year=2024,
+        )
+
+        assert result.loss_used == Decimal("500.00")
+        assert result.taxable_gain_after_carryover == Decimal("0.00")
+        assert result.total_tax_after_carryover == Decimal("0.00")
+        # 2017 vintage fully consumed → dropped. 2020 reduced to 200.
+        assert len(result.next_year_carryover.vintages) == 1
+        v = result.next_year_carryover.vintages[0]
+        assert v.year == 2020
+        assert v.amount == Decimal("200.00")
+
+    def test_gain_above_prior_taxes_remainder(self):
+        prior = PfuCarryover(
+            vintages=(
+                PfuLossVintage(year=2020, amount=Decimal("300")),
+            )
+        )
+        # +1,000 gain, 300 prior → 700 taxable. 12.8% = 89.6, 17.2% =
+        # 120.4, total = 210 (rounded to two decimals).
+        result = apply_pfu_carryover(
+            [_disp(proceeds="2000", cost="1000")],
+            prior,
+            current_year=2024,
+        )
+
+        assert result.loss_used == Decimal("300.00")
+        assert result.taxable_gain_after_carryover == Decimal("700.00")
+        assert result.total_tax_after_carryover == Decimal("210.00")
+        assert result.next_year_carryover == PfuCarryover.zero()
+
+
+# ---------------------------------------------------------------------------
+# 10-year expiry
+# ---------------------------------------------------------------------------
+
+
+class TestExpiry:
+    def test_vintage_at_ten_year_wall_is_expired(self):
+        # Loss vintage from 2014 against a 2024 gain: 2024 - 2014 = 10
+        # → expired (window is years < 10 since vintage).
+        prior = PfuCarryover(
+            vintages=(
+                PfuLossVintage(year=2014, amount=Decimal("500")),
+            )
+        )
+        result = apply_pfu_carryover(
+            [_disp(proceeds="2000", cost="1000")],
+            prior,
+            current_year=2024,
+        )
+
+        # Expired vintage cannot offset; full +1,000 gain is taxable.
+        assert result.loss_used == Decimal("0.00")
+        assert result.taxable_gain_after_carryover == Decimal("1000.00")
+        assert result.next_year_carryover == PfuCarryover.zero()
+        # Surfaced for audit.
+        assert len(result.expired) == 1
+        assert result.expired[0].year == 2014
+
+    def test_vintage_one_year_inside_window_still_usable(self):
+        # 2015 vintage in 2024 → 9 years, still valid.
+        prior = PfuCarryover(
+            vintages=(
+                PfuLossVintage(year=2015, amount=Decimal("500")),
+            )
+        )
+        result = apply_pfu_carryover(
+            [_disp(proceeds="2000", cost="1000")],
+            prior,
+            current_year=2024,
+        )
+
+        assert result.loss_used == Decimal("500.00")
+        assert result.taxable_gain_after_carryover == Decimal("500.00")
+        assert result.expired == ()
+
+
+# ---------------------------------------------------------------------------
+# Multi-year sequence
+# ---------------------------------------------------------------------------
+
+
+class TestMultiYearSequence:
+    def test_loss_year_then_partial_use_then_full_use(self):
+        # Year 1 (2024): loss of 1,000.
+        a = apply_pfu_carryover(
+            [_disp(proceeds="500", cost="1500")],
+            current_year=2024,
+        )
+        assert a.next_year_carryover.total == Decimal("1000.00")
+
+        # Year 2 (2025): gain of 600. Vintage drops to 400.
+        b = apply_pfu_carryover(
+            [_disp(proceeds="1600", cost="1000")],
+            a.next_year_carryover,
+            current_year=2025,
+        )
+        assert b.loss_used == Decimal("600.00")
+        assert b.taxable_gain_after_carryover == Decimal("0.00")
+        assert b.next_year_carryover.total == Decimal("400.00")
+        # 2024 vintage still tagged as such.
+        assert b.next_year_carryover.vintages[0].year == 2024
+
+        # Year 3 (2026): gain of 400. Carryover fully consumed.
+        c = apply_pfu_carryover(
+            [_disp(proceeds="1400", cost="1000")],
+            b.next_year_carryover,
+            current_year=2026,
+        )
+        assert c.loss_used == Decimal("400.00")
+        assert c.taxable_gain_after_carryover == Decimal("0.00")
+        assert c.next_year_carryover == PfuCarryover.zero()


### PR DESCRIPTION
## Summary

Vintage-tracked carry-forward under CGI Article 150-0 D 11: net capital losses on stock disposals carry forward for ten years and offset future stock gains FIFO by vintage. Vintages older than the window expire and are surfaced for audit.

API:
- \`PfuLossVintage\` — frozen dataclass; \`year\` (int) + non-negative \`amount\` (Decimal).
- \`PfuCarryover\` — tuple of vintages; \`zero()\` constructor; \`total\` property quantises to two decimals.
- \`normalised(carryover)\` — sorts vintages oldest-first and drops zero-amount entries (reuse this when callers hand-build a carryover for a multi-year run).
- \`PfuApplication\` — in-year \`PfuSummary\` + \`loss_used\` + \`taxable_gain_after_carryover\` + recomputed PFU breakdown (\`income_tax_after_carryover\`, \`social_charges_after_carryover\`, \`total_tax_after_carryover\`) + \`next_year_carryover\` + \`expired\` vintages dropped this year.
- \`apply_pfu_carryover(disposals, prior, *, current_year)\` — drops expired vintages first, then consumes oldest-first against the year's net gain, then either taxes the remainder or appends the year's net loss as a new vintage tagged with \`current_year\`.
- \`CARRY_FORWARD_YEARS\` constant (10).

Refs #155. \`Barème progressif\` election (CGI Art. 200 A 2 — same carry mechanics, different rate calc), per-asset-type segmentation (PEA / dérivés / SOFICA — filter upstream), and \`plus-values immobilières\` are still deferred.

## Test plan

### Vintage / carryover constructors
- [x] \`PfuLossVintage\` rejects negative amount; allows zero
- [x] \`PfuCarryover.zero()\` returns empty tuple, \`total = 0.00\`
- [x] \`PfuCarryover.total\` quantises sum
- [x] \`normalised\` sorts oldest-first and drops zero-amount entries

### Constants
- [x] \`CARRY_FORWARD_YEARS == 10\`

### No prior — same-year mechanics
- [x] Pure-gain year → no carry, just standard 30 % PFU
- [x] Pure-loss year → new vintage tagged with \`current_year\`

### Prior loss applied FIFO
- [x] Oldest vintage absorbs first; partially-consumed newer vintage carries forward
- [x] Gain above prior loss → remainder taxed at 12.8 % + 17.2 %

### 10-year expiry
- [x] Vintage at the 10-year wall is expired (cannot offset; surfaced via \`expired\`)
- [x] Vintage one year inside the window still usable

### Multi-year sequence
- [x] Loss → partial use → full use chain across three years preserves vintage tags