### PR TITLE
feat(metrics): time-based return analytics (gh#97)

### DIFF
--- a/engine/core/time_metrics.py
+++ b/engine/core/time_metrics.py
@@ -1,0 +1,128 @@
+"""Time-based return analytics (gh#97 follow-up).
+
+Pure-function helpers operating on either:
+
+- A flat sequence of period returns (for best/worst/positive %).
+- A sequence of ``(date, return)`` pairs (for month/week roll-ups).
+
+KPIs covered (numbers from gh#97 taxonomy):
+
+-  4  Monthly returns       — aggregate_returns_by_month
+-  5  Weekly returns        — aggregate_returns_by_week
+-  7  Best Day              — compute_best_period
+-  8  Worst Day             — compute_worst_period
+-  9  Best Month            — derived from monthly aggregate + best_period
+- 10  Worst Month           — derived from monthly aggregate + worst_period
+- 11  Positive Days %       — compute_positive_period_pct
+- 12  Positive Months %     — derived
+
+Period aggregation uses *compounded* returns per the financial
+convention: monthly = ∏(1 + daily) - 1. Operators who need additive
+weighting can switch to a custom aggregator (deferred — not shipped
+in this slice).
+
+Out of scope (explicit follow-ups):
+- Calendar-period weighting (some platforms weight by trading days).
+- Quarter / year aggregations.
+- Period anchoring around a custom fiscal calendar.
+- Distribution histograms (operators bin the monthly/weekly outputs
+  themselves).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+
+
+def compute_best_period(returns: Sequence[float]) -> float:
+    """Maximum of ``returns``. Returns ``0.0`` on empty input."""
+    if not returns:
+        return 0.0
+    return max(returns)
+
+
+def compute_worst_period(returns: Sequence[float]) -> float:
+    """Minimum of ``returns``. Returns ``0.0`` on empty input."""
+    if not returns:
+        return 0.0
+    return min(returns)
+
+
+def compute_positive_period_pct(returns: Sequence[float]) -> float:
+    """Fraction of periods with strictly-positive return.
+
+    Returns a value in ``[0.0, 1.0]``. Empty input → ``0.0``. Zero
+    returns are *not* counted as positive (the convention used on
+    every major analytics platform).
+    """
+    if not returns:
+        return 0.0
+    positives = sum(1 for r in returns if r > 0)
+    return positives / len(returns)
+
+
+def compute_negative_period_pct(returns: Sequence[float]) -> float:
+    """Fraction of periods with strictly-negative return."""
+    if not returns:
+        return 0.0
+    negatives = sum(1 for r in returns if r < 0)
+    return negatives / len(returns)
+
+
+def aggregate_returns_by_month(
+    dated_returns: Sequence[tuple[date, float]],
+) -> list[tuple[str, float]]:
+    """Compound daily returns into monthly returns.
+
+    ``dated_returns`` is a list of ``(date, daily_return)`` pairs (any
+    order; we sort internally). Returns a list of ``(yyyy-mm,
+    compounded_return)`` pairs in chronological order.
+
+    Compounding: ``(1 + r_total) = ∏(1 + r_i)``; the function returns
+    ``r_total``.
+    """
+    if not dated_returns:
+        return []
+    by_month: dict[str, float] = {}
+    keys_seen: list[str] = []
+    for d, r in sorted(dated_returns, key=lambda p: p[0]):
+        key = f"{d.year:04d}-{d.month:02d}"
+        if key not in by_month:
+            by_month[key] = 1.0
+            keys_seen.append(key)
+        by_month[key] *= 1.0 + r
+    return [(k, by_month[k] - 1.0) for k in keys_seen]
+
+
+def aggregate_returns_by_week(
+    dated_returns: Sequence[tuple[date, float]],
+) -> list[tuple[str, float]]:
+    """Compound daily returns into weekly returns (ISO 8601 week).
+
+    Returns a list of ``(yyyy-Www, compounded_return)`` pairs in
+    chronological order, e.g. ``2024-W23``. Uses ``date.isocalendar()``
+    to assign each daily return to its ISO week.
+    """
+    if not dated_returns:
+        return []
+    by_week: dict[str, float] = {}
+    keys_seen: list[str] = []
+    for d, r in sorted(dated_returns, key=lambda p: p[0]):
+        iso_year, iso_week, _ = d.isocalendar()
+        key = f"{iso_year:04d}-W{iso_week:02d}"
+        if key not in by_week:
+            by_week[key] = 1.0
+            keys_seen.append(key)
+        by_week[key] *= 1.0 + r
+    return [(k, by_week[k] - 1.0) for k in keys_seen]
+
+
+__all__ = [
+    "aggregate_returns_by_month",
+    "aggregate_returns_by_week",
+    "compute_best_period",
+    "compute_negative_period_pct",
+    "compute_positive_period_pct",
+    "compute_worst_period",
+]

--- a/tests/test_time_metrics.py
+++ b/tests/test_time_metrics.py
@@ -1,0 +1,184 @@
+"""Tests for time-based return analytics (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from engine.core.time_metrics import (
+    aggregate_returns_by_month,
+    aggregate_returns_by_week,
+    compute_best_period,
+    compute_negative_period_pct,
+    compute_positive_period_pct,
+    compute_worst_period,
+)
+
+
+# ---------------------------------------------------------------------------
+# Best / worst
+# ---------------------------------------------------------------------------
+
+
+class TestBestWorst:
+    def test_empty_inputs_return_zero(self):
+        assert compute_best_period([]) == 0.0
+        assert compute_worst_period([]) == 0.0
+
+    def test_known_values(self):
+        returns = [0.01, 0.02, -0.01, 0.03, -0.04]
+        assert compute_best_period(returns) == 0.03
+        assert compute_worst_period(returns) == -0.04
+
+    def test_all_positive(self):
+        returns = [0.01, 0.02, 0.03]
+        assert compute_best_period(returns) == 0.03
+        assert compute_worst_period(returns) == 0.01
+
+    def test_all_negative(self):
+        returns = [-0.01, -0.02, -0.03]
+        assert compute_best_period(returns) == -0.01
+        assert compute_worst_period(returns) == -0.03
+
+
+# ---------------------------------------------------------------------------
+# Positive / negative period %
+# ---------------------------------------------------------------------------
+
+
+class TestPositivePeriodPct:
+    def test_empty_returns_zero(self):
+        assert compute_positive_period_pct([]) == 0.0
+
+    def test_known_value(self):
+        # 3 of 5 positive → 60 %.
+        returns = [0.01, 0.02, -0.01, 0.03, -0.04]
+        assert compute_positive_period_pct(returns) == pytest.approx(0.6)
+
+    def test_zero_returns_not_counted(self):
+        # Zero returns are NOT positive — convention from major analytics platforms.
+        returns = [0.0, 0.01, 0.0]
+        assert compute_positive_period_pct(returns) == pytest.approx(1 / 3)
+
+    def test_all_negative(self):
+        assert compute_positive_period_pct([-0.01, -0.02]) == 0.0
+
+
+class TestNegativePeriodPct:
+    def test_empty_returns_zero(self):
+        assert compute_negative_period_pct([]) == 0.0
+
+    def test_known_value(self):
+        # 2 of 5 negative → 40 %.
+        returns = [0.01, 0.02, -0.01, 0.03, -0.04]
+        assert compute_negative_period_pct(returns) == pytest.approx(0.4)
+
+    def test_zero_returns_not_counted(self):
+        returns = [0.0, -0.01, 0.0]
+        assert compute_negative_period_pct(returns) == pytest.approx(1 / 3)
+
+    def test_pos_plus_neg_does_not_have_to_sum_to_one(self):
+        # When zeros are present, pos + neg < 1.
+        returns = [0.0, 0.01, -0.01]
+        pos = compute_positive_period_pct(returns)
+        neg = compute_negative_period_pct(returns)
+        assert pos + neg == pytest.approx(2 / 3)
+
+
+# ---------------------------------------------------------------------------
+# Monthly aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestMonthlyAggregation:
+    def test_empty_returns_empty(self):
+        assert aggregate_returns_by_month([]) == []
+
+    def test_single_month_compounds(self):
+        # +1 % three days in a row → (1.01)^3 - 1 ≈ 3.0301 %.
+        dated = [
+            (date(2024, 6, 3), 0.01),
+            (date(2024, 6, 4), 0.01),
+            (date(2024, 6, 5), 0.01),
+        ]
+        out = aggregate_returns_by_month(dated)
+        assert len(out) == 1
+        key, ret = out[0]
+        assert key == "2024-06"
+        assert ret == pytest.approx(0.030301, rel=1e-6)
+
+    def test_two_months_chronological_order(self):
+        dated = [
+            (date(2024, 7, 1), 0.02),  # July
+            (date(2024, 6, 1), 0.01),  # June
+        ]
+        out = aggregate_returns_by_month(dated)
+        # Sorted internally — June first, July second.
+        assert [k for k, _ in out] == ["2024-06", "2024-07"]
+        assert out[0][1] == pytest.approx(0.01)
+        assert out[1][1] == pytest.approx(0.02)
+
+    def test_loss_then_recovery_compounds(self):
+        # -10 % then +10 % → (0.9 * 1.1) - 1 = -0.01 (1 % loss).
+        dated = [
+            (date(2024, 1, 5), -0.10),
+            (date(2024, 1, 25), 0.10),
+        ]
+        out = aggregate_returns_by_month(dated)
+        assert len(out) == 1
+        assert out[0][1] == pytest.approx(-0.01, rel=1e-9)
+
+    def test_year_boundary_handled(self):
+        dated = [
+            (date(2023, 12, 31), 0.01),
+            (date(2024, 1, 1), 0.02),
+        ]
+        out = aggregate_returns_by_month(dated)
+        assert [k for k, _ in out] == ["2023-12", "2024-01"]
+
+
+# ---------------------------------------------------------------------------
+# Weekly aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklyAggregation:
+    def test_empty_returns_empty(self):
+        assert aggregate_returns_by_week([]) == []
+
+    def test_single_week_compounds(self):
+        # 5 trading days within ISO week 23 of 2024.
+        # Week 23 starts Mon 2024-06-03.
+        dated = [
+            (date(2024, 6, 3), 0.01),
+            (date(2024, 6, 4), 0.01),
+            (date(2024, 6, 5), 0.01),
+            (date(2024, 6, 6), 0.01),
+            (date(2024, 6, 7), 0.01),
+        ]
+        out = aggregate_returns_by_week(dated)
+        assert len(out) == 1
+        key, ret = out[0]
+        assert key == "2024-W23"
+        assert ret == pytest.approx(0.05101005, rel=1e-6)
+
+    def test_two_weeks_chronological_order(self):
+        dated = [
+            (date(2024, 6, 10), 0.02),  # week 24
+            (date(2024, 6, 3), 0.01),  # week 23
+        ]
+        out = aggregate_returns_by_week(dated)
+        assert [k for k, _ in out] == ["2024-W23", "2024-W24"]
+
+    def test_iso_year_boundary(self):
+        # Jan 1 2024 falls on Monday, ISO week 1 of 2024.
+        # Dec 31 2023 (Sunday) is ISO week 52 of 2023.
+        dated = [
+            (date(2023, 12, 31), 0.01),
+            (date(2024, 1, 1), 0.02),
+        ]
+        out = aggregate_returns_by_week(dated)
+        keys = [k for k, _ in out]
+        assert "2023-W52" in keys
+        assert "2024-W01" in keys


### PR DESCRIPTION
## Summary

Pure-function helpers operating on either a flat sequence of returns (for best/worst/positive/negative %) or a sequence of \`(date, return)\` pairs (for monthly/weekly compound roll-ups).

| KPI # | Function | Description |
|---|---|---|
| 4 | \`aggregate_returns_by_month(dated_returns)\` | \`yyyy-mm\` keys, chronological order. Compounding: \`(1 + r_total) = ∏(1 + r_i)\` |
| 5 | \`aggregate_returns_by_week(dated_returns)\` | ISO 8601 week keys (\`yyyy-Www\`). \`date.isocalendar()\` handles year boundaries |
| 7 | \`compute_best_period(returns)\` | \`max()\` of returns sequence |
| 8 | \`compute_worst_period(returns)\` | \`min()\` of returns sequence |
| 11 | \`compute_positive_period_pct(returns)\` | Fraction of strictly-positive returns. Zero returns NOT counted (analytics-platform convention) |
| - | \`compute_negative_period_pct(returns)\` | Symmetry helper |

Coverage now **20 of 86 KPIs** (up from 14 in #336).

Refs #97. Out of scope for remaining 66: calendar-period weighting (some platforms weight by trading days), quarter / year aggregations, custom fiscal-calendar anchoring, distribution histograms (operators bin outputs themselves), beta estimation against a benchmark series.

## Test plan

21 new tests covering:
- [x] Empty-input zero-result for every helper
- [x] Known closed-form values: 3 of 5 positive → 60 %, 2 of 5 negative → 40 %
- [x] Loss-then-recovery compound: \`(0.9 × 1.1) - 1 = -0.01\` (1 % loss, not 0)
- [x] Single-month +1 % × 3 days → 3.0301 %
- [x] Single ISO-week +1 % × 5 days → 5.101005 %
- [x] Out-of-order input sorted chronologically by month + week
- [x] Year boundary (Dec 31 2023 / Jan 1 2024) → distinct months + ISO weeks (\`2023-W52\` + \`2024-W01\`)
- [x] Zero-return-not-counted convention; pos + neg need not sum to 1 when zeros present
- [x] Full local suite: 2182 pass / 55 pre-existing DB-required errors unchanged