### PR TITLE
feat(tax): MiFID II RTS 22 transmission fields (gh#155 follow-up)

### DIFF
--- a/engine/core/tax/reports/mifid2.py
+++ b/engine/core/tax/reports/mifid2.py
@@ -27,10 +27,15 @@ Implemented (ESMA RTS 22 Annex Field number in parentheses):
 - 7  Buyer LEI / national ID
 - 8  Buyer decision-maker code (NATL when natural person, LEI for entity)
 - 9  Buyer decision-maker identifier (LEI / national ID / "NORE")
+- 10 Buyer transmission-of-order indicator (true when this firm
+     received the order from another transmitting firm)
+- 11 Transmitting firm identification code for the buyer side
 - 15 Seller identification type
 - 16 Seller LEI / national ID
 - 17 Seller decision-maker code
 - 18 Seller decision-maker identifier
+- 19 Seller transmission-of-order indicator
+- 20 Transmitting firm identification code for the seller side
 - 24 Investment-decision-within-firm algorithmic ID
 - 25 Country of branch supervising the investment decision
 - 26 Execution-within-firm algorithmic ID
@@ -51,10 +56,11 @@ Implemented (ESMA RTS 22 Annex Field number in parentheses):
 - 64 OTC post-trade indicator
 - 65 Commodity-derivative indicator
 
-Deferred (~33 fields) — explicit follow-ups:
+Deferred (~29 fields) — explicit follow-ups:
 
-- Intermediary fields (10-14 buyer transmission, 19-23 seller
-  transmission, plus party-A / party-B routing).
+- Remaining intermediary fields (12-14 buyer side; 21-23 seller side
+  — these only apply when the order passed through more than one
+  transmitting firm).
 - Commodity-derivative metadata block (fields 53-55: notional schedule,
   delivery type, contract type details).
 - Securities-financing-transaction flags (fields 56-61).
@@ -152,6 +158,14 @@ class MiFID2Transaction:
     buyer_decision_maker_id: str = ""  # field 9
     seller_decision_maker_code: str = ""  # field 17
     seller_decision_maker_id: str = ""  # field 18
+    # Transmission fields. Set ``*_transmission_indicator=True`` when
+    # this firm received the order from an upstream transmitting firm
+    # under MiFIR Article 4 transmission rules; populate the matching
+    # ``*_transmitting_firm_id`` with the upstream firm's LEI.
+    buyer_transmission_indicator: bool = False  # field 10
+    buyer_transmitting_firm_id: str = ""  # field 11
+    seller_transmission_indicator: bool = False  # field 19
+    seller_transmitting_firm_id: str = ""  # field 20
     # Algorithmic-decision identifiers. Empty string when the trade
     # was operator-initiated (no algo).
     investment_decision_algo_id: str = ""  # field 24
@@ -209,10 +223,14 @@ RTS_22_COLUMNS: tuple[str, ...] = (
     "buyer_id",  # 7
     "buyer_decision_maker_code",  # 8
     "buyer_decision_maker_id",  # 9
+    "buyer_transmission_indicator",  # 10
+    "buyer_transmitting_firm_id",  # 11
     "seller_id_type",  # 15
     "seller_id",  # 16
     "seller_decision_maker_code",  # 17
     "seller_decision_maker_id",  # 18
+    "seller_transmission_indicator",  # 19
+    "seller_transmitting_firm_id",  # 20
     "investment_decision_algo_id",  # 24
     "investment_decision_branch_country",  # 25
     "execution_algo_id",  # 26
@@ -257,10 +275,14 @@ def transactions_to_csv(transactions: list[MiFID2Transaction]) -> str:
                 t.buyer_id,
                 t.buyer_decision_maker_code,
                 t.buyer_decision_maker_id,
+                "true" if t.buyer_transmission_indicator else "false",
+                t.buyer_transmitting_firm_id,
                 t.seller_id_type.value,
                 t.seller_id,
                 t.seller_decision_maker_code,
                 t.seller_decision_maker_id,
+                "true" if t.seller_transmission_indicator else "false",
+                t.seller_transmitting_firm_id,
                 t.investment_decision_algo_id,
                 t.investment_decision_branch_country,
                 t.execution_algo_id,

--- a/tests/test_mifid2.py
+++ b/tests/test_mifid2.py
@@ -108,8 +108,13 @@ class TestColumnOrder:
         assert RTS_22_COLUMNS[2] == "executing_entity_lei"
         # No duplicates.
         assert len(set(RTS_22_COLUMNS)) == len(RTS_22_COLUMNS)
-        # 32 fields after adding the indicator block 62-65 (gh#155 follow-up).
-        assert len(RTS_22_COLUMNS) == 32
+        # 36 fields after adding the transmission block 10-11 + 19-20
+        # (gh#155 follow-up).
+        assert len(RTS_22_COLUMNS) == 36
+        assert "buyer_transmission_indicator" in RTS_22_COLUMNS
+        assert "buyer_transmitting_firm_id" in RTS_22_COLUMNS
+        assert "seller_transmission_indicator" in RTS_22_COLUMNS
+        assert "seller_transmitting_firm_id" in RTS_22_COLUMNS
         # Indicator columns at the tail.
         assert RTS_22_COLUMNS[-4] == "waiver_indicator"
         assert RTS_22_COLUMNS[-3] == "short_sale_indicator"
@@ -304,6 +309,63 @@ class TestIndicators62To65:
             "otc_post_trade_indicator",
             "commodity_derivative_indicator",
         ]
+
+
+class TestTransmissionFields10And19:
+    def test_transmission_defaults_render_false_or_blank(self):
+        out = transactions_to_csv([_txn()])
+        header, body = _parse(out)
+        idx = {col: i for i, col in enumerate(header)}
+        assert body[0][idx["buyer_transmission_indicator"]] == "false"
+        assert body[0][idx["buyer_transmitting_firm_id"]] == ""
+        assert body[0][idx["seller_transmission_indicator"]] == "false"
+        assert body[0][idx["seller_transmitting_firm_id"]] == ""
+
+    def test_populated_transmission_round_trips(self):
+        out = transactions_to_csv(
+            [
+                _txn(
+                    buyer_transmission_indicator=True,
+                    buyer_transmitting_firm_id="529900TXBUY1234567X",
+                    seller_transmission_indicator=True,
+                    seller_transmitting_firm_id="529900TXSEL1234567Y",
+                )
+            ]
+        )
+        header, body = _parse(out)
+        idx = {col: i for i, col in enumerate(header)}
+        assert body[0][idx["buyer_transmission_indicator"]] == "true"
+        assert (
+            body[0][idx["buyer_transmitting_firm_id"]]
+            == "529900TXBUY1234567X"
+        )
+        assert body[0][idx["seller_transmission_indicator"]] == "true"
+        assert (
+            body[0][idx["seller_transmitting_firm_id"]]
+            == "529900TXSEL1234567Y"
+        )
+
+    def test_transmission_block_sits_between_decision_maker_and_capacity(
+        self,
+    ):
+        # ESMA RTS 22 ordering: buyer transmission (10-11) follows the
+        # buyer decision-maker block (8-9) and precedes the seller
+        # identification block (15-16). Same pattern on the seller
+        # side: 19-20 between decision-maker (17-18) and the algo /
+        # branch decision block (24-27).
+        out = transactions_to_csv([_txn()])
+        header, _ = _parse(out)
+        idx = {col: i for i, col in enumerate(header)}
+        assert (
+            idx["buyer_decision_maker_id"]
+            < idx["buyer_transmission_indicator"]
+            < idx["seller_id_type"]
+        )
+        assert (
+            idx["seller_decision_maker_id"]
+            < idx["seller_transmission_indicator"]
+            < idx["investment_decision_algo_id"]
+        )
 
 
 class TestEmpty:


### PR DESCRIPTION
## Summary

Extend the MiFID II scaffold with the transmission-of-order block. Coverage now **36 of 65 fields** (up from 32 in #325).

New fields on \`MiFID2Transaction\` (defaults preserve backward compatibility — existing call sites remain green):

| Field | Name | Type | Notes |
|---|---|---|---|
| 10 | \`buyer_transmission_indicator\` | bool | True when this firm received the order from an upstream transmitting firm under MiFIR Article 4 |
| 11 | \`buyer_transmitting_firm_id\` | str (LEI) | LEI of the upstream firm |
| 19 | \`seller_transmission_indicator\` | bool | Same on the seller side |
| 20 | \`seller_transmitting_firm_id\` | str (LEI) | |

\`RTS_22_COLUMNS\` extended to 36 entries; the buyer transmission pair sits between the buyer decision-maker block (8-9) and the seller identification block (15-16); the seller transmission pair sits between the seller decision-maker block (17-18) and the algorithmic decision block (24-27).

Refs #155. Remaining ~29 fields (12-14 buyer further-transmission, 21-23 seller further-transmission, commodity-derivative metadata 53-55, securities-financing 56-61, ESMA XSD validation) still deferred.

## Test plan

- [x] \`RTS_22_COLUMNS\` length bumped 32 → 36; all 4 new column names present
- [x] Existing call sites still pass — defaults render \`false\` / blank
- [x] Populated transmission values round-trip through the CSV
- [x] Transmission columns sit between decision-maker and downstream blocks (ESMA ordering)
- [x] All 28 MiFID II tests pass
- [x] Full local suite: 1974 pass / 55 pre-existing DB-required errors unchanged