### PR TITLE
feat(tax): IRS Form 6781 Part III year-end disclosure (gh#155)

### DIFF
--- a/engine/core/tax/reports/__init__.py
+++ b/engine/core/tax/reports/__init__.py
@@ -88,6 +88,12 @@ from engine.core.tax.reports.form_6781_part_ii import (
     legs_to_csv,
     summarize_form6781_part_ii,
 )
+from engine.core.tax.reports.form_6781_part_iii import (
+    Form6781PartIIISummary,
+    YearEndPosition,
+    positions_to_csv,
+    summarize_form6781_part_iii,
+)
 from engine.core.tax.reports.section_1256_carryback import (
     CARRYBACK_YEARS,
     CarrybackAbsorption,
@@ -116,6 +122,7 @@ __all__ = [
     "DEDUCTIBLE_CAP_DEFAULT",
     "DEDUCTIBLE_CAP_MFS",
     "Form6781PartIISummary",
+    "Form6781PartIIISummary",
     "Form6781Summary",
     "KEST_RATE",
     "IdType",
@@ -163,6 +170,7 @@ __all__ = [
     "ShortSaleIndicator",
     "TaxableDisposal",
     "UnsupportedJurisdictionError",
+    "YearEndPosition",
     "apply_carryover",
     "apply_cgt_carryover",
     "apply_kest_carryover",
@@ -174,11 +182,13 @@ __all__ = [
     "flatten_summary_to_csv",
     "generate_1099b_rows",
     "legs_to_csv",
+    "positions_to_csv",
     "report_for_jurisdiction",
     "rows_to_csv",
     "summarize_cgt",
     "summarize_form6781",
     "summarize_form6781_part_ii",
+    "summarize_form6781_part_iii",
     "summarize_kest",
     "summarize_pfu",
     "summarize_schedule_d",

--- a/engine/core/tax/reports/form_6781_part_iii.py
+++ b/engine/core/tax/reports/form_6781_part_iii.py
@@ -1,0 +1,160 @@
+"""IRS Form 6781 Part III — Unrecognized Gains on Year-End Positions.
+
+Form 6781 Part III is *disclosure-only*: a taxpayer with positions
+still open on the last day of the tax year where the fair-market
+value exceeds basis must list each such position. There is no tax
+computation here — Part I (Section 1256 60/40 split) and Part II
+(§ 1092 straddle-loss deferral) do that work.
+
+Per-position rule
+-----------------
+A position appears on Part III when it has an *unrecognized gain* at
+year-end:
+
+    unrecognized_gain = max(year_end_fmv - basis, 0)
+
+Positions that are at-the-money or under water (``fmv <= basis``)
+do not appear. The summary surfaces the count and the aggregate
+unrecognized-gain total — useful as a sanity check against the
+caller's lot ledger.
+
+What's NOT here (explicit follow-ups)
+-------------------------------------
+- Holding-period classification (Part III is reported regardless of
+  holding period — the IRS uses it for aggregate disclosure).
+- Identification of which positions are part of a straddle pair
+  (the caller decides).
+- The Form 6781 attached statement listing each position with the
+  full set of optional metadata (CUSIP, account, broker LEI, etc.).
+- Schedule D pass-through. Part III is informational only.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+
+@dataclass(frozen=True)
+class YearEndPosition:
+    """One open position at year-end with its basis + year-end FMV.
+
+    Both money fields are non-negative. Positions where
+    ``year_end_fmv <= basis`` produce a zero ``unrecognized_gain`` and
+    are filtered out of the summary by
+    :func:`summarize_form6781_part_iii`.
+    """
+
+    description: str
+    acquired: date
+    year_end: date
+    basis: Decimal
+    year_end_fmv: Decimal
+
+    def __post_init__(self) -> None:
+        if self.acquired > self.year_end:
+            raise ValueError(
+                f"acquired {self.acquired} is after year_end {self.year_end}"
+            )
+        if self.basis < 0:
+            raise ValueError("basis must be non-negative")
+        if self.year_end_fmv < 0:
+            raise ValueError("year_end_fmv must be non-negative")
+
+    @property
+    def unrecognized_gain(self) -> Decimal:
+        delta = self.year_end_fmv - self.basis
+        return delta.quantize(_TWOPLACES) if delta > 0 else _ZERO
+
+    @property
+    def has_unrecognized_gain(self) -> bool:
+        return self.unrecognized_gain > 0
+
+
+@dataclass(frozen=True)
+class Form6781PartIIISummary:
+    """Year-level Form 6781 Part III totals (USD).
+
+    - ``position_count`` — the number of positions actually reported
+      (i.e. those with a positive ``unrecognized_gain``).
+    - ``total_unrecognized_gain`` — sum of the per-position
+      unrecognized gains.
+    - ``positions`` — the filtered list, oldest-acquisition-first so
+      callers can directly serialise into the form's attached
+      statement.
+    """
+
+    position_count: int
+    total_unrecognized_gain: Decimal
+    positions: tuple[YearEndPosition, ...]
+
+
+def summarize_form6781_part_iii(
+    positions: list[YearEndPosition],
+) -> Form6781PartIIISummary:
+    """Filter ``positions`` to those with a positive unrecognized gain
+    and aggregate the totals. Positions are sorted by acquisition date
+    (oldest first) for stable output.
+    """
+    reportable = [p for p in positions if p.has_unrecognized_gain]
+    reportable.sort(key=lambda p: p.acquired)
+
+    total = _ZERO
+    for p in reportable:
+        total += p.unrecognized_gain
+
+    return Form6781PartIIISummary(
+        position_count=len(reportable),
+        total_unrecognized_gain=total.quantize(_TWOPLACES),
+        positions=tuple(reportable),
+    )
+
+
+def positions_to_csv(positions: list[YearEndPosition]) -> str:
+    """Render the per-position detail in a Form-6781-Part-III-shaped
+    CSV. Includes every input position (including under-water ones,
+    so the caller can audit the filter); ``unrecognized_gain`` is the
+    derived column the IRS form actually displays.
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "description",
+            "acquired",
+            "year_end",
+            "basis",
+            "year_end_fmv",
+            "unrecognized_gain",
+        ]
+    )
+    for p in positions:
+        writer.writerow(
+            [
+                p.description,
+                p.acquired.isoformat(),
+                p.year_end.isoformat(),
+                _fmt(p.basis),
+                _fmt(p.year_end_fmv),
+                _fmt(p.unrecognized_gain),
+            ]
+        )
+    return buf.getvalue()
+
+
+def _fmt(value: Decimal) -> str:
+    return f"{value.quantize(_TWOPLACES)}"
+
+
+__all__ = [
+    "Form6781PartIIISummary",
+    "YearEndPosition",
+    "positions_to_csv",
+    "summarize_form6781_part_iii",
+]

--- a/tests/test_form_6781_part_iii.py
+++ b/tests/test_form_6781_part_iii.py
@@ -1,0 +1,221 @@
+"""Tests for IRS Form 6781 Part III year-end disclosure (gh#155)."""
+
+from __future__ import annotations
+
+import csv as _csv
+import io
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from engine.core.tax.reports import (
+    Form6781PartIIISummary,
+    YearEndPosition,
+    positions_to_csv,
+    summarize_form6781_part_iii,
+)
+
+
+def _pos(
+    *,
+    description: str = "ABC future",
+    acquired: date = date(2024, 6, 1),
+    year_end: date = date(2024, 12, 31),
+    basis: str = "1000",
+    fmv: str = "1500",
+) -> YearEndPosition:
+    return YearEndPosition(
+        description=description,
+        acquired=acquired,
+        year_end=year_end,
+        basis=Decimal(basis),
+        year_end_fmv=Decimal(fmv),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestPositionValidation:
+    def test_acquired_after_year_end_rejected(self):
+        with pytest.raises(ValueError):
+            YearEndPosition(
+                description="x",
+                acquired=date(2025, 1, 1),
+                year_end=date(2024, 12, 31),
+                basis=Decimal("100"),
+                year_end_fmv=Decimal("100"),
+            )
+
+    def test_negative_basis_rejected(self):
+        with pytest.raises(ValueError):
+            YearEndPosition(
+                description="x",
+                acquired=date(2024, 1, 1),
+                year_end=date(2024, 12, 31),
+                basis=Decimal("-1"),
+                year_end_fmv=Decimal("100"),
+            )
+
+    def test_negative_fmv_rejected(self):
+        with pytest.raises(ValueError):
+            YearEndPosition(
+                description="x",
+                acquired=date(2024, 1, 1),
+                year_end=date(2024, 12, 31),
+                basis=Decimal("100"),
+                year_end_fmv=Decimal("-1"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Per-position derived properties
+# ---------------------------------------------------------------------------
+
+
+class TestPerPosition:
+    def test_unrecognized_gain_when_fmv_above_basis(self):
+        p = _pos(basis="1000", fmv="1500")
+        assert p.unrecognized_gain == Decimal("500.00")
+        assert p.has_unrecognized_gain
+
+    def test_unrecognized_gain_zero_when_at_basis(self):
+        p = _pos(basis="1000", fmv="1000")
+        assert p.unrecognized_gain == Decimal("0.00")
+        assert not p.has_unrecognized_gain
+
+    def test_unrecognized_gain_zero_when_under_water(self):
+        p = _pos(basis="1500", fmv="1000")
+        # Loss positions never appear on Part III; the property
+        # clamps at zero rather than going negative.
+        assert p.unrecognized_gain == Decimal("0.00")
+        assert not p.has_unrecognized_gain
+
+
+# ---------------------------------------------------------------------------
+# Aggregation + filter
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    def test_empty_input_zero_summary(self):
+        s = summarize_form6781_part_iii([])
+
+        assert isinstance(s, Form6781PartIIISummary)
+        assert s.position_count == 0
+        assert s.total_unrecognized_gain == Decimal("0.00")
+        assert s.positions == ()
+
+
+class TestFilter:
+    def test_under_water_positions_dropped(self):
+        positions = [
+            _pos(description="A", basis="1000", fmv="1500"),
+            _pos(description="B at-the-money", basis="1000", fmv="1000"),
+            _pos(description="C under water", basis="1500", fmv="1000"),
+        ]
+
+        s = summarize_form6781_part_iii(positions)
+
+        # Only the gain leg (A) survives the filter.
+        assert s.position_count == 1
+        assert s.total_unrecognized_gain == Decimal("500.00")
+        assert len(s.positions) == 1
+        assert s.positions[0].description == "A"
+
+    def test_positions_sorted_oldest_first(self):
+        positions = [
+            _pos(
+                description="newer",
+                acquired=date(2024, 9, 1),
+                basis="100",
+                fmv="200",
+            ),
+            _pos(
+                description="oldest",
+                acquired=date(2024, 1, 1),
+                basis="100",
+                fmv="200",
+            ),
+            _pos(
+                description="middle",
+                acquired=date(2024, 6, 1),
+                basis="100",
+                fmv="200",
+            ),
+        ]
+
+        s = summarize_form6781_part_iii(positions)
+
+        assert [p.description for p in s.positions] == [
+            "oldest",
+            "middle",
+            "newer",
+        ]
+
+
+class TestAggregateTotal:
+    def test_total_quantises_to_two_decimals(self):
+        positions = [
+            _pos(basis="100.123", fmv="200.456"),
+            _pos(basis="50.111", fmv="75.999"),
+        ]
+        s = summarize_form6781_part_iii(positions)
+
+        # Each leg's gain is computed first then summed; the sum is
+        # quantised. (100.333 + 25.888 = 126.22 after two-decimal round.)
+        assert s.total_unrecognized_gain == Decimal("126.22")
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+class TestCsv:
+    def test_csv_header_and_per_position_row(self):
+        positions = [
+            _pos(
+                description="ABC future",
+                acquired=date(2024, 6, 1),
+                year_end=date(2024, 12, 31),
+                basis="1000",
+                fmv="1500",
+            )
+        ]
+
+        out = positions_to_csv(positions)
+        rows = list(_csv.reader(io.StringIO(out)))
+        assert rows[0] == [
+            "description",
+            "acquired",
+            "year_end",
+            "basis",
+            "year_end_fmv",
+            "unrecognized_gain",
+        ]
+        assert rows[1] == [
+            "ABC future",
+            "2024-06-01",
+            "2024-12-31",
+            "1000.00",
+            "1500.00",
+            "500.00",
+        ]
+
+    def test_csv_includes_under_water_positions_for_audit(self):
+        # The CSV is intentionally wider than the Form 6781 attached
+        # statement so callers can audit the filter — under-water
+        # positions show ``unrecognized_gain == 0.00`` rather than
+        # being dropped.
+        positions = [
+            _pos(description="loser", basis="1500", fmv="1000"),
+        ]
+
+        out = positions_to_csv(positions)
+        rows = list(_csv.reader(io.StringIO(out)))
+        assert len(rows) == 2
+        assert rows[1][-1] == "0.00"


### PR DESCRIPTION
## Summary

Disclosure-only year-end aggregator. A taxpayer with positions still open on the last day of the tax year where the FMV exceeds basis must list each such position on Form 6781 Part III. No tax computation here — Part I (60/40 split, #320) and Part II (§ 1092 deferral, #326) do that work.

API:
- \`YearEndPosition\` — frozen dataclass (\`description\`, \`acquired\`, \`year_end\`, \`basis\`, \`year_end_fmv\`). Validates date ordering + non-negative basis/FMV. \`.unrecognized_gain = max(year_end_fmv - basis, 0)\` clamps at zero so under-water positions never appear on the form. \`.has_unrecognized_gain\` is the filter predicate.
- \`Form6781PartIIISummary\` — \`position_count\` + \`total_unrecognized_gain\` + \`positions\` tuple, sorted oldest-acquisition-first for stable output.
- \`summarize_form6781_part_iii(positions)\` — filters out at-the-money and under-water positions; returns the gain-leg subset.
- \`positions_to_csv(positions)\` — wider-than-form CSV that includes every input (under-water rows surface \`unrecognized_gain == 0.00\`) so operators can audit the filter.

Refs #155. Out of scope: holding-period classification (Part III reported regardless), straddle-pair identification (caller decides), optional CUSIP/account/broker-LEI metadata block on the attached statement.

## Test plan

- [x] \`YearEndPosition\` rejects acquired-after-year-end + negative basis/FMV
- [x] \`unrecognized_gain\` = \`fmv - basis\` when above water
- [x] \`unrecognized_gain\` = 0 when at-the-money
- [x] \`unrecognized_gain\` = 0 when under water (clamps, no negatives)
- [x] Empty input → all-zero summary
- [x] Filter drops at-the-money + under-water rows
- [x] Surviving rows sorted oldest-first
- [x] Two-decimal quantise on the aggregate (round-trip 100.333 + 25.888 = 126.22)
- [x] CSV header + per-position row with ISO 8601 dates
- [x] CSV includes under-water rows for audit (unrecognized_gain == 0.00)
- [x] Full local suite: 1971 pass / 55 pre-existing DB-required errors unchanged