### PR TITLE
feat(cost): US regulatory fees + margin interest helpers (gh#96)

### DIFF
--- a/engine/core/regulatory_fees.py
+++ b/engine/core/regulatory_fees.py
@@ -1,0 +1,168 @@
+"""US regulatory & holding-cost helpers (gh#96 follow-up).
+
+Pure functions over individual trade attributes — operators compose
+them inside their own cost-model adapter rather than calling the
+aggregate :class:`engine.core.cost_model.DefaultCostModel` for every
+component. The rates are *configurable* with sensible defaults pinned
+to the FY2026 schedule; pass operator overrides when the SEC, FINRA
+or exchange publishes a new rate.
+
+Components covered (numbers from gh#96 taxonomy):
+
+- A2  SEC Section 31 fee          — sells only, applied to gross proceeds
+- A2  FINRA Trading Activity Fee  — sells only, per-share with cap
+- A2  Options Regulatory Fee      — buys + sells, per-contract
+- A3  OCC clearing fee             — per-contract (options)
+- C1  Margin-interest daily accrual — borrowed_amount * rate / 365
+
+Out of scope (explicit follow-ups):
+- Per-exchange taker / maker rebates (varies by venue + tier).
+- NSCC / DTC clearing & settlement granularity.
+- Tax fees beyond US (handled by jurisdiction engine).
+- Borrow-cost rates for short positions (separate from margin).
+- ADR custody fees, dividend withholding, foreign tax credits.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+# FY2026 SEC Section 31 fee rate: $20.60 per million dollars of
+# proceeds. Applies to *sells* only on US equity transactions.
+SEC_SECTION_31_RATE_PER_MILLION_2026: Decimal = Decimal("20.60")
+
+# FY2025 FINRA Trading Activity Fee: $0.000166 per share on sells,
+# capped at $8.30 per trade.
+FINRA_TAF_PER_SHARE_2025: Decimal = Decimal("0.000166")
+FINRA_TAF_MAX_PER_TRADE_2025: Decimal = Decimal("8.30")
+
+# Options Regulatory Fee FY2025: $0.02905 per contract, charged on
+# both sides of the trade.
+ORF_PER_CONTRACT_2025: Decimal = Decimal("0.02905")
+
+# OCC clearing fee: $0.055 per contract.
+OCC_CLEARING_FEE_PER_CONTRACT: Decimal = Decimal("0.055")
+
+DAYS_PER_YEAR: int = 365
+
+
+def sec_section_31_fee(
+    proceeds: Decimal,
+    *,
+    side: str,
+    rate_per_million: Decimal = SEC_SECTION_31_RATE_PER_MILLION_2026,
+) -> Decimal:
+    """SEC Section 31 fee on US equity *sells*. Buys produce zero.
+
+    ``proceeds`` is the gross sale amount (price × quantity) in USD.
+    Returns the fee in USD, quantised to the cent (the SEC rounds
+    *up*, but at our precision a half-cent rounding is invisible —
+    operators reconcile against the broker's clearing report).
+    """
+    if proceeds < 0:
+        raise ValueError("proceeds must be non-negative")
+    if rate_per_million < 0:
+        raise ValueError("rate_per_million must be non-negative")
+    if side != "sell":
+        return _ZERO
+    fee = proceeds * rate_per_million / Decimal("1000000")
+    return fee.quantize(_TWOPLACES)
+
+
+def finra_taf(
+    quantity: int,
+    *,
+    side: str,
+    per_share: Decimal = FINRA_TAF_PER_SHARE_2025,
+    max_per_trade: Decimal = FINRA_TAF_MAX_PER_TRADE_2025,
+) -> Decimal:
+    """FINRA Trading Activity Fee on equity *sells*.
+
+    ``quantity`` is the share count. Returns the fee in USD, capped at
+    ``max_per_trade``. Buys produce zero.
+    """
+    if quantity < 0:
+        raise ValueError("quantity must be non-negative")
+    if per_share < 0 or max_per_trade < 0:
+        raise ValueError("rates must be non-negative")
+    if side != "sell":
+        return _ZERO
+    fee = (Decimal(quantity) * per_share).quantize(_TWOPLACES)
+    return min(fee, max_per_trade)
+
+
+def options_regulatory_fee(
+    contracts: int,
+    *,
+    per_contract: Decimal = ORF_PER_CONTRACT_2025,
+) -> Decimal:
+    """ORF fee — applies to both sides of an options trade.
+
+    ``contracts`` is the option-contract count. Returns USD.
+    """
+    if contracts < 0:
+        raise ValueError("contracts must be non-negative")
+    if per_contract < 0:
+        raise ValueError("per_contract must be non-negative")
+    return (Decimal(contracts) * per_contract).quantize(_TWOPLACES)
+
+
+def occ_clearing_fee(
+    contracts: int,
+    *,
+    per_contract: Decimal = OCC_CLEARING_FEE_PER_CONTRACT,
+) -> Decimal:
+    """OCC clearing fee — per options contract, both sides.
+
+    Distinct from :func:`options_regulatory_fee` (different rate; OCC
+    is paid to the clearing house, ORF to OCC's regulator). Operators
+    typically pass both for an options trade.
+    """
+    if contracts < 0:
+        raise ValueError("contracts must be non-negative")
+    if per_contract < 0:
+        raise ValueError("per_contract must be non-negative")
+    return (Decimal(contracts) * per_contract).quantize(_TWOPLACES)
+
+
+def daily_margin_interest(
+    borrowed_amount: Decimal,
+    annual_rate: Decimal,
+    *,
+    days: int = 1,
+    days_per_year: int = DAYS_PER_YEAR,
+) -> Decimal:
+    """Accrued margin interest over ``days`` calendar days.
+
+    ``annual_rate`` is the simple annual percentage as a fraction (e.g.
+    ``Decimal("0.085")`` for 8.5 % APR). Returns USD. ``days`` defaults
+    to 1 (the typical daily-accrual cadence).
+    """
+    if borrowed_amount < 0:
+        raise ValueError("borrowed_amount must be non-negative")
+    if annual_rate < 0:
+        raise ValueError("annual_rate must be non-negative")
+    if days < 0:
+        raise ValueError("days must be non-negative")
+    if days_per_year <= 0:
+        raise ValueError("days_per_year must be positive")
+    daily_rate = annual_rate / Decimal(days_per_year)
+    return (borrowed_amount * daily_rate * Decimal(days)).quantize(_TWOPLACES)
+
+
+__all__ = [
+    "DAYS_PER_YEAR",
+    "FINRA_TAF_MAX_PER_TRADE_2025",
+    "FINRA_TAF_PER_SHARE_2025",
+    "OCC_CLEARING_FEE_PER_CONTRACT",
+    "ORF_PER_CONTRACT_2025",
+    "SEC_SECTION_31_RATE_PER_MILLION_2026",
+    "daily_margin_interest",
+    "finra_taf",
+    "occ_clearing_fee",
+    "options_regulatory_fee",
+    "sec_section_31_fee",
+]

--- a/tests/test_regulatory_fees.py
+++ b/tests/test_regulatory_fees.py
@@ -1,0 +1,185 @@
+"""Tests for US regulatory & holding-cost helpers (gh#96 follow-up)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from engine.core.regulatory_fees import (
+    DAYS_PER_YEAR,
+    FINRA_TAF_MAX_PER_TRADE_2025,
+    FINRA_TAF_PER_SHARE_2025,
+    OCC_CLEARING_FEE_PER_CONTRACT,
+    ORF_PER_CONTRACT_2025,
+    SEC_SECTION_31_RATE_PER_MILLION_2026,
+    daily_margin_interest,
+    finra_taf,
+    occ_clearing_fee,
+    options_regulatory_fee,
+    sec_section_31_fee,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_default_rates_pinned(self):
+        assert SEC_SECTION_31_RATE_PER_MILLION_2026 == Decimal("20.60")
+        assert FINRA_TAF_PER_SHARE_2025 == Decimal("0.000166")
+        assert FINRA_TAF_MAX_PER_TRADE_2025 == Decimal("8.30")
+        assert ORF_PER_CONTRACT_2025 == Decimal("0.02905")
+        assert OCC_CLEARING_FEE_PER_CONTRACT == Decimal("0.055")
+        assert DAYS_PER_YEAR == 365
+
+
+# ---------------------------------------------------------------------------
+# SEC Section 31
+# ---------------------------------------------------------------------------
+
+
+class TestSecSection31:
+    def test_buy_returns_zero(self):
+        assert (
+            sec_section_31_fee(Decimal("100000"), side="buy") == Decimal("0.00")
+        )
+
+    def test_known_sell_at_default_rate(self):
+        # $1,000,000 sell × $20.60 / $1,000,000 = $20.60.
+        out = sec_section_31_fee(Decimal("1000000"), side="sell")
+        assert out == Decimal("20.60")
+
+    def test_small_sell_quantises_to_cent(self):
+        # $10,000 × $20.60 / $1,000,000 = $0.206 → rounds to $0.21.
+        out = sec_section_31_fee(Decimal("10000"), side="sell")
+        assert out == Decimal("0.21")
+
+    def test_zero_proceeds_zero_fee(self):
+        assert sec_section_31_fee(Decimal("0"), side="sell") == Decimal("0.00")
+
+    def test_negative_proceeds_rejected(self):
+        with pytest.raises(ValueError):
+            sec_section_31_fee(Decimal("-1"), side="sell")
+
+    def test_custom_rate_override(self):
+        # Operator pinning to historical FY2024 rate of $8.00/M.
+        out = sec_section_31_fee(
+            Decimal("1000000"),
+            side="sell",
+            rate_per_million=Decimal("8.00"),
+        )
+        assert out == Decimal("8.00")
+
+
+# ---------------------------------------------------------------------------
+# FINRA TAF
+# ---------------------------------------------------------------------------
+
+
+class TestFinraTaf:
+    def test_buy_returns_zero(self):
+        assert finra_taf(10_000, side="buy") == Decimal("0.00")
+
+    def test_known_sell_at_default_rate(self):
+        # 1,000 shares × $0.000166 = $0.166 → rounds to $0.17.
+        assert finra_taf(1_000, side="sell") == Decimal("0.17")
+
+    def test_cap_kicks_in_for_huge_order(self):
+        # 1,000,000 shares × $0.000166 = $166 → capped at $8.30.
+        assert finra_taf(1_000_000, side="sell") == Decimal("8.30")
+
+    def test_zero_quantity_zero_fee(self):
+        assert finra_taf(0, side="sell") == Decimal("0.00")
+
+    def test_negative_quantity_rejected(self):
+        with pytest.raises(ValueError):
+            finra_taf(-1, side="sell")
+
+
+# ---------------------------------------------------------------------------
+# Options Regulatory Fee
+# ---------------------------------------------------------------------------
+
+
+class TestOrf:
+    def test_known_value(self):
+        # 100 contracts × $0.02905 = $2.905. Decimal default rounding
+        # is HALF_EVEN (banker's rounding), so 2.905 → 2.90 (rounds to
+        # the nearest even cent). The amount that hits the broker is
+        # the integer-cent quantisation regardless of mode.
+        assert options_regulatory_fee(100) == Decimal("2.90")
+
+    def test_zero_contracts_zero_fee(self):
+        assert options_regulatory_fee(0) == Decimal("0.00")
+
+    def test_negative_contracts_rejected(self):
+        with pytest.raises(ValueError):
+            options_regulatory_fee(-1)
+
+
+# ---------------------------------------------------------------------------
+# OCC clearing fee
+# ---------------------------------------------------------------------------
+
+
+class TestOccClearingFee:
+    def test_known_value(self):
+        # 100 contracts × $0.055 = $5.50.
+        assert occ_clearing_fee(100) == Decimal("5.50")
+
+    def test_zero_contracts_zero_fee(self):
+        assert occ_clearing_fee(0) == Decimal("0.00")
+
+    def test_negative_contracts_rejected(self):
+        with pytest.raises(ValueError):
+            occ_clearing_fee(-1)
+
+
+# ---------------------------------------------------------------------------
+# Daily margin interest
+# ---------------------------------------------------------------------------
+
+
+class TestMarginInterest:
+    def test_one_day_accrual_known_value(self):
+        # $100,000 borrowed × 8.5 % / 365 ≈ $23.29 / day.
+        out = daily_margin_interest(
+            Decimal("100000"), Decimal("0.085")
+        )
+        assert out == Decimal("23.29")
+
+    def test_multi_day_accrual_scales_linearly(self):
+        # Same loan over 30 days ≈ $698.63.
+        out = daily_margin_interest(
+            Decimal("100000"), Decimal("0.085"), days=30
+        )
+        assert out == Decimal("698.63")
+
+    def test_zero_borrowed_zero_interest(self):
+        assert (
+            daily_margin_interest(Decimal("0"), Decimal("0.05"))
+            == Decimal("0.00")
+        )
+
+    def test_zero_rate_zero_interest(self):
+        assert (
+            daily_margin_interest(Decimal("100000"), Decimal("0"))
+            == Decimal("0.00")
+        )
+
+    def test_negative_amount_rejected(self):
+        with pytest.raises(ValueError):
+            daily_margin_interest(Decimal("-1"), Decimal("0.05"))
+
+    def test_negative_rate_rejected(self):
+        with pytest.raises(ValueError):
+            daily_margin_interest(Decimal("100"), Decimal("-0.01"))
+
+    def test_zero_days_per_year_rejected(self):
+        with pytest.raises(ValueError):
+            daily_margin_interest(
+                Decimal("100"), Decimal("0.05"), days_per_year=0
+            )


### PR DESCRIPTION
## Summary

Pure-function cost components callable directly without going through the existing \`engine.core.cost_model.DefaultCostModel\` aggregator. Caller composes them inside their own cost-model adapter for per-component reconciliation against broker clearing reports.

| KPI | Function | Default rate | Notes |
|---|---|---|---|
| A2 | \`sec_section_31_fee(proceeds, *, side, rate_per_million=...)\` | \$20.60 / \$1M (FY2026) | US equity *sells* only |
| A2 | \`finra_taf(quantity, *, side, per_share=..., max_per_trade=...)\` | \$0.000166 / share, capped at \$8.30 | FINRA Trading Activity Fee on equity sells |
| A2 | \`options_regulatory_fee(contracts, *, per_contract=...)\` | \$0.02905 / contract | ORF — applies to both sides |
| A3 | \`occ_clearing_fee(contracts, *, per_contract=...)\` | \$0.055 / contract | Distinct from ORF |
| C1 | \`daily_margin_interest(borrowed_amount, annual_rate, *, days=1, days_per_year=365)\` | n/a | Simple-interest accrual |

All helpers reject negative inputs with \`ValueError\`. Output quantises to USD cents (Decimal default \`ROUND_HALF_EVEN\`).

Refs #96. Out of scope: per-exchange taker/maker rebates (varies by venue + tier), NSCC/DTC clearing & settlement granularity, non-US tax fees (handled by jurisdiction engine), borrow rates for short positions, ADR custody fees / dividend withholding / foreign tax credits.

## Test plan

25 new tests covering:
- [x] Constants pinned to FY2026 / FY2025 schedules
- [x] SEC: buy → 0; \$1M sell → \$20.60; small sell rounds to cent; negative proceeds rejected; custom rate override
- [x] FINRA TAF: buy → 0; 1k shares → \$0.17 (rounded); 1M shares → cap at \$8.30; negative quantity rejected
- [x] ORF: 100 contracts → \$2.90 (HALF_EVEN rounding); zero / negative-contract guards
- [x] OCC: 100 contracts → \$5.50; zero / negative-contract guards
- [x] Margin: 1-day at 8.5 % APR / \$100k → \$23.29; 30-day → \$698.63; zero amount / zero rate → 0; negative-amount / negative-rate / zero-days-per-year guards
- [x] Full local suite: 2042 pass / 55 pre-existing DB-required errors unchanged