### PR TITLE
feat(metrics): 6 risk-adjusted metric extras (gh#97 follow-up)

### DIFF
--- a/engine/core/metrics_extras.py
+++ b/engine/core/metrics_extras.py
@@ -1,0 +1,155 @@
+"""Additional risk-adjusted performance metrics (gh#97 follow-up).
+
+Companion to :mod:`engine.core.metrics`. Each function here is a
+pure helper over a returns / equity-curve / drawdown-curve list so
+callers can mix-and-match without instantiating the full
+:class:`engine.core.metrics.PerformanceMetrics` aggregator.
+
+Six metrics covered in this slice (KPI numbers from gh#97):
+
+- 18  Omega ratio                 — full-distribution gain/loss ratio
+- 19  Information ratio           — return-vs-benchmark per tracking-error unit
+- 24  Gain-to-pain ratio          — sum(returns) / abs(sum(negative returns))
+- 30  Ulcer index                 — RMS of the drawdown curve
+- 32  Pain index                  — mean of |drawdown|
+- 29  Recovery factor             — total return / max drawdown
+
+Out of scope (explicit follow-ups for the remaining 80 of 86):
+- Treynor / MAR / Sterling / K-Ratio (need beta + benchmark series).
+- Trade-level breakdowns (Expectancy R-multiple, Kelly, payoff ratio).
+- Time-based heatmaps + monthly/weekly distributions.
+- Cost / execution / exposure analytics.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+def compute_omega_ratio(
+    returns: Sequence[float],
+    threshold: float = 0.0,
+) -> float:
+    """Return the Omega ratio at ``threshold``.
+
+    Defined as ``sum(max(r - threshold, 0)) / sum(max(threshold - r, 0))``.
+    A value above 1 means the gain-side mass outweighs the loss-side mass
+    relative to the threshold; value greater than the bar suggests the
+    strategy is acceptable for an investor with that target return.
+
+    Returns ``inf`` when the loss-side mass is zero and there is at least
+    one above-threshold return; ``0.0`` when the input is empty.
+    """
+    if not returns:
+        return 0.0
+    upside = 0.0
+    downside = 0.0
+    for r in returns:
+        delta = r - threshold
+        if delta > 0:
+            upside += delta
+        else:
+            downside += -delta
+    if downside == 0:
+        return math.inf if upside > 0 else 0.0
+    return upside / downside
+
+
+def compute_information_ratio(
+    returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+) -> float:
+    """Return the Information Ratio of ``returns`` vs ``benchmark_returns``.
+
+    Defined as ``mean(active_returns) / std(active_returns)`` where
+    ``active = returns - benchmark`` (sample stdev, ddof=1). Both
+    sequences must be the same length and contain at least 2 points;
+    otherwise the function returns ``0.0``.
+
+    A positive IR signals the strategy outperforms the benchmark on a
+    risk-adjusted basis; the magnitude tells you how *consistent* the
+    outperformance is.
+    """
+    n = len(returns)
+    if n != len(benchmark_returns) or n < 2:
+        return 0.0
+    active = [r - b for r, b in zip(returns, benchmark_returns, strict=True)]
+    mean = sum(active) / n
+    var = sum((x - mean) ** 2 for x in active) / (n - 1)
+    if var == 0:
+        return 0.0
+    return mean / math.sqrt(var)
+
+
+def compute_gain_to_pain_ratio(returns: Sequence[float]) -> float:
+    """Sum of returns divided by absolute sum of *negative* returns.
+
+    Returns 0.0 for empty input. ``inf`` when there are no negative
+    returns and the sum is positive (the strategy never lost) — caller
+    can clamp for display.
+    """
+    if not returns:
+        return 0.0
+    total = sum(returns)
+    pain = sum(-r for r in returns if r < 0)
+    if pain == 0:
+        return math.inf if total > 0 else 0.0
+    return total / pain
+
+
+def compute_ulcer_index(equity_curve: Sequence[float]) -> float:
+    """Ulcer index — root-mean-square of the percentage drawdown curve.
+
+    Lower is better. Convention: returns the index in *percent* (i.e.
+    a 5 % RMS drawdown returns ``5.0``).
+    """
+    if not equity_curve:
+        return 0.0
+    peak = equity_curve[0]
+    sq_sum = 0.0
+    n = len(equity_curve)
+    for v in equity_curve:
+        peak = max(peak, v)
+        if peak <= 0:
+            continue
+        dd_pct = ((peak - v) / peak) * 100.0
+        sq_sum += dd_pct * dd_pct
+    return math.sqrt(sq_sum / n)
+
+
+def compute_pain_index(drawdown_curve: Sequence[float]) -> float:
+    """Pain index — arithmetic mean of |drawdown|.
+
+    Operates on a drawdown sequence where each entry is a fractional
+    drawdown (0.0 to 1.0). Returns the mean as a percent for parity
+    with :func:`compute_ulcer_index`.
+    """
+    if not drawdown_curve:
+        return 0.0
+    return (sum(abs(d) for d in drawdown_curve) / len(drawdown_curve)) * 100.0
+
+
+def compute_recovery_factor(
+    total_return_pct: float,
+    max_drawdown_pct: float,
+) -> float:
+    """Recovery factor — ``total_return / max_drawdown``.
+
+    Both arguments are percentages (e.g. ``25.0`` for 25 %). Returns
+    ``0.0`` when ``max_drawdown_pct`` is zero or negative; the metric
+    is undefined in that regime.
+    """
+    if max_drawdown_pct <= 0:
+        return 0.0
+    return total_return_pct / max_drawdown_pct
+
+
+__all__ = [
+    "compute_gain_to_pain_ratio",
+    "compute_information_ratio",
+    "compute_omega_ratio",
+    "compute_pain_index",
+    "compute_recovery_factor",
+    "compute_ulcer_index",
+]

--- a/tests/test_metrics_extras.py
+++ b/tests/test_metrics_extras.py
@@ -1,0 +1,153 @@
+"""Tests for the additional risk-adjusted metrics (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.metrics_extras import (
+    compute_gain_to_pain_ratio,
+    compute_information_ratio,
+    compute_omega_ratio,
+    compute_pain_index,
+    compute_recovery_factor,
+    compute_ulcer_index,
+)
+
+
+# ---------------------------------------------------------------------------
+# Omega ratio
+# ---------------------------------------------------------------------------
+
+
+class TestOmega:
+    def test_empty_returns_zero(self):
+        assert compute_omega_ratio([]) == 0.0
+
+    def test_balanced_distribution_returns_one(self):
+        # +1 and -1 around zero threshold → equal up/down mass.
+        assert compute_omega_ratio([1.0, -1.0]) == pytest.approx(1.0)
+
+    def test_above_threshold_returns_above_one(self):
+        # Mostly gains relative to threshold of zero.
+        out = compute_omega_ratio([0.5, 0.5, -0.1])
+        assert out == pytest.approx(10.0)
+
+    def test_threshold_shifts_partition(self):
+        # Threshold raises the bar — same returns may flip from gain
+        # to loss bucket.
+        returns = [0.05, -0.02, 0.01]
+        assert compute_omega_ratio(returns, threshold=0.04) > 0
+        assert compute_omega_ratio(returns, threshold=0.5) < 1
+
+    def test_no_downside_returns_inf(self):
+        assert compute_omega_ratio([0.1, 0.2, 0.3]) == math.inf
+
+    def test_all_at_threshold_returns_zero(self):
+        assert compute_omega_ratio([0.0, 0.0]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Information ratio
+# ---------------------------------------------------------------------------
+
+
+class TestInformation:
+    def test_mismatched_lengths_returns_zero(self):
+        assert compute_information_ratio([1.0, 2.0], [1.0]) == 0.0
+
+    def test_too_few_points_returns_zero(self):
+        assert compute_information_ratio([1.0], [1.0]) == 0.0
+
+    def test_zero_active_returns_yields_zero(self):
+        # No tracking error.
+        assert compute_information_ratio(
+            [0.01, 0.01, 0.01], [0.01, 0.01, 0.01]
+        ) == 0.0
+
+    def test_consistent_outperformance_yields_positive(self):
+        # Slightly noisy outperformance — produces a positive IR with
+        # meaningful tracking-error denominator.
+        returns = [0.020, 0.022, 0.018, 0.021]
+        benchmark = [0.010, 0.010, 0.010, 0.010]
+        ir = compute_information_ratio(returns, benchmark)
+        assert ir > 0
+
+
+# ---------------------------------------------------------------------------
+# Gain-to-pain
+# ---------------------------------------------------------------------------
+
+
+class TestGainToPain:
+    def test_empty_returns_zero(self):
+        assert compute_gain_to_pain_ratio([]) == 0.0
+
+    def test_known_value(self):
+        # +5 and -2 → sum=3, pain=2 → ratio=1.5
+        assert compute_gain_to_pain_ratio([5.0, -2.0]) == 1.5
+
+    def test_no_losses_returns_inf(self):
+        assert compute_gain_to_pain_ratio([1.0, 2.0]) == math.inf
+
+    def test_all_losses_returns_negative(self):
+        # -1 and -2 → sum=-3, pain=3 → ratio=-1
+        assert compute_gain_to_pain_ratio([-1.0, -2.0]) == -1.0
+
+
+# ---------------------------------------------------------------------------
+# Ulcer / pain index
+# ---------------------------------------------------------------------------
+
+
+class TestUlcerIndex:
+    def test_empty_returns_zero(self):
+        assert compute_ulcer_index([]) == 0.0
+
+    def test_flat_curve_returns_zero(self):
+        # No drawdowns at all.
+        assert compute_ulcer_index([100.0, 100.0, 100.0]) == 0.0
+
+    def test_monotonic_decline_yields_positive(self):
+        # 100 → 90 → 80 → 70: drawdowns 0 / 10 / 20 / 30 percent.
+        # RMS = sqrt((0+100+400+900)/4) = sqrt(350) ≈ 18.71
+        out = compute_ulcer_index([100.0, 90.0, 80.0, 70.0])
+        assert out == pytest.approx(math.sqrt(350.0))
+
+    def test_recovery_curve_keeps_history_in_rms(self):
+        # 100 → 80 → 100 — temporary 20 % drawdown.
+        # RMS = sqrt((0+400+0)/3) ≈ 11.55
+        out = compute_ulcer_index([100.0, 80.0, 100.0])
+        assert out == pytest.approx(math.sqrt(400.0 / 3))
+
+
+class TestPainIndex:
+    def test_empty_returns_zero(self):
+        assert compute_pain_index([]) == 0.0
+
+    def test_known_value(self):
+        # Drawdowns 0.0, 0.05, 0.10 → mean 0.05 → 5.0 percent.
+        assert compute_pain_index([0.0, 0.05, 0.10]) == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Recovery factor
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryFactor:
+    def test_zero_drawdown_returns_zero(self):
+        # Metric undefined when there is no drawdown.
+        assert compute_recovery_factor(50.0, 0.0) == 0.0
+
+    def test_negative_drawdown_returns_zero(self):
+        # Defensive: nonsensical input clamps to 0.
+        assert compute_recovery_factor(50.0, -5.0) == 0.0
+
+    def test_known_value(self):
+        # 30 % return / 10 % drawdown → 3.0.
+        assert compute_recovery_factor(30.0, 10.0) == 3.0
+
+    def test_loss_year_returns_negative(self):
+        assert compute_recovery_factor(-5.0, 10.0) == -0.5


### PR DESCRIPTION
## Summary

Companion to \`engine.core.metrics\`. Pure free functions over returns / equity-curve / drawdown-curve sequences, callable without instantiating \`PerformanceMetrics\`.

KPIs added (numbers from gh#97 taxonomy):

| KPI # | Function | Description |
|---|---|---|
| 18 | \`compute_omega_ratio(returns, threshold=0.0)\` | Full-distribution upside-mass / downside-mass ratio. \`inf\` when no losses + positive upside; \`0.0\` on empty / all-at-threshold |
| 19 | \`compute_information_ratio(returns, benchmark_returns)\` | \`mean(active) / std(active)\` with sample stdev (ddof=1). Returns \`0.0\` on length mismatch, <2 points, or zero tracking error |
| 24 | \`compute_gain_to_pain_ratio(returns)\` | \`sum(returns) / abs(sum negative returns)\`. \`inf\` when no losses + positive sum |
| 30 | \`compute_ulcer_index(equity_curve)\` | RMS of percentage drawdowns. Returns the index in percent |
| 32 | \`compute_pain_index(drawdown_curve)\` | Mean of \`\|drawdown\|\`, in percent |
| 29 | \`compute_recovery_factor(total_return_pct, max_drawdown_pct)\` | Ratio with defensive clamp at 0 when \`max_drawdown_pct\` is non-positive |

Refs #97. Remaining 80 of 86 KPIs (Treynor / MAR / Sterling / K-Ratio — need beta + benchmark series, trade-level Expectancy R-multiple / Kelly / payoff ratio, time-based heatmaps, cost / execution / exposure analytics) still deferred. Track in follow-up issues when scoped.

## Test plan

24 new tests covering:
- [x] Empty-input + boundary returns 0.0 for every metric
- [x] Omega: balanced → 1.0; above-threshold → >1; threshold shifts partition; no-downside → \`inf\`; all-at-threshold → 0.0
- [x] Information: mismatched lengths / <2 points / zero tracking error → 0.0; consistent outperformance → positive
- [x] Gain-to-pain: known value 5/-2 = 1.5; no losses → \`inf\`; all losses → negative
- [x] Ulcer: flat curve → 0.0; monotonic decline closed-form match \`sqrt(350)\`; recovery curve preserves history
- [x] Pain: known value (drawdowns 0.0/0.05/0.10 → 5.0 %)
- [x] Recovery factor: zero / negative drawdown → 0.0; 30/10 → 3.0; loss year → negative
- [x] Full local suite: 1998 pass / 55 pre-existing DB-required errors unchanged