### PR TITLE
feat(portfolio): cross-portfolio aggregator helpers (gh#89)

### DIFF
--- a/engine/core/portfolio_aggregator.py
+++ b/engine/core/portfolio_aggregator.py
@@ -1,0 +1,195 @@
+"""Cross-portfolio aggregation helpers (gh#89).
+
+Pure-function helpers operating on lightweight DTO inputs. The DB
+models, REST routes and UI for portfolio groups + tags are deferred
+follow-ups; this slice ships only the math layer that the eventual
+``GET /api/v1/portfolio-groups/{id}/analytics`` endpoint will call.
+
+Coverage:
+
+- ``combined_nav`` — sum of NAVs across portfolios
+- ``combined_equity_curve`` — element-wise sum of aligned equity series
+- ``correlation_matrix`` — Pearson correlation of return series
+- ``position_overlap`` — symbols held in 2+ portfolios with combined qty
+- ``aggregate_exposure`` — group-level exposure rolled up by classifier
+- ``filter_by_tags`` — set-membership filter for portfolio tags
+
+Out of scope:
+- Combined drawdown / Sharpe (call existing per-portfolio helpers on
+  the combined equity curve from this module).
+- ORM models for ``PortfolioGroup`` / ``portfolio_tags`` (deferred to
+  a DB-shaped follow-up).
+- REST surface and UI components.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class PortfolioView:
+    """Lightweight DTO consumed by aggregation helpers.
+
+    The real ``Portfolio`` class lives in ``engine.core.portfolio``;
+    aggregators take this minimal projection so they remain trivially
+    testable without instantiating the full portfolio machinery.
+    """
+
+    portfolio_id: str
+    nav: float
+    tags: frozenset[str] = field(default_factory=frozenset)
+    positions: Mapping[str, float] = field(default_factory=dict)
+
+
+def combined_nav(portfolios: Iterable[PortfolioView]) -> float:
+    """Sum of NAVs across portfolios. Empty input → ``0.0``."""
+    return sum(p.nav for p in portfolios)
+
+
+def combined_equity_curve(
+    curves: Sequence[Sequence[float]],
+) -> list[float]:
+    """Element-wise sum of equally-sampled equity curves.
+
+    All input curves must have identical length (the caller is
+    responsible for re-sampling to a common time index). Empty input
+    or empty curves return ``[]``.
+    """
+    if not curves:
+        return []
+    lengths = {len(c) for c in curves}
+    if len(lengths) > 1:
+        raise ValueError(
+            f"all equity curves must have equal length; got {sorted(lengths)}"
+        )
+    n = next(iter(lengths))
+    if n == 0:
+        return []
+    return [sum(c[i] for c in curves) for i in range(n)]
+
+
+def _mean(xs: Sequence[float]) -> float:
+    return sum(xs) / len(xs)
+
+
+def _pearson(xs: Sequence[float], ys: Sequence[float]) -> float:
+    """Pearson correlation. Returns 0.0 if either series has zero variance."""
+    if len(xs) != len(ys):
+        raise ValueError(f"series length mismatch: {len(xs)} vs {len(ys)}")
+    if len(xs) < 2:
+        return 0.0
+    mx, my = _mean(xs), _mean(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    dx = math.sqrt(sum((x - mx) ** 2 for x in xs))
+    dy = math.sqrt(sum((y - my) ** 2 for y in ys))
+    if dx == 0.0 or dy == 0.0:
+        return 0.0
+    return num / (dx * dy)
+
+
+def correlation_matrix(
+    return_series: Mapping[str, Sequence[float]],
+) -> dict[str, dict[str, float]]:
+    """Pearson correlation matrix across portfolio return series.
+
+    Keys are portfolio IDs. Diagonal is always ``1.0`` (or ``0.0`` for
+    a single-point series, since correlation is undefined). Off-diagonal
+    entries are symmetric. All series must have identical length.
+    """
+    keys = list(return_series.keys())
+    if not keys:
+        return {}
+    lengths = {len(s) for s in return_series.values()}
+    if len(lengths) > 1:
+        raise ValueError(
+            f"all return series must have equal length; got {sorted(lengths)}"
+        )
+    out: dict[str, dict[str, float]] = {k: {} for k in keys}
+    for i, a in enumerate(keys):
+        for j, b in enumerate(keys):
+            if i == j:
+                xs = return_series[a]
+                if len(xs) >= 2 and len(set(xs)) > 1:
+                    out[a][b] = 1.0
+                else:
+                    out[a][b] = 0.0
+            elif j < i:
+                out[a][b] = out[b][a]
+            else:
+                out[a][b] = _pearson(return_series[a], return_series[b])
+    return out
+
+
+def position_overlap(
+    portfolios: Iterable[PortfolioView],
+) -> dict[str, dict[str, float]]:
+    """Find symbols held by 2+ portfolios.
+
+    Returns ``symbol → {portfolio_id: quantity}`` containing only
+    symbols held in more than one portfolio. Caller is responsible for
+    deduping within a single portfolio before passing in.
+    """
+    by_symbol: dict[str, dict[str, float]] = {}
+    for p in portfolios:
+        for symbol, qty in p.positions.items():
+            by_symbol.setdefault(symbol, {})[p.portfolio_id] = qty
+    return {sym: holders for sym, holders in by_symbol.items() if len(holders) >= 2}
+
+
+def aggregate_exposure(
+    portfolios: Iterable[PortfolioView],
+    classifier: Mapping[str, str],
+    *,
+    default_bucket: str = "unknown",
+) -> dict[str, float]:
+    """Roll up notional exposure across portfolios by classifier bucket.
+
+    ``classifier`` maps ``symbol → bucket`` (e.g. asset class, sector,
+    geography). Symbols missing from the classifier go to
+    ``default_bucket``. Returns ``bucket → total_notional``.
+    """
+    out: dict[str, float] = {}
+    for p in portfolios:
+        for symbol, qty in p.positions.items():
+            bucket = classifier.get(symbol, default_bucket)
+            out[bucket] = out.get(bucket, 0.0) + qty
+    return out
+
+
+def filter_by_tags(
+    portfolios: Iterable[PortfolioView],
+    tags: Iterable[str],
+    *,
+    match: str = "any",
+) -> list[PortfolioView]:
+    """Filter portfolios by tag set.
+
+    ``match='any'`` returns portfolios that have at least one requested
+    tag. ``match='all'`` returns portfolios that have every requested
+    tag. ``match='none'`` returns portfolios that have none of the
+    requested tags. Empty ``tags`` returns the full input unchanged.
+    """
+    tag_set = frozenset(tags)
+    if not tag_set:
+        return list(portfolios)
+    if match == "any":
+        return [p for p in portfolios if p.tags & tag_set]
+    if match == "all":
+        return [p for p in portfolios if tag_set <= p.tags]
+    if match == "none":
+        return [p for p in portfolios if not (p.tags & tag_set)]
+    raise ValueError(f"match must be 'any', 'all', or 'none'; got {match!r}")
+
+
+__all__ = [
+    "PortfolioView",
+    "aggregate_exposure",
+    "combined_equity_curve",
+    "combined_nav",
+    "correlation_matrix",
+    "filter_by_tags",
+    "position_overlap",
+]

--- a/tests/test_portfolio_aggregator.py
+++ b/tests/test_portfolio_aggregator.py
@@ -1,0 +1,259 @@
+"""Tests for cross-portfolio aggregation helpers (gh#89)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.portfolio_aggregator import (
+    PortfolioView,
+    aggregate_exposure,
+    combined_equity_curve,
+    combined_nav,
+    correlation_matrix,
+    filter_by_tags,
+    position_overlap,
+)
+
+
+def _pv(
+    pid: str,
+    nav: float = 0.0,
+    *,
+    tags: frozenset[str] | None = None,
+    positions: dict[str, float] | None = None,
+) -> PortfolioView:
+    return PortfolioView(
+        portfolio_id=pid,
+        nav=nav,
+        tags=tags or frozenset(),
+        positions=positions or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# combined_nav
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedNav:
+    def test_empty_input_zero(self):
+        assert combined_nav([]) == 0.0
+
+    def test_single_portfolio(self):
+        assert combined_nav([_pv("a", 100.0)]) == 100.0
+
+    def test_sums_across_portfolios(self):
+        portfolios = [_pv("a", 100.0), _pv("b", 250.0), _pv("c", 50.0)]
+        assert combined_nav(portfolios) == 400.0
+
+    def test_negative_nav_subtracts(self):
+        # Margin account in the red — combined NAV must reflect.
+        portfolios = [_pv("a", 200.0), _pv("b", -50.0)]
+        assert combined_nav(portfolios) == 150.0
+
+
+# ---------------------------------------------------------------------------
+# combined_equity_curve
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedEquityCurve:
+    def test_empty_input_empty_output(self):
+        assert combined_equity_curve([]) == []
+
+    def test_single_curve_returned_as_list(self):
+        out = combined_equity_curve([[100.0, 110.0, 105.0]])
+        assert out == [100.0, 110.0, 105.0]
+
+    def test_two_curves_element_wise_sum(self):
+        out = combined_equity_curve([[100.0, 110.0], [50.0, 55.0]])
+        assert out == [150.0, 165.0]
+
+    def test_three_curves_element_wise_sum(self):
+        curves = [[1.0, 2.0, 3.0], [10.0, 20.0, 30.0], [100.0, 200.0, 300.0]]
+        out = combined_equity_curve(curves)
+        assert out == [111.0, 222.0, 333.0]
+
+    def test_unequal_length_rejected(self):
+        with pytest.raises(ValueError, match="equal length"):
+            combined_equity_curve([[1.0, 2.0], [1.0, 2.0, 3.0]])
+
+    def test_all_empty_curves(self):
+        out = combined_equity_curve([[], []])
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# correlation_matrix
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationMatrix:
+    def test_empty_input(self):
+        assert correlation_matrix({}) == {}
+
+    def test_single_series_diagonal_one(self):
+        out = correlation_matrix({"a": [0.01, 0.02, -0.01]})
+        assert out == {"a": {"a": 1.0}}
+
+    def test_perfectly_correlated(self):
+        out = correlation_matrix({"a": [1.0, 2.0, 3.0], "b": [2.0, 4.0, 6.0]})
+        assert out["a"]["b"] == pytest.approx(1.0)
+        assert out["b"]["a"] == pytest.approx(1.0)
+        assert out["a"]["a"] == 1.0
+        assert out["b"]["b"] == 1.0
+
+    def test_perfectly_anti_correlated(self):
+        out = correlation_matrix({"a": [1.0, 2.0, 3.0], "b": [3.0, 2.0, 1.0]})
+        assert out["a"]["b"] == pytest.approx(-1.0)
+
+    def test_uncorrelated(self):
+        # Symmetric series — Pearson should be 0.
+        out = correlation_matrix(
+            {"a": [1.0, -1.0, 1.0, -1.0], "b": [1.0, 1.0, -1.0, -1.0]}
+        )
+        assert out["a"]["b"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_constant_series_zero_correlation(self):
+        # No variance → undefined → 0.0 by convention.
+        out = correlation_matrix({"a": [1.0, 1.0, 1.0], "b": [1.0, 2.0, 3.0]})
+        assert out["a"]["b"] == 0.0
+        # Diagonal of constant series is 0 (no variation = undefined).
+        assert out["a"]["a"] == 0.0
+        assert out["b"]["b"] == 1.0
+
+    def test_unequal_length_rejected(self):
+        with pytest.raises(ValueError, match="equal length"):
+            correlation_matrix({"a": [1.0, 2.0], "b": [1.0, 2.0, 3.0]})
+
+    def test_matrix_is_symmetric(self):
+        out = correlation_matrix(
+            {
+                "a": [1.0, 2.0, 3.0, 4.0],
+                "b": [4.0, 3.0, 2.0, 1.0],
+                "c": [1.0, 4.0, 2.0, 3.0],
+            }
+        )
+        for a in out:
+            for b in out[a]:
+                assert math.isclose(out[a][b], out[b][a])
+
+
+# ---------------------------------------------------------------------------
+# position_overlap
+# ---------------------------------------------------------------------------
+
+
+class TestPositionOverlap:
+    def test_no_overlap_empty_result(self):
+        portfolios = [
+            _pv("a", positions={"AAPL": 10.0}),
+            _pv("b", positions={"GOOG": 5.0}),
+        ]
+        assert position_overlap(portfolios) == {}
+
+    def test_overlap_two_portfolios(self):
+        portfolios = [
+            _pv("a", positions={"AAPL": 10.0, "MSFT": 5.0}),
+            _pv("b", positions={"AAPL": 20.0}),
+        ]
+        out = position_overlap(portfolios)
+        assert out == {"AAPL": {"a": 10.0, "b": 20.0}}
+
+    def test_overlap_three_portfolios(self):
+        portfolios = [
+            _pv("a", positions={"AAPL": 10.0}),
+            _pv("b", positions={"AAPL": 20.0}),
+            _pv("c", positions={"AAPL": 30.0, "TSLA": 5.0}),
+        ]
+        out = position_overlap(portfolios)
+        assert out == {"AAPL": {"a": 10.0, "b": 20.0, "c": 30.0}}
+
+    def test_single_holder_excluded(self):
+        # TSLA only in one portfolio — must not appear in overlap.
+        portfolios = [
+            _pv("a", positions={"AAPL": 10.0, "TSLA": 5.0}),
+            _pv("b", positions={"AAPL": 20.0}),
+        ]
+        out = position_overlap(portfolios)
+        assert "TSLA" not in out
+        assert "AAPL" in out
+
+    def test_empty_portfolios(self):
+        assert position_overlap([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# aggregate_exposure
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateExposure:
+    def test_rolls_up_by_bucket(self):
+        portfolios = [
+            _pv("a", positions={"AAPL": 100.0, "GOOG": 50.0, "BTC": 1.0}),
+            _pv("b", positions={"AAPL": 200.0, "BTC": 2.0}),
+        ]
+        classifier = {"AAPL": "equity", "GOOG": "equity", "BTC": "crypto"}
+        out = aggregate_exposure(portfolios, classifier)
+        assert out == {"equity": 350.0, "crypto": 3.0}
+
+    def test_unknown_symbol_goes_to_default(self):
+        portfolios = [_pv("a", positions={"FOO": 10.0, "AAPL": 5.0})]
+        classifier = {"AAPL": "equity"}
+        out = aggregate_exposure(portfolios, classifier)
+        assert out == {"equity": 5.0, "unknown": 10.0}
+
+    def test_custom_default_bucket(self):
+        portfolios = [_pv("a", positions={"FOO": 10.0})]
+        out = aggregate_exposure(portfolios, {}, default_bucket="other")
+        assert out == {"other": 10.0}
+
+    def test_empty_portfolios(self):
+        assert aggregate_exposure([], {"AAPL": "equity"}) == {}
+
+
+# ---------------------------------------------------------------------------
+# filter_by_tags
+# ---------------------------------------------------------------------------
+
+
+class TestFilterByTags:
+    @pytest.fixture
+    def portfolios(self) -> list[PortfolioView]:
+        return [
+            _pv("a", tags=frozenset({"paper", "crypto-only"})),
+            _pv("b", tags=frozenset({"live", "aggressive"})),
+            _pv("c", tags=frozenset({"paper", "aggressive"})),
+            _pv("d", tags=frozenset()),
+        ]
+
+    def test_empty_tags_returns_all(self, portfolios):
+        out = filter_by_tags(portfolios, [])
+        assert [p.portfolio_id for p in out] == ["a", "b", "c", "d"]
+
+    def test_match_any_default(self, portfolios):
+        out = filter_by_tags(portfolios, ["paper"])
+        assert {p.portfolio_id for p in out} == {"a", "c"}
+
+    def test_match_any_multiple(self, portfolios):
+        out = filter_by_tags(portfolios, ["paper", "live"])
+        assert {p.portfolio_id for p in out} == {"a", "b", "c"}
+
+    def test_match_all(self, portfolios):
+        out = filter_by_tags(portfolios, ["paper", "aggressive"], match="all")
+        assert {p.portfolio_id for p in out} == {"c"}
+
+    def test_match_all_no_match(self, portfolios):
+        out = filter_by_tags(portfolios, ["paper", "live"], match="all")
+        assert out == []
+
+    def test_match_none(self, portfolios):
+        out = filter_by_tags(portfolios, ["paper"], match="none")
+        assert {p.portfolio_id for p in out} == {"b", "d"}
+
+    def test_invalid_match_mode_rejected(self, portfolios):
+        with pytest.raises(ValueError, match="match must be"):
+            filter_by_tags(portfolios, ["paper"], match="weird")


### PR DESCRIPTION
## Summary

Pure-Python slice of gh#89 (portfolio tagging, grouping, cross-portfolio analytics). This PR ships the math layer — the DB models, REST routes, and UI components are deferred follow-ups so this lands tightly.

## What ships

- ``PortfolioView`` — frozen DTO consumed by the aggregator (``portfolio_id``, ``nav``, ``tags``, ``positions``). The real ``Portfolio`` class stays in ``engine.core.portfolio``; this projection keeps the aggregator trivially testable without instantiating the full portfolio machinery.
- ``combined_nav(portfolios)`` — sum of NAVs across a group.
- ``combined_equity_curve(curves)`` — element-wise sum of equally-sampled curves; rejects unequal lengths (caller must re-sample first).
- ``correlation_matrix(return_series)`` — Pearson correlation across portfolio return series. Diagonal is ``1.0`` (or ``0.0`` for zero-variance / sub-2 series). Off-diagonal is symmetric.
- ``position_overlap(portfolios)`` — symbols held by 2+ portfolios, mapped to ``{portfolio_id: quantity}``.
- ``aggregate_exposure(portfolios, classifier, *, default_bucket)`` — roll up notional by classifier bucket (asset class, sector, geography). Unknown symbols fall through to ``default_bucket``.
- ``filter_by_tags(portfolios, tags, *, match)`` — set-membership filter; ``any`` / ``all`` / ``none`` match modes; empty tag set returns full input.

## Out of scope (explicit follow-ups)

- Combined drawdown / Sharpe → compose with existing per-portfolio metrics on the combined equity curve from this module.
- ORM models for ``PortfolioGroup`` and ``portfolio_tags`` (DB-shaped follow-up).
- REST surface (``POST/GET/PUT/DELETE /api/v1/portfolio-groups``, tag management endpoints).
- Frontend tag pills, group sidebar, aggregate dashboard.

## Test plan

- [x] 34 new unit tests in ``tests/test_portfolio_aggregator.py``:
  - ``combined_nav`` (4 cases incl. negative NAV)
  - ``combined_equity_curve`` (6 cases incl. unequal-length rejection)
  - ``correlation_matrix`` (8 cases incl. perfectly correlated, anti-correlated, uncorrelated, constant series, symmetry invariant)
  - ``position_overlap`` (5 cases)
  - ``aggregate_exposure`` (4 cases incl. custom default bucket)
  - ``filter_by_tags`` (7 cases incl. all 3 match modes + invalid mode rejection)
- [x] Full local suite green: ``2253 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted aggregator suite: 34/34 pass in 0.07 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)