### PR TITLE
ci: gate Release Please behind workflow_dispatch (manual only)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,21 @@
 name: Release Please
 
+# Manual trigger only. The default `push: main` trigger fails under
+# the org-level "Allow GitHub Actions to create and approve pull
+# requests" policy: release-please needs to create the release-PR,
+# which the org currently blocks. Operators run this workflow by
+# hand from the Actions tab once a personal-access-token (or GitHub
+# App token) is wired into the secrets store as RELEASE_PLEASE_TOKEN.
+#
+# To re-enable automatic release PRs:
+# 1. Create a fine-grained PAT or GitHub App with `contents: write`
+#    + `pull_requests: write` on this repo.
+# 2. Add it as the secret `RELEASE_PLEASE_TOKEN`.
+# 3. Pass `token: ${{ secrets.RELEASE_PLEASE_TOKEN }}` to the action
+#    below and restore the `push: main` trigger.
+
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

The \`push: main\` trigger on \`Release Please\` fails under the org-level policy that blocks GitHub Actions from creating or approving pull requests:

\`\`\`
##[error]release-please failed: GitHub Actions is not permitted to create or approve pull requests.
\`\`\`

The default \`GITHUB_TOKEN\` can't create the release-PR while that setting is off, so every merge to main produced a red Release Please run alongside the green CI run.

Switch the trigger to \`workflow_dispatch\` so the workflow only runs when an operator clicks "Run workflow" from the Actions tab. The action body is preserved verbatim so re-enabling automatic release PRs is a one-line change once a PAT (or GitHub App token) is wired into the secrets store as \`RELEASE_PLEASE_TOKEN\` — see the inline comment in the workflow for the three steps.

## Test plan

- [x] YAML parses cleanly (\`yaml.safe_load\`)
- [x] No code import path depends on this workflow
- [ ] After merge: confirm no automatic Release Please runs are queued on push events
- [ ] After merge: operator can still fire it manually from the Actions tab when needed