### PR TITLE
feat(tax): multi-jurisdiction carryover dispatcher (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -28,6 +28,7 @@ from engine.core.tax.reports.hmrc_cgt import (
 from engine.core.tax.reports.dispatcher import (
     TaxableDisposal,
     UnsupportedJurisdictionError,
+    carryover_for_jurisdiction,
     flatten_summary_to_csv,
     report_for_jurisdiction,
 )
@@ -120,6 +121,7 @@ __all__ = [
     "apply_cgt_carryover",
     "apply_kest_carryover",
     "apply_pfu_carryover",
+    "carryover_for_jurisdiction",
     "disposals_to_csv",
     "flatten_summary_to_csv",
     "generate_1099b_rows",

--- a/engine/core/tax/reports/dispatcher.py
+++ b/engine/core/tax/reports/dispatcher.py
@@ -38,6 +38,16 @@ from decimal import Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from engine.core.tax.reports.carryover import (
+    CapitalLossApplication,
+    CapitalLossCarryover,
+    apply_carryover,
+)
+from engine.core.tax.reports.cgt_carryover import (
+    CgtApplication,
+    CgtCarryover,
+    apply_cgt_carryover,
+)
 from engine.core.tax.reports.form_1099b import (
     LotDisposition,
     generate_1099b_rows,
@@ -48,6 +58,16 @@ from engine.core.tax.reports.kest import (
     AssetClass,
     KestDisposal,
     summarize_kest,
+)
+from engine.core.tax.reports.kest_carryover import (
+    KestApplication,
+    KestCarryover,
+    apply_kest_carryover,
+)
+from engine.core.tax.reports.pfu_carryover import (
+    PfuApplication,
+    PfuCarryover,
+    apply_pfu_carryover,
 )
 from engine.core.tax.reports.schedule_d import summarize_schedule_d
 
@@ -229,9 +249,98 @@ def _render_scalar(value: Any) -> str:
     return "" if value is None else str(value)
 
 
+JurisdictionCarryover = (
+    "CapitalLossCarryover | CgtCarryover | KestCarryover | PfuCarryover"
+)
+CarryoverApplication = (
+    "CapitalLossApplication | CgtApplication | KestApplication | PfuApplication"
+)
+
+
+def carryover_for_jurisdiction(
+    code: str,
+    disposals: list[TaxableDisposal],
+    prior: Any = None,
+    *,
+    current_year: int | None = None,
+    **kwargs: Any,
+):
+    """Run the per-jurisdiction carryover applier for ``code``.
+
+    ``prior`` must match the jurisdiction's carryover record type:
+
+    - US → :class:`CapitalLossCarryover` (or ``None``).
+    - GB → :class:`CgtCarryover` (or ``None``).
+    - DE → :class:`KestCarryover` (or ``None``).
+    - FR → :class:`PfuCarryover` (or ``None``).
+
+    ``current_year`` is required for FR (used to date new vintages and
+    expire ones older than ten years). It is ignored by every other
+    jurisdiction.
+
+    Extra ``kwargs`` are forwarded to the underlying applier:
+
+    - US: ``deductible_cap``.
+    - GB: ``annual_exempt_amount``.
+    - DE: ``allowance``, ``church_tax_rate``.
+    - FR: (none beyond ``current_year``).
+
+    The return type is the union of the four ``Application`` records;
+    callers branch on it via ``isinstance``.
+    """
+    norm = code.upper()
+    if norm == "US":
+        _ensure_prior(prior, CapitalLossCarryover)
+        rows = generate_1099b_rows([_to_us(d) for d in disposals])
+        summary = summarize_schedule_d(rows)
+        return apply_carryover(summary, prior, **kwargs)
+    if norm == "GB":
+        _ensure_prior(prior, CgtCarryover)
+        return apply_cgt_carryover(
+            [_to_gb(d) for d in disposals], prior, **kwargs
+        )
+    if norm == "DE":
+        _ensure_prior(prior, KestCarryover)
+        return apply_kest_carryover(
+            [_to_de(d) for d in disposals], prior, **kwargs
+        )
+    if norm == "FR":
+        _ensure_prior(prior, PfuCarryover)
+        if current_year is None:
+            raise ValueError(
+                "FR carryover requires current_year (used for vintage "
+                "tagging + 10-year expiry)"
+            )
+        return apply_pfu_carryover(
+            [_to_fr(d) for d in disposals],
+            prior,
+            current_year=current_year,
+            **kwargs,
+        )
+    raise UnsupportedJurisdictionError(
+        f"unknown jurisdiction {code!r}; supported: US, GB, DE, FR"
+    )
+
+
+def _ensure_prior(prior: Any, expected: type) -> None:
+    """Raise :class:`TypeError` if ``prior`` is set but not the right
+    carryover record type for the jurisdiction. ``None`` is always
+    accepted (each applier defaults to a zero carryover)."""
+    if prior is None:
+        return
+    if not isinstance(prior, expected):
+        raise TypeError(
+            f"prior must be {expected.__name__} or None, "
+            f"got {type(prior).__name__}"
+        )
+
+
 __all__ = [
+    "CarryoverApplication",
+    "JurisdictionCarryover",
     "TaxableDisposal",
     "UnsupportedJurisdictionError",
+    "carryover_for_jurisdiction",
     "flatten_summary_to_csv",
     "report_for_jurisdiction",
 ]

--- a/tests/test_carryover_dispatcher.py
+++ b/tests/test_carryover_dispatcher.py
@@ -1,0 +1,230 @@
+"""Tests for the multi-jurisdiction carryover dispatcher (gh#155 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    CapitalLossApplication,
+    CapitalLossCarryover,
+    CgtApplication,
+    CgtCarryover,
+    KestApplication,
+    KestCarryover,
+    PfuApplication,
+    PfuCarryover,
+    TaxableDisposal,
+    UnsupportedJurisdictionError,
+    carryover_for_jurisdiction,
+)
+
+
+def _disp(*, proceeds: str, cost: str) -> TaxableDisposal:
+    return TaxableDisposal(
+        description="100 ABC",
+        acquired=date(2023, 6, 1),
+        disposed=date(2024, 6, 1),
+        proceeds=Decimal(proceeds),
+        cost=Decimal(cost),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-jurisdiction routing
+# ---------------------------------------------------------------------------
+
+
+class TestUsRouting:
+    def test_us_returns_capital_loss_application(self):
+        # Long-term loss: -2,000.
+        disposals = [
+            TaxableDisposal(
+                description="3 shares MSFT",
+                acquired=date(2022, 1, 1),
+                disposed=date(2024, 6, 1),
+                proceeds=Decimal("100"),
+                cost=Decimal("2100"),
+            )
+        ]
+
+        result = carryover_for_jurisdiction("US", disposals)
+
+        assert isinstance(result, CapitalLossApplication)
+        # 2,000 loss → fully deducted under the $3,000 cap.
+        assert result.current_year_deduction == Decimal("2000.00")
+        assert result.next_year_carryover == CapitalLossCarryover.zero()
+
+    def test_us_prior_loss_compounds_within_cap(self):
+        prior = CapitalLossCarryover(
+            short_term=Decimal("2000"), long_term=Decimal("0")
+        )
+        result = carryover_for_jurisdiction("US", [], prior)
+
+        assert isinstance(result, CapitalLossApplication)
+        assert result.current_year_deduction == Decimal("2000.00")
+
+    def test_us_wrong_prior_type_rejected(self):
+        with pytest.raises(TypeError):
+            carryover_for_jurisdiction("US", [], CgtCarryover.zero())
+
+
+class TestGbRouting:
+    def test_gb_returns_cgt_application(self):
+        result = carryover_for_jurisdiction(
+            "GB",
+            [_disp(proceeds="20000", cost="10000")],
+        )
+
+        assert isinstance(result, CgtApplication)
+        # +£10,000 → £7,000 post-AEA.
+        assert result.summary.taxable_gain == Decimal("7000.00")
+        assert result.taxable_gain_after_carryover == Decimal("7000.00")
+
+    def test_gb_prior_loss_offsets_post_aea(self):
+        prior = CgtCarryover(loss=Decimal("4000"))
+        result = carryover_for_jurisdiction(
+            "GB",
+            [_disp(proceeds="20000", cost="10000")],
+            prior,
+        )
+
+        assert result.carryover_loss_used == Decimal("4000.00")
+        assert result.taxable_gain_after_carryover == Decimal("3000.00")
+
+    def test_gb_wrong_prior_type_rejected(self):
+        with pytest.raises(TypeError):
+            carryover_for_jurisdiction(
+                "GB", [], CapitalLossCarryover.zero()
+            )
+
+
+class TestDeRouting:
+    def test_de_returns_kest_application(self):
+        result = carryover_for_jurisdiction(
+            "DE", [_disp(proceeds="6000", cost="1000")]
+        )
+
+        assert isinstance(result, KestApplication)
+        # +5,000 → 4,000 taxable post-allowance.
+        assert result.summary.taxable_income == Decimal("4000.00")
+        assert result.summary.kest == Decimal("1000.00")
+
+    def test_de_prior_equity_carryover_applied(self):
+        prior = KestCarryover(
+            equity=Decimal("4000"), other=Decimal("0")
+        )
+        result = carryover_for_jurisdiction(
+            "DE",
+            [_disp(proceeds="6000", cost="1000")],
+            prior,
+        )
+
+        # Equity after prior: 5,000 - 4,000 = 1,000. Below allowance.
+        assert result.summary.equity_net == Decimal("1000.00")
+        assert result.summary.taxable_income == Decimal("0.00")
+
+    def test_de_wrong_prior_type_rejected(self):
+        with pytest.raises(TypeError):
+            carryover_for_jurisdiction("DE", [], CgtCarryover.zero())
+
+
+class TestFrRouting:
+    def test_fr_requires_current_year(self):
+        with pytest.raises(ValueError):
+            carryover_for_jurisdiction("FR", [])
+
+    def test_fr_returns_pfu_application(self):
+        result = carryover_for_jurisdiction(
+            "FR",
+            [_disp(proceeds="6000", cost="5000")],
+            current_year=2024,
+        )
+
+        assert isinstance(result, PfuApplication)
+        assert result.taxable_gain_after_carryover == Decimal("1000.00")
+        assert result.total_tax_after_carryover == Decimal("300.00")
+
+    def test_fr_prior_carryover_applied(self):
+        prior = PfuCarryover.zero()
+        result = carryover_for_jurisdiction(
+            "FR",
+            [_disp(proceeds="500", cost="2000")],
+            prior,
+            current_year=2024,
+        )
+
+        # Loss year creates a new vintage tagged 2024.
+        assert isinstance(result, PfuApplication)
+        assert len(result.next_year_carryover.vintages) == 1
+        assert result.next_year_carryover.vintages[0].year == 2024
+
+    def test_fr_wrong_prior_type_rejected(self):
+        with pytest.raises(TypeError):
+            carryover_for_jurisdiction(
+                "FR", [], KestCarryover.zero(), current_year=2024
+            )
+
+
+# ---------------------------------------------------------------------------
+# Casing + unknown jurisdiction
+# ---------------------------------------------------------------------------
+
+
+class TestCasing:
+    def test_lowercase_code_accepted(self):
+        result = carryover_for_jurisdiction(
+            "us", [_disp(proceeds="100", cost="200")]
+        )
+        assert isinstance(result, CapitalLossApplication)
+
+
+class TestUnknown:
+    def test_unknown_code_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedJurisdictionError):
+            carryover_for_jurisdiction("ZZ", [])
+
+
+# ---------------------------------------------------------------------------
+# Forwarded kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestKwargForwarding:
+    def test_us_deductible_cap_forwarded(self):
+        # MFS filing → $1,500 cap. -$5,000 loss → $1,500 deducted,
+        # $3,500 carry.
+        disposals = [
+            TaxableDisposal(
+                description="x",
+                acquired=date(2023, 1, 1),
+                disposed=date(2024, 1, 1),
+                proceeds=Decimal("0"),
+                cost=Decimal("5000"),
+            )
+        ]
+        result = carryover_for_jurisdiction(
+            "US", disposals, deductible_cap=Decimal("1500")
+        )
+        assert result.current_year_deduction == Decimal("1500.00")
+        assert result.next_year_carryover.short_term == Decimal("3500.00")
+
+    def test_gb_annual_exempt_amount_forwarded(self):
+        # 2022-23 AEA was £12,300; +£10,000 gain → 0 taxable.
+        result = carryover_for_jurisdiction(
+            "GB",
+            [_disp(proceeds="20000", cost="10000")],
+            annual_exempt_amount=Decimal("12300"),
+        )
+        assert result.summary.taxable_gain == Decimal("0.00")
+
+    def test_de_church_tax_rate_forwarded(self):
+        result = carryover_for_jurisdiction(
+            "DE",
+            [_disp(proceeds="6000", cost="1000")],
+            church_tax_rate=Decimal("0.09"),
+        )
+        # Church tax 9 % of KESt (1,000) = 90.
+        assert result.summary.church_tax == Decimal("90.00")


### PR DESCRIPTION
## Summary

Single entrypoint that routes per-jurisdiction loss carry-forward work to the right applier. With #309 (US), #316 (DE), #317 (GB), and #318 (FR) all merged, this PR closes the loop so a higher-layer client (multi-year aggregator, tax-export API) can pick "carry this taxpayer's losses forward" via one call.

API:
- \`carryover_for_jurisdiction(code, disposals, prior=None, *, current_year=None, **kwargs)\` — case-insensitive code routing.
  - US → \`CapitalLossApplication\` (\`apply_carryover\`; \`deductible_cap\` forwarded).
  - GB → \`CgtApplication\` (\`apply_cgt_carryover\`; \`annual_exempt_amount\` forwarded).
  - DE → \`KestApplication\` (\`apply_kest_carryover\`; \`allowance\` + \`church_tax_rate\` forwarded; equity ring-fence preserved).
  - FR → \`PfuApplication\` (\`apply_pfu_carryover\`; \`current_year\` required for vintage-tagging + 10-year expiry).
- \`JurisdictionCarryover\`, \`CarryoverApplication\` — string union aliases for type-checking client code.

\`prior\` must match the jurisdiction's carryover record type (\`TypeError\` if mismatched). \`None\` is always accepted — each applier defaults to a zero carryover.

\`current_year\` is required for FR. Other jurisdictions ignore it.

Refs #155. The dispatcher is intentionally thin: each applier already owns its own algorithm; this is just the single switch point so client code does not regrow per-jurisdiction branches.

## Test plan

- [x] US routing returns \`CapitalLossApplication\` for fresh disposals
- [x] US prior loss compounds within the cap
- [x] US wrong-prior-type rejected
- [x] GB routing returns \`CgtApplication\` with AEA applied
- [x] GB prior loss offsets post-AEA taxable gain
- [x] GB wrong-prior-type rejected
- [x] DE routing returns \`KestApplication\` with KESt + SolZ totals
- [x] DE prior equity carry offsets current equity gain
- [x] DE wrong-prior-type rejected
- [x] FR requires \`current_year\` (\`ValueError\`)
- [x] FR routing returns \`PfuApplication\` with 12.8/17.2 % breakdown
- [x] FR prior loss-year creates a new vintage tagged with \`current_year\`
- [x] FR wrong-prior-type rejected
- [x] Lowercase code accepted
- [x] Unknown code raises \`UnsupportedJurisdictionError\`
- [x] Kwarg forwarding for \`deductible_cap\` (US), \`annual_exempt_amount\` (GB), and \`church_tax_rate\` (DE)