### PR TITLE
feat(portfolio): rolling correlation analytics (gh#89)

### DIFF
--- a/engine/core/rolling_correlation.py
+++ b/engine/core/rolling_correlation.py
@@ -1,0 +1,161 @@
+"""Rolling correlation analytics (gh#89 follow-up).
+
+Pairwise rolling Pearson correlation across portfolio return series.
+Complements the static ``correlation_matrix`` in
+``engine.core.portfolio_aggregator`` (#339) which computes a single
+matrix over the full sample — these helpers compute the *time series*
+of pairwise correlations so callers can plot regime shifts.
+
+Output convention follows ``engine.core.rolling_metrics`` (#343):
+same-length output with ``None`` for the first ``window - 1`` indices.
+
+Coverage:
+
+- ``rolling_correlation`` — single-pair time series.
+- ``rolling_correlation_matrix`` — all pairs as a dict of lists.
+- ``mean_pairwise_correlation`` — single rolling series of mean
+  off-diagonal correlation across the group (the "diversification
+  loss" indicator).
+
+Out of scope:
+- Spearman / Kendall rank correlations.
+- Dynamic-conditional-correlation (DCC) GARCH.
+- Eigenvalue-spectrum tracking (Marchenko-Pastur cleanup) — separate slice.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+
+
+def _validate_window(window: int) -> None:
+    if window < 2:
+        raise ValueError("window must be >= 2")
+
+
+def _pearson(xs: Sequence[float], ys: Sequence[float]) -> float:
+    """Pearson correlation. Returns ``0.0`` on length mismatch or zero variance."""
+    n = len(xs)
+    if n != len(ys) or n < 2:
+        return 0.0
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    dx = math.sqrt(sum((x - mx) ** 2 for x in xs))
+    dy = math.sqrt(sum((y - my) ** 2 for y in ys))
+    if dx == 0.0 or dy == 0.0:
+        return 0.0
+    return num / (dx * dy)
+
+
+def rolling_correlation(
+    a: Sequence[float], b: Sequence[float], window: int
+) -> list[float | None]:
+    """Pearson correlation of ``a`` and ``b`` over each trailing window.
+
+    ``None`` for the first ``window - 1`` indices. Both inputs must be
+    the same length; mismatch raises ``ValueError``. Series shorter
+    than ``window`` return all-``None``.
+    """
+    _validate_window(window)
+    if len(a) != len(b):
+        raise ValueError(
+            f"series length mismatch: {len(a)} vs {len(b)}"
+        )
+    n = len(a)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    for i in range(window - 1, n):
+        out[i] = _pearson(
+            a[i - window + 1 : i + 1], b[i - window + 1 : i + 1]
+        )
+    return out
+
+
+def rolling_correlation_matrix(
+    return_series: Mapping[str, Sequence[float]], window: int
+) -> dict[str, dict[str, list[float | None]]]:
+    """All-pairs rolling correlation matrix.
+
+    Returns ``{key_a: {key_b: [rolling_corr_at_each_bar, ...]}}``.
+    Diagonal entries are ``1.0`` (after the first full window — earlier
+    indices remain ``None``; constant-window slices yield ``0.0`` since
+    correlation is undefined). Off-diagonal entries are symmetric. All
+    series must have identical length.
+    """
+    _validate_window(window)
+    keys = list(return_series.keys())
+    if not keys:
+        return {}
+    lengths = {len(s) for s in return_series.values()}
+    if len(lengths) > 1:
+        raise ValueError(
+            f"all return series must have equal length; got {sorted(lengths)}"
+        )
+    n = next(iter(lengths))
+    out: dict[str, dict[str, list[float | None]]] = {k: {} for k in keys}
+    for i, a in enumerate(keys):
+        for j, b in enumerate(keys):
+            if i == j:
+                series_a = return_series[a]
+                row: list[float | None] = [None] * n
+                for idx in range(window - 1, n):
+                    win = series_a[idx - window + 1 : idx + 1]
+                    row[idx] = 1.0 if len(set(win)) > 1 else 0.0
+                out[a][b] = row
+            elif j < i:
+                out[a][b] = list(out[b][a])
+            else:
+                out[a][b] = rolling_correlation(
+                    return_series[a], return_series[b], window
+                )
+    return out
+
+
+def mean_pairwise_correlation(
+    return_series: Mapping[str, Sequence[float]], window: int
+) -> list[float | None]:
+    """Average off-diagonal correlation across the group, per bar.
+
+    Returns a list of length ``len(returns)`` (the common series
+    length) with ``None`` for the first ``window - 1`` indices.
+    Returns ``[]`` for fewer than two series (no pairs to average).
+    """
+    _validate_window(window)
+    keys = list(return_series.keys())
+    if len(keys) < 2:
+        return []
+    lengths = {len(s) for s in return_series.values()}
+    if len(lengths) > 1:
+        raise ValueError(
+            f"all return series must have equal length; got {sorted(lengths)}"
+        )
+    n = next(iter(lengths))
+    if n < window:
+        return [None] * n
+    pair_series: list[list[float | None]] = []
+    for i in range(len(keys)):
+        for j in range(i + 1, len(keys)):
+            pair_series.append(
+                rolling_correlation(
+                    return_series[keys[i]], return_series[keys[j]], window
+                )
+            )
+    if not pair_series:
+        return [None] * n
+    out: list[float | None] = [None] * n
+    for idx in range(window - 1, n):
+        values = [s[idx] for s in pair_series if s[idx] is not None]
+        if values:
+            total = sum(values)  # type: ignore[arg-type]
+            out[idx] = total / len(values)
+    return out
+
+
+__all__ = [
+    "mean_pairwise_correlation",
+    "rolling_correlation",
+    "rolling_correlation_matrix",
+]

--- a/tests/test_rolling_correlation.py
+++ b/tests/test_rolling_correlation.py
@@ -1,0 +1,194 @@
+"""Tests for rolling correlation analytics (gh#89 follow-up)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.rolling_correlation import (
+    mean_pairwise_correlation,
+    rolling_correlation,
+    rolling_correlation_matrix,
+)
+
+
+# ---------------------------------------------------------------------------
+# rolling_correlation
+# ---------------------------------------------------------------------------
+
+
+class TestRollingCorrelation:
+    def test_empty_inputs_empty_output(self):
+        assert rolling_correlation([], [], 3) == []
+
+    def test_window_too_large_all_none(self):
+        out = rolling_correlation([0.01, 0.02], [0.01, 0.02], 5)
+        assert out == [None, None]
+
+    def test_first_indices_none(self):
+        out = rolling_correlation([1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], 3)
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_perfectly_correlated(self):
+        a = [1.0, 2.0, 3.0, 4.0, 5.0]
+        b = [2.0, 4.0, 6.0, 8.0, 10.0]
+        out = rolling_correlation(a, b, 3)
+        for v in out[2:]:
+            assert v == pytest.approx(1.0)
+
+    def test_perfectly_anti_correlated(self):
+        a = [1.0, 2.0, 3.0, 4.0, 5.0]
+        b = [5.0, 4.0, 3.0, 2.0, 1.0]
+        out = rolling_correlation(a, b, 3)
+        for v in out[2:]:
+            assert v == pytest.approx(-1.0)
+
+    def test_constant_series_zero_correlation(self):
+        # Zero variance in one series → 0.0 short-circuit.
+        a = [1.0, 1.0, 1.0, 1.0, 1.0]
+        b = [1.0, 2.0, 3.0, 4.0, 5.0]
+        out = rolling_correlation(a, b, 3)
+        for v in out[2:]:
+            assert v == 0.0
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            rolling_correlation([1.0, 2.0], [1.0, 2.0, 3.0], 2)
+
+    def test_window_one_rejected(self):
+        with pytest.raises(ValueError, match="window must be"):
+            rolling_correlation([1.0, 2.0], [1.0, 2.0], 1)
+
+    def test_output_length_matches_input(self):
+        out = rolling_correlation([1.0] * 10, [1.0] * 10, 3)
+        assert len(out) == 10
+
+    def test_regime_shift_visible(self):
+        # First half perfectly correlated, second half anti-correlated.
+        a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+        b = [2.0, 4.0, 6.0, 8.0, 6.0, 4.0, 2.0, 0.0]
+        out = rolling_correlation(a, b, 4)
+        # First full-window correlation is +1.
+        assert out[3] == pytest.approx(1.0)
+        # Last window's correlation is −1 (anti-correlated final 4 bars).
+        assert out[-1] == pytest.approx(-1.0)
+
+
+# ---------------------------------------------------------------------------
+# rolling_correlation_matrix
+# ---------------------------------------------------------------------------
+
+
+class TestRollingCorrelationMatrix:
+    def test_empty_input(self):
+        assert rolling_correlation_matrix({}, 3) == {}
+
+    def test_single_series_diagonal_only(self):
+        out = rolling_correlation_matrix({"a": [1.0, 2.0, 3.0, 4.0]}, 3)
+        assert list(out.keys()) == ["a"]
+        # Diagonal: None for first window-1, then 1.0 (variation present).
+        assert out["a"]["a"][:2] == [None, None]
+        assert out["a"]["a"][2] == 1.0
+
+    def test_two_series_off_diagonal_symmetric(self):
+        out = rolling_correlation_matrix(
+            {"a": [1.0, 2.0, 3.0, 4.0], "b": [4.0, 3.0, 2.0, 1.0]}, 3
+        )
+        for idx in range(2, 4):
+            ab = out["a"]["b"][idx]
+            ba = out["b"]["a"][idx]
+            assert ab is not None
+            assert ba is not None
+            assert math.isclose(ab, ba)
+
+    def test_diagonal_is_one_for_varying_series(self):
+        out = rolling_correlation_matrix(
+            {"a": [1.0, 2.0, 3.0, 4.0]}, 3
+        )
+        for v in out["a"]["a"][2:]:
+            assert v == 1.0
+
+    def test_diagonal_is_zero_for_constant_window(self):
+        # Constant series — variation == 0 → diagonal returns 0.0.
+        out = rolling_correlation_matrix(
+            {"a": [1.0, 1.0, 1.0, 1.0]}, 3
+        )
+        for v in out["a"]["a"][2:]:
+            assert v == 0.0
+
+    def test_unequal_lengths_rejected(self):
+        with pytest.raises(ValueError, match="equal length"):
+            rolling_correlation_matrix(
+                {"a": [1.0, 2.0], "b": [1.0, 2.0, 3.0]}, 2
+            )
+
+    def test_window_validation(self):
+        with pytest.raises(ValueError, match="window must be"):
+            rolling_correlation_matrix({"a": [1.0, 2.0]}, 1)
+
+
+# ---------------------------------------------------------------------------
+# mean_pairwise_correlation
+# ---------------------------------------------------------------------------
+
+
+class TestMeanPairwiseCorrelation:
+    def test_empty_returns_empty(self):
+        assert mean_pairwise_correlation({}, 3) == []
+
+    def test_single_series_returns_empty(self):
+        # Single portfolio — no pairs to average.
+        assert mean_pairwise_correlation({"a": [1.0, 2.0, 3.0]}, 3) == []
+
+    def test_first_indices_none(self):
+        out = mean_pairwise_correlation(
+            {"a": [1.0, 2.0, 3.0, 4.0], "b": [1.0, 2.0, 3.0, 4.0]}, 3
+        )
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_perfectly_correlated_group_yields_one(self):
+        out = mean_pairwise_correlation(
+            {
+                "a": [1.0, 2.0, 3.0, 4.0],
+                "b": [2.0, 4.0, 6.0, 8.0],
+                "c": [3.0, 6.0, 9.0, 12.0],
+            },
+            3,
+        )
+        for v in out[2:]:
+            assert v == pytest.approx(1.0)
+
+    def test_mixed_correlation(self):
+        # Two perfectly correlated and one anti-correlated.
+        # Pairs: (a,b)=1, (a,c)=-1, (b,c)=-1 → mean = -1/3.
+        out = mean_pairwise_correlation(
+            {
+                "a": [1.0, 2.0, 3.0, 4.0],
+                "b": [2.0, 4.0, 6.0, 8.0],
+                "c": [4.0, 3.0, 2.0, 1.0],
+            },
+            3,
+        )
+        # Last full-window value:
+        assert out[-1] == pytest.approx(-1 / 3, abs=1e-9)
+
+    def test_unequal_lengths_rejected(self):
+        with pytest.raises(ValueError, match="equal length"):
+            mean_pairwise_correlation(
+                {"a": [1.0, 2.0], "b": [1.0, 2.0, 3.0]}, 2
+            )
+
+    def test_output_length_matches_series(self):
+        out = mean_pairwise_correlation(
+            {"a": [1.0] * 10, "b": [2.0] * 10}, 3
+        )
+        assert len(out) == 10
+
+    def test_window_too_large_all_none(self):
+        out = mean_pairwise_correlation(
+            {"a": [1.0, 2.0], "b": [1.0, 2.0]}, 5
+        )
+        assert out == [None, None]


### PR DESCRIPTION
## Summary

Pairwise rolling Pearson correlation across portfolio return series. Complements the static ``correlation_matrix`` from #339 (single value per pair over the full sample) by computing the *time series* of pairwise correlations so callers can plot regime shifts (the "everything correlates to 1 in a crash" indicator).

Output convention follows ``engine.core.rolling_metrics`` (#343): same-length output with ``None`` for the first ``window - 1`` indices.

## What ships

- ``rolling_correlation(a, b, window)`` — single-pair time series. Rejects length mismatch.
- ``rolling_correlation_matrix(return_series, window)`` — all-pairs nested dict. Diagonal entries are ``1.0`` when the trailing window has variation, ``0.0`` otherwise (correlation undefined). Off-diagonal entries are symmetric. All series must have identical length.
- ``mean_pairwise_correlation(return_series, window)`` — average of all off-diagonal pair correlations per bar. Useful as a single-line "diversification loss" indicator.

## Out of scope

- Spearman / Kendall rank correlations.
- Dynamic-conditional-correlation (DCC) GARCH.
- Eigenvalue-spectrum tracking (Marchenko-Pastur cleanup) — separate slice.

## Test plan

- [x] 25 new unit tests in ``tests/test_rolling_correlation.py``:
  - ``rolling_correlation`` (10 cases incl. perfectly correlated/anti-correlated, constant series → 0.0, regime shift visibility, length-mismatch rejection)
  - ``rolling_correlation_matrix`` (7 cases incl. symmetry, diagonal=1.0 vs 0.0 for constant window, unequal-length rejection)
  - ``mean_pairwise_correlation`` (8 cases incl. single-series → empty, perfectly correlated → 1.0, mixed → exact -1/3)
- [x] Full local suite green: ``2455 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted suite: 25/25 pass in 0.07 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)