### PR TITLE
feat(data): sliding-window cleanup helpers (gh#90)

### DIFF
--- a/engine/data/retention_cleanup.py
+++ b/engine/data/retention_cleanup.py
@@ -1,0 +1,160 @@
+"""Sliding-window cleanup helpers for the retention engine (gh#90).
+
+Builds on the per-record decision helpers in ``engine.data.retention``.
+This module computes the *boundaries* that a cron-driven cleanup task
+will hand to bulk SQL ``DELETE`` / TimescaleDB ``compress_chunk`` calls.
+
+A cleanup pass for one policy resolves to two cutoff timestamps:
+
+- ``delete_before`` — every record older than this should be deleted
+  (or archived first if ``policy.archive_to`` is set).
+- ``compress_before`` — every record older than this but newer than
+  ``delete_before`` should be compressed.
+
+The actual SQL execution lives in the deferred cron worker; this module
+returns plain DTOs so the cron implementation stays mockable and the
+math stays trivially testable.
+
+Out of scope:
+- Celery beat / cron registration.
+- Bulk DELETE / compress_chunk SQL.
+- S3 archival writers.
+- Idempotency keys / lock-free retry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from engine.data.retention import RetentionPolicy
+
+DEFAULT_BATCH_SIZE = 10_000
+MAX_BATCH_SIZE = 100_000
+MIN_BATCH_SIZE = 100
+
+
+@dataclass(frozen=True)
+class CleanupWindow:
+    """Resolved cutoff timestamps for one cleanup pass.
+
+    ``delete_before`` is ``None`` when the policy keeps records forever.
+    ``compress_before`` is ``None`` when the policy has no compression
+    threshold. Both being ``None`` means the cleanup pass is a no-op
+    (e.g. ``backtest_results``).
+    """
+
+    dataset: str
+    delete_before: datetime | None
+    compress_before: datetime | None
+    archive_to: str | None
+
+    @property
+    def is_noop(self) -> bool:
+        return self.delete_before is None and self.compress_before is None
+
+
+def compute_cleanup_window(
+    policy: RetentionPolicy, *, now: datetime | None = None
+) -> CleanupWindow:
+    """Resolve cutoff timestamps for one policy.
+
+    Returns ``CleanupWindow`` with ``delete_before`` /
+    ``compress_before`` set to ``now - retain_days`` /
+    ``now - compress_after_days`` respectively, or ``None`` when the
+    corresponding setting is unset on the policy.
+    """
+    now = now if now is not None else datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    delete_before = (
+        now - timedelta(days=policy.retain_days)
+        if policy.retain_days is not None
+        else None
+    )
+    compress_before = (
+        now - timedelta(days=policy.compress_after_days)
+        if policy.compress_after_days is not None
+        else None
+    )
+    return CleanupWindow(
+        dataset=policy.dataset,
+        delete_before=delete_before,
+        compress_before=compress_before,
+        archive_to=policy.archive_to,
+    )
+
+
+def partition_boundaries(
+    window: CleanupWindow,
+    *,
+    chunk_days: int = 7,
+    now: datetime | None = None,
+) -> list[tuple[datetime, datetime]]:
+    """Slice the cleanup horizon into fixed-width windows.
+
+    Returns a list of ``(start, end)`` half-open intervals walking from
+    the oldest cutoff up to ``now``. ``chunk_days`` controls width.
+    The result is empty for a no-op window or a non-positive horizon.
+
+    The cron worker calls one bulk SQL query per slice so a single
+    pass cannot lock the table for an unbounded duration.
+    """
+    if chunk_days <= 0:
+        raise ValueError("chunk_days must be > 0")
+    now = now if now is not None else datetime.now(timezone.utc)
+    if window.is_noop:
+        return []
+    earliest = window.delete_before or window.compress_before
+    if earliest is None or earliest >= now:
+        return []
+    chunk = timedelta(days=chunk_days)
+    out: list[tuple[datetime, datetime]] = []
+    cursor = earliest
+    while cursor < now:
+        end = min(cursor + chunk, now)
+        out.append((cursor, end))
+        cursor = end
+    return out
+
+
+def batch_iter(
+    items: list[str], *, batch_size: int = DEFAULT_BATCH_SIZE
+) -> Iterator[list[str]]:
+    """Yield successive ``batch_size`` slices of ``items``.
+
+    Used by the cron worker to chunk record-id lists for bulk DELETE
+    calls. Validates ``batch_size`` against operator-friendly bounds.
+    """
+    if batch_size < MIN_BATCH_SIZE:
+        raise ValueError(f"batch_size must be >= {MIN_BATCH_SIZE}, got {batch_size}")
+    if batch_size > MAX_BATCH_SIZE:
+        raise ValueError(f"batch_size must be <= {MAX_BATCH_SIZE}, got {batch_size}")
+    for i in range(0, len(items), batch_size):
+        yield items[i : i + batch_size]
+
+
+def estimate_batches(item_count: int, *, batch_size: int = DEFAULT_BATCH_SIZE) -> int:
+    """Number of batches ``batch_iter`` will yield for ``item_count`` items."""
+    if item_count < 0:
+        raise ValueError("item_count must be >= 0")
+    if batch_size < MIN_BATCH_SIZE:
+        raise ValueError(f"batch_size must be >= {MIN_BATCH_SIZE}")
+    if batch_size > MAX_BATCH_SIZE:
+        raise ValueError(f"batch_size must be <= {MAX_BATCH_SIZE}")
+    if item_count == 0:
+        return 0
+    return (item_count + batch_size - 1) // batch_size
+
+
+__all__ = [
+    "CleanupWindow",
+    "DEFAULT_BATCH_SIZE",
+    "MAX_BATCH_SIZE",
+    "MIN_BATCH_SIZE",
+    "batch_iter",
+    "compute_cleanup_window",
+    "estimate_batches",
+    "partition_boundaries",
+]

--- a/tests/test_retention_cleanup.py
+++ b/tests/test_retention_cleanup.py
@@ -1,0 +1,269 @@
+"""Tests for sliding-window cleanup helpers (gh#90 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from engine.data.retention import RetentionPolicy
+from engine.data.retention_cleanup import (
+    DEFAULT_BATCH_SIZE,
+    MAX_BATCH_SIZE,
+    MIN_BATCH_SIZE,
+    CleanupWindow,
+    batch_iter,
+    compute_cleanup_window,
+    estimate_batches,
+    partition_boundaries,
+)
+
+UTC = timezone.utc
+NOW = datetime(2026, 5, 3, 12, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# compute_cleanup_window
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCleanupWindow:
+    def test_full_policy_resolves_both_cutoffs(self):
+        p = RetentionPolicy("ohlcv_1m", retain_days=90, compress_after_days=30)
+        w = compute_cleanup_window(p, now=NOW)
+        assert w.dataset == "ohlcv_1m"
+        assert w.delete_before == NOW - timedelta(days=90)
+        assert w.compress_before == NOW - timedelta(days=30)
+        assert w.archive_to is None
+        assert w.is_noop is False
+
+    def test_keep_forever_policy_no_delete_cutoff(self):
+        p = RetentionPolicy("ohlcv_1d", retain_days=None, compress_after_days=365)
+        w = compute_cleanup_window(p, now=NOW)
+        assert w.delete_before is None
+        assert w.compress_before == NOW - timedelta(days=365)
+        assert w.is_noop is False
+
+    def test_no_compression_policy(self):
+        p = RetentionPolicy("webhook_deliveries", retain_days=30)
+        w = compute_cleanup_window(p, now=NOW)
+        assert w.delete_before == NOW - timedelta(days=30)
+        assert w.compress_before is None
+
+    def test_keep_forever_no_compression_is_noop(self):
+        # backtest_results: never deletes, never compresses.
+        p = RetentionPolicy("backtest_results", retain_days=None)
+        w = compute_cleanup_window(p, now=NOW)
+        assert w.delete_before is None
+        assert w.compress_before is None
+        assert w.is_noop is True
+
+    def test_archive_to_propagated(self):
+        p = RetentionPolicy(
+            "ohlcv_1m",
+            retain_days=90,
+            compress_after_days=30,
+            archive_to="s3://bucket/archive/",
+        )
+        w = compute_cleanup_window(p, now=NOW)
+        assert w.archive_to == "s3://bucket/archive/"
+
+    def test_naive_now_rejected(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        with pytest.raises(ValueError, match="timezone-aware"):
+            compute_cleanup_window(p, now=datetime(2026, 1, 1))
+
+    def test_default_now_uses_utc(self):
+        p = RetentionPolicy("foo", retain_days=30)
+        w = compute_cleanup_window(p)
+        assert w.delete_before is not None
+        assert w.delete_before.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# partition_boundaries
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionBoundaries:
+    def test_noop_window_returns_empty(self):
+        w = CleanupWindow(
+            "foo", delete_before=None, compress_before=None, archive_to=None
+        )
+        assert partition_boundaries(w, now=NOW) == []
+
+    def test_simple_horizon_chunked(self):
+        # delete_before = 21 days ago; chunk_days=7 → 3 slices.
+        w = CleanupWindow(
+            "foo",
+            delete_before=NOW - timedelta(days=21),
+            compress_before=None,
+            archive_to=None,
+        )
+        out = partition_boundaries(w, chunk_days=7, now=NOW)
+        assert len(out) == 3
+        assert out[0] == (NOW - timedelta(days=21), NOW - timedelta(days=14))
+        assert out[1] == (NOW - timedelta(days=14), NOW - timedelta(days=7))
+        assert out[2] == (NOW - timedelta(days=7), NOW)
+
+    def test_uses_delete_floor_when_set(self):
+        # delete_before is set → it floors the horizon (newer than compress_before).
+        w = CleanupWindow(
+            "foo",
+            delete_before=NOW - timedelta(days=5),
+            compress_before=NOW - timedelta(days=14),
+            archive_to=None,
+        )
+        out = partition_boundaries(w, chunk_days=7, now=NOW)
+        assert out[0][0] == NOW - timedelta(days=5)
+
+    def test_keep_forever_uses_compress_floor(self):
+        # delete_before is None (keep forever), compress is set.
+        w = CleanupWindow(
+            "ohlcv_1d",
+            delete_before=None,
+            compress_before=NOW - timedelta(days=14),
+            archive_to=None,
+        )
+        out = partition_boundaries(w, chunk_days=7, now=NOW)
+        assert len(out) == 2
+        assert out[0][0] == NOW - timedelta(days=14)
+        assert out[-1][1] == NOW
+
+    def test_partial_final_chunk_clamped_to_now(self):
+        # 10 days, chunk=7 → first 7-day, final 3-day clamped to now.
+        w = CleanupWindow(
+            "foo",
+            delete_before=NOW - timedelta(days=10),
+            compress_before=None,
+            archive_to=None,
+        )
+        out = partition_boundaries(w, chunk_days=7, now=NOW)
+        assert len(out) == 2
+        assert out[0] == (NOW - timedelta(days=10), NOW - timedelta(days=3))
+        assert out[1] == (NOW - timedelta(days=3), NOW)
+
+    def test_future_cutoff_returns_empty(self):
+        w = CleanupWindow(
+            "foo",
+            delete_before=NOW + timedelta(days=10),
+            compress_before=None,
+            archive_to=None,
+        )
+        assert partition_boundaries(w, now=NOW) == []
+
+    def test_zero_chunk_rejected(self):
+        w = CleanupWindow(
+            "foo",
+            delete_before=NOW - timedelta(days=1),
+            compress_before=None,
+            archive_to=None,
+        )
+        with pytest.raises(ValueError, match="chunk_days"):
+            partition_boundaries(w, chunk_days=0, now=NOW)
+
+    def test_negative_chunk_rejected(self):
+        w = CleanupWindow(
+            "foo",
+            delete_before=NOW - timedelta(days=1),
+            compress_before=None,
+            archive_to=None,
+        )
+        with pytest.raises(ValueError, match="chunk_days"):
+            partition_boundaries(w, chunk_days=-1, now=NOW)
+
+    def test_chunks_cover_horizon_contiguously(self):
+        w = CleanupWindow(
+            "foo",
+            delete_before=NOW - timedelta(days=30),
+            compress_before=None,
+            archive_to=None,
+        )
+        out = partition_boundaries(w, chunk_days=7, now=NOW)
+        # Each chunk's end == next chunk's start (half-open intervals).
+        for i in range(len(out) - 1):
+            assert out[i][1] == out[i + 1][0]
+
+
+# ---------------------------------------------------------------------------
+# batch_iter
+# ---------------------------------------------------------------------------
+
+
+class TestBatchIter:
+    def test_empty_input_no_yields(self):
+        assert list(batch_iter([])) == []
+
+    def test_single_full_batch(self):
+        items = [f"id_{i}" for i in range(MIN_BATCH_SIZE)]
+        out = list(batch_iter(items, batch_size=MIN_BATCH_SIZE))
+        assert len(out) == 1
+        assert out[0] == items
+
+    def test_multiple_batches(self):
+        items = [f"id_{i}" for i in range(250)]
+        out = list(batch_iter(items, batch_size=100))
+        assert len(out) == 3
+        assert out[0] == items[:100]
+        assert out[1] == items[100:200]
+        assert out[2] == items[200:250]
+
+    def test_partial_final_batch(self):
+        items = [f"id_{i}" for i in range(105)]
+        out = list(batch_iter(items, batch_size=100))
+        assert len(out) == 2
+        assert len(out[1]) == 5
+
+    def test_too_small_batch_rejected(self):
+        with pytest.raises(ValueError, match="batch_size must be >="):
+            list(batch_iter(["a"], batch_size=MIN_BATCH_SIZE - 1))
+
+    def test_too_large_batch_rejected(self):
+        with pytest.raises(ValueError, match="batch_size must be <="):
+            list(batch_iter(["a"], batch_size=MAX_BATCH_SIZE + 1))
+
+    def test_default_batch_size(self):
+        items = [f"id_{i}" for i in range(DEFAULT_BATCH_SIZE + 50)]
+        out = list(batch_iter(items))
+        assert len(out) == 2
+        assert len(out[0]) == DEFAULT_BATCH_SIZE
+        assert len(out[1]) == 50
+
+
+# ---------------------------------------------------------------------------
+# estimate_batches
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateBatches:
+    def test_zero_items_zero_batches(self):
+        assert estimate_batches(0) == 0
+
+    def test_exact_multiple(self):
+        assert estimate_batches(20_000, batch_size=10_000) == 2
+
+    def test_partial_final_batch_counted(self):
+        assert estimate_batches(20_001, batch_size=10_000) == 3
+
+    def test_smaller_than_batch(self):
+        assert estimate_batches(50, batch_size=10_000) == 1
+
+    def test_negative_count_rejected(self):
+        with pytest.raises(ValueError, match="item_count"):
+            estimate_batches(-1)
+
+    def test_too_small_batch_rejected(self):
+        with pytest.raises(ValueError, match="batch_size"):
+            estimate_batches(100, batch_size=MIN_BATCH_SIZE - 1)
+
+    def test_too_large_batch_rejected(self):
+        with pytest.raises(ValueError, match="batch_size"):
+            estimate_batches(100, batch_size=MAX_BATCH_SIZE + 1)
+
+    def test_matches_batch_iter_count(self):
+        # Sanity: estimate must match the actual yield count.
+        items = [str(i) for i in range(12_345)]
+        for bs in (100, 1000, 5000, 10_000):
+            assert estimate_batches(len(items), batch_size=bs) == len(
+                list(batch_iter(items, batch_size=bs))
+            )


### PR DESCRIPTION
## Summary

Follow-up to #338. The first slice landed per-record decision helpers (``decide_action``, ``is_expired``); this slice adds the cron-window math layer that bulk DELETE / TimescaleDB ``compress_chunk`` SQL will be parameterised from.

A cleanup pass for one policy resolves to two cutoff timestamps:

- ``delete_before`` — every record older than this should be deleted (or archived first if ``policy.archive_to`` is set).
- ``compress_before`` — every record older than this but newer than ``delete_before`` should be compressed.

The cron worker then walks the horizon as half-open ``(start, end)`` intervals so a single sweep cannot lock the table for an unbounded duration.

## What ships

- ``CleanupWindow`` frozen DTO with ``delete_before`` / ``compress_before`` (``None`` when the policy doesn't set them) and ``is_noop`` short-circuit for keep-forever-no-compress policies like ``backtest_results``.
- ``compute_cleanup_window(policy, *, now)`` resolves the cutoffs from a ``RetentionPolicy``; rejects naive ``now``.
- ``partition_boundaries(window, *, chunk_days=7, now)`` slices the horizon into fixed-width windows; clamps the final chunk to ``now``; returns empty for noop / future / non-positive horizons; rejects ``chunk_days <= 0``.
- ``batch_iter(items, *, batch_size=10_000)`` yields slices for bulk DELETE calls; ``MIN_BATCH_SIZE=100`` / ``MAX_BATCH_SIZE=100k`` enforced.
- ``estimate_batches(item_count, *, batch_size)`` matches the actual yield count (sanity-tested across multiple batch sizes).

## Out of scope (still deferred)

- Celery beat / cron registration.
- Bulk DELETE / ``compress_chunk`` SQL.
- S3 archival writers.
- ``GET/PUT/POST /api/v1/settings/retention[/storage|/cleanup]`` REST surface.
- Idempotency keys / lock-free retry.

## Test plan

- [x] 31 new unit tests in ``tests/test_retention_cleanup.py``:
  - ``compute_cleanup_window`` (7 cases incl. keep-forever, no-compression, archive_to propagation, naive-rejection)
  - ``partition_boundaries`` (9 cases incl. noop, simple horizon, contiguous half-open coverage, partial final chunk, future cutoff, zero/negative chunk rejection)
  - ``batch_iter`` (7 cases incl. boundary batch sizes, default size, partial final batch)
  - ``estimate_batches`` (8 cases incl. matches-batch_iter cross-check across multiple batch sizes)
- [x] Full local suite green: ``2284 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted cleanup suite: 31/31 pass in 0.16 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)