### PR TITLE
feat(metrics): rolling trade-stat + Calmar time series (gh#97)

### DIFF
--- a/engine/core/rolling_trade_stats.py
+++ b/engine/core/rolling_trade_stats.py
@@ -1,0 +1,147 @@
+"""Rolling trade-stat + Calmar time series (gh#97 follow-up).
+
+Pure-function helpers producing the *full* rolling series of trade-level
+metrics across an input sequence. Complements the full-period helpers
+in ``engine.core.trade_stats`` (#346) and ``engine.core.rolling_metrics``
+(#343) by giving callers chartable rolling versions of profit factor,
+hit ratio, win/loss, and Calmar.
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 56b Rolling Calmar           — ``rolling_calmar``
+- 61  Rolling profit factor    — ``rolling_profit_factor``
+- 62  Rolling hit ratio        — ``rolling_hit_ratio``
+- 63  Rolling win/loss ratio   — ``rolling_win_loss_ratio``
+
+Output convention follows ``engine.core.rolling_metrics`` (#343):
+same-length output with ``None`` for the first ``window - 1`` indices.
+
+Out of scope:
+- Rolling MAR / Sterling — analogous slice when needed.
+- Rolling expectancy — caller can compose from rolling_mean +
+  rolling_hit_ratio.
+- Calendar-time rollups (those live in ``engine.core.time_metrics``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from engine.core.drawdown_analytics import underwater_curve
+from engine.core.trade_stats import (
+    hit_ratio,
+    profit_factor,
+    win_loss_ratio,
+)
+
+
+def _validate_window(window: int) -> None:
+    if window < 2:
+        raise ValueError("window must be >= 2")
+
+
+def rolling_hit_ratio(
+    trade_pnls: Sequence[float], window: int
+) -> list[float | None]:
+    """Hit ratio over each ``window``-sized trailing slice of trades.
+
+    ``None`` for the first ``window - 1`` indices.
+    """
+    _validate_window(window)
+    n = len(trade_pnls)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    for i in range(window - 1, n):
+        out[i] = hit_ratio(trade_pnls[i - window + 1 : i + 1])
+    return out
+
+
+def rolling_profit_factor(
+    trade_pnls: Sequence[float], window: int
+) -> list[float | None]:
+    """Profit factor over each trailing window.
+
+    Mirrors ``engine.core.trade_stats.profit_factor`` semantics:
+    ``None`` for windows with no losses, ``0.0`` for windows with no
+    wins, ``0.0`` for empty windows. ``None`` for first ``window - 1``
+    indices (insufficient data).
+    """
+    _validate_window(window)
+    n = len(trade_pnls)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    for i in range(window - 1, n):
+        out[i] = profit_factor(trade_pnls[i - window + 1 : i + 1])
+    return out
+
+
+def rolling_win_loss_ratio(
+    trade_pnls: Sequence[float], window: int
+) -> list[float | None]:
+    """Win/loss ratio over each trailing window."""
+    _validate_window(window)
+    n = len(trade_pnls)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    for i in range(window - 1, n):
+        out[i] = win_loss_ratio(trade_pnls[i - window + 1 : i + 1])
+    return out
+
+
+def _annualised_return(equity_window: Sequence[float], periods_per_year: int) -> float:
+    """Compounded return × (periods_per_year / window) — annualised."""
+    if len(equity_window) < 2 or equity_window[0] <= 0:
+        return 0.0
+    total_return = equity_window[-1] / equity_window[0] - 1.0
+    bars = len(equity_window) - 1
+    if bars <= 0:
+        return 0.0
+    years = bars / periods_per_year
+    if years <= 0:
+        return 0.0
+    return (1.0 + total_return) ** (1.0 / years) - 1.0
+
+
+def rolling_calmar(
+    equity: Sequence[float],
+    window: int,
+    *,
+    periods_per_year: int = 252,
+) -> list[float | None]:
+    """Annualised return / max drawdown over each trailing window.
+
+    Calmar uses the underwater curve (``engine.core.drawdown_analytics``)
+    inside each window to find the deepest drawdown, then divides
+    annualised return by that magnitude. Returns ``None`` when the
+    window has no drawdown (avoids divide-by-zero) and the annualised
+    return is positive (Calmar undefined). Returns ``0.0`` when the
+    annualised return is non-positive with zero drawdown.
+    """
+    _validate_window(window)
+    if periods_per_year <= 0:
+        raise ValueError("periods_per_year must be > 0")
+    n = len(equity)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    for i in range(window - 1, n):
+        win = equity[i - window + 1 : i + 1]
+        ann_ret = _annualised_return(win, periods_per_year)
+        uw = underwater_curve(win)
+        max_dd = -min(uw) if uw else 0.0
+        if max_dd <= 0.0:
+            out[i] = 0.0 if ann_ret <= 0.0 else None
+        else:
+            out[i] = ann_ret / max_dd
+    return out
+
+
+__all__ = [
+    "rolling_calmar",
+    "rolling_hit_ratio",
+    "rolling_profit_factor",
+    "rolling_win_loss_ratio",
+]

--- a/tests/test_rolling_trade_stats.py
+++ b/tests/test_rolling_trade_stats.py
@@ -1,0 +1,150 @@
+"""Tests for rolling trade-stat + Calmar time series (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.rolling_trade_stats import (
+    rolling_calmar,
+    rolling_hit_ratio,
+    rolling_profit_factor,
+    rolling_win_loss_ratio,
+)
+
+
+# ---------------------------------------------------------------------------
+# rolling_hit_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestRollingHitRatio:
+    def test_empty_returns_empty(self):
+        assert rolling_hit_ratio([], 3) == []
+
+    def test_window_too_large_all_none(self):
+        assert rolling_hit_ratio([1.0, -1.0], 5) == [None, None]
+
+    def test_first_indices_none(self):
+        out = rolling_hit_ratio([1.0, -1.0, 1.0, 1.0], 3)
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_known_values(self):
+        # window=3 over [1, -1, 1, 1, -1]
+        # idx 2: [1,-1,1] → 2/3.
+        # idx 3: [-1,1,1] → 2/3.
+        # idx 4: [1,1,-1] → 2/3.
+        out = rolling_hit_ratio([1.0, -1.0, 1.0, 1.0, -1.0], 3)
+        assert out[2] == pytest.approx(2 / 3)
+        assert out[3] == pytest.approx(2 / 3)
+        assert out[4] == pytest.approx(2 / 3)
+
+    def test_window_one_rejected(self):
+        with pytest.raises(ValueError, match="window must be"):
+            rolling_hit_ratio([1.0, -1.0], 1)
+
+
+# ---------------------------------------------------------------------------
+# rolling_profit_factor
+# ---------------------------------------------------------------------------
+
+
+class TestRollingProfitFactor:
+    def test_empty_returns_empty(self):
+        assert rolling_profit_factor([], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_profit_factor([1.0, -1.0, 1.0], 3)
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_no_losses_in_window_returns_none(self):
+        # Window [1, 2, 3] — no losses → None (infinite PF).
+        out = rolling_profit_factor([1.0, 2.0, 3.0], 3)
+        assert out[2] is None
+
+    def test_known_value(self):
+        # Window [10, -5, 20]: gross profit 30, gross loss 5 → 6.0.
+        out = rolling_profit_factor([10.0, -5.0, 20.0], 3)
+        assert out[2] == pytest.approx(6.0)
+
+    def test_no_wins_returns_zero(self):
+        out = rolling_profit_factor([-1.0, -2.0, -3.0], 3)
+        assert out[2] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# rolling_win_loss_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestRollingWinLossRatio:
+    def test_empty_returns_empty(self):
+        assert rolling_win_loss_ratio([], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_win_loss_ratio([1.0, -1.0, 1.0], 3)
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_known_value(self):
+        # Window [20, -10, 20]: avg_win 20, avg_loss -10 → 2.0.
+        out = rolling_win_loss_ratio([20.0, -10.0, 20.0], 3)
+        assert out[2] == pytest.approx(2.0)
+
+    def test_all_wins_returns_zero(self):
+        # No losses → 0.0 (consistent with full-period helper).
+        out = rolling_win_loss_ratio([1.0, 2.0, 3.0], 3)
+        assert out[2] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# rolling_calmar
+# ---------------------------------------------------------------------------
+
+
+class TestRollingCalmar:
+    def test_empty_returns_empty(self):
+        assert rolling_calmar([], 3) == []
+
+    def test_window_too_large_all_none(self):
+        assert rolling_calmar([100.0, 110.0], 5) == [None, None]
+
+    def test_first_indices_none(self):
+        out = rolling_calmar([100.0, 110.0, 105.0, 115.0], 3)
+        assert out[:2] == [None, None]
+
+    def test_no_drawdown_positive_return_none(self):
+        # Monotonic increase, no drawdown → Calmar undefined → None.
+        out = rolling_calmar([100.0, 105.0, 110.0, 115.0], 3, periods_per_year=252)
+        # Last window: monotonic up → no drawdown, ann_ret > 0 → None.
+        assert out[-1] is None
+
+    def test_no_drawdown_flat_return_zero(self):
+        # Flat curve → ann_ret 0, no drawdown → 0.0.
+        out = rolling_calmar([100.0, 100.0, 100.0, 100.0], 3, periods_per_year=252)
+        assert out[-1] == 0.0
+
+    def test_drawdown_present_returns_finite(self):
+        # 100 → 90 → 100 → 110 with window 4: ann_ret > 0, max_dd = 0.10.
+        out = rolling_calmar(
+            [100.0, 90.0, 100.0, 110.0], 4, periods_per_year=252
+        )
+        assert out[-1] is not None
+        assert out[-1] > 0
+
+    def test_negative_periods_per_year_rejected(self):
+        with pytest.raises(ValueError, match="periods_per_year"):
+            rolling_calmar([100.0, 110.0, 105.0], 2, periods_per_year=-1)
+
+    def test_zero_periods_per_year_rejected(self):
+        with pytest.raises(ValueError, match="periods_per_year"):
+            rolling_calmar([100.0, 110.0, 105.0], 2, periods_per_year=0)
+
+    def test_window_one_rejected(self):
+        with pytest.raises(ValueError, match="window must be"):
+            rolling_calmar([100.0, 110.0], 1)
+
+    def test_output_length_matches_input(self):
+        out = rolling_calmar([100.0] * 10, 3)
+        assert len(out) == 10


### PR DESCRIPTION
## Summary

Pure-function helpers producing the *full* rolling series of trade-level metrics. Complements the full-period helpers in ``engine.core.trade_stats`` (#346) and the rolling Sharpe / Sortino / vol time series in ``engine.core.rolling_metrics`` (#343).

Adds gh#97 KPIs **56b** (rolling Calmar), **61** (rolling profit factor), **62** (rolling hit ratio), **63** (rolling win/loss ratio).

## What ships

- ``rolling_hit_ratio(trade_pnls, window)`` — fraction of winning trades over each trailing window.
- ``rolling_profit_factor(trade_pnls, window)`` — gross profit / gross loss per window. Mirrors full-period semantics: ``None`` for no-loss windows (infinite PF), ``0.0`` for no-win windows.
- ``rolling_win_loss_ratio(trade_pnls, window)`` — ``avg_win / |avg_loss|`` per window; ``0.0`` when either side is empty.
- ``rolling_calmar(equity, window, *, periods_per_year=252)`` — annualised return / max drawdown using the underwater curve from ``engine.core.drawdown_analytics``. ``None`` for no-drawdown positive-return windows (Calmar undefined); ``0.0`` for flat / non-positive-return windows with zero drawdown.

## Output convention

Same as ``engine.core.rolling_metrics`` (#343): same-length output with ``None`` for the first ``window - 1`` indices so callers can distinguish "not enough data yet" from "zero".

## Out of scope

- Rolling MAR / Sterling — analogous slice when needed.
- Rolling expectancy — caller can compose from ``rolling_mean`` + ``rolling_hit_ratio``.
- Calendar-period rollups (already in ``engine.core.time_metrics``).

## Test plan

- [x] 24 new unit tests in ``tests/test_rolling_trade_stats.py``:
  - ``rolling_hit_ratio`` (5 cases incl. window-too-large all-None, known 2/3 windows)
  - ``rolling_profit_factor`` (5 cases incl. no-losses → None, no-wins → 0.0)
  - ``rolling_win_loss_ratio`` (4 cases incl. all-wins → 0.0)
  - ``rolling_calmar`` (10 cases incl. no-drawdown-positive-return → None, no-drawdown-flat → 0.0, drawdown-present finite, periods_per_year validation)
- [x] Full local suite green: ``2526 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted suite: 24/24 pass in 0.07 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)