### PR TITLE
feat(tax): IRS Form 6781 Part II § 1092 straddle-loss limitation (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -82,6 +82,12 @@ from engine.core.tax.reports.form_6781 import (
     contracts_to_csv,
     summarize_form6781,
 )
+from engine.core.tax.reports.form_6781_part_ii import (
+    Form6781PartIISummary,
+    StraddleLeg,
+    legs_to_csv,
+    summarize_form6781_part_ii,
+)
 from engine.core.tax.reports.section_1256_carryback import (
     CARRYBACK_YEARS,
     CarrybackAbsorption,
@@ -109,6 +115,7 @@ __all__ = [
     "CHURCH_TAX_RATE_OTHER",
     "DEDUCTIBLE_CAP_DEFAULT",
     "DEDUCTIBLE_CAP_MFS",
+    "Form6781PartIISummary",
     "Form6781Summary",
     "KEST_RATE",
     "IdType",
@@ -152,6 +159,7 @@ __all__ = [
     "ScheduleDPartTotal",
     "ScheduleDSummary",
     "Section1256Carryback",
+    "StraddleLeg",
     "ShortSaleIndicator",
     "TaxableDisposal",
     "UnsupportedJurisdictionError",
@@ -165,10 +173,12 @@ __all__ = [
     "disposals_to_csv",
     "flatten_summary_to_csv",
     "generate_1099b_rows",
+    "legs_to_csv",
     "report_for_jurisdiction",
     "rows_to_csv",
     "summarize_cgt",
     "summarize_form6781",
+    "summarize_form6781_part_ii",
     "summarize_kest",
     "summarize_pfu",
     "summarize_schedule_d",

--- a/engine/core/tax/reports/form_6781_part_ii.py
+++ b/engine/core/tax/reports/form_6781_part_ii.py
@@ -1,0 +1,158 @@
+"""IRS Form 6781 Part II — Section 1092 straddle-loss limitation.
+
+A straddle (IRC § 1092) is an offsetting pair of positions in actively-
+traded personal property: closing one leg at a loss when the other
+leg still has an unrealized gain triggers a *deferral* of the loss to
+the extent of the offsetting unrealized gain.
+
+Per-leg rule (Form 6781 Part II)
+-------------------------------
+For each straddle pair where the loss leg has been closed:
+
+- ``allowed_loss = max(recognized_loss - unrecognized_offsetting_gain, 0)``
+- ``deferred_loss = recognized_loss - allowed_loss``
+
+The deferred portion carries forward into the basis of the still-open
+offsetting leg under § 1092(a)(1)(B). This module does not modify the
+basis itself — it surfaces the ``deferred_loss`` so the caller's lot
+ledger applies the adjustment.
+
+What's NOT here (explicit follow-ups)
+-------------------------------------
+- Identification of straddles. The caller pairs the legs upstream;
+  detection logic (covered calls, married puts, debit spreads, etc.)
+  is a separate concern.
+- Mixed-straddle § 1256(d) opt-out election. When elected, a mixed
+  straddle is reported on Form 6781 Part I instead — Part II is for
+  non-elected straddles.
+- Form 6781 Part III (unrecognized year-end positions disclosure).
+- § 263(g) carrying-charge capitalization on straddles.
+- Identified-Straddle election under § 1092(a)(2) (cross-pair offset).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from decimal import Decimal
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+
+@dataclass(frozen=True)
+class StraddleLeg:
+    """One closed loss leg with the offsetting leg's unrecognized gain.
+
+    Both ``recognized_loss`` and ``unrecognized_offsetting_gain`` are
+    *non-negative* magnitudes (not signed gain/loss values). The leg
+    represents a closed position that booked a loss; the offset is the
+    still-open opposing position's unrealized gain at the disposal
+    date.
+    """
+
+    description: str
+    recognized_loss: Decimal
+    unrecognized_offsetting_gain: Decimal
+
+    def __post_init__(self) -> None:
+        if self.recognized_loss < 0:
+            raise ValueError("recognized_loss must be non-negative")
+        if self.unrecognized_offsetting_gain < 0:
+            raise ValueError(
+                "unrecognized_offsetting_gain must be non-negative"
+            )
+
+    @property
+    def allowed_loss(self) -> Decimal:
+        """Per-leg allowed loss: only the portion above the offset."""
+        delta = self.recognized_loss - self.unrecognized_offsetting_gain
+        return delta.quantize(_TWOPLACES) if delta > 0 else _ZERO
+
+    @property
+    def deferred_loss(self) -> Decimal:
+        """Per-leg deferred loss = recognized - allowed."""
+        return (self.recognized_loss - self.allowed_loss).quantize(_TWOPLACES)
+
+
+@dataclass(frozen=True)
+class Form6781PartIISummary:
+    """Year-level Form 6781 Part II totals (USD)."""
+
+    leg_count: int
+    total_recognized_loss: Decimal
+    total_unrecognized_offsetting_gain: Decimal
+    total_allowed_loss: Decimal
+    total_deferred_loss: Decimal
+
+
+def summarize_form6781_part_ii(
+    legs: list[StraddleLeg],
+) -> Form6781PartIISummary:
+    """Aggregate ``legs`` into the Form 6781 Part II per-year totals.
+
+    The per-leg deferral is independent (each pair stands alone) — no
+    cross-pair offset under § 1092 outside an Identified-Straddle
+    election (which we don't model). The summary therefore sums each
+    leg's own allowed and deferred amounts.
+    """
+    total_loss = _ZERO
+    total_offset = _ZERO
+    total_allowed = _ZERO
+    total_deferred = _ZERO
+    for leg in legs:
+        total_loss += leg.recognized_loss
+        total_offset += leg.unrecognized_offsetting_gain
+        total_allowed += leg.allowed_loss
+        total_deferred += leg.deferred_loss
+
+    return Form6781PartIISummary(
+        leg_count=len(legs),
+        total_recognized_loss=total_loss.quantize(_TWOPLACES),
+        total_unrecognized_offsetting_gain=total_offset.quantize(_TWOPLACES),
+        total_allowed_loss=total_allowed.quantize(_TWOPLACES),
+        total_deferred_loss=total_deferred.quantize(_TWOPLACES),
+    )
+
+
+def legs_to_csv(legs: list[StraddleLeg]) -> str:
+    """Render the per-leg detail in a Form-6781-Part-II-shaped CSV.
+
+    Columns mirror the form's Part II layout (description + the four
+    per-leg amounts). Money is quantised to two decimals.
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "description",
+            "recognized_loss",
+            "unrecognized_offsetting_gain",
+            "allowed_loss",
+            "deferred_loss",
+        ]
+    )
+    for leg in legs:
+        writer.writerow(
+            [
+                leg.description,
+                _fmt(leg.recognized_loss),
+                _fmt(leg.unrecognized_offsetting_gain),
+                _fmt(leg.allowed_loss),
+                _fmt(leg.deferred_loss),
+            ]
+        )
+    return buf.getvalue()
+
+
+def _fmt(value: Decimal) -> str:
+    return f"{value.quantize(_TWOPLACES)}"
+
+
+__all__ = [
+    "Form6781PartIISummary",
+    "StraddleLeg",
+    "legs_to_csv",
+    "summarize_form6781_part_ii",
+]

--- a/tests/test_form_6781_part_ii.py
+++ b/tests/test_form_6781_part_ii.py
@@ -1,0 +1,171 @@
+"""Tests for Form 6781 Part II § 1092 straddle-loss limitation (gh#155)."""
+
+from __future__ import annotations
+
+import csv as _csv
+import io
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    Form6781PartIISummary,
+    StraddleLeg,
+    legs_to_csv,
+    summarize_form6781_part_ii,
+)
+
+
+def _leg(
+    *,
+    description: str = "ABC long call",
+    loss: str,
+    offset: str,
+) -> StraddleLeg:
+    return StraddleLeg(
+        description=description,
+        recognized_loss=Decimal(loss),
+        unrecognized_offsetting_gain=Decimal(offset),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestStraddleLegValidation:
+    def test_negative_recognized_loss_rejected(self):
+        with pytest.raises(ValueError):
+            StraddleLeg(
+                description="x",
+                recognized_loss=Decimal("-1"),
+                unrecognized_offsetting_gain=Decimal("0"),
+            )
+
+    def test_negative_offset_gain_rejected(self):
+        with pytest.raises(ValueError):
+            StraddleLeg(
+                description="x",
+                recognized_loss=Decimal("0"),
+                unrecognized_offsetting_gain=Decimal("-1"),
+            )
+
+    def test_both_zero_allowed(self):
+        # Degenerate but legal — operator may pass an empty stub.
+        leg = StraddleLeg(
+            description="x",
+            recognized_loss=Decimal("0"),
+            unrecognized_offsetting_gain=Decimal("0"),
+        )
+        assert leg.allowed_loss == Decimal("0.00")
+        assert leg.deferred_loss == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Per-leg deferral mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestLegMechanics:
+    def test_loss_below_offset_fully_deferred(self):
+        # Loss 100, offsetting gain 300 → entire loss deferred.
+        leg = _leg(loss="100", offset="300")
+        assert leg.allowed_loss == Decimal("0.00")
+        assert leg.deferred_loss == Decimal("100.00")
+
+    def test_loss_equal_offset_fully_deferred(self):
+        leg = _leg(loss="500", offset="500")
+        assert leg.allowed_loss == Decimal("0.00")
+        assert leg.deferred_loss == Decimal("500.00")
+
+    def test_loss_above_offset_excess_allowed(self):
+        # Loss 1,000, offset 300 → 700 allowed, 300 deferred.
+        leg = _leg(loss="1000", offset="300")
+        assert leg.allowed_loss == Decimal("700.00")
+        assert leg.deferred_loss == Decimal("300.00")
+
+    def test_zero_offset_full_loss_allowed(self):
+        # No offsetting unrealized gain → no deferral.
+        leg = _leg(loss="500", offset="0")
+        assert leg.allowed_loss == Decimal("500.00")
+        assert leg.deferred_loss == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    def test_empty_input_zero_summary(self):
+        s = summarize_form6781_part_ii([])
+
+        assert isinstance(s, Form6781PartIISummary)
+        assert s.leg_count == 0
+        assert s.total_recognized_loss == Decimal("0.00")
+        assert s.total_unrecognized_offsetting_gain == Decimal("0.00")
+        assert s.total_allowed_loss == Decimal("0.00")
+        assert s.total_deferred_loss == Decimal("0.00")
+
+
+class TestAggregation:
+    def test_per_leg_sums_independently(self):
+        # No cross-pair offset under § 1092 outside identified-straddle
+        # election (not modelled). Each leg's allowed/deferred is summed
+        # independently.
+        legs = [
+            _leg(loss="1000", offset="300"),  # 700 allowed, 300 deferred
+            _leg(loss="200", offset="500"),  # 0 allowed, 200 deferred
+            _leg(loss="800", offset="0"),  # 800 allowed, 0 deferred
+        ]
+        s = summarize_form6781_part_ii(legs)
+
+        assert s.leg_count == 3
+        assert s.total_recognized_loss == Decimal("2000.00")
+        assert s.total_unrecognized_offsetting_gain == Decimal("800.00")
+        assert s.total_allowed_loss == Decimal("1500.00")
+        assert s.total_deferred_loss == Decimal("500.00")
+        # Sanity: allowed + deferred always equals recognized total.
+        assert (
+            s.total_allowed_loss + s.total_deferred_loss
+            == s.total_recognized_loss
+        )
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+class TestCsv:
+    def test_csv_header_and_per_leg_row(self):
+        legs = [_leg(description="ABC put", loss="1000", offset="300")]
+
+        out = legs_to_csv(legs)
+        rows = list(_csv.reader(io.StringIO(out)))
+        assert len(rows) == 2
+        assert rows[0] == [
+            "description",
+            "recognized_loss",
+            "unrecognized_offsetting_gain",
+            "allowed_loss",
+            "deferred_loss",
+        ]
+        assert rows[1] == [
+            "ABC put",
+            "1000.00",
+            "300.00",
+            "700.00",
+            "300.00",
+        ]
+
+    def test_csv_quantises_to_two_decimals(self):
+        legs = [_leg(loss="100.123", offset="50.456")]
+
+        out = legs_to_csv(legs)
+        rows = list(_csv.reader(io.StringIO(out)))
+        # Both columns rendered to exactly two decimals; allowed/
+        # deferred derived from the same precision.
+        assert rows[1][1] == "100.12"
+        assert rows[1][2] == "50.46"


### PR DESCRIPTION
## Summary

Per-leg straddle-loss deferral under IRC § 1092. Closing one leg of an offsetting position pair at a loss when the other leg still has an unrealized gain triggers a deferral up to the offset amount. The deferred portion eventually carries into the basis of the still-open offsetting leg under § 1092(a)(1)(B); this module surfaces the deferred amount so the caller's lot ledger applies the basis bump.

API:
- \`StraddleLeg\` — frozen dataclass (\`description\`, \`recognized_loss\`, \`unrecognized_offsetting_gain\`). Both money fields are *non-negative magnitudes* (not signed gain/loss values); rejects negatives. \`.allowed_loss = max(loss - offset, 0)\` and \`.deferred_loss = loss - allowed_loss\` are derived properties.
- \`Form6781PartIISummary\` — \`leg_count\` + \`total_recognized_loss\` + \`total_unrecognized_offsetting_gain\` + \`total_allowed_loss\` + \`total_deferred_loss\`.
- \`summarize_form6781_part_ii(legs)\` — sums each leg's allowed and deferred amounts independently. No cross-pair offset under § 1092 outside the Identified-Straddle election (not modelled). Sanity invariant: \`allowed + deferred = recognized\`.
- \`legs_to_csv(legs)\` — Form-6781-Part-II-shaped CSV.

Refs #155. Out of scope:
- Pairing the straddle legs upstream (caller's lot ledger).
- Mixed-straddle § 1256(d) opt-out election (when elected, the pair reports on Part I instead — already handled by \`form_6781.py\`).
- Form 6781 Part III (unrecognized year-end positions disclosure).
- § 263(g) carrying-charge capitalisation.
- Identified-Straddle election under § 1092(a)(2) (cross-pair offset).

## Test plan

- [x] StraddleLeg rejects negative \`recognized_loss\` / \`unrecognized_offsetting_gain\`; allows zero
- [x] \`allowed_loss\` = 0 when loss ≤ offset; equals \`loss - offset\` otherwise
- [x] \`deferred_loss\` always equals \`recognized_loss - allowed_loss\`
- [x] Zero-offset case: full loss allowed, no deferral
- [x] Empty input → all-zero summary
- [x] Multi-leg aggregation sums each leg independently and preserves the \`allowed + deferred = recognized\` invariant
- [x] CSV header + per-leg row + 2-decimal quantising
- [x] Full local suite: 1959 pass / 55 pre-existing DB-required errors unchanged