### PR TITLE
feat(metrics): return-distribution + tail-risk metrics (gh#97)

### DIFF
--- a/engine/core/distribution_metrics.py
+++ b/engine/core/distribution_metrics.py
@@ -1,0 +1,254 @@
+"""Return-distribution + tail-risk metrics (gh#97 follow-up).
+
+Pure-function helpers operating on a flat sequence of period returns.
+Adds the distributional and tail-risk KPIs that complement the
+existing Sharpe / Sortino / drawdown layers.
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 38  Skewness                — ``skewness``
+- 39  Kurtosis (excess)       — ``kurtosis``
+- 40  Value at Risk (VaR)     — ``value_at_risk_historical``,
+                                ``value_at_risk_parametric``
+- 41  Conditional VaR / ES    — ``conditional_value_at_risk``
+- 42  Tail ratio              — ``tail_ratio``
+
+Conventions:
+
+- VaR / CVaR are returned as *positive* magnitudes representing the
+  magnitude of the loss (e.g. ``0.05`` = a 5 % loss). The caller
+  decides whether to display them as negative depending on UI.
+- Confidence levels are passed as the *upper* bound: ``0.95`` means
+  "95 % VaR" (5 % tail). Bounded ``(0.0, 1.0)``.
+- Empty input returns ``0.0`` from every helper.
+
+Out of scope:
+- Filtered historical simulation (FHS) — separate slice.
+- Cornish-Fisher expansion VaR — separate slice.
+- Monte Carlo VaR (the existing ``engine.core.monte_carlo`` module
+  covers MC simulation; this module sticks to closed-form / empirical).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+def _mean(xs: Sequence[float]) -> float:
+    return sum(xs) / len(xs)
+
+
+def _stdev(xs: Sequence[float], *, ddof: int = 1) -> float:
+    n = len(xs)
+    if n - ddof <= 0:
+        return 0.0
+    m = _mean(xs)
+    var = sum((x - m) ** 2 for x in xs) / (n - ddof)
+    return math.sqrt(var)
+
+
+def skewness(returns: Sequence[float]) -> float:
+    """Sample skewness (Fisher-Pearson, bias-corrected for small n).
+
+    Returns ``0.0`` for empty input, fewer than 3 data points, or a
+    zero-variance series.
+    """
+    n = len(returns)
+    if n < 3:
+        return 0.0
+    m = _mean(returns)
+    s = _stdev(returns)
+    if s == 0.0:
+        return 0.0
+    raw = sum((r - m) ** 3 for r in returns) / n
+    biased = raw / (s**3)
+    correction = math.sqrt(n * (n - 1)) / (n - 2)
+    return correction * biased
+
+
+def kurtosis(returns: Sequence[float]) -> float:
+    """Excess kurtosis (kurtosis − 3, the Fisher convention).
+
+    Bias-corrected per Joanes & Gill (1998). Normal distribution → 0;
+    fat tails → > 0; thin tails → < 0. Returns ``0.0`` for empty input,
+    fewer than 4 data points, or a zero-variance series.
+    """
+    n = len(returns)
+    if n < 4:
+        return 0.0
+    m = _mean(returns)
+    s = _stdev(returns)
+    if s == 0.0:
+        return 0.0
+    raw = sum((r - m) ** 4 for r in returns) / n
+    biased = raw / (s**4) - 3
+    correction = (n - 1) / ((n - 2) * (n - 3))
+    return correction * ((n + 1) * biased + 6)
+
+
+def _validate_confidence(confidence: float) -> None:
+    if not 0.0 < confidence < 1.0:
+        raise ValueError(
+            f"confidence must be in (0, 1); got {confidence}"
+        )
+
+
+def value_at_risk_historical(
+    returns: Sequence[float], *, confidence: float = 0.95
+) -> float:
+    """Historical-simulation VaR at the given confidence level.
+
+    Returns the *magnitude* of the loss at the ``(1 - confidence)``
+    quantile (positive value). For example ``confidence=0.95`` returns
+    the 5th-percentile loss as a positive number.
+
+    Returns ``0.0`` when the cutoff is non-negative (e.g. all returns
+    positive). Empty input → ``0.0``.
+    """
+    if not returns:
+        return 0.0
+    _validate_confidence(confidence)
+    sorted_r = sorted(returns)
+    cutoff_idx = int((1 - confidence) * len(sorted_r))
+    cutoff_idx = min(cutoff_idx, len(sorted_r) - 1)
+    threshold = sorted_r[cutoff_idx]
+    return max(-threshold, 0.0)
+
+
+def value_at_risk_parametric(
+    returns: Sequence[float], *, confidence: float = 0.95
+) -> float:
+    """Parametric VaR assuming Gaussian returns.
+
+    Uses ``VaR = -(μ + z · σ)`` where z is the standard-normal quantile
+    at ``1 - confidence``. Approximates z via inverse-CDF rational
+    approximation (Beasley-Springer-Moro), so no scipy dependency.
+    Returns ``0.0`` for empty input, fewer than 2 points, or zero
+    variance.
+    """
+    n = len(returns)
+    if n < 2:
+        return 0.0
+    _validate_confidence(confidence)
+    m = _mean(returns)
+    s = _stdev(returns)
+    if s == 0.0:
+        return 0.0
+    z = _inverse_normal_cdf(1 - confidence)
+    return max(-(m + z * s), 0.0)
+
+
+def _inverse_normal_cdf(p: float) -> float:
+    """Inverse of the standard-normal CDF via Beasley-Springer-Moro.
+
+    Accurate to about 1e-9 across the unit interval.
+    """
+    if p <= 0.0 or p >= 1.0:
+        raise ValueError(f"p must be in (0, 1); got {p}")
+    a = (
+        -3.969683028665376e1,
+        2.209460984245205e2,
+        -2.759285104469687e2,
+        1.383577518672690e2,
+        -3.066479806614716e1,
+        2.506628277459239,
+    )
+    b = (
+        -5.447609879822406e1,
+        1.615858368580409e2,
+        -1.556989798598866e2,
+        6.680131188771972e1,
+        -1.328068155288572e1,
+    )
+    c = (
+        -7.784894002430293e-3,
+        -3.223964580411365e-1,
+        -2.400758277161838,
+        -2.549732539343734,
+        4.374664141464968,
+        2.938163982698783,
+    )
+    d = (
+        7.784695709041462e-3,
+        3.224671290700398e-1,
+        2.445134137142996,
+        3.754408661907416,
+    )
+    p_low = 0.02425
+    p_high = 1 - p_low
+    if p < p_low:
+        q = math.sqrt(-2 * math.log(p))
+        return (
+            ((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]
+        ) / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+    if p <= p_high:
+        q = p - 0.5
+        r = q * q
+        return (
+            (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q
+        ) / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+    q = math.sqrt(-2 * math.log(1 - p))
+    return -(
+        ((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]
+    ) / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+
+
+def conditional_value_at_risk(
+    returns: Sequence[float], *, confidence: float = 0.95
+) -> float:
+    """Conditional VaR / Expected Shortfall (historical).
+
+    Mean of returns at or below the ``(1 - confidence)`` quantile, as a
+    positive magnitude. Empty input or non-negative tail → ``0.0``.
+    """
+    if not returns:
+        return 0.0
+    _validate_confidence(confidence)
+    sorted_r = sorted(returns)
+    cutoff_idx = int((1 - confidence) * len(sorted_r))
+    if cutoff_idx == 0:
+        return max(-sorted_r[0], 0.0)
+    tail = sorted_r[:cutoff_idx]
+    if not tail:
+        return 0.0
+    avg_loss = sum(tail) / len(tail)
+    return max(-avg_loss, 0.0)
+
+
+def tail_ratio(
+    returns: Sequence[float], *, percentile: float = 0.95
+) -> float:
+    """Right-tail / left-tail magnitude ratio.
+
+    ``ratio = |percentile-th return| / |(1-percentile)-th return|``.
+
+    A value > 1 means upside tail bigger than downside tail. Useful
+    for quickly spotting positive-skew strategies. Returns ``0.0`` for
+    empty input or when the left-tail magnitude is zero.
+    """
+    if not returns:
+        return 0.0
+    if not 0.5 < percentile < 1.0:
+        raise ValueError(
+            f"percentile must be in (0.5, 1.0); got {percentile}"
+        )
+    sorted_r = sorted(returns)
+    n = len(sorted_r)
+    upper_idx = min(int(percentile * n), n - 1)
+    lower_idx = max(int((1 - percentile) * n), 0)
+    upper = abs(sorted_r[upper_idx])
+    lower = abs(sorted_r[lower_idx])
+    if lower == 0.0:
+        return 0.0
+    return upper / lower
+
+
+__all__ = [
+    "conditional_value_at_risk",
+    "kurtosis",
+    "skewness",
+    "tail_ratio",
+    "value_at_risk_historical",
+    "value_at_risk_parametric",
+]

--- a/tests/test_distribution_metrics.py
+++ b/tests/test_distribution_metrics.py
@@ -1,0 +1,252 @@
+"""Tests for return-distribution + tail-risk metrics (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.distribution_metrics import (
+    _inverse_normal_cdf,
+    conditional_value_at_risk,
+    kurtosis,
+    skewness,
+    tail_ratio,
+    value_at_risk_historical,
+    value_at_risk_parametric,
+)
+
+
+# ---------------------------------------------------------------------------
+# skewness
+# ---------------------------------------------------------------------------
+
+
+class TestSkewness:
+    def test_empty_returns_zero(self):
+        assert skewness([]) == 0.0
+
+    def test_too_few_points_returns_zero(self):
+        assert skewness([0.01, 0.02]) == 0.0
+
+    def test_zero_variance_returns_zero(self):
+        assert skewness([0.01, 0.01, 0.01, 0.01]) == 0.0
+
+    def test_symmetric_distribution_near_zero(self):
+        # Symmetric around 0 → skew ≈ 0.
+        out = skewness([-2.0, -1.0, 0.0, 1.0, 2.0])
+        assert abs(out) < 1e-9
+
+    def test_positive_skew_long_right_tail(self):
+        # Long right tail → positive skew.
+        out = skewness([-1.0, -1.0, -1.0, 0.0, 0.0, 5.0])
+        assert out > 0
+
+    def test_negative_skew_long_left_tail(self):
+        out = skewness([-5.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+        assert out < 0
+
+
+# ---------------------------------------------------------------------------
+# kurtosis
+# ---------------------------------------------------------------------------
+
+
+class TestKurtosis:
+    def test_empty_returns_zero(self):
+        assert kurtosis([]) == 0.0
+
+    def test_too_few_points_returns_zero(self):
+        assert kurtosis([0.01, 0.02, 0.03]) == 0.0
+
+    def test_zero_variance_returns_zero(self):
+        assert kurtosis([0.01, 0.01, 0.01, 0.01]) == 0.0
+
+    def test_uniform_distribution_negative_excess(self):
+        # Uniform has excess kurtosis around -1.2.
+        out = kurtosis([-2.0, -1.0, 0.0, 1.0, 2.0, -2.0, -1.0, 0.0, 1.0, 2.0])
+        assert out < 0
+
+    def test_fat_tails_positive_excess(self):
+        # Long-tailed series with heavy outliers → positive excess kurtosis.
+        out = kurtosis(
+            [
+                0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0,
+                10.0, -10.0,
+            ]
+        )
+        assert out > 0
+
+
+# ---------------------------------------------------------------------------
+# VaR — historical
+# ---------------------------------------------------------------------------
+
+
+class TestVaRHistorical:
+    def test_empty_returns_zero(self):
+        assert value_at_risk_historical([]) == 0.0
+
+    def test_all_positive_returns_zero(self):
+        assert value_at_risk_historical([0.01, 0.02, 0.03, 0.04, 0.05]) == 0.0
+
+    def test_known_5pct_quantile(self):
+        # Mostly losses; 5th-percentile is a real loss → positive magnitude.
+        returns = [-i / 100 for i in range(100)]
+        out = value_at_risk_historical(returns, confidence=0.95)
+        assert out > 0
+
+    def test_higher_confidence_means_bigger_var(self):
+        returns = [-0.05, -0.04, -0.03, -0.02, -0.01, 0.01, 0.02, 0.03, 0.04, 0.05]
+        var_95 = value_at_risk_historical(returns, confidence=0.95)
+        var_99 = value_at_risk_historical(returns, confidence=0.99)
+        assert var_99 >= var_95
+
+    def test_invalid_confidence_zero(self):
+        with pytest.raises(ValueError, match="confidence"):
+            value_at_risk_historical([0.01, 0.02], confidence=0.0)
+
+    def test_invalid_confidence_one(self):
+        with pytest.raises(ValueError, match="confidence"):
+            value_at_risk_historical([0.01, 0.02], confidence=1.0)
+
+
+# ---------------------------------------------------------------------------
+# VaR — parametric
+# ---------------------------------------------------------------------------
+
+
+class TestVaRParametric:
+    def test_empty_returns_zero(self):
+        assert value_at_risk_parametric([]) == 0.0
+
+    def test_too_few_points_returns_zero(self):
+        assert value_at_risk_parametric([0.01]) == 0.0
+
+    def test_zero_variance_returns_zero(self):
+        assert value_at_risk_parametric([0.01, 0.01, 0.01]) == 0.0
+
+    def test_normal_returns_positive_var(self):
+        # Mean-zero modest variance → 95 % VaR > 0.
+        returns = [0.01, -0.01, 0.02, -0.02, 0.005, -0.005, 0.015, -0.015]
+        out = value_at_risk_parametric(returns, confidence=0.95)
+        assert out > 0
+
+    def test_higher_confidence_means_bigger_var(self):
+        returns = [0.01, -0.01, 0.02, -0.02, 0.005, -0.005, 0.015, -0.015]
+        var_95 = value_at_risk_parametric(returns, confidence=0.95)
+        var_99 = value_at_risk_parametric(returns, confidence=0.99)
+        assert var_99 > var_95
+
+    def test_invalid_confidence_rejected(self):
+        with pytest.raises(ValueError, match="confidence"):
+            value_at_risk_parametric([0.01, 0.02, 0.03], confidence=-0.5)
+
+
+# ---------------------------------------------------------------------------
+# Conditional VaR / ES
+# ---------------------------------------------------------------------------
+
+
+class TestCVaR:
+    def test_empty_returns_zero(self):
+        assert conditional_value_at_risk([]) == 0.0
+
+    def test_all_positive_returns_zero(self):
+        assert (
+            conditional_value_at_risk([0.01, 0.02, 0.03, 0.04, 0.05]) == 0.0
+        )
+
+    def test_cvar_geq_var(self):
+        # CVaR (mean of tail) is always ≥ VaR (boundary of tail).
+        returns = [-0.05, -0.04, -0.03, -0.02, -0.01, 0.01, 0.02, 0.03, 0.04, 0.05]
+        var = value_at_risk_historical(returns, confidence=0.9)
+        cvar = conditional_value_at_risk(returns, confidence=0.9)
+        assert cvar >= var
+
+    def test_known_value(self):
+        # 10 returns. 90 % CVaR = mean of worst 10 % = -0.05 → magnitude 0.05.
+        returns = [-0.05, -0.04, -0.03, -0.02, -0.01, 0.01, 0.02, 0.03, 0.04, 0.05]
+        out = conditional_value_at_risk(returns, confidence=0.9)
+        assert out == pytest.approx(0.05)
+
+    def test_invalid_confidence_rejected(self):
+        with pytest.raises(ValueError, match="confidence"):
+            conditional_value_at_risk([0.01, 0.02], confidence=2.0)
+
+
+# ---------------------------------------------------------------------------
+# tail_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestTailRatio:
+    def test_empty_returns_zero(self):
+        assert tail_ratio([]) == 0.0
+
+    def test_symmetric_returns_one(self):
+        # Symmetric distribution → tails equal → ratio = 1.
+        out = tail_ratio([-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0], percentile=0.85)
+        assert out == pytest.approx(1.0)
+
+    def test_positive_skew_ratio_above_one(self):
+        # Big right tail.
+        out = tail_ratio(
+            [-1.0, -1.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5.0, 5.0],
+            percentile=0.9,
+        )
+        assert out > 1.0
+
+    def test_negative_skew_ratio_below_one(self):
+        out = tail_ratio(
+            [-5.0, -5.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+            percentile=0.9,
+        )
+        assert out < 1.0
+
+    def test_lower_tail_zero_returns_zero(self):
+        # All non-negative — lower-tail magnitude 0 → ratio 0.
+        out = tail_ratio([0.0, 0.0, 0.0, 1.0, 2.0], percentile=0.9)
+        assert out == 0.0
+
+    def test_invalid_percentile_rejected(self):
+        with pytest.raises(ValueError, match="percentile"):
+            tail_ratio([0.01, 0.02, 0.03], percentile=0.5)
+        with pytest.raises(ValueError, match="percentile"):
+            tail_ratio([0.01, 0.02, 0.03], percentile=1.0)
+
+
+# ---------------------------------------------------------------------------
+# inverse normal CDF (helper used by parametric VaR)
+# ---------------------------------------------------------------------------
+
+
+class TestInverseNormalCDF:
+    def test_median_is_zero(self):
+        assert _inverse_normal_cdf(0.5) == pytest.approx(0.0, abs=1e-9)
+
+    def test_one_sigma_lower(self):
+        # Φ⁻¹(0.1587) ≈ -1.0
+        out = _inverse_normal_cdf(0.1587)
+        assert out == pytest.approx(-1.0, abs=1e-3)
+
+    def test_one_sigma_upper(self):
+        out = _inverse_normal_cdf(0.8413)
+        assert out == pytest.approx(1.0, abs=1e-3)
+
+    def test_95pct_quantile(self):
+        # Φ⁻¹(0.95) ≈ 1.6449
+        assert _inverse_normal_cdf(0.95) == pytest.approx(1.6449, abs=1e-3)
+
+    def test_invalid_p_rejected(self):
+        with pytest.raises(ValueError, match="p must be"):
+            _inverse_normal_cdf(0.0)
+        with pytest.raises(ValueError, match="p must be"):
+            _inverse_normal_cdf(1.0)
+
+    def test_finite_at_extremes(self):
+        # Tail values must remain finite.
+        assert math.isfinite(_inverse_normal_cdf(0.001))
+        assert math.isfinite(_inverse_normal_cdf(0.999))


### PR DESCRIPTION
## Summary

Pure-function helpers for the distributional and tail-risk KPIs that complement the existing Sharpe / Sortino / drawdown layers. No scipy dependency — uses Beasley-Springer-Moro inverse-CDF for the parametric VaR.

Adds gh#97 KPIs **38** (skewness), **39** (excess kurtosis), **40** (VaR historical + parametric), **41** (CVaR / Expected Shortfall), **42** (tail ratio).

## What ships

- ``skewness(returns)`` — bias-corrected Fisher-Pearson sample skewness; ``0.0`` for empty / n < 3 / zero-variance.
- ``kurtosis(returns)`` — bias-corrected excess kurtosis per Joanes & Gill (1998); fat tails > 0, thin tails < 0; normal → 0.
- ``value_at_risk_historical(returns, *, confidence=0.95)`` — empirical-quantile loss magnitude.
- ``value_at_risk_parametric(returns, *, confidence=0.95)`` — Gaussian VaR ``-(μ + z · σ)`` via Beasley-Springer-Moro inverse-CDF (~1e-9 accuracy across the unit interval).
- ``conditional_value_at_risk(returns, *, confidence=0.95)`` — mean of tail beyond VaR.
- ``tail_ratio(returns, *, percentile=0.95)`` — right-tail / left-tail magnitude ratio.

## Conventions

- VaR / CVaR returned as **positive magnitudes** (caller decides display sign).
- ``confidence`` is the *upper* bound: ``0.95`` means "95 % VaR" (5 % tail). Bounded ``(0.0, 1.0)``.
- ``percentile`` for ``tail_ratio`` bounded ``(0.5, 1.0)``.
- Empty input → ``0.0`` from every helper.

## Out of scope

- Filtered historical simulation (FHS) — separate slice.
- Cornish-Fisher expansion VaR — separate slice.
- Monte Carlo VaR — already covered by ``engine.core.monte_carlo``.

## Test plan

- [x] 40 new unit tests in ``tests/test_distribution_metrics.py``:
  - ``skewness`` (6 cases incl. symmetric≈0, positive/negative skew)
  - ``kurtosis`` (5 cases incl. uniform negative-excess, fat tails positive)
  - ``value_at_risk_historical`` (6 cases incl. monotonic in confidence, validation)
  - ``value_at_risk_parametric`` (6 cases incl. monotonic in confidence)
  - ``conditional_value_at_risk`` (5 cases incl. CVaR ≥ VaR identity, known value)
  - ``tail_ratio`` (6 cases incl. symmetric=1, positive-skew>1, percentile validation)
  - ``_inverse_normal_cdf`` (6 cases incl. median=0, ±σ, 95th pct≈1.6449, finite at extremes)
- [x] Full local suite green: ``2430 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted distribution suite: 40/40 pass in 0.08 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)