### PR TITLE
feat(metrics): drawdown duration + recovery analytics (gh#97)

### DIFF
--- a/engine/core/drawdown_analytics.py
+++ b/engine/core/drawdown_analytics.py
@@ -1,0 +1,210 @@
+"""Drawdown duration + recovery analytics (gh#97 follow-up).
+
+Pure-function helpers operating on equity curves. Complements the
+class-bound helpers in ``engine.core.metrics.PerformanceMetrics`` by
+exposing the same primitives as testable module-level functions and
+adding episode enumeration that the existing report layer doesn't have.
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 18  Average drawdown        — derivable from ``drawdown_episodes``
+- 19  Max drawdown duration   — ``max_drawdown_duration``
+- 24  Recovery time           — ``time_to_recovery``
+- 25  Underwater curve        — ``underwater_curve``
+- 33  Drawdown count          — ``len(drawdown_episodes(...))``
+
+A drawdown *episode* runs from one all-time-high (the peak) down to a
+trough and back to the next all-time-high (the recovery). An episode
+is *open* when the equity curve has not yet recovered to its peak by
+the end of the input — its ``recovery_idx`` is ``None``.
+
+Out of scope:
+- Calendar-time conversion (these helpers count *periods*, i.e. list
+  indices). The caller knows whether a period is one day, one bar,
+  etc.
+- Conditional drawdown at risk (CDaR) — separate skewness slice.
+- Drawdown-duration distribution histograms (caller bins themselves).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DrawdownEpisode:
+    """One peak → trough → (recovery | open) drawdown episode.
+
+    ``peak_idx`` — index of the all-time high that started the episode.
+    ``trough_idx`` — index of the lowest point during the episode.
+    ``recovery_idx`` — index of the bar that returned to ``peak`` value;
+    ``None`` if the curve has not yet recovered by the last input.
+    ``depth_pct`` — peak-to-trough decline as a positive fraction
+    (e.g. ``0.10`` = 10 % drawdown).
+    """
+
+    peak_idx: int
+    trough_idx: int
+    recovery_idx: int | None
+    depth_pct: float
+
+    @property
+    def duration(self) -> int:
+        """Bars from peak to recovery (or to trough if open)."""
+        end = self.recovery_idx if self.recovery_idx is not None else self.trough_idx
+        return end - self.peak_idx
+
+    @property
+    def time_to_trough(self) -> int:
+        return self.trough_idx - self.peak_idx
+
+    @property
+    def is_open(self) -> bool:
+        return self.recovery_idx is None
+
+
+def underwater_curve(equity: Sequence[float]) -> list[float]:
+    """Per-bar percent-below-all-time-high (a non-positive series).
+
+    ``0.0`` when the bar matches the running peak. Empty input → empty
+    output. Non-positive peaks (zero or negative) yield ``0.0`` for that
+    bar by convention.
+    """
+    if not equity:
+        return []
+    out: list[float] = []
+    peak = equity[0]
+    for v in equity:
+        if v > peak:
+            peak = v
+        if peak <= 0:
+            out.append(0.0)
+        else:
+            out.append((v - peak) / peak)
+    return out
+
+
+def drawdown_episodes(equity: Sequence[float]) -> list[DrawdownEpisode]:
+    """Enumerate every drawdown episode in chronological order.
+
+    Returns an empty list for fewer than two inputs or a strictly
+    monotonically increasing series. The final episode may be open
+    (``recovery_idx is None``) when the curve has not recovered by
+    the last input.
+    """
+    if len(equity) < 2:
+        return []
+    episodes: list[DrawdownEpisode] = []
+    peak_value = equity[0]
+    peak_idx = 0
+    trough_idx = 0
+    trough_value = equity[0]
+    in_drawdown = False
+    for i in range(1, len(equity)):
+        v = equity[i]
+        if not in_drawdown:
+            if v < peak_value:
+                in_drawdown = True
+                trough_value = v
+                trough_idx = i
+            elif v > peak_value:
+                peak_value = v
+                peak_idx = i
+        else:
+            if v < trough_value:
+                trough_value = v
+                trough_idx = i
+            if v >= peak_value:
+                depth = (
+                    (peak_value - trough_value) / peak_value
+                    if peak_value > 0
+                    else 0.0
+                )
+                episodes.append(
+                    DrawdownEpisode(
+                        peak_idx=peak_idx,
+                        trough_idx=trough_idx,
+                        recovery_idx=i,
+                        depth_pct=depth,
+                    )
+                )
+                in_drawdown = False
+                peak_value = v
+                peak_idx = i
+    if in_drawdown:
+        depth = (
+            (peak_value - trough_value) / peak_value if peak_value > 0 else 0.0
+        )
+        episodes.append(
+            DrawdownEpisode(
+                peak_idx=peak_idx,
+                trough_idx=trough_idx,
+                recovery_idx=None,
+                depth_pct=depth,
+            )
+        )
+    return episodes
+
+
+def max_drawdown_duration(equity: Sequence[float]) -> int:
+    """Longest peak-to-recovery (or peak-to-trough for open) span.
+
+    Returns ``0`` for empty / single-point / monotonically increasing
+    inputs.
+    """
+    eps = drawdown_episodes(equity)
+    return max((e.duration for e in eps), default=0)
+
+
+def time_to_recovery(equity: Sequence[float]) -> int | None:
+    """Bars from the deepest trough to recovery.
+
+    ``None`` if the deepest drawdown has not recovered by the last
+    input. ``0`` for empty / monotonically increasing inputs (no
+    drawdown). When multiple episodes share the maximum depth, the
+    earliest one is used.
+    """
+    eps = drawdown_episodes(equity)
+    if not eps:
+        return 0
+    deepest = max(eps, key=lambda e: e.depth_pct)
+    if deepest.recovery_idx is None:
+        return None
+    return deepest.recovery_idx - deepest.trough_idx
+
+
+def average_drawdown(equity: Sequence[float]) -> float:
+    """Mean depth of all drawdown episodes (positive fraction).
+
+    Returns ``0.0`` for inputs with no drawdowns. Open episodes count
+    at their current depth.
+    """
+    eps = drawdown_episodes(equity)
+    if not eps:
+        return 0.0
+    return sum(e.depth_pct for e in eps) / len(eps)
+
+
+def current_drawdown_pct(equity: Sequence[float]) -> float:
+    """Last-bar drawdown as a positive fraction below the running peak.
+
+    ``0.0`` for empty input or for a bar that matches the running peak.
+    """
+    if not equity:
+        return 0.0
+    peak = max(equity)
+    if peak <= 0:
+        return 0.0
+    return max((peak - equity[-1]) / peak, 0.0)
+
+
+__all__ = [
+    "DrawdownEpisode",
+    "average_drawdown",
+    "current_drawdown_pct",
+    "drawdown_episodes",
+    "max_drawdown_duration",
+    "time_to_recovery",
+    "underwater_curve",
+]

--- a/tests/test_drawdown_analytics.py
+++ b/tests/test_drawdown_analytics.py
@@ -1,0 +1,243 @@
+"""Tests for drawdown duration + recovery analytics (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.drawdown_analytics import (
+    DrawdownEpisode,
+    average_drawdown,
+    current_drawdown_pct,
+    drawdown_episodes,
+    max_drawdown_duration,
+    time_to_recovery,
+    underwater_curve,
+)
+
+
+# ---------------------------------------------------------------------------
+# underwater_curve
+# ---------------------------------------------------------------------------
+
+
+class TestUnderwaterCurve:
+    def test_empty_input_empty_output(self):
+        assert underwater_curve([]) == []
+
+    def test_monotonic_increase_all_zero(self):
+        assert underwater_curve([100.0, 110.0, 120.0]) == [0.0, 0.0, 0.0]
+
+    def test_first_bar_is_zero(self):
+        # First bar matches its own peak.
+        out = underwater_curve([100.0, 90.0, 95.0])
+        assert out[0] == 0.0
+
+    def test_drawdown_then_recovery(self):
+        # 100 → 80 (-20%) → 100 (back to peak).
+        out = underwater_curve([100.0, 80.0, 100.0])
+        assert out == [0.0, pytest.approx(-0.2), 0.0]
+
+    def test_new_peak_resets_underwater(self):
+        out = underwater_curve([100.0, 80.0, 110.0, 99.0])
+        assert out[2] == 0.0
+        assert out[3] == pytest.approx(-0.1)
+
+    def test_non_positive_peak_yields_zero(self):
+        # All-zero curve — peak <= 0, all bars underwater 0.
+        assert underwater_curve([0.0, 0.0, 0.0]) == [0.0, 0.0, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# drawdown_episodes
+# ---------------------------------------------------------------------------
+
+
+class TestDrawdownEpisodes:
+    def test_empty_returns_empty(self):
+        assert drawdown_episodes([]) == []
+
+    def test_single_point_returns_empty(self):
+        assert drawdown_episodes([100.0]) == []
+
+    def test_monotonic_increase_returns_empty(self):
+        assert drawdown_episodes([100.0, 110.0, 120.0]) == []
+
+    def test_simple_episode(self):
+        # 100 → 80 → 100 → recovery.
+        out = drawdown_episodes([100.0, 90.0, 80.0, 90.0, 100.0])
+        assert len(out) == 1
+        e = out[0]
+        assert e.peak_idx == 0
+        assert e.trough_idx == 2
+        assert e.recovery_idx == 4
+        assert e.depth_pct == pytest.approx(0.2)
+        assert e.is_open is False
+
+    def test_open_episode_no_recovery(self):
+        # 100 → 80 → 90 (still below peak at end).
+        out = drawdown_episodes([100.0, 80.0, 90.0])
+        assert len(out) == 1
+        e = out[0]
+        assert e.recovery_idx is None
+        assert e.is_open is True
+        assert e.trough_idx == 1
+        assert e.depth_pct == pytest.approx(0.2)
+
+    def test_two_independent_episodes(self):
+        # Peak 100 → trough 80 → recovery 100 → new peak 120 → trough 100 → recovery 120.
+        out = drawdown_episodes([100.0, 80.0, 100.0, 120.0, 100.0, 120.0])
+        assert len(out) == 2
+        assert out[0].peak_idx == 0
+        assert out[0].trough_idx == 1
+        assert out[0].recovery_idx == 2
+        assert out[1].peak_idx == 3
+        assert out[1].trough_idx == 4
+        assert out[1].recovery_idx == 5
+
+    def test_new_peak_after_recovery_starts_new_episode(self):
+        # Recovery to original peak is enough — new high after that
+        # still belongs to the next episode.
+        out = drawdown_episodes([100.0, 80.0, 100.0, 110.0, 90.0, 110.0])
+        assert len(out) == 2
+
+    def test_zero_peak_depth_is_zero(self):
+        # Peak == 0 → depth_pct guard returns 0.0.
+        out = drawdown_episodes([0.0, -10.0, 0.0])
+        assert len(out) == 1
+        assert out[0].depth_pct == 0.0
+
+    def test_episode_duration_property(self):
+        # Peak idx 0, recovery idx 4 → duration 4.
+        out = drawdown_episodes([100.0, 90.0, 80.0, 90.0, 100.0])
+        assert out[0].duration == 4
+
+    def test_open_episode_duration_uses_trough(self):
+        # Peak 0, trough 1, no recovery → duration 1 (peak → trough).
+        out = drawdown_episodes([100.0, 80.0, 90.0])
+        assert out[0].duration == 1
+
+    def test_time_to_trough_property(self):
+        # Peak 0 → trough 2.
+        out = drawdown_episodes([100.0, 90.0, 80.0, 90.0, 100.0])
+        assert out[0].time_to_trough == 2
+
+
+# ---------------------------------------------------------------------------
+# max_drawdown_duration
+# ---------------------------------------------------------------------------
+
+
+class TestMaxDrawdownDuration:
+    def test_empty_returns_zero(self):
+        assert max_drawdown_duration([]) == 0
+
+    def test_monotonic_returns_zero(self):
+        assert max_drawdown_duration([100.0, 110.0, 120.0]) == 0
+
+    def test_simple_episode(self):
+        # Peak 0 → recovery 4 = duration 4.
+        assert max_drawdown_duration([100.0, 90.0, 80.0, 90.0, 100.0]) == 4
+
+    def test_takes_longest_episode(self):
+        # Episode A: idx 0→2 (dur 2). Episode B: idx 3→8 (dur 5).
+        equity = [100.0, 80.0, 100.0, 120.0, 110.0, 100.0, 90.0, 110.0, 120.0]
+        assert max_drawdown_duration(equity) == 5
+
+    def test_open_episode_counted(self):
+        # 100 → 80 → 90 (still down at end). Duration = 1 (peak → trough).
+        assert max_drawdown_duration([100.0, 80.0, 90.0]) == 1
+
+
+# ---------------------------------------------------------------------------
+# time_to_recovery
+# ---------------------------------------------------------------------------
+
+
+class TestTimeToRecovery:
+    def test_empty_returns_zero(self):
+        assert time_to_recovery([]) == 0
+
+    def test_monotonic_returns_zero(self):
+        assert time_to_recovery([100.0, 110.0, 120.0]) == 0
+
+    def test_recovered_episode_returns_periods(self):
+        # Trough at idx 2, recovery at idx 4 → 2 periods.
+        assert time_to_recovery([100.0, 90.0, 80.0, 90.0, 100.0]) == 2
+
+    def test_open_deepest_returns_none(self):
+        # 100 → 80 → 90 → not recovered → None.
+        assert time_to_recovery([100.0, 80.0, 90.0]) is None
+
+    def test_picks_deepest_episode(self):
+        # Episode A: depth 10 %, recovers in 1.
+        # Episode B: depth 30 %, recovers in 2.
+        equity = [100.0, 90.0, 100.0, 120.0, 84.0, 100.0, 120.0]
+        # Episode B is deepest. Trough at idx 4 (84). Recovery at idx 6 (120).
+        assert time_to_recovery(equity) == 2
+
+
+# ---------------------------------------------------------------------------
+# average_drawdown
+# ---------------------------------------------------------------------------
+
+
+class TestAverageDrawdown:
+    def test_empty_returns_zero(self):
+        assert average_drawdown([]) == 0.0
+
+    def test_no_drawdown_returns_zero(self):
+        assert average_drawdown([100.0, 110.0, 120.0]) == 0.0
+
+    def test_single_episode(self):
+        assert average_drawdown([100.0, 80.0, 100.0]) == pytest.approx(0.2)
+
+    def test_two_episodes_averages_depth(self):
+        # Episode A: 20% depth. Episode B: 10% depth. Mean = 0.15.
+        equity = [100.0, 80.0, 100.0, 120.0, 108.0, 120.0]
+        assert average_drawdown(equity) == pytest.approx(0.15)
+
+
+# ---------------------------------------------------------------------------
+# current_drawdown_pct
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentDrawdownPct:
+    def test_empty_returns_zero(self):
+        assert current_drawdown_pct([]) == 0.0
+
+    def test_at_peak_returns_zero(self):
+        assert current_drawdown_pct([100.0, 110.0, 120.0]) == 0.0
+
+    def test_below_peak(self):
+        # Peak 120, last bar 96 → 20 % drawdown.
+        assert current_drawdown_pct([100.0, 120.0, 96.0]) == pytest.approx(0.2)
+
+    def test_non_positive_peak_returns_zero(self):
+        assert current_drawdown_pct([0.0, -5.0, -10.0]) == 0.0
+
+    def test_recovered_above_old_peak(self):
+        # New peak. Current matches latest peak → 0.0.
+        assert current_drawdown_pct([100.0, 80.0, 110.0, 110.0]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# DrawdownEpisode invariants
+# ---------------------------------------------------------------------------
+
+
+class TestDrawdownEpisodeInvariants:
+    def test_frozen_dataclass(self):
+        e = DrawdownEpisode(0, 1, 2, 0.1)
+        with pytest.raises(Exception):
+            e.peak_idx = 99  # type: ignore[misc]
+
+    def test_is_open_when_no_recovery(self):
+        e = DrawdownEpisode(0, 5, None, 0.2)
+        assert e.is_open is True
+        assert e.duration == 5
+
+    def test_is_closed_when_recovery_set(self):
+        e = DrawdownEpisode(0, 5, 10, 0.2)
+        assert e.is_open is False
+        assert e.duration == 10


### PR DESCRIPTION
## Summary

Pure-function helpers operating on equity curves. Complements the class-bound helpers already in ``engine.core.metrics.PerformanceMetrics`` (currently private methods) by exposing the same primitives as testable module-level functions and adds episode enumeration the existing report layer doesn't have.

Adds gh#97 KPIs **18** (avg drawdown), **19** (max drawdown duration), **24** (recovery time), **25** (underwater curve), **33** (drawdown count).

## What ships

- ``DrawdownEpisode`` — frozen dataclass with ``peak_idx``, ``trough_idx``, ``recovery_idx`` (``None`` when open), ``depth_pct``. Derived properties: ``duration`` (peak→recovery, or peak→trough if open), ``time_to_trough``, ``is_open``.
- ``underwater_curve(equity)`` — non-positive series, percent below running peak per bar. Returns ``0.0`` for non-positive peak by convention. Empty input → empty output.
- ``drawdown_episodes(equity)`` — chronological enumeration of every drawdown episode. Final episode may be open (``recovery_idx is None``) when curve has not recovered by last input.
- ``max_drawdown_duration(equity)`` — longest peak-to-recovery (or peak-to-trough for open) span in periods.
- ``time_to_recovery(equity)`` — bars from deepest trough to recovery; ``None`` when deepest drawdown has not recovered.
- ``average_drawdown(equity)`` — mean depth across all episodes (open episodes count at current depth).
- ``current_drawdown_pct(equity)`` — last-bar percent below all-time high.

## Why pure-function module + class methods both

The existing class methods in ``PerformanceMetrics`` need an instance and bundle drawdown analytics with the rest of the report. The eventual analytics endpoint (``GET /api/v1/portfolios/{id}/drawdown-episodes``) needs the same math without instantiating the full report. Future PR can have the class methods delegate to this module.

## Out of scope

- Calendar-time conversion (these helpers count *periods*, i.e. list indices). Caller knows whether a period is one day, one bar, etc.
- Conditional drawdown at risk (CDaR) — separate skewness slice.
- Drawdown-duration distribution histograms (caller bins themselves).

## Test plan

- [x] 39 new unit tests in ``tests/test_drawdown_analytics.py``:
  - ``underwater_curve`` (6 cases incl. monotonic, recovery-resets-peak, non-positive peak)
  - ``drawdown_episodes`` (11 cases incl. simple, open, two-episode, zero-peak depth, all derived properties)
  - ``max_drawdown_duration`` (5 cases incl. takes-longest, open episode counted)
  - ``time_to_recovery`` (5 cases incl. picks-deepest, open-deepest returns None)
  - ``average_drawdown`` (4 cases)
  - ``current_drawdown_pct`` (5 cases)
  - ``DrawdownEpisode`` invariants (3 cases incl. frozen, open vs closed duration)
- [x] Full local suite green: ``2358 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted drawdown suite: 39/39 pass in 0.09 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)