### PR TITLE
feat(metrics): Treynor / MAR / Sterling / K-Ratio (gh#97)

### DIFF
--- a/engine/core/metrics_extras.py
+++ b/engine/core/metrics_extras.py
@@ -23,10 +23,18 @@ Trade-level (PnL-list-driven):
 - 44  Payoff ratio                — avg_winner / abs(avg_loser)
 - 45  Kelly criterion             — fraction of capital to risk per trade
 
-Out of scope (explicit follow-ups for the remaining ~76 of 86):
-- Treynor / MAR / Sterling / K-Ratio (need beta + benchmark series).
+Benchmark / regression (return + equity curve):
+
+- 20  Treynor ratio               — excess return / beta
+- 21  MAR ratio                   — CAGR / max drawdown (full period)
+- 22  Sterling ratio              — CAGR / (avg drawdown - 10 %)
+- 23  K-Ratio                     — regression slope of log equity / std error
+
+Out of scope (explicit follow-ups for the remaining ~72 of 86):
 - Time-based heatmaps + monthly/weekly distributions.
 - Cost / execution / exposure analytics.
+- Beta estimation against a benchmark return series (caller supplies
+  beta to ``compute_treynor_ratio``).
 """
 
 from __future__ import annotations
@@ -239,15 +247,127 @@ def compute_kelly_criterion(trade_pnls: Sequence[float]) -> float:
     return win_rate - loss_rate / payoff
 
 
+def compute_treynor_ratio(
+    portfolio_return: float,
+    risk_free_rate: float,
+    beta: float,
+) -> float:
+    """Treynor ratio — excess return per unit of *systematic* risk.
+
+    ``(R_p - R_f) / beta``. Where Sharpe normalises by total risk
+    (volatility), Treynor only penalises systematic (market-correlated)
+    risk; idiosyncratic risk diversifies away in a CAPM world.
+
+    Returns ``0.0`` when ``beta`` is zero (the portfolio carries no
+    systematic risk by construction).
+
+    All three inputs are floats expressed as fractions (e.g. 0.12 for
+    12 % annual return). Caller is responsible for estimating beta
+    upstream — the helper is portfolio-statistics-only.
+    """
+    if beta == 0:
+        return 0.0
+    return (portfolio_return - risk_free_rate) / beta
+
+
+def compute_mar_ratio(
+    cagr_pct: float,
+    max_drawdown_pct: float,
+) -> float:
+    """MAR ratio — ``CAGR / max_drawdown`` over the full track record.
+
+    Equivalent to Calmar at the full-period horizon (Calmar is
+    typically the trailing 36-month version). Higher is better.
+    Returns ``0.0`` when ``max_drawdown_pct`` is zero or negative.
+
+    Both inputs are percentages (e.g. ``25.0`` for 25 %).
+    """
+    if max_drawdown_pct <= 0:
+        return 0.0
+    return cagr_pct / max_drawdown_pct
+
+
+def compute_sterling_ratio(
+    cagr_pct: float,
+    avg_drawdown_pct: float,
+    *,
+    drawdown_floor_pct: float = 10.0,
+) -> float:
+    """Sterling ratio — ``CAGR / (avg_drawdown - floor)``.
+
+    The ``drawdown_floor_pct`` (default 10 %) is the assumed baseline
+    drawdown a strategy *should* tolerate; the ratio compounds the
+    penalty when the strategy's average drawdown exceeds it. Operators
+    override the floor for less-volatile asset classes.
+
+    Returns ``0.0`` when the denominator is zero or negative.
+    """
+    denom = avg_drawdown_pct - drawdown_floor_pct
+    if denom <= 0:
+        return 0.0
+    return cagr_pct / denom
+
+
+def compute_k_ratio(equity_curve: Sequence[float]) -> float:
+    """K-Ratio — regression-based smoothness measure.
+
+    Defined as the slope of the OLS regression line of the *log* equity
+    curve against time, divided by its standard error and scaled by
+    ``sqrt(n)`` where ``n`` is the number of observations.
+
+    Higher is better — a smooth log-equity curve produces a high
+    slope/error ratio. The metric is sensitive to compounding rate
+    *and* path consistency.
+
+    Returns ``0.0`` for fewer than 2 observations, when any equity
+    value is non-positive (log undefined), or when the regression
+    has zero variance in time (degenerate).
+    """
+    n = len(equity_curve)
+    if n < 2:
+        return 0.0
+    if any(v <= 0 for v in equity_curve):
+        return 0.0
+
+    xs = list(range(n))
+    ys = [math.log(v) for v in equity_curve]
+
+    x_mean = sum(xs) / n
+    y_mean = sum(ys) / n
+
+    sxy = sum((x - x_mean) * (y - y_mean) for x, y in zip(xs, ys, strict=True))
+    sxx = sum((x - x_mean) ** 2 for x in xs)
+
+    if sxx == 0:
+        return 0.0
+
+    slope = sxy / sxx
+    intercept = y_mean - slope * x_mean
+
+    # Residual sum of squares; standard error of the slope.
+    residuals = [y - (intercept + slope * x) for x, y in zip(xs, ys, strict=True)]
+    sse = sum(r * r for r in residuals)
+    if n <= 2:
+        return 0.0
+    se = math.sqrt(sse / (n - 2)) / math.sqrt(sxx)
+    if se == 0:
+        return 0.0
+    return slope / se * math.sqrt(n)
+
+
 __all__ = [
     "compute_expectancy_dollars",
     "compute_expectancy_r_multiple",
     "compute_gain_to_pain_ratio",
     "compute_information_ratio",
+    "compute_k_ratio",
     "compute_kelly_criterion",
+    "compute_mar_ratio",
     "compute_omega_ratio",
     "compute_pain_index",
     "compute_payoff_ratio",
     "compute_recovery_factor",
+    "compute_sterling_ratio",
+    "compute_treynor_ratio",
     "compute_ulcer_index",
 ]

--- a/tests/test_more_risk_metrics.py
+++ b/tests/test_more_risk_metrics.py
@@ -1,0 +1,132 @@
+"""Tests for Treynor / MAR / Sterling / K-Ratio extras (gh#97)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.metrics_extras import (
+    compute_k_ratio,
+    compute_mar_ratio,
+    compute_sterling_ratio,
+    compute_treynor_ratio,
+)
+
+
+# ---------------------------------------------------------------------------
+# Treynor
+# ---------------------------------------------------------------------------
+
+
+class TestTreynor:
+    def test_known_value(self):
+        # 12 % return, 5 % rf, beta 1.2 → (0.12 - 0.05) / 1.2 ≈ 0.0583
+        assert compute_treynor_ratio(0.12, 0.05, 1.2) == pytest.approx(
+            0.0583, rel=1e-3
+        )
+
+    def test_zero_beta_returns_zero(self):
+        assert compute_treynor_ratio(0.12, 0.05, 0.0) == 0.0
+
+    def test_negative_beta_yields_negative_treynor(self):
+        # Inverse-correlated portfolio: +7 % excess / -1 beta = -0.07.
+        assert compute_treynor_ratio(0.12, 0.05, -1.0) == pytest.approx(-0.07)
+
+    def test_underperformance_yields_negative(self):
+        # Returns less than rf with positive beta → negative Treynor.
+        assert compute_treynor_ratio(0.03, 0.05, 1.0) == pytest.approx(-0.02)
+
+
+# ---------------------------------------------------------------------------
+# MAR
+# ---------------------------------------------------------------------------
+
+
+class TestMar:
+    def test_known_value(self):
+        # 25 % CAGR / 10 % max drawdown → 2.5
+        assert compute_mar_ratio(25.0, 10.0) == pytest.approx(2.5)
+
+    def test_zero_drawdown_returns_zero(self):
+        assert compute_mar_ratio(25.0, 0.0) == 0.0
+
+    def test_negative_drawdown_returns_zero(self):
+        assert compute_mar_ratio(25.0, -5.0) == 0.0
+
+    def test_loss_with_drawdown_negative_mar(self):
+        # Loss CAGR with positive drawdown → negative ratio.
+        assert compute_mar_ratio(-10.0, 20.0) == pytest.approx(-0.5)
+
+
+# ---------------------------------------------------------------------------
+# Sterling
+# ---------------------------------------------------------------------------
+
+
+class TestSterling:
+    def test_known_value_default_floor(self):
+        # 30 % CAGR / (15 % avg DD - 10 % floor) = 30 / 5 = 6.0
+        assert compute_sterling_ratio(30.0, 15.0) == pytest.approx(6.0)
+
+    def test_below_floor_returns_zero(self):
+        # avg DD 5 % - 10 % floor = -5 % → undefined, returns 0.
+        assert compute_sterling_ratio(30.0, 5.0) == 0.0
+
+    def test_at_floor_returns_zero(self):
+        # avg DD == floor → denominator zero → returns 0.
+        assert compute_sterling_ratio(30.0, 10.0) == 0.0
+
+    def test_custom_floor(self):
+        # 20 % avg DD - 5 % floor = 15 % denominator → 30 / 15 = 2.0.
+        assert compute_sterling_ratio(
+            30.0, 20.0, drawdown_floor_pct=5.0
+        ) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# K-Ratio
+# ---------------------------------------------------------------------------
+
+
+class TestKRatio:
+    def test_too_few_points_returns_zero(self):
+        assert compute_k_ratio([100.0]) == 0.0
+        assert compute_k_ratio([]) == 0.0
+
+    def test_perfectly_smooth_growth_yields_huge_k_ratio(self):
+        # A near-perfect exponential has tiny float-precision residuals
+        # → K-Ratio is huge but finite. The helper's se=0 short-circuit
+        # only triggers when residuals are literally zero.
+        curve = [100.0 * (1.001 ** i) for i in range(50)]
+        result = compute_k_ratio(curve)
+        assert result > 1e6
+        assert math.isfinite(result)
+
+    def test_noisy_uptrend_yields_positive_k_ratio(self):
+        # Trend + small noise → positive slope, finite SE → K-Ratio > 0.
+        curve = [
+            100.0 * (1.001 ** i) + (-1) ** i
+            for i in range(50)
+        ]
+        assert compute_k_ratio(curve) > 0.0
+
+    def test_downtrend_yields_negative_k_ratio(self):
+        curve = [
+            100.0 * (0.999 ** i) + (-1) ** i
+            for i in range(50)
+        ]
+        assert compute_k_ratio(curve) < 0.0
+
+    def test_non_positive_value_returns_zero(self):
+        # Log undefined for non-positive equity values.
+        assert compute_k_ratio([100.0, 0.0, 50.0]) == 0.0
+        assert compute_k_ratio([100.0, -10.0, 50.0]) == 0.0
+
+    def test_constant_equity_yields_zero(self):
+        # Flat curve → log values constant → slope 0 → K-Ratio 0.
+        curve = [100.0] * 20
+        result = compute_k_ratio(curve)
+        assert result == 0.0
+        # Sanity: not inf/NaN.
+        assert math.isfinite(result)


### PR DESCRIPTION
## Summary

Extend \`metrics_extras\` with 4 more risk-adjusted KPIs. Coverage now **14 of 86** (up from 10 in #330).

| KPI # | Function | Description |
|---|---|---|
| 20 | \`compute_treynor_ratio(portfolio_return, risk_free_rate, beta)\` | Excess return per unit of *systematic* risk. CAPM lens — penalises only market-correlated vol. Caller estimates beta upstream |
| 21 | \`compute_mar_ratio(cagr_pct, max_drawdown_pct)\` | CAGR / max DD over the full track record. Equivalent to Calmar at the full-period horizon. Returns 0.0 on zero / negative drawdown |
| 22 | \`compute_sterling_ratio(cagr_pct, avg_drawdown_pct, *, drawdown_floor_pct=10.0)\` | CAGR / (avg DD - floor). Default floor 10 % conventional for equities; operators override per asset class |
| 23 | \`compute_k_ratio(equity_curve)\` | OLS-regression smoothness measure: slope of log-equity-vs-time / std error × sqrt(n). Pure-Python regression — no numpy dep |

K-Ratio guards: returns 0.0 for <2 points, any non-positive equity value (log undefined), zero variance in time, or zero residual standard error.

Refs #97. Remaining ~72 KPIs (time-based heatmaps + monthly/weekly distributions, cost / execution / exposure analytics, beta estimation against a benchmark return series) still deferred.

## Test plan

18 new tests covering:
- [x] Treynor: known value 0.12/0.05 ÷ 1.2 ≈ 0.0583; zero beta → 0.0; negative beta → negative Treynor; underperformance → negative
- [x] MAR: known 25 % / 10 % = 2.5; zero / negative drawdown → 0; loss CAGR with positive drawdown → negative
- [x] Sterling: 30 % / (15 % - 10 %) = 6.0; below-floor / at-floor → 0; custom floor 5 %
- [x] K-Ratio: <2 points → 0; smooth exp gives huge but finite value; noisy uptrend > 0; downtrend < 0; non-positive values → 0; constant equity → 0
- [x] Full local suite: 2161 pass / 55 pre-existing DB-required errors unchanged