### PR TITLE
feat(cost): hard-to-borrow + dividend handling (gh#96)

### DIFF
--- a/engine/core/holding_costs.py
+++ b/engine/core/holding_costs.py
@@ -1,0 +1,139 @@
+"""Holding-cost helpers (gh#96 follow-up).
+
+Pure-function helpers for costs that accrue *while a position is
+open* — distinct from execution costs that fire at trade-event time.
+
+Components covered (numbers from gh#96 taxonomy):
+
+- C2  hard_to_borrow_cost                    — short-position daily borrow fee
+- C3  dividend_payment / reinvested_shares   — dividend handling
+
+Out of scope (explicit follow-ups):
+- Stock-loan rebate (institutional negative-fee tier when borrow
+  demand drops below supply).
+- C4 ADR custody fees (account-level, separate ledger).
+- C5 Foreign withholding tax on cross-border dividends (handled by
+  jurisdiction engine).
+- Special / qualified dividend distinction (caller passes the gross
+  amount; tax treatment lives in the tax module).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+_FOURPLACES = Decimal("0.0001")
+
+DAYS_PER_YEAR: int = 365
+
+
+def hard_to_borrow_cost(
+    short_market_value: Decimal,
+    annual_rate: Decimal,
+    *,
+    days: int = 1,
+    days_per_year: int = DAYS_PER_YEAR,
+) -> Decimal:
+    """Daily hard-to-borrow accrual for a short position.
+
+    ``short_market_value`` is the *current market value* of the short
+    (positive Decimal). ``annual_rate`` is the simple annual HTB rate
+    as a fraction (e.g. ``Decimal("0.15")`` for 15 % APR — typical for
+    moderately-hard-to-borrow names; severely-restricted names can
+    exceed 100 %).
+
+    Returns the accrued cost in USD over ``days`` calendar days.
+    """
+    if short_market_value < 0:
+        raise ValueError("short_market_value must be non-negative")
+    if annual_rate < 0:
+        raise ValueError("annual_rate must be non-negative")
+    if days < 0:
+        raise ValueError("days must be non-negative")
+    if days_per_year <= 0:
+        raise ValueError("days_per_year must be positive")
+    daily_rate = annual_rate / Decimal(days_per_year)
+    return (short_market_value * daily_rate * Decimal(days)).quantize(_TWOPLACES)
+
+
+def dividend_payment(
+    shares_held: Decimal,
+    dividend_per_share: Decimal,
+) -> Decimal:
+    """Cash dividend received: ``shares_held × dividend_per_share``.
+
+    Both inputs are non-negative. Returns USD quantised to the cent.
+    Operators apply withholding-tax adjustments separately via the
+    jurisdiction engine; this helper is the gross dividend.
+    """
+    if shares_held < 0:
+        raise ValueError("shares_held must be non-negative")
+    if dividend_per_share < 0:
+        raise ValueError("dividend_per_share must be non-negative")
+    return (shares_held * dividend_per_share).quantize(_TWOPLACES)
+
+
+def reinvested_shares(
+    cash_amount: Decimal,
+    reinvestment_price: Decimal,
+    *,
+    fractional: bool = True,
+) -> Decimal:
+    """Number of shares purchased under a DRIP at ``reinvestment_price``.
+
+    With ``fractional=True`` (the default — most US brokers' DRIPs
+    support fractional shares), returns the exact share count to four
+    decimal places. With ``fractional=False`` (some broker programs
+    or non-US accounts), truncates to the integer share count and the
+    caller handles the residual cash.
+
+    Returns 0 when ``cash_amount`` is 0; raises on negative inputs or
+    non-positive ``reinvestment_price``.
+    """
+    if cash_amount < 0:
+        raise ValueError("cash_amount must be non-negative")
+    if reinvestment_price <= 0:
+        raise ValueError("reinvestment_price must be positive")
+    raw = cash_amount / reinvestment_price
+    if fractional:
+        return raw.quantize(_FOURPLACES)
+    # Integer truncation: drop everything after the decimal point.
+    return Decimal(int(raw))
+
+
+def reinvestment_residual_cash(
+    cash_amount: Decimal,
+    reinvestment_price: Decimal,
+    shares_purchased: Decimal,
+) -> Decimal:
+    """Cash left over after a DRIP purchase.
+
+    Useful when ``fractional=False`` truncates the share count and the
+    broker returns the remainder to cash. With ``fractional=True``
+    this typically returns ``0.00``.
+    """
+    if cash_amount < 0:
+        raise ValueError("cash_amount must be non-negative")
+    if reinvestment_price < 0:
+        raise ValueError("reinvestment_price must be non-negative")
+    if shares_purchased < 0:
+        raise ValueError("shares_purchased must be non-negative")
+    spent = (shares_purchased * reinvestment_price).quantize(_TWOPLACES)
+    residual = (cash_amount - spent).quantize(_TWOPLACES)
+    if residual < 0:
+        raise ValueError(
+            "shares_purchased exceeds what cash_amount can buy at "
+            "reinvestment_price"
+        )
+    return residual
+
+
+__all__ = [
+    "DAYS_PER_YEAR",
+    "dividend_payment",
+    "hard_to_borrow_cost",
+    "reinvested_shares",
+    "reinvestment_residual_cash",
+]

--- a/tests/test_holding_costs.py
+++ b/tests/test_holding_costs.py
@@ -1,0 +1,196 @@
+"""Tests for holding-cost helpers (gh#96 follow-up)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from engine.core.holding_costs import (
+    DAYS_PER_YEAR,
+    dividend_payment,
+    hard_to_borrow_cost,
+    reinvested_shares,
+    reinvestment_residual_cash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_days_per_year(self):
+        assert DAYS_PER_YEAR == 365
+
+
+# ---------------------------------------------------------------------------
+# Hard-to-borrow
+# ---------------------------------------------------------------------------
+
+
+class TestHardToBorrow:
+    def test_one_day_at_15_pct(self):
+        # $100k short × 15 % / 365 ≈ $41.10 / day.
+        assert hard_to_borrow_cost(
+            Decimal("100000"), Decimal("0.15")
+        ) == Decimal("41.10")
+
+    def test_30_days_scales_linearly(self):
+        out = hard_to_borrow_cost(
+            Decimal("100000"), Decimal("0.15"), days=30
+        )
+        assert out == Decimal("1232.88")
+
+    def test_extreme_htb_rate(self):
+        # Severely-restricted name, 200 % APR, $50k short, one day.
+        # 50k × 2.0 / 365 ≈ $273.97 / day.
+        out = hard_to_borrow_cost(
+            Decimal("50000"), Decimal("2.0"), days=1
+        )
+        assert out == Decimal("273.97")
+
+    def test_zero_short_zero_cost(self):
+        assert hard_to_borrow_cost(
+            Decimal("0"), Decimal("0.10")
+        ) == Decimal("0.00")
+
+    def test_zero_rate_zero_cost(self):
+        assert hard_to_borrow_cost(
+            Decimal("100000"), Decimal("0")
+        ) == Decimal("0.00")
+
+    def test_negative_short_value_rejected(self):
+        with pytest.raises(ValueError):
+            hard_to_borrow_cost(Decimal("-1"), Decimal("0.10"))
+
+    def test_negative_rate_rejected(self):
+        with pytest.raises(ValueError):
+            hard_to_borrow_cost(Decimal("100"), Decimal("-0.01"))
+
+    def test_negative_days_rejected(self):
+        with pytest.raises(ValueError):
+            hard_to_borrow_cost(
+                Decimal("100"), Decimal("0.10"), days=-1
+            )
+
+    def test_zero_days_per_year_rejected(self):
+        with pytest.raises(ValueError):
+            hard_to_borrow_cost(
+                Decimal("100"), Decimal("0.10"), days_per_year=0
+            )
+
+
+# ---------------------------------------------------------------------------
+# Dividend payment
+# ---------------------------------------------------------------------------
+
+
+class TestDividendPayment:
+    def test_known_value(self):
+        # 250 shares × $0.42 = $105.00
+        assert dividend_payment(
+            Decimal("250"), Decimal("0.42")
+        ) == Decimal("105.00")
+
+    def test_fractional_shares(self):
+        # 100.5 shares × $1.00 = $100.50
+        assert dividend_payment(
+            Decimal("100.5"), Decimal("1.00")
+        ) == Decimal("100.50")
+
+    def test_zero_shares_zero_dividend(self):
+        assert dividend_payment(
+            Decimal("0"), Decimal("1.00")
+        ) == Decimal("0.00")
+
+    def test_zero_per_share_zero_dividend(self):
+        assert dividend_payment(
+            Decimal("100"), Decimal("0")
+        ) == Decimal("0.00")
+
+    def test_negative_shares_rejected(self):
+        with pytest.raises(ValueError):
+            dividend_payment(Decimal("-1"), Decimal("1.00"))
+
+    def test_negative_dividend_rejected(self):
+        with pytest.raises(ValueError):
+            dividend_payment(Decimal("100"), Decimal("-0.01"))
+
+
+# ---------------------------------------------------------------------------
+# DRIP reinvestment
+# ---------------------------------------------------------------------------
+
+
+class TestReinvestedShares:
+    def test_fractional_default(self):
+        # $105.00 / $50.00 = 2.1 shares.
+        assert reinvested_shares(
+            Decimal("105"), Decimal("50")
+        ) == Decimal("2.1000")
+
+    def test_fractional_quantises_to_four_decimals(self):
+        # $100 / $33 = 3.0303030303... → 3.0303 (4dp).
+        assert reinvested_shares(
+            Decimal("100"), Decimal("33")
+        ) == Decimal("3.0303")
+
+    def test_integer_truncation_with_fractional_false(self):
+        # $105 / $50 = 2.1 → 2 (integer truncation).
+        assert reinvested_shares(
+            Decimal("105"), Decimal("50"), fractional=False
+        ) == Decimal("2")
+
+    def test_zero_cash_zero_shares(self):
+        assert reinvested_shares(
+            Decimal("0"), Decimal("50")
+        ) == Decimal("0.0000")
+
+    def test_negative_cash_rejected(self):
+        with pytest.raises(ValueError):
+            reinvested_shares(Decimal("-1"), Decimal("50"))
+
+    def test_zero_price_rejected(self):
+        with pytest.raises(ValueError):
+            reinvested_shares(Decimal("100"), Decimal("0"))
+
+    def test_negative_price_rejected(self):
+        with pytest.raises(ValueError):
+            reinvested_shares(Decimal("100"), Decimal("-1"))
+
+
+class TestReinvestmentResidualCash:
+    def test_integer_truncation_residual(self):
+        # $105 cash, 2 shares × $50 = $100 spent → $5 residual.
+        assert reinvestment_residual_cash(
+            Decimal("105"), Decimal("50"), Decimal("2")
+        ) == Decimal("5.00")
+
+    def test_full_fractional_purchase_zero_residual(self):
+        # $105 cash, 2.1 shares × $50 = $105 spent → 0 residual.
+        assert reinvestment_residual_cash(
+            Decimal("105"), Decimal("50"), Decimal("2.1")
+        ) == Decimal("0.00")
+
+    def test_overspend_rejected(self):
+        # 3 × $50 = $150 > $100 cash → residual would be negative.
+        with pytest.raises(ValueError):
+            reinvestment_residual_cash(
+                Decimal("100"), Decimal("50"), Decimal("3")
+            )
+
+    def test_negative_inputs_rejected(self):
+        with pytest.raises(ValueError):
+            reinvestment_residual_cash(
+                Decimal("-1"), Decimal("50"), Decimal("0")
+            )
+        with pytest.raises(ValueError):
+            reinvestment_residual_cash(
+                Decimal("100"), Decimal("-1"), Decimal("0")
+            )
+        with pytest.raises(ValueError):
+            reinvestment_residual_cash(
+                Decimal("100"), Decimal("50"), Decimal("-1")
+            )


### PR DESCRIPTION
## Summary

Pure-function helpers for costs that accrue *while a position is open* — distinct from execution-time fees.

| KPI | Function | Notes |
|---|---|---|
| C2 | \`hard_to_borrow_cost(short_market_value, annual_rate, *, days=1, days_per_year=365)\` | Short-position daily borrow accrual. Severely-restricted names exceed 100 % APR |
| C3 | \`dividend_payment(shares_held, dividend_per_share)\` | Gross dividend cash. Withholding-tax adjustments live in the tax module |
| C3 | \`reinvested_shares(cash_amount, reinvestment_price, *, fractional=True)\` | DRIP share count. Fractional default quantises to 4 dp; integer-only mode for non-fractional broker programs |
| C3 | \`reinvestment_residual_cash(cash_amount, reinvestment_price, shares_purchased)\` | Residual when integer truncation leaves unspent cash. Rejects overspend |

All helpers reject negative inputs with \`ValueError\`. Output quantises to USD cents for cash amounts and 4dp for fractional shares.

Refs #96 (now 13 cost components shipped). Out of scope: stock-loan rebate (institutional negative-fee tier when borrow demand drops below supply), ADR custody fees (account-level, separate ledger), foreign withholding tax on cross-border dividends (handled by jurisdiction engine), special / qualified dividend distinction (caller passes gross; tax treatment lives in tax module).

## Test plan

27 new tests covering:
- [x] HTB: 1-day at 15 % APR / \$100k → \$41.10; 30-day → \$1232.88; extreme 200 % APR → \$273.97/day; zero / negative guards
- [x] Dividend: 250 × \$0.42 → \$105.00; fractional shares 100.5 × \$1.00 → \$100.50; zero guards
- [x] DRIP fractional default: \$105 / \$50 → 2.1000 (4dp); \$100 / \$33 → 3.0303
- [x] DRIP integer mode: \$105 / \$50 → 2 (truncates)
- [x] Residual cash: integer truncation leaves \$5.00 from \$105 / 2 shares × \$50; full fractional purchase leaves \$0.00
- [x] Overspend rejected; all negative-input guards
- [x] Full local suite: 2118 pass / 55 pre-existing DB-required errors unchanged