### PR TITLE
feat(metrics): trade-level performance stats (gh#97)

### DIFF
--- a/engine/core/trade_stats.py
+++ b/engine/core/trade_stats.py
@@ -1,0 +1,175 @@
+"""Trade-level performance statistics (gh#97 follow-up).
+
+Pure-function helpers operating on a sequence of trade PnLs (signed
+floats: ``> 0`` = win, ``< 0`` = loss, ``0`` = breakeven). Complements
+the class-bound private methods in
+``engine.core.metrics.PerformanceMetrics`` and adds metrics that
+weren't previously exposed.
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 44  Max consecutive wins    — ``max_consecutive_wins``
+- 45  Max consecutive losses  — ``max_consecutive_losses``
+- 46  Current streak          — ``current_streak``
+- 47  Profit factor           — ``profit_factor``
+- 48  Average win / loss      — ``average_win``, ``average_loss``
+- 49  Win/loss ratio          — ``win_loss_ratio``
+- 50  Hit ratio               — ``hit_ratio``
+- 55  Largest single trade    — ``largest_win``, ``largest_loss``
+
+Conventions:
+
+- Breakeven trades (``pnl == 0``) are *not* counted as wins or losses.
+- Empty input returns ``0.0`` (or ``None`` for ``profit_factor`` when
+  no losses exist — distinguishing "infinite ratio" from "no data").
+- Streaks are reported as positive ints; ``current_streak`` returns
+  signed (positive for win streak, negative for loss).
+
+Out of scope:
+- Per-symbol rollups (caller groups themselves).
+- Win/loss expectancy (already shipped in ``engine.core.metrics_extras``).
+- MAE / MFE — separate slice (intra-trade excursion data needed).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def hit_ratio(trade_pnls: Sequence[float]) -> float:
+    """Fraction of trades with strictly-positive PnL.
+
+    Returns ``0.0`` for empty input. Breakeven trades are *not* counted
+    as wins (consistent convention with ``compute_positive_period_pct``
+    in ``engine.core.time_metrics``).
+    """
+    if not trade_pnls:
+        return 0.0
+    wins = sum(1 for p in trade_pnls if p > 0)
+    return wins / len(trade_pnls)
+
+
+def average_win(trade_pnls: Sequence[float]) -> float:
+    """Mean of strictly-positive trade PnLs. ``0.0`` if no wins."""
+    wins = [p for p in trade_pnls if p > 0]
+    if not wins:
+        return 0.0
+    return sum(wins) / len(wins)
+
+
+def average_loss(trade_pnls: Sequence[float]) -> float:
+    """Mean of strictly-negative trade PnLs (returned as a negative number).
+
+    ``0.0`` if no losses.
+    """
+    losses = [p for p in trade_pnls if p < 0]
+    if not losses:
+        return 0.0
+    return sum(losses) / len(losses)
+
+
+def win_loss_ratio(trade_pnls: Sequence[float]) -> float:
+    """Average win / |average loss|.
+
+    Returns ``0.0`` when there are no losses (caller distinguishes
+    "no losses, all wins" via ``hit_ratio`` and ``average_win``).
+    Returns ``0.0`` when there are no wins.
+    """
+    avg_w = average_win(trade_pnls)
+    avg_l = average_loss(trade_pnls)
+    if avg_w == 0.0 or avg_l == 0.0:
+        return 0.0
+    return avg_w / abs(avg_l)
+
+
+def profit_factor(trade_pnls: Sequence[float]) -> float | None:
+    """Gross profit / gross loss.
+
+    Returns ``None`` when there are no losing trades (mathematically
+    infinite — caller decides how to display). Returns ``0.0`` for
+    empty input or no winning trades.
+    """
+    if not trade_pnls:
+        return 0.0
+    gross_profit = sum(p for p in trade_pnls if p > 0)
+    gross_loss = sum(-p for p in trade_pnls if p < 0)
+    if gross_loss == 0.0:
+        return None if gross_profit > 0 else 0.0
+    return gross_profit / gross_loss
+
+
+def largest_win(trade_pnls: Sequence[float]) -> float:
+    """Largest single winning trade. ``0.0`` if no wins."""
+    wins = [p for p in trade_pnls if p > 0]
+    if not wins:
+        return 0.0
+    return max(wins)
+
+
+def largest_loss(trade_pnls: Sequence[float]) -> float:
+    """Largest single losing trade (returned negative). ``0.0`` if no losses."""
+    losses = [p for p in trade_pnls if p < 0]
+    if not losses:
+        return 0.0
+    return min(losses)
+
+
+def max_consecutive_wins(trade_pnls: Sequence[float]) -> int:
+    """Longest run of strictly-positive trades. Breakeven breaks the streak."""
+    longest = 0
+    current = 0
+    for p in trade_pnls:
+        if p > 0:
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def max_consecutive_losses(trade_pnls: Sequence[float]) -> int:
+    """Longest run of strictly-negative trades. Breakeven breaks the streak."""
+    longest = 0
+    current = 0
+    for p in trade_pnls:
+        if p < 0:
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def current_streak(trade_pnls: Sequence[float]) -> int:
+    """Signed streak length at the end of the sequence.
+
+    Positive = winning streak, negative = losing streak, ``0`` =
+    last trade was breakeven (or empty input).
+    """
+    if not trade_pnls:
+        return 0
+    last = trade_pnls[-1]
+    if last == 0:
+        return 0
+    sign = 1 if last > 0 else -1
+    streak = 0
+    for p in reversed(trade_pnls):
+        if (sign == 1 and p > 0) or (sign == -1 and p < 0):
+            streak += 1
+        else:
+            break
+    return streak * sign
+
+
+__all__ = [
+    "average_loss",
+    "average_win",
+    "current_streak",
+    "hit_ratio",
+    "largest_loss",
+    "largest_win",
+    "max_consecutive_losses",
+    "max_consecutive_wins",
+    "profit_factor",
+    "win_loss_ratio",
+]

--- a/tests/test_trade_stats.py
+++ b/tests/test_trade_stats.py
@@ -1,0 +1,227 @@
+"""Tests for trade-level performance statistics (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.trade_stats import (
+    average_loss,
+    average_win,
+    current_streak,
+    hit_ratio,
+    largest_loss,
+    largest_win,
+    max_consecutive_losses,
+    max_consecutive_wins,
+    profit_factor,
+    win_loss_ratio,
+)
+
+
+# ---------------------------------------------------------------------------
+# hit_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestHitRatio:
+    def test_empty_returns_zero(self):
+        assert hit_ratio([]) == 0.0
+
+    def test_all_wins(self):
+        assert hit_ratio([10.0, 20.0, 30.0]) == pytest.approx(1.0)
+
+    def test_all_losses(self):
+        assert hit_ratio([-10.0, -20.0]) == 0.0
+
+    def test_mixed(self):
+        # 3 of 5 positive → 0.6.
+        assert hit_ratio([10.0, -5.0, 20.0, -3.0, 15.0]) == pytest.approx(0.6)
+
+    def test_breakeven_not_counted(self):
+        # Convention: breakeven not a win.
+        assert hit_ratio([0.0, 10.0, 0.0]) == pytest.approx(1 / 3)
+
+
+# ---------------------------------------------------------------------------
+# average_win / average_loss
+# ---------------------------------------------------------------------------
+
+
+class TestAverageWin:
+    def test_empty_returns_zero(self):
+        assert average_win([]) == 0.0
+
+    def test_no_wins_returns_zero(self):
+        assert average_win([-10.0, -20.0]) == 0.0
+
+    def test_known_value(self):
+        # Wins: 10, 20, 30 → mean 20.
+        assert average_win([10.0, -5.0, 20.0, 30.0]) == pytest.approx(20.0)
+
+    def test_breakeven_not_a_win(self):
+        # Wins: 10 only. Mean 10.
+        assert average_win([0.0, 10.0, 0.0]) == pytest.approx(10.0)
+
+
+class TestAverageLoss:
+    def test_empty_returns_zero(self):
+        assert average_loss([]) == 0.0
+
+    def test_no_losses_returns_zero(self):
+        assert average_loss([10.0, 20.0]) == 0.0
+
+    def test_known_value_negative(self):
+        # Losses: -10, -20 → mean -15.
+        assert average_loss([10.0, -10.0, -20.0]) == pytest.approx(-15.0)
+
+    def test_breakeven_not_a_loss(self):
+        assert average_loss([0.0, -10.0, 0.0]) == pytest.approx(-10.0)
+
+
+# ---------------------------------------------------------------------------
+# win_loss_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestWinLossRatio:
+    def test_empty_returns_zero(self):
+        assert win_loss_ratio([]) == 0.0
+
+    def test_no_losses_returns_zero(self):
+        # Convention: 0.0, not infinity.
+        assert win_loss_ratio([10.0, 20.0]) == 0.0
+
+    def test_no_wins_returns_zero(self):
+        assert win_loss_ratio([-10.0, -20.0]) == 0.0
+
+    def test_known_value(self):
+        # avg_win = 20, avg_loss = -10 → ratio 2.0.
+        assert win_loss_ratio([20.0, -10.0]) == pytest.approx(2.0)
+
+    def test_symmetric_payoff_ratio_one(self):
+        assert win_loss_ratio([10.0, -10.0]) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# profit_factor
+# ---------------------------------------------------------------------------
+
+
+class TestProfitFactor:
+    def test_empty_returns_zero(self):
+        assert profit_factor([]) == 0.0
+
+    def test_no_losses_returns_none(self):
+        # Mathematically infinite — None preserves "no data" vs "infinity".
+        assert profit_factor([10.0, 20.0]) is None
+
+    def test_no_wins_returns_zero(self):
+        assert profit_factor([-10.0, -20.0]) == 0.0
+
+    def test_breakeven_only_returns_zero(self):
+        assert profit_factor([0.0, 0.0]) == 0.0
+
+    def test_known_value(self):
+        # gross profit 30, gross loss 15 → 2.0.
+        assert profit_factor([10.0, 20.0, -5.0, -10.0]) == pytest.approx(2.0)
+
+    def test_breakeven_does_not_affect(self):
+        assert profit_factor([10.0, 0.0, -5.0]) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# largest_win / largest_loss
+# ---------------------------------------------------------------------------
+
+
+class TestLargestWin:
+    def test_empty_returns_zero(self):
+        assert largest_win([]) == 0.0
+
+    def test_no_wins_returns_zero(self):
+        assert largest_win([-10.0, -20.0]) == 0.0
+
+    def test_known_value(self):
+        assert largest_win([5.0, 100.0, -50.0, 25.0]) == 100.0
+
+
+class TestLargestLoss:
+    def test_empty_returns_zero(self):
+        assert largest_loss([]) == 0.0
+
+    def test_no_losses_returns_zero(self):
+        assert largest_loss([5.0, 10.0]) == 0.0
+
+    def test_known_value_negative(self):
+        # Largest loss = most negative = -50.
+        assert largest_loss([5.0, 100.0, -50.0, -25.0]) == -50.0
+
+
+# ---------------------------------------------------------------------------
+# max_consecutive_wins / max_consecutive_losses
+# ---------------------------------------------------------------------------
+
+
+class TestMaxConsecutiveWins:
+    def test_empty_returns_zero(self):
+        assert max_consecutive_wins([]) == 0
+
+    def test_no_wins_returns_zero(self):
+        assert max_consecutive_wins([-1.0, -2.0]) == 0
+
+    def test_simple_streak(self):
+        assert max_consecutive_wins([1.0, 2.0, 3.0, -1.0, 1.0]) == 3
+
+    def test_streak_at_end(self):
+        assert max_consecutive_wins([-1.0, 1.0, 2.0, 3.0, 4.0]) == 4
+
+    def test_breakeven_breaks_streak(self):
+        # 1, 1, 0, 1 → longest run is 2.
+        assert max_consecutive_wins([1.0, 1.0, 0.0, 1.0]) == 2
+
+
+class TestMaxConsecutiveLosses:
+    def test_empty_returns_zero(self):
+        assert max_consecutive_losses([]) == 0
+
+    def test_no_losses_returns_zero(self):
+        assert max_consecutive_losses([1.0, 2.0]) == 0
+
+    def test_simple_streak(self):
+        assert max_consecutive_losses([1.0, -1.0, -2.0, -3.0, 1.0]) == 3
+
+    def test_breakeven_breaks_streak(self):
+        assert max_consecutive_losses([-1.0, -1.0, 0.0, -1.0]) == 2
+
+
+# ---------------------------------------------------------------------------
+# current_streak
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentStreak:
+    def test_empty_returns_zero(self):
+        assert current_streak([]) == 0
+
+    def test_breakeven_last_returns_zero(self):
+        assert current_streak([1.0, 1.0, 0.0]) == 0
+
+    def test_winning_streak_positive(self):
+        assert current_streak([-1.0, 1.0, 1.0, 1.0]) == 3
+
+    def test_losing_streak_negative(self):
+        assert current_streak([1.0, -1.0, -1.0]) == -2
+
+    def test_single_win(self):
+        assert current_streak([1.0]) == 1
+
+    def test_single_loss(self):
+        assert current_streak([-1.0]) == -1
+
+    def test_full_winning_run(self):
+        assert current_streak([1.0, 2.0, 3.0]) == 3
+
+    def test_breakeven_in_middle_breaks_streak(self):
+        # Ends in winning, but breakeven before breaks it. Streak counts
+        # only from the breakeven onward → 1.
+        assert current_streak([1.0, 1.0, 0.0, 1.0]) == 1


### PR DESCRIPTION
## Summary

Pure-function helpers operating on a sequence of signed trade PnLs (``> 0`` = win, ``< 0`` = loss, ``0`` = breakeven). Complements the class-bound private methods in ``engine.core.metrics.PerformanceMetrics`` and adds metrics that weren't previously exposed at module level (hit ratio, win/loss ratio, current streak, average/largest win/loss).

Adds gh#97 KPIs **44** (max consecutive wins), **45** (max consecutive losses), **46** (current streak), **47** (profit factor), **48** (average win/loss), **49** (win/loss ratio), **50** (hit ratio), **55** (largest single trade).

## What ships

- ``hit_ratio(trade_pnls)`` — fraction of strictly-positive trades.
- ``average_win`` / ``average_loss`` — mean of strictly positive / negative trades.
- ``win_loss_ratio`` — ``avg_win / |avg_loss|``; ``0.0`` when either side empty.
- ``profit_factor(trade_pnls)`` — gross profit / gross loss. Returns ``None`` when there are no losing trades (preserves "no data" vs "infinity" distinction).
- ``largest_win`` / ``largest_loss`` — single-trade max / min (loss returned negative).
- ``max_consecutive_wins`` / ``max_consecutive_losses`` — longest runs (breakeven breaks the streak).
- ``current_streak(trade_pnls)`` — signed length: positive = winning streak, negative = losing streak, ``0`` = last trade breakeven or empty.

## Convention

Breakeven trades (``pnl == 0``) are *not* counted as wins or losses. Consistent with ``compute_positive_period_pct`` in ``engine.core.time_metrics``.

## Why pure-function module + class methods both

The class methods in ``PerformanceMetrics`` bundle these into the full report. Future analytics endpoints need the same math without instantiating a report. Future PR can have the class methods delegate to this module.

## Out of scope

- Per-symbol rollups (caller groups themselves).
- Win/loss expectancy (already shipped in ``engine.core.metrics_extras``).
- MAE / MFE — separate slice (needs intra-trade excursion data).

## Test plan

- [x] 47 new unit tests in ``tests/test_trade_stats.py``:
  - ``hit_ratio`` (5 cases incl. breakeven not counted)
  - ``average_win`` / ``average_loss`` (8 cases)
  - ``win_loss_ratio`` (5 cases incl. no-losses → 0.0, symmetric → 1.0)
  - ``profit_factor`` (6 cases incl. no-losses → ``None``, breakeven-only → 0.0)
  - ``largest_win`` / ``largest_loss`` (6 cases)
  - ``max_consecutive_wins`` / ``max_consecutive_losses`` (9 cases incl. breakeven breaks streak)
  - ``current_streak`` (8 cases incl. breakeven-mid breaks streak, single-trade, signed)
- [x] Full local suite green: ``2502 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted suite: 47/47 pass in 0.08 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)