### PR TITLE
feat(portfolio): concentration + variance decomposition (gh#89)

### DIFF
--- a/engine/core/portfolio_concentration.py
+++ b/engine/core/portfolio_concentration.py
@@ -1,0 +1,158 @@
+"""Concentration + volatility decomposition helpers (gh#89 follow-up).
+
+Pure-function helpers on top of the cross-portfolio aggregator from
+#339. Concentration analytics answer "how diversified is this group?":
+
+- Herfindahl-Hirschman Index (HHI) over weights
+- Top-N concentration share
+- Effective N (1 / HHI) — equivalent number of equally-weighted holdings
+- Gini coefficient over weights
+- Idiosyncratic / systematic variance decomposition
+
+Conventions:
+
+- Weights are passed as a ``Mapping[str, float]`` of ``key → weight``.
+  We sum-to-one internally so callers can pass raw exposures and get
+  a comparable index across groups.
+- All functions return ``0.0`` for empty input rather than raising —
+  consistent with the existing metrics layer (``engine.core.metrics``).
+
+Out of scope:
+- Bayesian shrinkage on the weight covariance matrix.
+- Turnover-decay weighting for time-varying weights.
+- Dollar-Volume-weighted concentration (operators bin themselves).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+
+def _normalise(weights: Mapping[str, float]) -> dict[str, float]:
+    """Re-scale weights to sum to one, dropping non-positive entries."""
+    positive = {k: w for k, w in weights.items() if w > 0}
+    total = sum(positive.values())
+    if total <= 0:
+        return {}
+    return {k: w / total for k, w in positive.items()}
+
+
+def hhi(weights: Mapping[str, float]) -> float:
+    """Herfindahl-Hirschman Index over normalised weights.
+
+    Returns a value in ``[0, 1]``. ``0`` for empty input. ``1`` for a
+    fully concentrated single-holding portfolio. Weights are normalised
+    to sum-to-one internally; non-positive entries are dropped.
+    """
+    norm = _normalise(weights)
+    if not norm:
+        return 0.0
+    return sum(w * w for w in norm.values())
+
+
+def effective_n(weights: Mapping[str, float]) -> float:
+    """Effective number of equally-weighted holdings, ``1 / HHI``.
+
+    Returns ``0.0`` for empty input. A perfectly diversified portfolio
+    of N equal holdings has ``effective_n = N``.
+    """
+    h = hhi(weights)
+    return 1.0 / h if h > 0 else 0.0
+
+
+def top_n_share(weights: Mapping[str, float], n: int) -> float:
+    """Combined weight of the top ``n`` holdings (after normalisation).
+
+    Returns ``0.0`` for empty input or ``n <= 0``. Caps at ``1.0`` when
+    ``n >= len(weights)``.
+    """
+    if n <= 0:
+        return 0.0
+    norm = _normalise(weights)
+    if not norm:
+        return 0.0
+    sorted_weights = sorted(norm.values(), reverse=True)
+    return sum(sorted_weights[:n])
+
+
+def gini_coefficient(weights: Mapping[str, float]) -> float:
+    """Gini coefficient of the (normalised) weight distribution.
+
+    ``0`` = perfectly equal, approaches ``1`` as concentration grows.
+    Uses the standard sorted-pair formula:
+
+        G = (2 · Σᵢ i·xᵢ) / (n · Σ xᵢ) − (n + 1) / n
+
+    where ``x`` is sorted ascending and ``i`` is 1-indexed.
+    """
+    norm = _normalise(weights)
+    if not norm:
+        return 0.0
+    n = len(norm)
+    if n == 1:
+        return 0.0
+    sorted_w = sorted(norm.values())
+    cumulative = sum((i + 1) * w for i, w in enumerate(sorted_w))
+    total = sum(sorted_w)
+    if total == 0.0:
+        return 0.0
+    return (2 * cumulative) / (n * total) - (n + 1) / n
+
+
+def variance_decomposition(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+) -> dict[str, float]:
+    """Decompose portfolio variance into systematic and idiosyncratic.
+
+    Uses the standard CAPM-style decomposition:
+
+        var(P) = β² · var(B) + var(ε)
+
+    where β is OLS slope of P on B and ε is the residual. Returns a
+    dict with keys ``total_variance``, ``systematic_variance``,
+    ``idiosyncratic_variance``, ``beta``, and ``r_squared``.
+
+    Returns all-zero values for series shorter than 2, length mismatch,
+    or zero-variance benchmark / portfolio.
+    """
+    zero = {
+        "total_variance": 0.0,
+        "systematic_variance": 0.0,
+        "idiosyncratic_variance": 0.0,
+        "beta": 0.0,
+        "r_squared": 0.0,
+    }
+    n = len(portfolio_returns)
+    if n != len(benchmark_returns) or n < 2:
+        return zero
+    mp = sum(portfolio_returns) / n
+    mb = sum(benchmark_returns) / n
+    cov = (
+        sum((p - mp) * (b - mb) for p, b in zip(portfolio_returns, benchmark_returns))
+        / n
+    )
+    var_b = sum((b - mb) ** 2 for b in benchmark_returns) / n
+    var_p = sum((p - mp) ** 2 for p in portfolio_returns) / n
+    if var_b == 0.0 or var_p == 0.0:
+        return zero
+    beta = cov / var_b
+    systematic = beta * beta * var_b
+    idiosyncratic = max(var_p - systematic, 0.0)
+    r_squared = systematic / var_p if var_p > 0 else 0.0
+    return {
+        "total_variance": var_p,
+        "systematic_variance": systematic,
+        "idiosyncratic_variance": idiosyncratic,
+        "beta": beta,
+        "r_squared": r_squared,
+    }
+
+
+__all__ = [
+    "effective_n",
+    "gini_coefficient",
+    "hhi",
+    "top_n_share",
+    "variance_decomposition",
+]

--- a/tests/test_portfolio_concentration.py
+++ b/tests/test_portfolio_concentration.py
@@ -1,0 +1,222 @@
+"""Tests for portfolio concentration + variance decomposition (gh#89 follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.portfolio_concentration import (
+    effective_n,
+    gini_coefficient,
+    hhi,
+    top_n_share,
+    variance_decomposition,
+)
+
+
+# ---------------------------------------------------------------------------
+# HHI
+# ---------------------------------------------------------------------------
+
+
+class TestHHI:
+    def test_empty_returns_zero(self):
+        assert hhi({}) == 0.0
+
+    def test_single_holding_is_one(self):
+        # Perfectly concentrated.
+        assert hhi({"AAPL": 100.0}) == pytest.approx(1.0)
+
+    def test_two_equal_holdings(self):
+        # 0.5² + 0.5² = 0.5
+        assert hhi({"a": 50.0, "b": 50.0}) == pytest.approx(0.5)
+
+    def test_four_equal_holdings(self):
+        # 4 · 0.25² = 0.25
+        weights = {f"x{i}": 25.0 for i in range(4)}
+        assert hhi(weights) == pytest.approx(0.25)
+
+    def test_unequal_holdings(self):
+        # 70/30 split → 0.7² + 0.3² = 0.58
+        assert hhi({"a": 70.0, "b": 30.0}) == pytest.approx(0.58)
+
+    def test_normalises_unscaled_input(self):
+        # Same result regardless of scale.
+        scaled = hhi({"a": 700.0, "b": 300.0})
+        unscaled = hhi({"a": 7.0, "b": 3.0})
+        assert scaled == pytest.approx(unscaled)
+
+    def test_drops_non_positive_weights(self):
+        out = hhi({"a": 50.0, "b": 50.0, "c": 0.0, "d": -10.0})
+        # Only a and b counted → 0.5
+        assert out == pytest.approx(0.5)
+
+    def test_all_zero_returns_zero(self):
+        assert hhi({"a": 0.0, "b": 0.0}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# effective_n
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveN:
+    def test_empty_returns_zero(self):
+        assert effective_n({}) == 0.0
+
+    def test_single_holding_is_one(self):
+        assert effective_n({"a": 100.0}) == pytest.approx(1.0)
+
+    def test_n_equal_holdings(self):
+        for n in (2, 5, 10, 100):
+            weights = {f"x{i}": 1.0 for i in range(n)}
+            assert effective_n(weights) == pytest.approx(float(n))
+
+    def test_concentrated_portfolio_low_effective_n(self):
+        # 90/10 split → effective_n = 1 / (0.81 + 0.01) ≈ 1.22
+        out = effective_n({"a": 90.0, "b": 10.0})
+        assert 1.2 < out < 1.3
+
+
+# ---------------------------------------------------------------------------
+# top_n_share
+# ---------------------------------------------------------------------------
+
+
+class TestTopNShare:
+    def test_empty_returns_zero(self):
+        assert top_n_share({}, 1) == 0.0
+
+    def test_zero_n_returns_zero(self):
+        assert top_n_share({"a": 100.0}, 0) == 0.0
+
+    def test_negative_n_returns_zero(self):
+        assert top_n_share({"a": 100.0}, -1) == 0.0
+
+    def test_top_one(self):
+        # Top-1 of 60/30/10 = 0.6
+        assert top_n_share({"a": 60.0, "b": 30.0, "c": 10.0}, 1) == pytest.approx(0.6)
+
+    def test_top_two(self):
+        # Top-2 of 60/30/10 = 0.9
+        assert top_n_share({"a": 60.0, "b": 30.0, "c": 10.0}, 2) == pytest.approx(0.9)
+
+    def test_n_exceeds_holdings_caps_at_one(self):
+        out = top_n_share({"a": 60.0, "b": 40.0}, 100)
+        assert out == pytest.approx(1.0)
+
+    def test_picks_largest_regardless_of_input_order(self):
+        # Smallest holding listed first — function still returns top weights.
+        out = top_n_share({"tiny": 1.0, "huge": 99.0}, 1)
+        assert out == pytest.approx(0.99)
+
+
+# ---------------------------------------------------------------------------
+# Gini coefficient
+# ---------------------------------------------------------------------------
+
+
+class TestGini:
+    def test_empty_returns_zero(self):
+        assert gini_coefficient({}) == 0.0
+
+    def test_single_holding_returns_zero(self):
+        # Single holder is "perfectly equal" by convention here.
+        assert gini_coefficient({"a": 100.0}) == 0.0
+
+    def test_perfectly_equal_distribution(self):
+        weights = {f"x{i}": 1.0 for i in range(10)}
+        assert gini_coefficient(weights) == pytest.approx(0.0, abs=1e-12)
+
+    def test_two_holdings_one_dominant(self):
+        # 99/1 split — close to maximally unequal for n=2.
+        out = gini_coefficient({"a": 99.0, "b": 1.0})
+        # Max possible Gini for n=2 is 0.5 (perfect inequality).
+        assert 0.45 < out <= 0.5
+
+    def test_value_bounded_zero_one(self):
+        # Skew-heavy 5-holding distribution.
+        out = gini_coefficient({"a": 100.0, "b": 1.0, "c": 1.0, "d": 1.0, "e": 1.0})
+        assert 0.0 <= out < 1.0
+
+    def test_drops_non_positive_weights(self):
+        equal_pos = {f"x{i}": 1.0 for i in range(5)}
+        with_zeros = {**equal_pos, "z": 0.0, "n": -10.0}
+        assert gini_coefficient(with_zeros) == pytest.approx(
+            gini_coefficient(equal_pos)
+        )
+
+
+# ---------------------------------------------------------------------------
+# variance_decomposition
+# ---------------------------------------------------------------------------
+
+
+class TestVarianceDecomposition:
+    def test_empty_returns_all_zero(self):
+        out = variance_decomposition([], [])
+        assert all(v == 0.0 for v in out.values())
+
+    def test_single_point_returns_all_zero(self):
+        out = variance_decomposition([0.01], [0.01])
+        assert all(v == 0.0 for v in out.values())
+
+    def test_length_mismatch_returns_all_zero(self):
+        out = variance_decomposition([0.01, 0.02], [0.01, 0.02, 0.03])
+        assert all(v == 0.0 for v in out.values())
+
+    def test_zero_variance_benchmark_returns_all_zero(self):
+        out = variance_decomposition([0.01, -0.01, 0.02], [0.01, 0.01, 0.01])
+        assert all(v == 0.0 for v in out.values())
+
+    def test_perfect_correlation_yields_full_systematic(self):
+        # Portfolio = 1 × benchmark → β = 1, var = systematic, idio = 0.
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = list(bench)
+        out = variance_decomposition(port, bench)
+        assert out["beta"] == pytest.approx(1.0)
+        assert out["systematic_variance"] == pytest.approx(out["total_variance"])
+        assert out["idiosyncratic_variance"] == pytest.approx(0.0, abs=1e-12)
+        assert out["r_squared"] == pytest.approx(1.0)
+
+    def test_amplified_beta(self):
+        # Portfolio = 2 × benchmark → β = 2.
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [2 * b for b in bench]
+        out = variance_decomposition(port, bench)
+        assert out["beta"] == pytest.approx(2.0)
+        assert out["r_squared"] == pytest.approx(1.0)
+
+    def test_inverse_correlation_negative_beta(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [-b for b in bench]
+        out = variance_decomposition(port, bench)
+        assert out["beta"] == pytest.approx(-1.0)
+        # Systematic = β² · var(B), still positive.
+        assert out["systematic_variance"] > 0
+        assert out["r_squared"] == pytest.approx(1.0)
+
+    def test_orthogonal_returns_zero_beta(self):
+        # Mean-zero anti-symmetric ⇒ covariance zero.
+        bench = [1.0, -1.0, 1.0, -1.0]
+        port = [1.0, 1.0, -1.0, -1.0]
+        out = variance_decomposition(port, bench)
+        assert out["beta"] == pytest.approx(0.0, abs=1e-12)
+        assert out["systematic_variance"] == pytest.approx(0.0, abs=1e-12)
+        # All variance is idiosyncratic.
+        assert out["idiosyncratic_variance"] == pytest.approx(out["total_variance"])
+
+    def test_idiosyncratic_never_negative(self):
+        # Numerical edge case: even noisy inputs can't produce negative idio.
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02, 0.005, -0.015]
+        port = [0.012, -0.018, 0.029, -0.013, 0.021, 0.003, -0.017]
+        out = variance_decomposition(port, bench)
+        assert out["idiosyncratic_variance"] >= 0.0
+
+    def test_identity_holds(self):
+        # var(P) = systematic + idiosyncratic (within float tolerance).
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [0.012, -0.018, 0.029, -0.013, 0.021]
+        out = variance_decomposition(port, bench)
+        assert out["systematic_variance"] + out["idiosyncratic_variance"] == pytest.approx(
+            out["total_variance"], rel=1e-9
+        )


### PR DESCRIPTION
## Summary

Follow-up to #339 (cross-portfolio aggregator). Adds the diversification + risk-decomposition layer that the deferred ``GET /api/v1/portfolio-groups/{id}/analytics`` endpoint will surface.

## What ships

- ``hhi(weights)`` — Herfindahl-Hirschman Index over normalised weights, in ``[0, 1]``. Sum-to-one is applied internally so callers can pass raw exposures and get a comparable index across groups. Non-positive entries dropped silently.
- ``effective_n(weights)`` — equivalent number of equally-weighted holdings, ``1 / HHI``. Useful for risk-budgeting and drawdown-reserve sizing.
- ``top_n_share(weights, n)`` — combined weight of the top-``n`` holdings after normalisation; caps at ``1.0`` when ``n`` exceeds the holding count.
- ``gini_coefficient(weights)`` — sorted-pair Gini formula. ``0`` = perfectly equal; bounded above by ``(n-1)/n`` for ``n`` holdings.
- ``variance_decomposition(portfolio_returns, benchmark_returns)`` — CAPM-style decomposition: ``var(P) = β² · var(B) + var(ε)``. Returns ``total_variance``, ``systematic_variance``, ``idiosyncratic_variance``, ``beta``, and ``r_squared``. All-zero short-circuit on empty / length-mismatched / zero-variance inputs.

## Out of scope (still deferred)

- Bayesian shrinkage on the weight covariance matrix.
- Turnover-decay weighting for time-varying weights.
- Dollar-Volume-weighted concentration (operators bin themselves).

## Test plan

- [x] 35 new unit tests in ``tests/test_portfolio_concentration.py``:
  - ``hhi`` (8 cases incl. scale invariance, non-positive dropping, all-zero)
  - ``effective_n`` (4 cases incl. n=1..100 equal-holding identity)
  - ``top_n_share`` (7 cases incl. n=0/-1, n>holdings cap)
  - ``gini_coefficient`` (6 cases incl. perfectly-equal, max-inequality bound)
  - ``variance_decomposition`` (10 cases incl. perfect-correlation identity, β=2 amplification, β=-1 inversion, orthogonal/zero-β, identity ``var(P) = sys + idio``)
- [x] Full local suite green: ``2319 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted concentration suite: 35/35 pass in 0.18 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)