### PR TITLE
feat(metrics): trade-level Kelly + payoff + R-expectancy (gh#97)

### DIFF
--- a/engine/core/metrics_extras.py
+++ b/engine/core/metrics_extras.py
@@ -5,18 +5,26 @@ pure helper over a returns / equity-curve / drawdown-curve list so
 callers can mix-and-match without instantiating the full
 :class:`engine.core.metrics.PerformanceMetrics` aggregator.
 
-Six metrics covered in this slice (KPI numbers from gh#97):
+Metrics covered (KPI numbers from gh#97):
+
+Risk-adjusted (sequence-level):
 
 - 18  Omega ratio                 — full-distribution gain/loss ratio
 - 19  Information ratio           — return-vs-benchmark per tracking-error unit
 - 24  Gain-to-pain ratio          — sum(returns) / abs(sum(negative returns))
+- 29  Recovery factor             — total return / max drawdown
 - 30  Ulcer index                 — RMS of the drawdown curve
 - 32  Pain index                  — mean of |drawdown|
-- 29  Recovery factor             — total return / max drawdown
 
-Out of scope (explicit follow-ups for the remaining 80 of 86):
+Trade-level (PnL-list-driven):
+
+- 39  Expectancy ($)              — win_rate * avg_win - loss_rate * avg_loss
+- 40  Expectancy (R-multiple)     — expectancy / avg risk per trade
+- 44  Payoff ratio                — avg_winner / abs(avg_loser)
+- 45  Kelly criterion             — fraction of capital to risk per trade
+
+Out of scope (explicit follow-ups for the remaining ~76 of 86):
 - Treynor / MAR / Sterling / K-Ratio (need beta + benchmark series).
-- Trade-level breakdowns (Expectancy R-multiple, Kelly, payoff ratio).
 - Time-based heatmaps + monthly/weekly distributions.
 - Cost / execution / exposure analytics.
 """
@@ -145,11 +153,101 @@ def compute_recovery_factor(
     return total_return_pct / max_drawdown_pct
 
 
+def compute_payoff_ratio(trade_pnls: Sequence[float]) -> float:
+    """Payoff ratio = avg(winners) / abs(avg(losers)).
+
+    Returns ``0.0`` for empty input or when there are no losers and no
+    winners. ``inf`` when there are winners but no losers.
+    """
+    if not trade_pnls:
+        return 0.0
+    winners = [p for p in trade_pnls if p > 0]
+    losers = [p for p in trade_pnls if p < 0]
+    if not winners:
+        return 0.0
+    if not losers:
+        return math.inf
+    avg_win = sum(winners) / len(winners)
+    avg_loss = abs(sum(losers) / len(losers))
+    if avg_loss == 0:
+        return math.inf
+    return avg_win / avg_loss
+
+
+def compute_expectancy_dollars(trade_pnls: Sequence[float]) -> float:
+    """Per-trade dollar expectancy.
+
+    Defined as ``win_rate * avg_win - loss_rate * avg_loss`` where
+    ``avg_loss`` is the *positive* magnitude of the average loser. A
+    profitable system has expectancy > 0. Equivalent to the simple
+    arithmetic mean of all trade PnLs (the formula is just an
+    expanded form of that mean).
+
+    Returns ``0.0`` on empty input.
+    """
+    if not trade_pnls:
+        return 0.0
+    return sum(trade_pnls) / len(trade_pnls)
+
+
+def compute_expectancy_r_multiple(
+    trade_pnls: Sequence[float],
+    avg_risk_per_trade: float,
+) -> float:
+    """Expectancy expressed in R-multiples.
+
+    R is the per-trade *risk capital*. Dividing the dollar expectancy
+    by R normalises it: an expectancy of 0.5 R means a typical trade
+    earns half the amount the trader risked. Returns ``0.0`` on empty
+    input or non-positive ``avg_risk_per_trade``.
+    """
+    if not trade_pnls or avg_risk_per_trade <= 0:
+        return 0.0
+    return compute_expectancy_dollars(trade_pnls) / avg_risk_per_trade
+
+
+def compute_kelly_criterion(trade_pnls: Sequence[float]) -> float:
+    """Kelly criterion — optimal fraction of capital to risk per trade.
+
+    ``f* = win_rate - loss_rate / payoff_ratio``. Result is the
+    *theoretical* optimum that maximises long-run geometric growth;
+    operators typically apply a half-Kelly or quarter-Kelly haircut
+    to absorb estimation error.
+
+    Returns ``0.0`` on empty input, when there are no losers (Kelly is
+    not defined for never-losing systems and ``inf`` capital is not a
+    useful answer), or when the payoff ratio cannot be formed.
+    Negative results are *not* clamped — a negative Kelly means the
+    caller should not take the trade.
+    """
+    if not trade_pnls:
+        return 0.0
+    winners = [p for p in trade_pnls if p > 0]
+    losers = [p for p in trade_pnls if p < 0]
+    if not winners or not losers:
+        return 0.0
+    n = len(trade_pnls)
+    win_rate = len(winners) / n
+    loss_rate = len(losers) / n
+    avg_win = sum(winners) / len(winners)
+    avg_loss = abs(sum(losers) / len(losers))
+    if avg_loss == 0:
+        return 0.0
+    payoff = avg_win / avg_loss
+    if payoff == 0:
+        return 0.0
+    return win_rate - loss_rate / payoff
+
+
 __all__ = [
+    "compute_expectancy_dollars",
+    "compute_expectancy_r_multiple",
     "compute_gain_to_pain_ratio",
     "compute_information_ratio",
+    "compute_kelly_criterion",
     "compute_omega_ratio",
     "compute_pain_index",
+    "compute_payoff_ratio",
     "compute_recovery_factor",
     "compute_ulcer_index",
 ]

--- a/tests/test_trade_metrics.py
+++ b/tests/test_trade_metrics.py
@@ -1,0 +1,118 @@
+"""Tests for trade-level metrics extras (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.metrics_extras import (
+    compute_expectancy_dollars,
+    compute_expectancy_r_multiple,
+    compute_kelly_criterion,
+    compute_payoff_ratio,
+)
+
+
+# ---------------------------------------------------------------------------
+# Payoff ratio
+# ---------------------------------------------------------------------------
+
+
+class TestPayoffRatio:
+    def test_empty_returns_zero(self):
+        assert compute_payoff_ratio([]) == 0.0
+
+    def test_known_value(self):
+        # avg_win = (200 + 100) / 2 = 150
+        # avg_loss = abs((-50 + -100) / 2) = 75
+        # payoff = 150 / 75 = 2.0
+        assert compute_payoff_ratio([200, 100, -50, -100]) == pytest.approx(2.0)
+
+    def test_no_winners_returns_zero(self):
+        assert compute_payoff_ratio([-10, -20]) == 0.0
+
+    def test_no_losers_returns_inf(self):
+        assert compute_payoff_ratio([100, 50]) == math.inf
+
+    def test_zero_pnls_treated_as_neither(self):
+        # All zeros → no winners, no losers → 0.0 (no winners path).
+        assert compute_payoff_ratio([0.0, 0.0, 0.0]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Expectancy in dollars
+# ---------------------------------------------------------------------------
+
+
+class TestExpectancyDollars:
+    def test_empty_returns_zero(self):
+        assert compute_expectancy_dollars([]) == 0.0
+
+    def test_balanced_returns_zero(self):
+        assert compute_expectancy_dollars([100, -100]) == 0.0
+
+    def test_known_value(self):
+        # mean of [200, 100, -50, -100] = 37.5
+        assert compute_expectancy_dollars([200, 100, -50, -100]) == 37.5
+
+    def test_negative_when_losing_system(self):
+        assert compute_expectancy_dollars([10, -50]) == -20.0
+
+
+# ---------------------------------------------------------------------------
+# Expectancy in R-multiples
+# ---------------------------------------------------------------------------
+
+
+class TestExpectancyRMultiple:
+    def test_empty_returns_zero(self):
+        assert compute_expectancy_r_multiple([], 100.0) == 0.0
+
+    def test_zero_risk_returns_zero(self):
+        assert compute_expectancy_r_multiple([100, -50], 0.0) == 0.0
+
+    def test_negative_risk_returns_zero(self):
+        # Defensive: nonsensical risk → 0.0.
+        assert compute_expectancy_r_multiple([100, -50], -1.0) == 0.0
+
+    def test_known_value(self):
+        # mean PnL 37.5, R = 50 → 0.75 R per trade.
+        out = compute_expectancy_r_multiple([200, 100, -50, -100], 50.0)
+        assert out == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------------
+# Kelly criterion
+# ---------------------------------------------------------------------------
+
+
+class TestKelly:
+    def test_empty_returns_zero(self):
+        assert compute_kelly_criterion([]) == 0.0
+
+    def test_no_winners_returns_zero(self):
+        assert compute_kelly_criterion([-10, -20]) == 0.0
+
+    def test_no_losers_returns_zero(self):
+        # Never-losing system → Kelly undefined; we return 0 rather
+        # than inf so the caller doesn't risk infinite capital.
+        assert compute_kelly_criterion([10, 20]) == 0.0
+
+    def test_balanced_50_50_zero_edge_returns_zero(self):
+        # 50 % win-rate with 1.0 payoff ratio → Kelly = 0.5 - 0.5/1 = 0.
+        out = compute_kelly_criterion([100, -100])
+        assert out == pytest.approx(0.0)
+
+    def test_high_win_rate_high_payoff_positive_kelly(self):
+        # 3 winners (avg 100) + 1 loser (-50). win_rate=0.75, loss_rate=0.25,
+        # payoff = 100/50 = 2. Kelly = 0.75 - 0.25/2 = 0.625.
+        out = compute_kelly_criterion([100, 100, 100, -50])
+        assert out == pytest.approx(0.625)
+
+    def test_negative_kelly_when_edge_negative(self):
+        # 1 winner of 10, 3 losers of -50 each.
+        # win_rate=0.25, loss_rate=0.75, payoff=10/50=0.2.
+        # Kelly = 0.25 - 0.75/0.2 = -3.5 → caller skips the trade.
+        out = compute_kelly_criterion([10, -50, -50, -50])
+        assert out == pytest.approx(-3.5)


### PR DESCRIPTION
## Summary

Extend \`metrics_extras\` with 4 trade-level KPIs over a list of per-trade PnL amounts. Coverage now **10 of 86 KPIs** (up from 6 in #329).

| KPI # | Function | Description |
|---|---|---|
| 39 | \`compute_expectancy_dollars(trade_pnls)\` | Per-trade dollar expectancy. Equivalent to arithmetic mean of all PnLs (the formal \`win_rate * avg_win - loss_rate * avg_loss\` formula reduces to the mean for any partition into winners and losers). |
| 40 | \`compute_expectancy_r_multiple(trade_pnls, avg_risk_per_trade)\` | Dollar expectancy normalised by per-trade risk capital. Returns \`0.0\` for empty input or non-positive risk. |
| 44 | \`compute_payoff_ratio(trade_pnls)\` | \`avg(winners) / abs(avg(losers))\`. Returns \`inf\` when there are winners but no losers; \`0.0\` when there are no winners. |
| 45 | \`compute_kelly_criterion(trade_pnls)\` | \`f* = win_rate - loss_rate / payoff_ratio\`. Returns \`0.0\` for empty / one-sided inputs; never returns \`inf\` even when winners-only (caller does not risk infinite capital). Negative results NOT clamped — a negative Kelly is the caller's signal to skip the trade. |

Documented expectation: operators typically apply a half- or quarter-Kelly haircut to absorb estimation error (caller's responsibility).

Refs #97. Remaining ~76 KPIs (Treynor / MAR / Sterling / K-Ratio — need beta + benchmark series; time-based heatmaps; cost / execution / exposure analytics) still deferred.

## Test plan

19 new tests covering:
- [x] Payoff: empty → 0; known 200/100/-50/-100 = 2.0; no winners → 0; no losers → \`inf\`; all-zero → 0
- [x] Expectancy \$: empty → 0; balanced → 0; known 200/100/-50/-100 = 37.5; losing system → negative
- [x] Expectancy R: empty → 0; zero/negative risk → 0; known 200/100/-50/-100 with R=50 → 0.75 R
- [x] Kelly: empty / no winners / no losers → 0; balanced 50/50 + 1.0 payoff → 0 (no edge); high-edge 100×3 + -50 → 0.625; negative-edge 10 + -50×3 → -3.5
- [x] Full local suite: 2017 pass / 55 pre-existing DB-required errors unchanged