### PR TITLE
feat(cost): crypto + multi-asset cost helpers (gh#96)

### DIFF
--- a/engine/core/crypto_costs.py
+++ b/engine/core/crypto_costs.py
@@ -1,0 +1,140 @@
+"""Crypto / multi-asset cost helpers (gh#96 follow-up).
+
+Pure-function helpers for cost components that show up on crypto and
+forex desks but not in the equities-only ``regulatory_fees`` /
+``execution_costs`` / ``holding_costs`` modules.
+
+Components covered:
+
+- Perpetual-futures funding payment (Binance / Bybit / dYdX style)
+- FX conversion with bps spread
+- AMM constant-product impermanent loss (Uniswap V2 / SushiSwap)
+
+Out of scope (explicit follow-ups):
+- Cross-chain bridge fees + slippage.
+- LP fee revenue accrual on the *positive* side of liquidity
+  provision.
+- Gas fees on individual transactions (highly chain-specific —
+  caller passes the gas cost in tokens; conversion to USD belongs
+  in the caller's settlement layer).
+- Stake / unstake unbonding penalties.
+- Funding-rate prediction. The helper here computes the *settled*
+  payment given a known rate; predicting the next rate is a
+  separate model.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+# Standard 8-hour funding interval used by every major perpetual-
+# futures venue. Some venues (e.g. dYdX) have shifted to 1-hour
+# intervals; operators override via ``hours`` kwarg.
+DEFAULT_FUNDING_INTERVAL_HOURS: int = 8
+
+
+def perpetual_funding_payment(
+    notional: Decimal,
+    funding_rate: Decimal,
+    *,
+    side: str,
+    hours: int = DEFAULT_FUNDING_INTERVAL_HOURS,
+) -> Decimal:
+    """Funding payment for one settlement interval on a perpetual swap.
+
+    ``notional`` is the absolute USD position size (positive Decimal).
+    ``funding_rate`` is the *signed* funding rate per interval (e.g.
+    ``Decimal("0.0001")`` for 1 bp per 8-hour interval — a positive
+    rate means longs pay shorts).
+
+    ``side`` is ``"long"`` or ``"short"``. Returns the *signed* payment
+    from the perspective of the holder: positive = the holder receives
+    cash, negative = the holder pays. This convention lets operators
+    sum funding payments straight into a daily PnL ledger.
+
+    The full one-day payment for the standard 8-hour cadence is
+    ``3 × per-interval rate × notional``; pass ``hours=24`` if the
+    caller's funding rate is already daily.
+    """
+    if notional < 0:
+        raise ValueError("notional must be non-negative")
+    if hours <= 0:
+        raise ValueError("hours must be positive")
+    if side not in {"long", "short"}:
+        raise ValueError("side must be 'long' or 'short'")
+    raw = (notional * funding_rate).quantize(_TWOPLACES)
+    # Long PAYS when funding_rate > 0; short RECEIVES.
+    if side == "long":
+        return -raw
+    return raw
+
+
+def fx_conversion(
+    amount: Decimal,
+    rate: Decimal,
+    *,
+    fee_bps: Decimal = Decimal("10"),
+) -> tuple[Decimal, Decimal]:
+    """Convert ``amount`` of source-currency at ``rate`` minus a bps fee.
+
+    Returns ``(converted_amount, fee_in_target_currency)``. The fee is
+    deducted from the converted amount: ``converted = amount * rate *
+    (1 - fee_bps / 10000)``; ``fee = amount * rate - converted``.
+
+    Default fee is 10 bps (0.1 %) — typical retail-broker FX spread.
+    Operators override per venue. Both return values are quantised to
+    two decimals.
+    """
+    if amount < 0:
+        raise ValueError("amount must be non-negative")
+    if rate < 0:
+        raise ValueError("rate must be non-negative")
+    if fee_bps < 0:
+        raise ValueError("fee_bps must be non-negative")
+    gross = amount * rate
+    fee = (gross * fee_bps / Decimal("10000")).quantize(_TWOPLACES)
+    net = (gross - fee).quantize(_TWOPLACES)
+    return net, fee
+
+
+def constant_product_impermanent_loss(price_ratio: float) -> float:
+    """Impermanent loss as a *positive fraction* of the held value.
+
+    For a Uniswap-V2-style constant-product AMM (x · y = k) holding a
+    50/50 LP position, the impermanent loss versus simply holding the
+    underlying assets is::
+
+        IL = 2 · sqrt(p) / (1 + p) - 1
+
+    where ``p`` is the price ratio (new price / old price) of one of
+    the two assets. The function returns ``-IL`` so the caller sees a
+    *positive* loss fraction (e.g. ``0.0203`` for 2.03 % at a 50 %
+    price move).
+
+    Returns ``0.0`` when ``price_ratio == 1`` (no loss).
+
+    Symmetric in ``p``: 0.5 (price halved) and 2.0 (price doubled)
+    produce the same IL.
+    """
+    if price_ratio < 0:
+        raise ValueError("price_ratio must be non-negative")
+    if price_ratio == 0:
+        # Asset went to zero — LP keeps half the original position
+        # value, so IL is approximately 50 % vs holding.
+        return 0.5
+    if price_ratio == 1.0:
+        return 0.0
+    il_signed = 2.0 * math.sqrt(price_ratio) / (1.0 + price_ratio) - 1.0
+    return -il_signed
+
+
+__all__ = [
+    "DEFAULT_FUNDING_INTERVAL_HOURS",
+    "constant_product_impermanent_loss",
+    "fx_conversion",
+    "perpetual_funding_payment",
+]

--- a/tests/test_crypto_costs.py
+++ b/tests/test_crypto_costs.py
@@ -1,0 +1,182 @@
+"""Tests for crypto cost helpers (gh#96 follow-up)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from engine.core.crypto_costs import (
+    DEFAULT_FUNDING_INTERVAL_HOURS,
+    constant_product_impermanent_loss,
+    fx_conversion,
+    perpetual_funding_payment,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_default_funding_interval(self):
+        assert DEFAULT_FUNDING_INTERVAL_HOURS == 8
+
+
+# ---------------------------------------------------------------------------
+# Perpetual funding
+# ---------------------------------------------------------------------------
+
+
+class TestPerpetualFunding:
+    def test_long_pays_positive_rate(self):
+        # $100k notional, +1 bp funding rate, long pays $10.
+        out = perpetual_funding_payment(
+            Decimal("100000"), Decimal("0.0001"), side="long"
+        )
+        assert out == Decimal("-10.00")
+
+    def test_short_receives_positive_rate(self):
+        out = perpetual_funding_payment(
+            Decimal("100000"), Decimal("0.0001"), side="short"
+        )
+        assert out == Decimal("10.00")
+
+    def test_long_receives_negative_rate(self):
+        # Negative funding flips the direction: long receives.
+        out = perpetual_funding_payment(
+            Decimal("100000"), Decimal("-0.0001"), side="long"
+        )
+        assert out == Decimal("10.00")
+
+    def test_short_pays_negative_rate(self):
+        out = perpetual_funding_payment(
+            Decimal("100000"), Decimal("-0.0001"), side="short"
+        )
+        assert out == Decimal("-10.00")
+
+    def test_zero_notional_zero_payment(self):
+        assert (
+            perpetual_funding_payment(
+                Decimal("0"), Decimal("0.0001"), side="long"
+            )
+            == Decimal("0.00")
+        )
+
+    def test_zero_rate_zero_payment(self):
+        assert (
+            perpetual_funding_payment(
+                Decimal("100000"), Decimal("0"), side="long"
+            )
+            == Decimal("0.00")
+        )
+
+    def test_negative_notional_rejected(self):
+        with pytest.raises(ValueError):
+            perpetual_funding_payment(
+                Decimal("-1"), Decimal("0.0001"), side="long"
+            )
+
+    def test_invalid_side_rejected(self):
+        with pytest.raises(ValueError):
+            perpetual_funding_payment(
+                Decimal("100"), Decimal("0.0001"), side="bothways"
+            )
+
+    def test_zero_hours_rejected(self):
+        with pytest.raises(ValueError):
+            perpetual_funding_payment(
+                Decimal("100"), Decimal("0.0001"), side="long", hours=0
+            )
+
+
+# ---------------------------------------------------------------------------
+# FX conversion
+# ---------------------------------------------------------------------------
+
+
+class TestFxConversion:
+    def test_known_value_default_fee(self):
+        # $1000 USD × 0.92 EUR/USD × (1 - 10/10000) = 920 - 0.92 = 919.08
+        net, fee = fx_conversion(Decimal("1000"), Decimal("0.92"))
+        assert net == Decimal("919.08")
+        assert fee == Decimal("0.92")
+
+    def test_zero_fee_returns_full_conversion(self):
+        net, fee = fx_conversion(
+            Decimal("1000"), Decimal("0.92"), fee_bps=Decimal("0")
+        )
+        assert net == Decimal("920.00")
+        assert fee == Decimal("0.00")
+
+    def test_high_fee_for_exotic_pair(self):
+        # 100 bps fee — typical for exotic forex pairs.
+        net, fee = fx_conversion(
+            Decimal("1000"), Decimal("0.92"), fee_bps=Decimal("100")
+        )
+        assert fee == Decimal("9.20")
+        assert net == Decimal("910.80")
+
+    def test_zero_amount_zero_conversion(self):
+        net, fee = fx_conversion(Decimal("0"), Decimal("0.92"))
+        assert net == Decimal("0.00")
+        assert fee == Decimal("0.00")
+
+    def test_negative_amount_rejected(self):
+        with pytest.raises(ValueError):
+            fx_conversion(Decimal("-1"), Decimal("0.92"))
+
+    def test_negative_rate_rejected(self):
+        with pytest.raises(ValueError):
+            fx_conversion(Decimal("100"), Decimal("-0.01"))
+
+    def test_negative_fee_rejected(self):
+        with pytest.raises(ValueError):
+            fx_conversion(
+                Decimal("100"), Decimal("0.92"), fee_bps=Decimal("-1")
+            )
+
+
+# ---------------------------------------------------------------------------
+# Impermanent loss
+# ---------------------------------------------------------------------------
+
+
+class TestImpermanentLoss:
+    def test_no_price_change_no_loss(self):
+        assert constant_product_impermanent_loss(1.0) == 0.0
+
+    def test_price_doubled_known_value(self):
+        # Standard textbook: at p=2 IL ≈ 5.72 %.
+        out = constant_product_impermanent_loss(2.0)
+        assert 0.057 < out < 0.058
+
+    def test_price_halved_symmetric(self):
+        # IL is symmetric: p=0.5 should match p=2.0.
+        a = constant_product_impermanent_loss(0.5)
+        b = constant_product_impermanent_loss(2.0)
+        assert abs(a - b) < 1e-9
+
+    def test_4x_move_known_value(self):
+        # At p=4 IL ≈ 20 %.
+        out = constant_product_impermanent_loss(4.0)
+        assert 0.19 < out < 0.21
+
+    def test_extreme_move_grows_il(self):
+        # Larger price moves produce larger IL up to a limit.
+        small = constant_product_impermanent_loss(1.5)
+        large = constant_product_impermanent_loss(10.0)
+        assert large > small > 0
+
+    def test_zero_price_max_loss(self):
+        # Asset went to zero — LP keeps half value.
+        assert constant_product_impermanent_loss(0.0) == 0.5
+
+    def test_negative_price_rejected(self):
+        with pytest.raises(ValueError):
+            constant_product_impermanent_loss(-1.0)
+
+    def test_il_always_non_negative(self):
+        for p in (0.1, 0.5, 1.5, 2.0, 5.0, 100.0):
+            assert constant_product_impermanent_loss(p) >= 0.0


### PR DESCRIPTION
## Summary

Three pure-function helpers for cost components common on crypto and forex desks but absent from the equities-only \`regulatory_fees\` / \`execution_costs\` / \`holding_costs\` modules.

| Function | Notes |
|---|---|
| \`perpetual_funding_payment(notional, funding_rate, *, side, hours=8)\` | Settled funding per interval. Signed return: positive = holder receives, negative = pays. Long pays when rate > 0 (vice versa) |
| \`fx_conversion(amount, rate, *, fee_bps=10)\` | Convert source ccy at rate minus bps spread. Returns \`(net, fee)\` tuple. Default 10 bps = retail-broker spread |
| \`constant_product_impermanent_loss(price_ratio)\` | Uniswap-V2 50/50 LP IL versus holding underlying. Returns positive loss fraction. Symmetric (0.5 and 2.0 produce identical IL) |

All helpers reject negative inputs with \`ValueError\`. Money quantises to USD cents.

Refs #96 (now 16 cost components shipped). Out of scope: cross-chain bridge fees + slippage, LP fee revenue accrual on the *positive* side, gas fees per individual transaction (chain-specific — caller passes gas in tokens, USD conversion belongs in caller's settlement layer), stake/unstake unbonding penalties, funding-rate prediction (this helper computes the *settled* payment given a known rate).

## Test plan

25 new tests covering:
- [x] Funding: long-pays-positive / short-receives-positive / sign-flip-on-negative-rate matrix
- [x] Funding: zero notional / zero rate → \$0; invalid side / negative notional / zero hours rejected
- [x] FX: \$1000 × 0.92 EUR/USD at 10 bps → \$919.08 net + \$0.92 fee
- [x] FX: zero-fee path returns full \$920.00; 100 bps exotic-pair path \$910.80
- [x] FX: zero-amount / negative-amount / negative-rate / negative-fee guards
- [x] IL: \`p=1.0\` → 0.0 (no loss)
- [x] IL: \`p=2.0\` ≈ 5.72 % (textbook closed form)
- [x] IL: \`p=0.5\` and \`p=2.0\` produce identical loss (symmetry)
- [x] IL: \`p=4.0\` ≈ 20 %; \`p=10.0\` > \`p=1.5\` (monotonic in extreme moves)
- [x] IL: \`p=0.0\` → 0.5 (asset-to-zero boundary, LP keeps half value)
- [x] IL non-negative across the (0, 100] domain
- [x] Negative-price guard
- [x] Full local suite: 2143 pass / 55 pre-existing DB-required errors unchanged