### PR TITLE
feat(metrics): rolling-window time-series metrics (gh#97)

### DIFF
--- a/engine/core/rolling_metrics.py
+++ b/engine/core/rolling_metrics.py
@@ -1,0 +1,194 @@
+"""Rolling-window time-series metrics (gh#97 follow-up).
+
+Pure-function helpers producing the *full* rolling series across an
+input return sequence. Complements the class-bound
+``_rolling_window_metrics`` helper in ``engine.core.metrics`` which
+returns only the *latest* snapshot per window size — this module
+returns one value per input bar so callers can plot
+rolling-Sharpe / rolling-vol charts.
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 56  Rolling Sharpe          — ``rolling_sharpe``
+- 57  Rolling Sortino         — ``rolling_sortino``
+- 58  Rolling volatility      — ``rolling_volatility``
+- 59  Rolling return          — ``rolling_return``
+- 60  Rolling mean return     — ``rolling_mean``
+
+Output convention:
+
+- Each helper returns a list the same length as the input.
+- Indices before the first full window are ``None`` (not ``0.0``) so
+  callers can distinguish "not enough data yet" from "zero".
+- Annualisation factor defaults to 252 (US trading days). Pass 365 for
+  daily crypto, 12 for monthly returns, etc.
+
+Out of scope:
+- Bias correction (Lo 2002) for rolling Sharpe — caller can post-process.
+- Welford's online-variance — current pass is O(N · W); fine up to a
+  few million bars.
+- Calendar-period rollups (those live in ``engine.core.time_metrics``).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+DEFAULT_ANNUALISATION = 252
+
+
+def _validate_window(window: int) -> None:
+    if window < 2:
+        raise ValueError("window must be >= 2")
+
+
+def rolling_mean(
+    returns: Sequence[float], window: int
+) -> list[float | None]:
+    """Mean of each ``window``-sized slice ending at index ``i``.
+
+    ``None`` for the first ``window - 1`` indices.
+    """
+    _validate_window(window)
+    n = len(returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    for i in range(window - 1, n):
+        slice_ = returns[i - window + 1 : i + 1]
+        out[i] = sum(slice_) / window
+    return out
+
+
+def _stdev(xs: Sequence[float], *, ddof: int = 1) -> float:
+    n = len(xs)
+    if n - ddof <= 0:
+        return 0.0
+    m = sum(xs) / n
+    var = sum((x - m) ** 2 for x in xs) / (n - ddof)
+    return math.sqrt(var)
+
+
+def rolling_volatility(
+    returns: Sequence[float],
+    window: int,
+    *,
+    annualisation_factor: int = DEFAULT_ANNUALISATION,
+) -> list[float | None]:
+    """Annualised volatility (% as decimal, e.g. ``0.20`` = 20 %).
+
+    Standard deviation × √(annualisation_factor). ``None`` for the
+    first ``window - 1`` indices.
+    """
+    _validate_window(window)
+    if annualisation_factor <= 0:
+        raise ValueError("annualisation_factor must be > 0")
+    n = len(returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    sqrt_ann = math.sqrt(annualisation_factor)
+    for i in range(window - 1, n):
+        slice_ = returns[i - window + 1 : i + 1]
+        out[i] = _stdev(slice_) * sqrt_ann
+    return out
+
+
+def rolling_sharpe(
+    returns: Sequence[float],
+    window: int,
+    *,
+    risk_free_rate: float = 0.0,
+    annualisation_factor: int = DEFAULT_ANNUALISATION,
+) -> list[float | None]:
+    """Annualised rolling Sharpe ratio.
+
+    ``risk_free_rate`` is the *annualised* rate (e.g. ``0.05`` for 5 %);
+    converted to per-period internally. Returns ``0.0`` for windows
+    where the std is zero (a degenerate flat-return window).
+    """
+    _validate_window(window)
+    if annualisation_factor <= 0:
+        raise ValueError("annualisation_factor must be > 0")
+    n = len(returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    rf_per_period = risk_free_rate / annualisation_factor
+    sqrt_ann = math.sqrt(annualisation_factor)
+    for i in range(window - 1, n):
+        slice_ = returns[i - window + 1 : i + 1]
+        mean = sum(slice_) / window
+        sd = _stdev(slice_)
+        if sd == 0.0:
+            out[i] = 0.0
+        else:
+            out[i] = (mean - rf_per_period) / sd * sqrt_ann
+    return out
+
+
+def rolling_sortino(
+    returns: Sequence[float],
+    window: int,
+    *,
+    risk_free_rate: float = 0.0,
+    annualisation_factor: int = DEFAULT_ANNUALISATION,
+) -> list[float | None]:
+    """Annualised rolling Sortino ratio.
+
+    Uses downside deviation (RMS of negative excess returns) in the
+    denominator. Returns ``0.0`` for windows where the downside
+    deviation is zero (no losing periods inside the window).
+    """
+    _validate_window(window)
+    if annualisation_factor <= 0:
+        raise ValueError("annualisation_factor must be > 0")
+    n = len(returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    rf_per_period = risk_free_rate / annualisation_factor
+    sqrt_ann = math.sqrt(annualisation_factor)
+    for i in range(window - 1, n):
+        slice_ = returns[i - window + 1 : i + 1]
+        mean = sum(slice_) / window
+        downside_sq = [min(r - rf_per_period, 0.0) ** 2 for r in slice_]
+        downside_dev = math.sqrt(sum(downside_sq) / window)
+        if downside_dev == 0.0:
+            out[i] = 0.0
+        else:
+            out[i] = (mean - rf_per_period) / downside_dev * sqrt_ann
+    return out
+
+
+def rolling_return(
+    returns: Sequence[float], window: int
+) -> list[float | None]:
+    """Compounded return over each ``window``-sized trailing slice.
+
+    ``(1 + r_total) = ∏(1 + r_i)``; returns ``r_total``. ``None`` for
+    the first ``window - 1`` indices.
+    """
+    _validate_window(window)
+    n = len(returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    for i in range(window - 1, n):
+        slice_ = returns[i - window + 1 : i + 1]
+        product = 1.0
+        for r in slice_:
+            product *= 1.0 + r
+        out[i] = product - 1.0
+    return out
+
+
+__all__ = [
+    "DEFAULT_ANNUALISATION",
+    "rolling_mean",
+    "rolling_return",
+    "rolling_sharpe",
+    "rolling_sortino",
+    "rolling_volatility",
+]

--- a/tests/test_rolling_metrics.py
+++ b/tests/test_rolling_metrics.py
@@ -1,0 +1,209 @@
+"""Tests for rolling-window time-series metrics (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.rolling_metrics import (
+    DEFAULT_ANNUALISATION,
+    rolling_mean,
+    rolling_return,
+    rolling_sharpe,
+    rolling_sortino,
+    rolling_volatility,
+)
+
+
+# ---------------------------------------------------------------------------
+# rolling_mean
+# ---------------------------------------------------------------------------
+
+
+class TestRollingMean:
+    def test_empty_returns_empty(self):
+        assert rolling_mean([], 3) == []
+
+    def test_window_too_large_all_none(self):
+        assert rolling_mean([0.01, 0.02], 5) == [None, None]
+
+    def test_first_window_minus_one_indices_none(self):
+        out = rolling_mean([0.01, 0.02, 0.03, 0.04], 3)
+        assert out[0] is None
+        assert out[1] is None
+        assert out[2] is not None
+
+    def test_known_values(self):
+        # Window=3 mean.
+        out = rolling_mean([1.0, 2.0, 3.0, 4.0, 5.0], 3)
+        assert out == [
+            None,
+            None,
+            pytest.approx(2.0),
+            pytest.approx(3.0),
+            pytest.approx(4.0),
+        ]
+
+    def test_window_one_rejected(self):
+        with pytest.raises(ValueError, match="window must be"):
+            rolling_mean([0.01, 0.02], 1)
+
+    def test_zero_window_rejected(self):
+        with pytest.raises(ValueError, match="window must be"):
+            rolling_mean([0.01], 0)
+
+    def test_output_length_matches_input(self):
+        for n in (5, 10, 50):
+            out = rolling_mean([0.01] * n, 3)
+            assert len(out) == n
+
+
+# ---------------------------------------------------------------------------
+# rolling_volatility
+# ---------------------------------------------------------------------------
+
+
+class TestRollingVolatility:
+    def test_empty_returns_empty(self):
+        assert rolling_volatility([], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_volatility([0.01, 0.02, 0.03], 3)
+        assert out[0] is None
+        assert out[1] is None
+        assert out[2] is not None
+
+    def test_constant_returns_zero_volatility(self):
+        out = rolling_volatility([0.01] * 10, 5)
+        for v in out[4:]:
+            assert v == pytest.approx(0.0, abs=1e-12)
+
+    def test_increasing_variance_increases_vol(self):
+        # Calm window then volatile window.
+        returns = [0.01, 0.01, 0.01, 0.01, 0.01, 0.05, -0.05, 0.05, -0.05, 0.05]
+        out = rolling_volatility(returns, 5, annualisation_factor=252)
+        # Latest window has high variance; earlier full-window has zero.
+        assert out[4] == pytest.approx(0.0, abs=1e-12)
+        assert out[-1] is not None
+        assert out[-1] > out[4]
+
+    def test_default_annualisation(self):
+        # Default is 252 — multiplier is sqrt(252).
+        returns = [0.01, -0.01, 0.01, -0.01, 0.01]
+        out_default = rolling_volatility(returns, 5)
+        out_custom = rolling_volatility(returns, 5, annualisation_factor=252)
+        assert out_default[-1] == out_custom[-1]
+        assert DEFAULT_ANNUALISATION == 252
+
+    def test_zero_annualisation_rejected(self):
+        with pytest.raises(ValueError, match="annualisation_factor"):
+            rolling_volatility([0.01, 0.02, 0.03], 3, annualisation_factor=0)
+
+    def test_negative_annualisation_rejected(self):
+        with pytest.raises(ValueError, match="annualisation_factor"):
+            rolling_volatility([0.01, 0.02, 0.03], 3, annualisation_factor=-1)
+
+
+# ---------------------------------------------------------------------------
+# rolling_sharpe
+# ---------------------------------------------------------------------------
+
+
+class TestRollingSharpe:
+    def test_empty_returns_empty(self):
+        assert rolling_sharpe([], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_sharpe([0.01, 0.02, 0.03], 3)
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_constant_returns_zero_sharpe(self):
+        # Zero std → zero Sharpe.
+        out = rolling_sharpe([0.01] * 5, 5)
+        assert out[-1] == 0.0
+
+    def test_positive_drift_positive_sharpe(self):
+        out = rolling_sharpe([0.01, 0.02, 0.015, 0.018, 0.012], 5)
+        assert out[-1] > 0
+
+    def test_negative_drift_negative_sharpe(self):
+        out = rolling_sharpe([-0.01, -0.02, -0.015, -0.018, -0.012], 5)
+        assert out[-1] < 0
+
+    def test_constant_returns_with_high_rf_still_zero(self):
+        # Constant returns → std==0 → 0.0 short-circuit (regardless of rf).
+        returns = [0.0001] * 5
+        out = rolling_sharpe(returns, 5, risk_free_rate=1.0)
+        assert out[-1] == 0.0
+
+    def test_rf_with_variance_negative_sharpe(self):
+        # Variance > 0, rf > mean → negative excess Sharpe.
+        returns = [0.0, 0.0001, 0.0, 0.0001, 0.0]
+        out = rolling_sharpe(returns, 5, risk_free_rate=1.0)
+        assert out[-1] < 0
+
+
+# ---------------------------------------------------------------------------
+# rolling_sortino
+# ---------------------------------------------------------------------------
+
+
+class TestRollingSortino:
+    def test_empty_returns_empty(self):
+        assert rolling_sortino([], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_sortino([0.01, 0.02, 0.03], 3)
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_no_negatives_zero_downside_returns_zero(self):
+        # All positive returns with rf=0 → no downside dev → 0.0 short-circuit.
+        out = rolling_sortino([0.01, 0.02, 0.03, 0.04, 0.05], 5)
+        assert out[-1] == 0.0
+
+    def test_mixed_returns_finite_sortino(self):
+        out = rolling_sortino(
+            [0.02, -0.01, 0.03, -0.02, 0.04, 0.01, -0.01], 5
+        )
+        assert out[-1] is not None
+        assert math.isfinite(out[-1])
+
+    def test_negative_drift_negative_sortino(self):
+        out = rolling_sortino([-0.01, -0.02, -0.015, -0.018, -0.012], 5)
+        assert out[-1] < 0
+
+
+# ---------------------------------------------------------------------------
+# rolling_return
+# ---------------------------------------------------------------------------
+
+
+class TestRollingReturn:
+    def test_empty_returns_empty(self):
+        assert rolling_return([], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_return([0.01, 0.02, 0.03], 3)
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_compounding(self):
+        # +1 % three times → (1.01)^3 - 1 ≈ 0.030301.
+        out = rolling_return([0.01, 0.01, 0.01], 3)
+        assert out[-1] == pytest.approx(0.030301, rel=1e-9)
+
+    def test_loss_then_recovery_compounds(self):
+        # -10% then +10% → (0.9 × 1.1) - 1 = -0.01.
+        out = rolling_return([-0.10, 0.10], 2)
+        assert out[-1] == pytest.approx(-0.01, rel=1e-9)
+
+    def test_window_one_rejected(self):
+        with pytest.raises(ValueError, match="window must be"):
+            rolling_return([0.01, 0.02], 1)
+
+    def test_output_length_matches_input(self):
+        out = rolling_return([0.01, 0.02, 0.03, 0.04, 0.05], 3)
+        assert len(out) == 5


### PR DESCRIPTION
## Summary

Pure-function helpers producing the *full* rolling series across an input return sequence. Complements the class-bound ``_rolling_window_metrics`` helper in ``engine.core.metrics`` which returns only the *latest* snapshot per window size — these helpers return one value per input bar so callers can plot rolling-Sharpe / rolling-vol charts.

Adds gh#97 KPIs **56** (rolling Sharpe), **57** (rolling Sortino), **58** (rolling vol), **59** (rolling return), **60** (rolling mean).

## What ships

- ``rolling_mean(returns, window)`` — mean of each ``window``-sized trailing slice.
- ``rolling_volatility(returns, window, *, annualisation_factor=252)`` — annualised std as decimal (e.g. ``0.20`` = 20 %).
- ``rolling_sharpe(returns, window, *, risk_free_rate=0.0, annualisation_factor=252)`` — annualised excess return / std. Zero std → 0.0 short-circuit.
- ``rolling_sortino(returns, window, *, risk_free_rate=0.0, annualisation_factor=252)`` — downside-deviation denominator (RMS of negative excess). Zero downside dev → 0.0 short-circuit.
- ``rolling_return(returns, window)`` — compounded trailing return: ``(1 + r_total) = ∏(1 + r_i)``.

## Output convention

- Same length as input.
- ``None`` for the first ``window - 1`` indices so callers can distinguish "not enough data yet" from "zero".
- ``window < 2`` rejected. ``annualisation_factor <= 0`` rejected.
- ``risk_free_rate`` is the *annualised* rate; converted per-period internally.

## Why pure-function module + class methods both

The class method in ``PerformanceMetrics`` bundles all rolling metrics into one ``RollingWindowMetrics`` snapshot for the report. The chart layer needs the *full series* without instantiating a report. Future PR can have the class method delegate to these helpers.

## Out of scope

- Bias correction (Lo 2002) for rolling Sharpe — caller can post-process.
- Welford's online-variance — current pass is O(N · W); fine up to a few million bars.
- Calendar-period rollups (those live in ``engine.core.time_metrics``).

## Test plan

- [x] 32 new unit tests in ``tests/test_rolling_metrics.py``:
  - ``rolling_mean`` (7 cases incl. window-too-large, validation, length identity)
  - ``rolling_volatility`` (7 cases incl. constant=0, calm-then-volatile, default annualisation, zero/negative annualisation rejection)
  - ``rolling_sharpe`` (7 cases incl. constant=0, positive/negative drift, rf-with-variance negative)
  - ``rolling_sortino`` (5 cases incl. zero-downside short-circuit, finite mixed)
  - ``rolling_return`` (6 cases incl. compounding identity, loss-then-recovery)
- [x] Full local suite green: ``2390 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted rolling suite: 32/32 pass in 0.07 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)