### PR TITLE
feat(cost): Almgren-Chriss square-root market-impact (gh#96)

### DIFF
--- a/engine/core/market_impact.py
+++ b/engine/core/market_impact.py
@@ -1,0 +1,141 @@
+"""Almgren-Chriss square-root market-impact model (gh#96 follow-up).
+
+The institutional standard for estimating execution cost when an
+order is large relative to the asset's average daily volume. Models
+the price drift caused by the trade itself, decomposed into:
+
+- *Temporary impact* — the price movement that reverts after the
+  execution finishes (related to liquidity provision spreads).
+- *Permanent impact* — information leakage / supply-demand shift
+  that does not revert.
+
+Core formula (one-way trade, single instrument)::
+
+    impact = η * σ * sqrt(Q / (V * T))
+
+Where:
+
+- ``η`` (eta) — the dimensionless impact coefficient. Empirical
+  literature places it in the range 0.1–0.5 for liquid US equities.
+  We default to 0.314 (Almgren et al., 2005, "Direct Estimation of
+  Equity Market Impact", Risk Magazine).
+- ``σ`` (sigma) — the asset's *daily* volatility, expressed as a
+  fraction (e.g. 0.02 for a 2 % daily move).
+- ``Q`` — the absolute trade quantity (shares).
+- ``V`` — the asset's average daily volume (shares).
+- ``T`` — the execution horizon in trading days. Use ``1`` for a
+  full-day VWAP execution, ``0.5`` for a half-day, etc.
+
+The function returns the impact as a *price fraction* (e.g. 0.0015
+for 15 basis points). Callers multiply by the reference price to
+turn it into a dollar amount per share.
+
+Out of scope (explicit follow-ups)
+----------------------------------
+- Multi-asset portfolio impact + cross-impact terms.
+- Time-varying η (intraday seasonality).
+- Risk-aversion-driven optimal execution scheduling (the full
+  Almgren-Chriss optimisation, not just the impact estimate).
+- Limit-order-book microstructure effects (queue position, opp.
+  cost of resting).
+"""
+
+from __future__ import annotations
+
+import math
+
+# Almgren et al. (2005) baseline. Operators override per asset class
+# / liquidity bucket via the ``eta`` kwarg.
+DEFAULT_ETA: float = 0.314
+
+# Permanent impact as a fraction of temporary impact. Empirical range
+# 0.1–0.3; we pin 0.2 as the midpoint for the default.
+DEFAULT_PERMANENT_FRACTION: float = 0.2
+
+
+def compute_temporary_impact(
+    quantity: float,
+    daily_volume: float,
+    daily_volatility: float,
+    *,
+    eta: float = DEFAULT_ETA,
+    horizon_days: float = 1.0,
+) -> float:
+    """Square-root temporary-impact estimate as a *price fraction*.
+
+    Returns ``0.0`` when ``quantity``, ``daily_volume``, or
+    ``daily_volatility`` is zero. Negative inputs raise.
+
+    The formula assumes the execution drains a fraction
+    ``quantity / (daily_volume * horizon_days)`` of the available
+    liquidity over ``horizon_days`` days; the impact scales with the
+    square root of that fraction.
+    """
+    _check_non_negative("quantity", quantity)
+    _check_non_negative("daily_volume", daily_volume)
+    _check_non_negative("daily_volatility", daily_volatility)
+    _check_non_negative("eta", eta)
+    if horizon_days <= 0:
+        raise ValueError("horizon_days must be positive")
+    if quantity == 0 or daily_volume == 0 or daily_volatility == 0:
+        return 0.0
+    participation = quantity / (daily_volume * horizon_days)
+    return eta * daily_volatility * math.sqrt(participation)
+
+
+def compute_permanent_impact(
+    temporary_impact: float,
+    *,
+    permanent_fraction: float = DEFAULT_PERMANENT_FRACTION,
+) -> float:
+    """Permanent component as a fixed fraction of temporary impact.
+
+    The Almgren-Chriss decomposition treats permanent impact as a
+    constant fraction of the total — typically 10–30 %. Operators
+    calibrate per asset class.
+    """
+    _check_non_negative("temporary_impact", temporary_impact)
+    _check_non_negative("permanent_fraction", permanent_fraction)
+    return temporary_impact * permanent_fraction
+
+
+def compute_total_market_impact(
+    quantity: float,
+    daily_volume: float,
+    daily_volatility: float,
+    *,
+    eta: float = DEFAULT_ETA,
+    horizon_days: float = 1.0,
+    permanent_fraction: float = DEFAULT_PERMANENT_FRACTION,
+) -> tuple[float, float, float]:
+    """Return ``(temporary, permanent, total)`` impact fractions.
+
+    Convenience wrapper that runs both halves of the decomposition in
+    one call. Operators dollar-cost the result by multiplying each
+    fraction by the reference price.
+    """
+    temp = compute_temporary_impact(
+        quantity,
+        daily_volume,
+        daily_volatility,
+        eta=eta,
+        horizon_days=horizon_days,
+    )
+    perm = compute_permanent_impact(
+        temp, permanent_fraction=permanent_fraction
+    )
+    return temp, perm, temp + perm
+
+
+def _check_non_negative(name: str, value: float) -> None:
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
+
+
+__all__ = [
+    "DEFAULT_ETA",
+    "DEFAULT_PERMANENT_FRACTION",
+    "compute_permanent_impact",
+    "compute_temporary_impact",
+    "compute_total_market_impact",
+]

--- a/tests/test_market_impact.py
+++ b/tests/test_market_impact.py
@@ -1,0 +1,194 @@
+"""Tests for the Almgren-Chriss market-impact helpers (gh#96 follow-up)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.market_impact import (
+    DEFAULT_ETA,
+    DEFAULT_PERMANENT_FRACTION,
+    compute_permanent_impact,
+    compute_temporary_impact,
+    compute_total_market_impact,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_eta_pinned(self):
+        assert DEFAULT_ETA == 0.314
+
+    def test_permanent_fraction_pinned(self):
+        assert DEFAULT_PERMANENT_FRACTION == 0.2
+
+
+# ---------------------------------------------------------------------------
+# Temporary impact
+# ---------------------------------------------------------------------------
+
+
+class TestTemporaryImpact:
+    def test_zero_quantity_returns_zero(self):
+        assert (
+            compute_temporary_impact(0, 1_000_000, 0.02) == 0.0
+        )
+
+    def test_zero_volume_returns_zero(self):
+        assert (
+            compute_temporary_impact(1000, 0, 0.02) == 0.0
+        )
+
+    def test_zero_volatility_returns_zero(self):
+        assert (
+            compute_temporary_impact(1000, 1_000_000, 0) == 0.0
+        )
+
+    def test_known_value(self):
+        # 100k shares against 10M ADV at 2% daily vol, η=0.314.
+        # participation = 100k / 10M = 0.01
+        # impact = 0.314 * 0.02 * sqrt(0.01) = 0.314 * 0.02 * 0.1
+        #        = 0.000628
+        out = compute_temporary_impact(
+            100_000, 10_000_000, 0.02
+        )
+        assert out == pytest.approx(0.000628, rel=1e-9)
+
+    def test_horizon_dilutes_impact(self):
+        # Spreading the same order over 4 days should halve the
+        # impact (sqrt(1/4) = 0.5).
+        one_day = compute_temporary_impact(
+            100_000, 10_000_000, 0.02, horizon_days=1.0
+        )
+        four_days = compute_temporary_impact(
+            100_000, 10_000_000, 0.02, horizon_days=4.0
+        )
+        assert four_days == pytest.approx(one_day * 0.5, rel=1e-9)
+
+    def test_quadrupling_quantity_doubles_impact(self):
+        # sqrt(4) = 2 — square-root scaling with quantity.
+        small = compute_temporary_impact(
+            1000, 10_000_000, 0.02
+        )
+        large = compute_temporary_impact(
+            4000, 10_000_000, 0.02
+        )
+        assert large == pytest.approx(small * 2.0, rel=1e-9)
+
+    def test_eta_override(self):
+        # Doubling η doubles the impact.
+        baseline = compute_temporary_impact(
+            1000, 10_000_000, 0.02, eta=0.314
+        )
+        doubled = compute_temporary_impact(
+            1000, 10_000_000, 0.02, eta=0.628
+        )
+        assert doubled == pytest.approx(baseline * 2.0, rel=1e-9)
+
+    def test_negative_quantity_rejected(self):
+        with pytest.raises(ValueError):
+            compute_temporary_impact(-1, 1_000_000, 0.02)
+
+    def test_negative_volume_rejected(self):
+        with pytest.raises(ValueError):
+            compute_temporary_impact(100, -1, 0.02)
+
+    def test_negative_volatility_rejected(self):
+        with pytest.raises(ValueError):
+            compute_temporary_impact(100, 1_000_000, -0.01)
+
+    def test_zero_horizon_rejected(self):
+        with pytest.raises(ValueError):
+            compute_temporary_impact(100, 1_000_000, 0.02, horizon_days=0)
+
+    def test_negative_horizon_rejected(self):
+        with pytest.raises(ValueError):
+            compute_temporary_impact(100, 1_000_000, 0.02, horizon_days=-1)
+
+
+# ---------------------------------------------------------------------------
+# Permanent impact
+# ---------------------------------------------------------------------------
+
+
+class TestPermanentImpact:
+    def test_default_fraction(self):
+        # Permanent = 20 % of temporary by default.
+        assert compute_permanent_impact(0.001) == pytest.approx(0.0002)
+
+    def test_custom_fraction(self):
+        out = compute_permanent_impact(
+            0.001, permanent_fraction=0.3
+        )
+        assert out == pytest.approx(0.0003)
+
+    def test_zero_temporary_zero_permanent(self):
+        assert compute_permanent_impact(0.0) == 0.0
+
+    def test_negative_temporary_rejected(self):
+        with pytest.raises(ValueError):
+            compute_permanent_impact(-0.001)
+
+    def test_negative_fraction_rejected(self):
+        with pytest.raises(ValueError):
+            compute_permanent_impact(0.001, permanent_fraction=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# Total market impact (decomposition wrapper)
+# ---------------------------------------------------------------------------
+
+
+class TestTotalMarketImpact:
+    def test_returns_three_components_summing_to_total(self):
+        temp, perm, total = compute_total_market_impact(
+            100_000, 10_000_000, 0.02
+        )
+        assert total == pytest.approx(temp + perm, rel=1e-9)
+
+    def test_temp_matches_compute_temporary_alone(self):
+        temp, _perm, _total = compute_total_market_impact(
+            100_000, 10_000_000, 0.02
+        )
+        alone = compute_temporary_impact(100_000, 10_000_000, 0.02)
+        assert temp == pytest.approx(alone)
+
+    def test_perm_uses_permanent_fraction_kwarg(self):
+        temp, perm, _total = compute_total_market_impact(
+            100_000, 10_000_000, 0.02, permanent_fraction=0.25
+        )
+        assert perm == pytest.approx(temp * 0.25, rel=1e-9)
+
+    def test_zero_quantity_zero_components(self):
+        temp, perm, total = compute_total_market_impact(
+            0, 10_000_000, 0.02
+        )
+        assert temp == 0.0
+        assert perm == 0.0
+        assert total == 0.0
+
+    def test_full_decomposition_known_value(self):
+        # 100k against 10M ADV at 2 % vol, η=0.314, perm_frac=0.2
+        # temp = 0.314 * 0.02 * sqrt(0.01) = 0.000628
+        # perm = 0.000628 * 0.2 = 0.0001256
+        # total = 0.000628 + 0.0001256 = 0.0007536
+        temp, perm, total = compute_total_market_impact(
+            100_000, 10_000_000, 0.02
+        )
+        assert temp == pytest.approx(0.000628, rel=1e-9)
+        assert perm == pytest.approx(0.0001256, rel=1e-9)
+        assert total == pytest.approx(0.0007536, rel=1e-9)
+
+    def test_basis_points_within_typical_range(self):
+        # A 1 % participation should produce impact within tens of bps.
+        _, _, total = compute_total_market_impact(
+            100_000, 10_000_000, 0.02
+        )
+        # Sanity: ~7.5 bps for the example above.
+        assert 0.0001 < total < 0.005
+        assert math.isfinite(total)


### PR DESCRIPTION
## Summary

Pure-formula market-impact estimator — institutional standard for trades large relative to the asset's average daily volume. Models the price drift caused by the trade itself, decomposed into:

- **Temporary impact** — reverts after execution finishes (liquidity-provision spreads).
- **Permanent impact** — information leakage / supply-demand shift that does not revert.

Core formula: \`impact = η · σ · sqrt(Q / (V · T))\`.

API:

| Function | Description |
|---|---|
| \`compute_temporary_impact(quantity, daily_volume, daily_volatility, *, eta=0.314, horizon_days=1.0)\` | Square-root impact as a price fraction (0.001 = 10 bps). Zero on any zero input; negatives reject |
| \`compute_permanent_impact(temporary_impact, *, permanent_fraction=0.2)\` | Fixed-fraction permanent component. 10–30 % range typical |
| \`compute_total_market_impact(...)\` | Returns \`(temp, perm, total)\` tuple — caller dollar-costs by multiplying by reference price |

Defaults pinned to Almgren et al. (2005) *"Direct Estimation of Equity Market Impact"* (Risk Magazine): \`η = 0.314\` baseline, permanent fraction = 0.2 midpoint of the empirical 10–30 % range. Operators override per asset class / liquidity bucket via kwargs.

Refs #96. Out of scope: multi-asset cross-impact, time-varying η, full Almgren-Chriss optimal-execution scheduling, limit-order-book microstructure (queue position, opp. cost of resting).

## Test plan

25 new tests covering:
- [x] Constants pinned (η = 0.314, permanent fraction = 0.2)
- [x] Zero quantity / volume / volatility → 0.0
- [x] Known value: 100 k against 10 M ADV at 2 % vol → 6.28 bps temp + 1.256 bps perm = 7.536 bps total
- [x] Square-root scaling: 4× quantity ⇒ 2× impact; 4× horizon ⇒ 0.5× impact
- [x] η doubling → impact doubles
- [x] Permanent fraction kwarg pass-through
- [x] Negative / zero-horizon validation guards on every input
- [x] Decomposition wrapper sums to total within rounding
- [x] Sanity check that the 7.5 bps example sits within 1 bp – 50 bps band
- [x] Full local suite: 2067 pass / 55 pre-existing DB-required errors unchanged