### PR TITLE
feat(tax): MiFID II RTS 22 transaction-report scaffold (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -32,6 +32,14 @@ from engine.core.tax.reports.dispatcher import (
     flatten_summary_to_csv,
     report_for_jurisdiction,
 )
+from engine.core.tax.reports.mifid2 import (
+    RTS_22_COLUMNS,
+    IdType,
+    MiFID2Transaction,
+    Side,
+    TradingCapacity,
+    transactions_to_csv,
+)
 from engine.core.tax.reports.france_pfu import (
     PFU_INCOME_TAX_RATE,
     PFU_SOCIAL_CHARGES_RATE,
@@ -95,10 +103,15 @@ __all__ = [
     "DEDUCTIBLE_CAP_MFS",
     "Form6781Summary",
     "KEST_RATE",
+    "IdType",
     "LONG_TERM_PCT",
+    "MiFID2Transaction",
     "PFU_INCOME_TAX_RATE",
+    "RTS_22_COLUMNS",
     "SHORT_TERM_PCT",
     "Section1256Contract",
+    "Side",
+    "TradingCapacity",
     "PFU_SOCIAL_CHARGES_RATE",
     "PFU_TOTAL_RATE",
     "PfuApplication",
@@ -146,4 +159,5 @@ __all__ = [
     "summarize_pfu",
     "summarize_schedule_d",
     "summary_to_csv",
+    "transactions_to_csv",
 ]

--- a/engine/core/tax/reports/mifid2.py
+++ b/engine/core/tax/reports/mifid2.py
@@ -1,0 +1,223 @@
+"""MiFID II RTS 22 transaction-report scaffold (gh#155).
+
+Renders the most-essential ~20 of the 65 fields ESMA's Regulatory
+Technical Standard 22 (Commission Delegated Regulation 2017/590)
+requires for post-trade transaction reports. The intent is to give
+operators a serialiser they can wire into their own reporting
+pipelines without owning the full RTS 22 schema themselves.
+
+Operators of an EU MiFID II investment firm are required to send the
+T+1 transaction report to their National Competent Authority via an
+Approved Reporting Mechanism (ARM). This module produces a CSV that
+matches the ARM's expected layout for the *core* fields; downstream
+tooling enriches the file with the remaining fields (notification
+codes, decision-maker IDs, waiver indicators, commodity-derivative
+flags, etc.).
+
+Field coverage
+--------------
+Implemented (ESMA RTS 22 Annex Field number in parentheses):
+
+- 1  Transaction reference number
+- 2  Trading venue transaction identification code
+- 3  Executing entity LEI
+- 4  Investment-firm-covered indicator
+- 5  Submitting entity LEI
+- 6  Buyer identification type
+- 7  Buyer LEI / national ID
+- 15 Seller identification type
+- 16 Seller LEI / national ID
+- 28 Trading date and time (UTC)
+- 29 Trading capacity
+- 30 Quantity
+- 31 Quantity currency / unit (XBT/USD/etc.)
+- 32 Side (buy/sell)
+- 33 Price
+- 34 Price currency
+- 35 Country of branch (where applicable)
+- 36 Trading venue (MIC code)
+- 41 Instrument identification code (ISIN)
+- 43 CFI code
+
+Deferred (~45 fields) — explicit follow-ups:
+
+- Counterparty fields beyond the buyer/seller pair
+  (intermediary IDs, transmission codes).
+- Decision-maker fields 8–14 and 17–24 (algorithmic ID, decision-
+  maker LEI, executor ID, etc.).
+- Commodity-derivative indicators (fields 53–55).
+- Securities-financing-transaction flags (fields 56–62).
+- Waivers and short-sale indicator (fields 63–65).
+- Schema validation against the official ESMA XSD.
+
+What's NOT here
+---------------
+- ARM-specific transport (FIX, SFTP, MQ). Operators wire that.
+- Reference-data resolution (ISIN ↔ CFI lookups).
+- Position reporting under MiFIR Article 26(2) — different schema.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+
+_TWOPLACES = Decimal("0.01")
+
+
+class Side(str, Enum):
+    BUYI = "BUYI"  # ESMA RTS 22 buy code
+    SELL = "SELL"  # ESMA RTS 22 sell code
+
+
+class TradingCapacity(str, Enum):
+    """ESMA RTS 22 trading-capacity codes."""
+
+    DEAL = "DEAL"  # dealing on own account
+    MTCH = "MTCH"  # matched principal
+    AOTC = "AOTC"  # any other trading capacity (agency)
+
+
+class IdType(str, Enum):
+    """Identification type for buyer/seller. The full RTS 22 set is
+    larger; this scaffold covers LEI for entities and NIDN (national
+    identifier) for natural persons."""
+
+    LEI = "LEI"
+    NIDN = "NIDN"
+
+
+@dataclass(frozen=True)
+class MiFID2Transaction:
+    """Minimum-viable RTS 22 transaction record."""
+
+    transaction_reference_number: str
+    venue_transaction_id: str | None
+    executing_entity_lei: str
+    investment_firm_covered: bool
+    submitting_entity_lei: str
+    buyer_id_type: IdType
+    buyer_id: str
+    seller_id_type: IdType
+    seller_id: str
+    trading_capacity: TradingCapacity
+    quantity: Decimal
+    quantity_unit_or_ccy: str
+    price: Decimal
+    price_currency: str
+    trading_datetime: datetime
+    trading_venue: str
+    instrument_isin: str
+    cfi_code: str
+    side: Side
+    branch_country: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.transaction_reference_number:
+            raise ValueError("transaction_reference_number must be non-empty")
+        if not self.executing_entity_lei:
+            raise ValueError("executing_entity_lei must be non-empty")
+        if not self.submitting_entity_lei:
+            raise ValueError("submitting_entity_lei must be non-empty")
+        if self.quantity <= 0:
+            raise ValueError("quantity must be positive")
+        if self.price < 0:
+            raise ValueError("price must be non-negative")
+        if (
+            self.trading_datetime.tzinfo is None
+            or self.trading_datetime.utcoffset() is None
+        ):
+            raise ValueError(
+                "trading_datetime must be timezone-aware (UTC required by RTS 22)"
+            )
+
+
+# ESMA expects an exact column order for ARM submission.
+RTS_22_COLUMNS: tuple[str, ...] = (
+    "transaction_reference_number",  # 1
+    "venue_transaction_id",  # 2
+    "executing_entity_lei",  # 3
+    "investment_firm_covered",  # 4
+    "submitting_entity_lei",  # 5
+    "buyer_id_type",  # 6
+    "buyer_id",  # 7
+    "seller_id_type",  # 15
+    "seller_id",  # 16
+    "trading_datetime",  # 28
+    "trading_capacity",  # 29
+    "quantity",  # 30
+    "quantity_unit_or_ccy",  # 31
+    "side",  # 32
+    "price",  # 33
+    "price_currency",  # 34
+    "branch_country",  # 35
+    "trading_venue",  # 36
+    "instrument_isin",  # 41
+    "cfi_code",  # 43
+)
+
+
+def transactions_to_csv(transactions: list[MiFID2Transaction]) -> str:
+    """Render ``transactions`` to RTS-22-shaped CSV.
+
+    Datetimes serialise as ``YYYY-MM-DDTHH:MM:SS.ffffffZ`` (UTC),
+    booleans render as ``true`` / ``false``, decimals quantise to two
+    places. Empty optional values become empty strings.
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(RTS_22_COLUMNS)
+    for t in transactions:
+        writer.writerow(
+            [
+                t.transaction_reference_number,
+                t.venue_transaction_id or "",
+                t.executing_entity_lei,
+                "true" if t.investment_firm_covered else "false",
+                t.submitting_entity_lei,
+                t.buyer_id_type.value,
+                t.buyer_id,
+                t.seller_id_type.value,
+                t.seller_id,
+                _fmt_dt(t.trading_datetime),
+                t.trading_capacity.value,
+                _fmt_money(t.quantity),
+                t.quantity_unit_or_ccy,
+                t.side.value,
+                _fmt_money(t.price),
+                t.price_currency,
+                t.branch_country,
+                t.trading_venue,
+                t.instrument_isin,
+                t.cfi_code,
+            ]
+        )
+    return buf.getvalue()
+
+
+def _fmt_money(value: Decimal) -> str:
+    return f"{value.quantize(_TWOPLACES)}"
+
+
+def _fmt_dt(value: datetime) -> str:
+    """ESMA expects UTC datetimes in the extended ISO 8601 form ending
+    in ``Z``. Convert to UTC first so a non-UTC timezone-aware input
+    is normalised, then patch ``+00:00`` to ``Z``."""
+    iso = value.astimezone(UTC).isoformat()
+    if iso.endswith("+00:00"):
+        return iso[:-6] + "Z"
+    return iso
+
+
+__all__ = [
+    "RTS_22_COLUMNS",
+    "IdType",
+    "MiFID2Transaction",
+    "Side",
+    "TradingCapacity",
+    "transactions_to_csv",
+]

--- a/tests/test_mifid2.py
+++ b/tests/test_mifid2.py
@@ -1,0 +1,196 @@
+"""Tests for the MiFID II RTS 22 transaction-report scaffold (gh#155)."""
+
+from __future__ import annotations
+
+import csv as _csv
+import io
+from datetime import UTC, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    RTS_22_COLUMNS,
+    IdType,
+    MiFID2Transaction,
+    Side,
+    TradingCapacity,
+    transactions_to_csv,
+)
+
+
+def _txn(**overrides) -> MiFID2Transaction:
+    base: dict = {
+        "transaction_reference_number": "TRN-0001",
+        "venue_transaction_id": "VTID-001",
+        "executing_entity_lei": "529900XYZABC1234567A",
+        "investment_firm_covered": True,
+        "submitting_entity_lei": "529900XYZABC1234567A",
+        "buyer_id_type": IdType.LEI,
+        "buyer_id": "529900BUYR1234567X",
+        "seller_id_type": IdType.LEI,
+        "seller_id": "529900SELR1234567Y",
+        "trading_capacity": TradingCapacity.AOTC,
+        "quantity": Decimal("100"),
+        "quantity_unit_or_ccy": "UNIT",
+        "price": Decimal("12.50"),
+        "price_currency": "EUR",
+        "trading_datetime": datetime(2024, 6, 1, 14, 30, 15, tzinfo=UTC),
+        "trading_venue": "XPAR",
+        "instrument_isin": "FR0000131104",
+        "cfi_code": "ESVUFR",
+        "side": Side.BUYI,
+        "branch_country": "FR",
+    }
+    base.update(overrides)
+    return MiFID2Transaction(**base)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_empty_reference_rejected(self):
+        with pytest.raises(ValueError):
+            _txn(transaction_reference_number="")
+
+    def test_empty_executing_entity_rejected(self):
+        with pytest.raises(ValueError):
+            _txn(executing_entity_lei="")
+
+    def test_empty_submitting_entity_rejected(self):
+        with pytest.raises(ValueError):
+            _txn(submitting_entity_lei="")
+
+    def test_zero_quantity_rejected(self):
+        with pytest.raises(ValueError):
+            _txn(quantity=Decimal("0"))
+
+    def test_negative_price_rejected(self):
+        with pytest.raises(ValueError):
+            _txn(price=Decimal("-1"))
+
+    def test_naive_datetime_rejected(self):
+        # RTS 22 requires UTC. Naive datetimes are ambiguous.
+        with pytest.raises(ValueError):
+            _txn(trading_datetime=datetime(2024, 6, 1, 14, 30, 15))
+
+
+# ---------------------------------------------------------------------------
+# Constants / enums
+# ---------------------------------------------------------------------------
+
+
+class TestEnums:
+    def test_side_codes_match_esma(self):
+        assert Side.BUYI.value == "BUYI"
+        assert Side.SELL.value == "SELL"
+
+    def test_trading_capacity_codes_match_esma(self):
+        assert TradingCapacity.DEAL.value == "DEAL"
+        assert TradingCapacity.MTCH.value == "MTCH"
+        assert TradingCapacity.AOTC.value == "AOTC"
+
+    def test_id_type_codes_match_esma(self):
+        assert IdType.LEI.value == "LEI"
+        assert IdType.NIDN.value == "NIDN"
+
+
+class TestColumnOrder:
+    def test_columns_match_rts22_field_order(self):
+        # First three are reference + venue id + executing LEI;
+        # quantity comes after the buyer/seller block; CFI is last.
+        assert RTS_22_COLUMNS[0] == "transaction_reference_number"
+        assert RTS_22_COLUMNS[1] == "venue_transaction_id"
+        assert RTS_22_COLUMNS[2] == "executing_entity_lei"
+        assert RTS_22_COLUMNS[-1] == "cfi_code"
+        # No duplicates.
+        assert len(set(RTS_22_COLUMNS)) == len(RTS_22_COLUMNS)
+        # Exactly 20 fields in this scaffold.
+        assert len(RTS_22_COLUMNS) == 20
+
+
+# ---------------------------------------------------------------------------
+# CSV serialisation
+# ---------------------------------------------------------------------------
+
+
+def _parse(text: str) -> tuple[list[str], list[list[str]]]:
+    rows = list(_csv.reader(io.StringIO(text)))
+    return rows[0], rows[1:]
+
+
+class TestCsv:
+    def test_header_matches_column_constant(self):
+        out = transactions_to_csv([_txn()])
+        header, _ = _parse(out)
+        assert header == list(RTS_22_COLUMNS)
+
+    def test_single_transaction_row_shape(self):
+        out = transactions_to_csv([_txn()])
+        header, body = _parse(out)
+        assert len(body) == 1
+        idx = {col: i for i, col in enumerate(header)}
+        row = body[0]
+
+        assert row[idx["transaction_reference_number"]] == "TRN-0001"
+        assert row[idx["executing_entity_lei"]] == "529900XYZABC1234567A"
+        assert row[idx["investment_firm_covered"]] == "true"
+        assert row[idx["buyer_id_type"]] == "LEI"
+        assert row[idx["seller_id"]] == "529900SELR1234567Y"
+        assert row[idx["trading_capacity"]] == "AOTC"
+        assert row[idx["quantity"]] == "100.00"
+        assert row[idx["price"]] == "12.50"
+        assert row[idx["side"]] == "BUYI"
+        assert row[idx["instrument_isin"]] == "FR0000131104"
+        assert row[idx["cfi_code"]] == "ESVUFR"
+
+    def test_datetime_serialises_utc_with_z_suffix(self):
+        out = transactions_to_csv([_txn()])
+        _, body = _parse(out)
+        # Datetime column should end with "Z", not "+00:00".
+        assert "2024-06-01T14:30:15Z" in body[0]
+        for cell in body[0]:
+            if cell.startswith("2024-06-01"):
+                assert cell.endswith("Z")
+                assert "+00:00" not in cell
+
+    def test_non_utc_datetime_normalised_to_utc(self):
+        # +02:00 timezone — should convert to 12:30:15Z.
+        cest = timezone(timedelta(hours=2))
+        out = transactions_to_csv(
+            [
+                _txn(
+                    trading_datetime=datetime(
+                        2024, 6, 1, 14, 30, 15, tzinfo=cest
+                    )
+                )
+            ]
+        )
+        _, body = _parse(out)
+        assert any(
+            cell == "2024-06-01T12:30:15Z"
+            for cell in body[0]
+        )
+
+    def test_empty_optional_venue_id_renders_blank(self):
+        out = transactions_to_csv([_txn(venue_transaction_id=None)])
+        header, body = _parse(out)
+        idx = {col: i for i, col in enumerate(header)}
+        assert body[0][idx["venue_transaction_id"]] == ""
+
+    def test_investment_firm_false_renders_lowercase_false(self):
+        out = transactions_to_csv([_txn(investment_firm_covered=False)])
+        header, body = _parse(out)
+        idx = {col: i for i, col in enumerate(header)}
+        assert body[0][idx["investment_firm_covered"]] == "false"
+
+
+class TestEmpty:
+    def test_empty_list_yields_header_only(self):
+        out = transactions_to_csv([])
+        header, body = _parse(out)
+        assert header == list(RTS_22_COLUMNS)
+        assert body == []


### PR DESCRIPTION
## Summary

Renders the most-essential 20 of the 65 fields ESMA's Regulatory Technical Standard 22 (Commission Delegated Regulation 2017/590) requires for post-trade transaction reports. Operators wire this CSV into their Approved Reporting Mechanism (ARM) pipeline; downstream tooling enriches with the remaining ~45 fields.

API:
- \`MiFID2Transaction\` — frozen dataclass with the core fields: reference, venue-txn-id, executing/submitting LEI, buyer/seller id + type, trading capacity, quantity + unit, price + currency, trading datetime UTC, MIC code, ISIN, CFI, side, branch country. Validates non-empty reference + LEIs, positive quantity, non-negative price, and timezone-aware datetime (RTS 22 mandates UTC).
- \`Side\` / \`TradingCapacity\` / \`IdType\` enums with ESMA codes (\`BUYI\`/\`SELL\`, \`DEAL\`/\`MTCH\`/\`AOTC\`, \`LEI\`/\`NIDN\`).
- \`RTS_22_COLUMNS\` — constant pinning the column order ARMs expect.
- \`transactions_to_csv(transactions)\` — RTS-22-shaped CSV. Datetimes serialise as \`YYYY-MM-DDTHH:MM:SSZ\` (UTC, normalised from any tz-aware input), booleans as \`true\`/\`false\`, decimals quantised to two places.

Implemented field numbers (ESMA Annex): 1, 2, 3, 4, 5, 6, 7, 15, 16, 28, 29, 30, 31, 32, 33, 34, 35, 36, 41, 43.

Refs #155. Deferred (~45 fields):
- Counterparty / intermediary / transmission codes
- Decision-maker fields 8-14 + 17-24 (algo-id, decision-maker LEI, executor id)
- Commodity-derivative indicators (53-55)
- Securities-financing-transaction flags (56-62)
- Waivers + short-sale indicator (63-65)
- ESMA XSD validation
- ARM transport (FIX / SFTP / MQ)
- Reference-data resolution (ISIN ↔ CFI lookups)
- Position reporting under MiFIR Article 26(2)

## Test plan

- [x] Validation: empty reference / executing LEI / submitting LEI rejected
- [x] Validation: zero quantity / negative price / naive datetime rejected
- [x] Enum codes match ESMA spec (Side / TradingCapacity / IdType)
- [x] \`RTS_22_COLUMNS\` is exactly 20 unique fields with the right anchors
- [x] CSV header equals \`RTS_22_COLUMNS\`
- [x] Single-transaction row carries every field in the right column
- [x] UTC datetime renders with \`Z\` suffix (not \`+00:00\`)
- [x] Non-UTC datetime normalises to UTC (CEST 14:30 → 12:30Z)
- [x] Empty optional \`venue_transaction_id\` renders blank
- [x] Boolean \`investment_firm_covered\` renders as \`true\` / \`false\` lowercase
- [x] Empty list yields header-only CSV