### PR TITLE
feat(cost): execution cost helpers (gh#96)

### DIFF
--- a/engine/core/execution_costs.py
+++ b/engine/core/execution_costs.py
@@ -1,0 +1,155 @@
+"""Execution cost helpers (gh#96 follow-up).
+
+Pure-function cost components composable with the existing
+:class:`engine.core.cost_model.DefaultCostModel`. Each helper returns
+a USD ``Decimal`` quantised to the cent.
+
+Components covered (numbers from gh#96 taxonomy):
+
+- A3  exchange_taker_fee / exchange_maker_rebate — per-share venue fees
+- A4  nscc_clearing_fee                          — per-side NSCC fee
+- B1  half_spread_cost                           — half the bid/ask spread
+- B5  opportunity_cost                           — unfilled-shares price drift
+
+Out of scope (explicit follow-ups):
+- DTC transfer fees (different fee schedule, account-level).
+- Per-venue tier-aware maker rebates (operators thread their broker
+  tier into ``rate_per_share``).
+- Locked-up cost-of-carry on partial fills (different module).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+# NSCC continuous net-settlement fee schedule (FY2025): roughly
+# $0.0002 per side. Operators reconcile against their clearing report
+# via the ``per_side`` kwarg.
+NSCC_FEE_PER_SIDE_2025: Decimal = Decimal("0.0002")
+
+# Typical exchange taker fee on an aggressive order. Different venues
+# (NYSE / NASDAQ / ARCA / BATS) have different rates; this default
+# represents the high-water mark, $0.0030 per share.
+DEFAULT_TAKER_FEE_PER_SHARE: Decimal = Decimal("0.0030")
+
+# Typical maker rebate for adding liquidity, $0.0020 per share. Some
+# venues pay you to post; others charge access. Operators override
+# per-venue.
+DEFAULT_MAKER_REBATE_PER_SHARE: Decimal = Decimal("0.0020")
+
+
+def half_spread_cost(
+    spread: Decimal,
+    quantity: int,
+) -> Decimal:
+    """Cost of crossing half the bid/ask spread on an aggressive order.
+
+    ``spread`` is the bid/ask spread in *price units* (e.g.
+    ``Decimal("0.01")`` for a one-cent spread). The half-spread is the
+    expected slippage when crossing a market order: a buy pays the
+    ask, a sell hits the bid, and on average half the round-trip
+    spread is paid each side.
+
+    Returns the dollar cost; quantises to the cent. Negative inputs
+    raise.
+    """
+    if spread < 0:
+        raise ValueError("spread must be non-negative")
+    if quantity < 0:
+        raise ValueError("quantity must be non-negative")
+    return ((spread / 2) * Decimal(quantity)).quantize(_TWOPLACES)
+
+
+def nscc_clearing_fee(
+    quantity: int,
+    *,
+    per_side: Decimal = NSCC_FEE_PER_SIDE_2025,
+) -> Decimal:
+    """NSCC continuous net-settlement fee for one side of a US equity
+    trade.
+
+    ``quantity`` is the share count for this side. Returns USD. The
+    fee applies symmetrically to both buys and sells.
+    """
+    if quantity < 0:
+        raise ValueError("quantity must be non-negative")
+    if per_side < 0:
+        raise ValueError("per_side must be non-negative")
+    return (Decimal(quantity) * per_side).quantize(_TWOPLACES)
+
+
+def exchange_taker_fee(
+    quantity: int,
+    *,
+    rate_per_share: Decimal = DEFAULT_TAKER_FEE_PER_SHARE,
+) -> Decimal:
+    """Per-share exchange taker fee (aggressive / liquidity-removing).
+
+    Returns the dollar fee, quantised to the cent. Operators pass
+    their venue-specific rate via ``rate_per_share``.
+    """
+    if quantity < 0:
+        raise ValueError("quantity must be non-negative")
+    if rate_per_share < 0:
+        raise ValueError("rate_per_share must be non-negative")
+    return (Decimal(quantity) * rate_per_share).quantize(_TWOPLACES)
+
+
+def exchange_maker_rebate(
+    quantity: int,
+    *,
+    rate_per_share: Decimal = DEFAULT_MAKER_REBATE_PER_SHARE,
+) -> Decimal:
+    """Per-share exchange maker rebate (passive / liquidity-adding).
+
+    Returns a *positive* dollar amount the venue pays the trader.
+    Operators interpret it as a negative cost when summing the full
+    cost stack. Defaults to $0.0020 per share but varies widely by
+    venue and tier.
+    """
+    if quantity < 0:
+        raise ValueError("quantity must be non-negative")
+    if rate_per_share < 0:
+        raise ValueError("rate_per_share must be non-negative")
+    return (Decimal(quantity) * rate_per_share).quantize(_TWOPLACES)
+
+
+def opportunity_cost(
+    unfilled_shares: int,
+    price_change: Decimal,
+) -> Decimal:
+    """Implementation-shortfall opportunity cost on unfilled shares.
+
+    ``price_change`` is the signed price drift between the decision
+    timestamp and the cancel/expire timestamp, in *price units*. For
+    a buy that didn't fill, a positive ``price_change`` means the
+    market ran away — operator pays opportunity cost. For a sell, a
+    negative ``price_change`` means the market dropped before the
+    sell completed — also a loss.
+
+    Caller signs ``price_change`` so that a positive value always
+    represents a *cost* (i.e. for a buy pass ``new_price - old_price``;
+    for a sell pass ``old_price - new_price``).
+
+    Returns USD; rounds to cent. Negative ``price_change`` produces a
+    negative cost (favourable drift offsets the implementation
+    shortfall in the operator's reconciliation).
+    """
+    if unfilled_shares < 0:
+        raise ValueError("unfilled_shares must be non-negative")
+    return (Decimal(unfilled_shares) * price_change).quantize(_TWOPLACES)
+
+
+__all__ = [
+    "DEFAULT_MAKER_REBATE_PER_SHARE",
+    "DEFAULT_TAKER_FEE_PER_SHARE",
+    "NSCC_FEE_PER_SIDE_2025",
+    "exchange_maker_rebate",
+    "exchange_taker_fee",
+    "half_spread_cost",
+    "nscc_clearing_fee",
+    "opportunity_cost",
+]

--- a/tests/test_execution_costs.py
+++ b/tests/test_execution_costs.py
@@ -1,0 +1,162 @@
+"""Tests for execution cost helpers (gh#96 follow-up)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from engine.core.execution_costs import (
+    DEFAULT_MAKER_REBATE_PER_SHARE,
+    DEFAULT_TAKER_FEE_PER_SHARE,
+    NSCC_FEE_PER_SIDE_2025,
+    exchange_maker_rebate,
+    exchange_taker_fee,
+    half_spread_cost,
+    nscc_clearing_fee,
+    opportunity_cost,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_defaults_pinned(self):
+        assert NSCC_FEE_PER_SIDE_2025 == Decimal("0.0002")
+        assert DEFAULT_TAKER_FEE_PER_SHARE == Decimal("0.0030")
+        assert DEFAULT_MAKER_REBATE_PER_SHARE == Decimal("0.0020")
+
+
+# ---------------------------------------------------------------------------
+# half_spread_cost
+# ---------------------------------------------------------------------------
+
+
+class TestHalfSpread:
+    def test_known_value(self):
+        # 1-cent spread × 1000 shares × 0.5 = $5.00
+        assert half_spread_cost(Decimal("0.01"), 1000) == Decimal("5.00")
+
+    def test_wide_illiquid_spread(self):
+        # 50 bps spread on $100 stock → $0.50 spread, half = $0.25
+        # × 200 shares = $50.00
+        assert half_spread_cost(Decimal("0.50"), 200) == Decimal("50.00")
+
+    def test_zero_quantity_zero_cost(self):
+        assert half_spread_cost(Decimal("0.05"), 0) == Decimal("0.00")
+
+    def test_zero_spread_zero_cost(self):
+        assert half_spread_cost(Decimal("0"), 1000) == Decimal("0.00")
+
+    def test_negative_spread_rejected(self):
+        with pytest.raises(ValueError):
+            half_spread_cost(Decimal("-0.01"), 100)
+
+    def test_negative_quantity_rejected(self):
+        with pytest.raises(ValueError):
+            half_spread_cost(Decimal("0.01"), -1)
+
+
+# ---------------------------------------------------------------------------
+# nscc_clearing_fee
+# ---------------------------------------------------------------------------
+
+
+class TestNsccFee:
+    def test_known_value(self):
+        # 100,000 shares × $0.0002 = $20.00
+        assert nscc_clearing_fee(100_000) == Decimal("20.00")
+
+    def test_zero_quantity_zero_fee(self):
+        assert nscc_clearing_fee(0) == Decimal("0.00")
+
+    def test_negative_quantity_rejected(self):
+        with pytest.raises(ValueError):
+            nscc_clearing_fee(-1)
+
+    def test_per_side_override(self):
+        # Operator pin to a different rate.
+        assert (
+            nscc_clearing_fee(100_000, per_side=Decimal("0.0005"))
+            == Decimal("50.00")
+        )
+
+
+# ---------------------------------------------------------------------------
+# exchange_taker_fee
+# ---------------------------------------------------------------------------
+
+
+class TestTakerFee:
+    def test_known_value(self):
+        # 1000 shares × $0.0030 = $3.00
+        assert exchange_taker_fee(1000) == Decimal("3.00")
+
+    def test_custom_rate(self):
+        # Some venues charge $0.0029.
+        assert (
+            exchange_taker_fee(1000, rate_per_share=Decimal("0.0029"))
+            == Decimal("2.90")
+        )
+
+    def test_zero_quantity_zero_fee(self):
+        assert exchange_taker_fee(0) == Decimal("0.00")
+
+    def test_negative_quantity_rejected(self):
+        with pytest.raises(ValueError):
+            exchange_taker_fee(-1)
+
+
+# ---------------------------------------------------------------------------
+# exchange_maker_rebate
+# ---------------------------------------------------------------------------
+
+
+class TestMakerRebate:
+    def test_known_value(self):
+        # 1000 shares × $0.0020 = $2.00 paid TO the trader.
+        assert exchange_maker_rebate(1000) == Decimal("2.00")
+
+    def test_custom_rate(self):
+        assert (
+            exchange_maker_rebate(1000, rate_per_share=Decimal("0.0030"))
+            == Decimal("3.00")
+        )
+
+    def test_zero_quantity_zero_rebate(self):
+        assert exchange_maker_rebate(0) == Decimal("0.00")
+
+
+# ---------------------------------------------------------------------------
+# opportunity_cost
+# ---------------------------------------------------------------------------
+
+
+class TestOpportunityCost:
+    def test_buy_market_runs_away_positive_cost(self):
+        # 100 unfilled shares, market moved $0.50 against the buy
+        # → caller passes +0.50 as the signed drift; cost = $50.00.
+        assert opportunity_cost(100, Decimal("0.50")) == Decimal("50.00")
+
+    def test_favourable_drift_yields_negative_cost(self):
+        # Market dropped $0.20 while buy was waiting — buyer would
+        # have been better off waiting longer; opportunity cost is
+        # negative (a *gain* in implementation-shortfall terms).
+        assert opportunity_cost(100, Decimal("-0.20")) == Decimal("-20.00")
+
+    def test_zero_unfilled_zero_cost(self):
+        assert opportunity_cost(0, Decimal("1.00")) == Decimal("0.00")
+
+    def test_zero_drift_zero_cost(self):
+        assert opportunity_cost(100, Decimal("0")) == Decimal("0.00")
+
+    def test_negative_unfilled_rejected(self):
+        with pytest.raises(ValueError):
+            opportunity_cost(-1, Decimal("0.01"))
+
+    def test_quantises_to_cent(self):
+        # Awkward fractional drift: 100 shares × 0.123 = 12.30.
+        assert opportunity_cost(100, Decimal("0.123")) == Decimal("12.30")


### PR DESCRIPTION
## Summary

5 pure-function cost components composable with the existing \`engine.core.cost_model.DefaultCostModel\` aggregator. Each helper returns a USD \`Decimal\` quantised to the cent.

| KPI | Function | Default | Notes |
|---|---|---|---|
| B1 | \`half_spread_cost(spread, quantity)\` | n/a | Cost of crossing half the bid/ask on an aggressive order |
| A4 | \`nscc_clearing_fee(quantity, *, per_side=...)\` | \$0.0002 / share / side (FY2025) | NSCC continuous net-settlement |
| A3 | \`exchange_taker_fee(quantity, *, rate_per_share=...)\` | \$0.0030 / share | Per-venue aggressive-order fee |
| A3 | \`exchange_maker_rebate(quantity, *, rate_per_share=...)\` | \$0.0020 / share | Per-venue passive-order payout — *positive* amount; caller signs as negative cost when summing |
| B5 | \`opportunity_cost(unfilled_shares, price_change)\` | n/a | Implementation-shortfall on unfilled shares; caller signs drift so positive value = cost |

All helpers reject negative inputs with \`ValueError\`. Output quantises to USD cents (Decimal \`HALF_EVEN\`).

Refs #96. Out of scope: DTC transfer fees (account-level, different schedule), per-venue tier-aware maker rebates (operator threads broker tier into \`rate_per_share\`), locked-up cost-of-carry on partial fills (different module).

## Test plan

24 new tests covering:
- [x] Constants pinned to FY2025 schedules
- [x] Half-spread: 1¢ × 1000 → \$5.00; wide-illiquid 50¢ × 200 → \$50.00; zero / negative guards
- [x] NSCC: 100k shares → \$20.00; per-side override; zero / negative guards
- [x] Taker: default \$0.003 → 1k = \$3.00; custom \$0.0029 rounds to \$2.90
- [x] Maker: default \$0.002 → 1k = \$2.00; custom rate
- [x] Opportunity cost: buy with adverse \$0.50 drift × 100 → \$50.00; favourable -\$0.20 drift → -\$20.00; zero / negative guards
- [x] Awkward fractional drift quantises to cent (12.30)
- [x] Full local suite: 2091 pass / 55 pre-existing DB-required errors unchanged