### PR TITLE
feat(data): retention policy decision helpers (gh#90)

### DIFF
--- a/engine/data/retention.py
+++ b/engine/data/retention.py
@@ -1,0 +1,178 @@
+"""Data retention policy helpers (gh#90).
+
+Pure-Python policy model + decision helpers. Cron, API, S3 archival
+and TimescaleDB compression are deferred follow-ups (this slice ships
+only the in-memory policy engine that downstream pieces will call).
+
+Per-dataset defaults follow gh#90's spec literally:
+
+- ``ohlcv_1m``: retain 90 d, compress after 30 d
+- ``ohlcv_1d``: keep forever, compress after 365 d
+- ``backtest_results``: keep forever
+- ``trade_log``: keep forever (tax compliance)
+- ``portfolio_snapshots``: retain 365 d, compress after 90 d
+- ``webhook_deliveries``: retain 30 d
+- ``evaluation_log``: retain 90 d, compress after 30 d
+
+Out of scope:
+- Celery beat scheduling / cron registration.
+- S3 archival writers.
+- TimescaleDB ``compress_chunk`` wiring.
+- ``GET/PUT /api/v1/settings/retention`` REST surface.
+- Storage-usage reporting per dataset.
+- YAML config ingestion.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+
+
+class RetentionAction(str, Enum):
+    """What to do with a record under a policy."""
+
+    KEEP = "keep"
+    COMPRESS = "compress"
+    DELETE = "delete"
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """Retention rules for one dataset.
+
+    ``retain_days = None`` means *keep forever*. ``compress_after_days``
+    must not exceed ``retain_days`` (you cannot compress data that has
+    already been deleted). ``archive_to = None`` means hard-delete on
+    expiry; a non-null path means archive there before delete (the
+    archive writer itself is out of scope for this slice).
+    """
+
+    dataset: str
+    retain_days: int | None
+    compress_after_days: int | None = None
+    archive_to: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.dataset:
+            raise ValueError("dataset name required")
+        if self.retain_days is not None and self.retain_days < 0:
+            raise ValueError("retain_days must be >= 0 or None")
+        if self.compress_after_days is not None and self.compress_after_days < 0:
+            raise ValueError("compress_after_days must be >= 0 or None")
+        if (
+            self.retain_days is not None
+            and self.compress_after_days is not None
+            and self.compress_after_days > self.retain_days
+        ):
+            raise ValueError(
+                "compress_after_days cannot exceed retain_days "
+                "(would compress already-deleted data)"
+            )
+
+
+DEFAULT_POLICIES: Mapping[str, RetentionPolicy] = {
+    "ohlcv_1m": RetentionPolicy("ohlcv_1m", retain_days=90, compress_after_days=30),
+    "ohlcv_1d": RetentionPolicy(
+        "ohlcv_1d", retain_days=None, compress_after_days=365
+    ),
+    "backtest_results": RetentionPolicy("backtest_results", retain_days=None),
+    "trade_log": RetentionPolicy("trade_log", retain_days=None),
+    "portfolio_snapshots": RetentionPolicy(
+        "portfolio_snapshots", retain_days=365, compress_after_days=90
+    ),
+    "webhook_deliveries": RetentionPolicy("webhook_deliveries", retain_days=30),
+    "evaluation_log": RetentionPolicy(
+        "evaluation_log", retain_days=90, compress_after_days=30
+    ),
+}
+
+
+def _ensure_aware(dt: datetime, label: str) -> datetime:
+    if dt.tzinfo is None:
+        raise ValueError(f"{label} must be timezone-aware")
+    return dt
+
+
+def _age_days(record_ts: datetime, *, now: datetime) -> float:
+    """Age of a record in fractional days (negative if record is in the future)."""
+    _ensure_aware(record_ts, "record_ts")
+    _ensure_aware(now, "now")
+    delta = now - record_ts
+    return delta.total_seconds() / 86_400.0
+
+
+def is_expired(
+    record_ts: datetime, policy: RetentionPolicy, *, now: datetime | None = None
+) -> bool:
+    """``True`` when the record is older than ``policy.retain_days``.
+
+    ``retain_days = None`` ⇒ never expired. Future-dated records are
+    treated as not expired (negative age).
+    """
+    if policy.retain_days is None:
+        return False
+    now = now if now is not None else datetime.now(timezone.utc)
+    age = _age_days(record_ts, now=now)
+    return age > policy.retain_days
+
+
+def is_compressible(
+    record_ts: datetime, policy: RetentionPolicy, *, now: datetime | None = None
+) -> bool:
+    """``True`` when the record is old enough to compress but not yet expired."""
+    if policy.compress_after_days is None:
+        return False
+    now = now if now is not None else datetime.now(timezone.utc)
+    age = _age_days(record_ts, now=now)
+    if age <= policy.compress_after_days:
+        return False
+    return not is_expired(record_ts, policy, now=now)
+
+
+def decide_action(
+    record_ts: datetime, policy: RetentionPolicy, *, now: datetime | None = None
+) -> RetentionAction:
+    """Resolve ``DELETE`` > ``COMPRESS`` > ``KEEP`` for one record."""
+    now = now if now is not None else datetime.now(timezone.utc)
+    if is_expired(record_ts, policy, now=now):
+        return RetentionAction.DELETE
+    if is_compressible(record_ts, policy, now=now):
+        return RetentionAction.COMPRESS
+    return RetentionAction.KEEP
+
+
+def partition_by_action(
+    records: Iterable[tuple[str, datetime]],
+    policy: RetentionPolicy,
+    *,
+    now: datetime | None = None,
+) -> dict[RetentionAction, list[str]]:
+    """Bucket ``(record_id, timestamp)`` pairs by required action.
+
+    Always returns all three keys (possibly empty lists). The caller
+    supplies record IDs of any string-coercible shape; this helper does
+    no I/O.
+    """
+    now = now if now is not None else datetime.now(timezone.utc)
+    buckets: dict[RetentionAction, list[str]] = {
+        RetentionAction.KEEP: [],
+        RetentionAction.COMPRESS: [],
+        RetentionAction.DELETE: [],
+    }
+    for record_id, ts in records:
+        buckets[decide_action(ts, policy, now=now)].append(record_id)
+    return buckets
+
+
+__all__ = [
+    "DEFAULT_POLICIES",
+    "RetentionAction",
+    "RetentionPolicy",
+    "decide_action",
+    "is_compressible",
+    "is_expired",
+    "partition_by_action",
+]

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,270 @@
+"""Tests for data retention policy helpers (gh#90)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from engine.data.retention import (
+    DEFAULT_POLICIES,
+    RetentionAction,
+    RetentionPolicy,
+    decide_action,
+    is_compressible,
+    is_expired,
+    partition_by_action,
+)
+
+UTC = timezone.utc
+NOW = datetime(2026, 5, 3, 12, 0, tzinfo=UTC)
+
+
+def _ago(days: float) -> datetime:
+    return NOW - timedelta(days=days)
+
+
+# ---------------------------------------------------------------------------
+# RetentionPolicy validation
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionPolicy:
+    def test_minimum_valid_policy(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        assert p.dataset == "foo"
+        assert p.retain_days == 30
+        assert p.compress_after_days is None
+        assert p.archive_to is None
+
+    def test_full_valid_policy(self):
+        p = RetentionPolicy(
+            "foo",
+            retain_days=365,
+            compress_after_days=30,
+            archive_to="s3://bucket/archive/",
+        )
+        assert p.compress_after_days == 30
+        assert p.archive_to == "s3://bucket/archive/"
+
+    def test_keep_forever_policy(self):
+        p = RetentionPolicy("foo", retain_days=None, compress_after_days=365)
+        assert p.retain_days is None
+
+    def test_empty_dataset_rejected(self):
+        with pytest.raises(ValueError, match="dataset"):
+            RetentionPolicy("", retain_days=30)
+
+    def test_negative_retain_days_rejected(self):
+        with pytest.raises(ValueError, match="retain_days"):
+            RetentionPolicy("foo", retain_days=-1)
+
+    def test_negative_compress_days_rejected(self):
+        with pytest.raises(ValueError, match="compress_after_days"):
+            RetentionPolicy("foo", retain_days=30, compress_after_days=-1)
+
+    def test_compress_after_retain_rejected(self):
+        # Cannot compress data that has been deleted.
+        with pytest.raises(ValueError, match="cannot exceed retain_days"):
+            RetentionPolicy("foo", retain_days=30, compress_after_days=60)
+
+    def test_compress_equal_retain_allowed(self):
+        # Edge case: compress_after == retain — degenerate but legal.
+        p = RetentionPolicy("foo", retain_days=30, compress_after_days=30)
+        assert p.compress_after_days == 30
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_POLICIES (pin to gh#90 spec)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPolicies:
+    def test_ohlcv_1m(self):
+        p = DEFAULT_POLICIES["ohlcv_1m"]
+        assert p.retain_days == 90
+        assert p.compress_after_days == 30
+
+    def test_ohlcv_1d_keeps_forever(self):
+        p = DEFAULT_POLICIES["ohlcv_1d"]
+        assert p.retain_days is None
+        assert p.compress_after_days == 365
+
+    def test_backtest_results_keeps_forever(self):
+        p = DEFAULT_POLICIES["backtest_results"]
+        assert p.retain_days is None
+        assert p.compress_after_days is None
+
+    def test_trade_log_keeps_forever_for_tax(self):
+        # Critical: tax compliance — must never auto-delete.
+        p = DEFAULT_POLICIES["trade_log"]
+        assert p.retain_days is None
+
+    def test_portfolio_snapshots(self):
+        p = DEFAULT_POLICIES["portfolio_snapshots"]
+        assert p.retain_days == 365
+        assert p.compress_after_days == 90
+
+    def test_webhook_deliveries(self):
+        p = DEFAULT_POLICIES["webhook_deliveries"]
+        assert p.retain_days == 30
+        assert p.compress_after_days is None
+
+    def test_evaluation_log(self):
+        p = DEFAULT_POLICIES["evaluation_log"]
+        assert p.retain_days == 90
+        assert p.compress_after_days == 30
+
+
+# ---------------------------------------------------------------------------
+# is_expired
+# ---------------------------------------------------------------------------
+
+
+class TestIsExpired:
+    def test_keep_forever_never_expires(self):
+        p = RetentionPolicy("foo", retain_days=None)
+        assert is_expired(_ago(10_000), p, now=NOW) is False
+
+    def test_within_window_not_expired(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        assert is_expired(_ago(15), p, now=NOW) is False
+
+    def test_at_boundary_not_expired(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        # Exactly retain_days old — strictly *older than* expires it.
+        assert is_expired(_ago(30), p, now=NOW) is False
+
+    def test_past_boundary_expired(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        assert is_expired(_ago(31), p, now=NOW) is True
+
+    def test_future_record_not_expired(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        future = NOW + timedelta(days=10)
+        assert is_expired(future, p, now=NOW) is False
+
+    def test_naive_record_ts_rejected(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        naive = datetime(2026, 1, 1)
+        with pytest.raises(ValueError, match="timezone-aware"):
+            is_expired(naive, p, now=NOW)
+
+    def test_default_now_uses_utc(self):
+        # Smoke: omitting `now` should not raise.
+        p = RetentionPolicy("foo", retain_days=30)
+        assert is_expired(datetime.now(UTC), p) is False
+
+
+# ---------------------------------------------------------------------------
+# is_compressible
+# ---------------------------------------------------------------------------
+
+
+class TestIsCompressible:
+    def test_no_compress_setting_never_compressible(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        assert is_compressible(_ago(20), p, now=NOW) is False
+
+    def test_too_recent_not_compressible(self):
+        p = RetentionPolicy("foo", retain_days=90, compress_after_days=30)
+        assert is_compressible(_ago(15), p, now=NOW) is False
+
+    def test_past_compress_threshold_compressible(self):
+        p = RetentionPolicy("foo", retain_days=90, compress_after_days=30)
+        assert is_compressible(_ago(45), p, now=NOW) is True
+
+    def test_expired_records_not_compressible(self):
+        # Once expired, the record is queued for delete, not compress.
+        p = RetentionPolicy("foo", retain_days=90, compress_after_days=30)
+        assert is_compressible(_ago(120), p, now=NOW) is False
+
+    def test_keep_forever_with_compress_threshold(self):
+        # ohlcv_1d shape: never expires, but old data still gets compressed.
+        p = RetentionPolicy("foo", retain_days=None, compress_after_days=365)
+        assert is_compressible(_ago(400), p, now=NOW) is True
+
+
+# ---------------------------------------------------------------------------
+# decide_action precedence
+# ---------------------------------------------------------------------------
+
+
+class TestDecideAction:
+    def test_recent_record_keep(self):
+        p = RetentionPolicy("foo", retain_days=90, compress_after_days=30)
+        assert decide_action(_ago(5), p, now=NOW) is RetentionAction.KEEP
+
+    def test_older_than_compress_returns_compress(self):
+        p = RetentionPolicy("foo", retain_days=90, compress_after_days=30)
+        assert decide_action(_ago(45), p, now=NOW) is RetentionAction.COMPRESS
+
+    def test_older_than_retain_returns_delete(self):
+        p = RetentionPolicy("foo", retain_days=90, compress_after_days=30)
+        assert decide_action(_ago(120), p, now=NOW) is RetentionAction.DELETE
+
+    def test_delete_takes_precedence_over_compress(self):
+        # 100 days old: past compress threshold (30) AND past retain (90) → DELETE.
+        p = RetentionPolicy("foo", retain_days=90, compress_after_days=30)
+        action = decide_action(_ago(100), p, now=NOW)
+        assert action is RetentionAction.DELETE
+
+    def test_keep_forever_never_deletes(self):
+        p = RetentionPolicy("trade_log", retain_days=None)
+        # 10 years old — must still be KEEP.
+        assert decide_action(_ago(3650), p, now=NOW) is RetentionAction.KEEP
+
+    def test_keep_forever_with_compress_returns_compress_when_old(self):
+        p = RetentionPolicy("ohlcv_1d", retain_days=None, compress_after_days=365)
+        assert (
+            decide_action(_ago(400), p, now=NOW) is RetentionAction.COMPRESS
+        )
+
+
+# ---------------------------------------------------------------------------
+# partition_by_action
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionByAction:
+    def test_empty_records_returns_three_empty_buckets(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        out = partition_by_action([], p, now=NOW)
+        assert out == {
+            RetentionAction.KEEP: [],
+            RetentionAction.COMPRESS: [],
+            RetentionAction.DELETE: [],
+        }
+
+    def test_mixed_records_partition_correctly(self):
+        p = RetentionPolicy("foo", retain_days=90, compress_after_days=30)
+        records = [
+            ("a", _ago(5)),  # keep
+            ("b", _ago(45)),  # compress
+            ("c", _ago(60)),  # compress
+            ("d", _ago(120)),  # delete
+            ("e", _ago(15)),  # keep
+        ]
+        out = partition_by_action(records, p, now=NOW)
+        assert out[RetentionAction.KEEP] == ["a", "e"]
+        assert out[RetentionAction.COMPRESS] == ["b", "c"]
+        assert out[RetentionAction.DELETE] == ["d"]
+
+    def test_preserves_input_order_within_bucket(self):
+        # Important for downstream batch ops that need stable ordering.
+        p = RetentionPolicy("foo", retain_days=30)
+        records = [
+            ("z", _ago(5)),
+            ("y", _ago(10)),
+            ("x", _ago(2)),
+        ]
+        out = partition_by_action(records, p, now=NOW)
+        assert out[RetentionAction.KEEP] == ["z", "y", "x"]
+
+    def test_keep_forever_bucket_never_deletes(self):
+        p = DEFAULT_POLICIES["trade_log"]
+        records = [(f"trade_{i}", _ago(i * 365)) for i in range(5)]
+        out = partition_by_action(records, p, now=NOW)
+        assert len(out[RetentionAction.KEEP]) == 5
+        assert out[RetentionAction.DELETE] == []
+        assert out[RetentionAction.COMPRESS] == []


### PR DESCRIPTION
## Summary

Pure-Python slice of gh#90: per-dataset retention policy model + decision helpers. This is the in-memory engine that downstream pieces (cron job, REST API, S3 archival, TimescaleDB compression) will call. Cron / API / archival / compression themselves are deferred follow-ups so this PR stays small and reviewable.

## What ships

- ``RetentionPolicy`` frozen dataclass with ``__post_init__`` validation:
  - empty dataset rejected
  - negative ``retain_days`` / ``compress_after_days`` rejected
  - ``compress_after_days`` cannot exceed ``retain_days`` (would compress already-deleted data)
- ``DEFAULT_POLICIES`` pinned to the gh#90 spec verbatim:
  | Dataset | Retain | Compress after |
  |---|---|---|
  | ``ohlcv_1m`` | 90 d | 30 d |
  | ``ohlcv_1d`` | ∞ | 365 d |
  | ``backtest_results`` | ∞ | — |
  | ``trade_log`` | ∞ (tax compliance) | — |
  | ``portfolio_snapshots`` | 365 d | 90 d |
  | ``webhook_deliveries`` | 30 d | — |
  | ``evaluation_log`` | 90 d | 30 d |
- Decision helpers:
  - ``is_expired(record_ts, policy)`` — strictly older than ``retain_days``
  - ``is_compressible(record_ts, policy)`` — past compress threshold but not yet expired
  - ``decide_action(record_ts, policy)`` — resolves DELETE > COMPRESS > KEEP
  - ``partition_by_action(records, policy)`` — buckets ``(id, ts)`` pairs into all three actions, preserves input order within each bucket, always returns three keys
- All datetime inputs must be tz-aware; naive timestamps raise ``ValueError``.

## Out of scope (explicit follow-ups)

- Celery beat scheduling / cron registration.
- S3 archival writers (``archive_to`` field is recorded but not consumed).
- TimescaleDB ``compress_chunk`` wiring.
- ``GET/PUT /api/v1/settings/retention`` REST surface.
- Storage-usage reporting per dataset.
- YAML config ingestion.

## Test plan

- [x] 37 new unit tests in ``tests/test_retention.py``:
  - ``RetentionPolicy`` validation (8 cases incl. boundary ``compress_after == retain``)
  - ``DEFAULT_POLICIES`` pinning (7 datasets)
  - ``is_expired`` (incl. forever, boundary, future-dated, naive-rejection)
  - ``is_compressible`` (incl. expired-not-compressible, forever-with-compress)
  - ``decide_action`` (incl. DELETE > COMPRESS precedence, ``trade_log`` 10-year-old still KEEP)
  - ``partition_by_action`` (empty, mixed, order-preservation, forever bucket)
- [x] Full local suite green: ``2219 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted retention suite: 37/37 pass in 4.6 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)