### PR TITLE
feat(metrics): MAE/MFE excursion analytics (gh#97)

### DIFF
--- a/engine/core/excursion_stats.py
+++ b/engine/core/excursion_stats.py
@@ -1,0 +1,140 @@
+"""Intra-trade excursion analytics — MAE / MFE / efficiency (gh#97 follow-up).
+
+Pure-function helpers operating on a sequence of ``TradeExcursion``
+records — one per closed trade, each carrying the entry / exit prices
+plus the most adverse and most favourable mark-to-market levels seen
+between entry and exit. These metrics can't be derived from terminal
+PnL alone and complement ``engine.core.trade_stats`` (#346).
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 64  Maximum Adverse Excursion (MAE)        — ``mean_mae`` / ``max_mae``
+- 65  Maximum Favourable Excursion (MFE)     — ``mean_mfe`` / ``max_mfe``
+- 66  Edge ratio (MFE / MAE)                 — ``edge_ratio``
+- 67  Trade efficiency (PnL / MFE for wins)  — ``trade_efficiency``
+
+Conventions:
+
+- ``mae`` is recorded as a positive magnitude (max drawdown inside
+  the trade as a fraction of entry price). ``mfe`` is also a positive
+  magnitude (max unrealised gain inside the trade).
+- All helpers handle empty input by returning ``0.0``.
+- Long vs short side is encoded by the sign convention on excursion
+  values themselves; the caller computes them once at trade close and
+  hands the magnitudes to this module.
+
+Out of scope:
+- Bar-level path reconstruction (caller already collapsed each trade
+  to its (pnl, mfe, mae) summary).
+- Time-to-MFE / time-to-MAE (separate slice — needs timestamps).
+- Per-symbol / per-strategy rollups.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TradeExcursion:
+    """One trade's terminal pnl plus its intra-trade excursion magnitudes.
+
+    ``pnl`` — terminal trade PnL (signed: positive = win, negative = loss).
+    ``mfe`` — maximum favourable excursion as a positive magnitude (best
+    unrealised gain inside the trade).
+    ``mae`` — maximum adverse excursion as a positive magnitude (worst
+    unrealised loss inside the trade). Always ``>= 0``.
+    """
+
+    pnl: float
+    mfe: float
+    mae: float
+
+    def __post_init__(self) -> None:
+        if self.mfe < 0:
+            raise ValueError(f"mfe must be >= 0; got {self.mfe}")
+        if self.mae < 0:
+            raise ValueError(f"mae must be >= 0; got {self.mae}")
+
+
+def mean_mae(trades: Sequence[TradeExcursion]) -> float:
+    """Average MAE across trades. ``0.0`` for empty input."""
+    if not trades:
+        return 0.0
+    return sum(t.mae for t in trades) / len(trades)
+
+
+def mean_mfe(trades: Sequence[TradeExcursion]) -> float:
+    """Average MFE across trades. ``0.0`` for empty input."""
+    if not trades:
+        return 0.0
+    return sum(t.mfe for t in trades) / len(trades)
+
+
+def max_mae(trades: Sequence[TradeExcursion]) -> float:
+    """Worst single-trade MAE. ``0.0`` for empty input."""
+    if not trades:
+        return 0.0
+    return max(t.mae for t in trades)
+
+
+def max_mfe(trades: Sequence[TradeExcursion]) -> float:
+    """Best single-trade MFE. ``0.0`` for empty input."""
+    if not trades:
+        return 0.0
+    return max(t.mfe for t in trades)
+
+
+def edge_ratio(trades: Sequence[TradeExcursion]) -> float:
+    """Mean MFE / mean MAE (Sweeney's edge ratio).
+
+    Returns ``0.0`` for empty input or when mean MAE is zero (caller
+    distinguishes "no losses" via ``mean_mae == 0``).
+    """
+    avg_mfe = mean_mfe(trades)
+    avg_mae = mean_mae(trades)
+    if avg_mae == 0.0:
+        return 0.0
+    return avg_mfe / avg_mae
+
+
+def trade_efficiency(trades: Sequence[TradeExcursion]) -> float:
+    """Average ``pnl / mfe`` for winning trades.
+
+    Tells you how much of the favourable excursion the strategy
+    captured. ``1.0`` = exited at the high; ``0.5`` = gave back half;
+    negative is impossible by construction (a winning trade has
+    pnl > 0 and mfe ≥ pnl). Returns ``0.0`` if no winning trades or
+    if all wins have ``mfe == 0`` (degenerate).
+    """
+    eligible = [t for t in trades if t.pnl > 0 and t.mfe > 0]
+    if not eligible:
+        return 0.0
+    return sum(t.pnl / t.mfe for t in eligible) / len(eligible)
+
+
+def adverse_efficiency(trades: Sequence[TradeExcursion]) -> float:
+    """Average ``|pnl| / mae`` for losing trades.
+
+    Tells you how much of the adverse excursion the loss captured.
+    A losing trade with pnl == -mae stopped at the worst tick (1.0);
+    a tighter stop yields ``< 1.0``. Returns ``0.0`` if no losing
+    trades or all losses have ``mae == 0``.
+    """
+    eligible = [t for t in trades if t.pnl < 0 and t.mae > 0]
+    if not eligible:
+        return 0.0
+    return sum(abs(t.pnl) / t.mae for t in eligible) / len(eligible)
+
+
+__all__ = [
+    "TradeExcursion",
+    "adverse_efficiency",
+    "edge_ratio",
+    "max_mae",
+    "max_mfe",
+    "mean_mae",
+    "mean_mfe",
+    "trade_efficiency",
+]

--- a/tests/test_excursion_stats.py
+++ b/tests/test_excursion_stats.py
@@ -1,0 +1,223 @@
+"""Tests for MAE/MFE excursion analytics (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.excursion_stats import (
+    TradeExcursion,
+    adverse_efficiency,
+    edge_ratio,
+    max_mae,
+    max_mfe,
+    mean_mae,
+    mean_mfe,
+    trade_efficiency,
+)
+
+
+# ---------------------------------------------------------------------------
+# TradeExcursion DTO
+# ---------------------------------------------------------------------------
+
+
+class TestTradeExcursion:
+    def test_valid_construction(self):
+        t = TradeExcursion(pnl=10.0, mfe=15.0, mae=3.0)
+        assert t.pnl == 10.0
+        assert t.mfe == 15.0
+        assert t.mae == 3.0
+
+    def test_negative_mfe_rejected(self):
+        with pytest.raises(ValueError, match="mfe must be"):
+            TradeExcursion(pnl=10.0, mfe=-1.0, mae=3.0)
+
+    def test_negative_mae_rejected(self):
+        with pytest.raises(ValueError, match="mae must be"):
+            TradeExcursion(pnl=10.0, mfe=15.0, mae=-1.0)
+
+    def test_zero_excursions_allowed(self):
+        # Trade closed instantly with no path data.
+        t = TradeExcursion(pnl=0.0, mfe=0.0, mae=0.0)
+        assert t.mfe == 0.0
+        assert t.mae == 0.0
+
+    def test_frozen(self):
+        t = TradeExcursion(pnl=10.0, mfe=15.0, mae=3.0)
+        with pytest.raises(Exception):
+            t.pnl = 99.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# mean_mae / max_mae
+# ---------------------------------------------------------------------------
+
+
+class TestMAE:
+    def test_mean_empty_returns_zero(self):
+        assert mean_mae([]) == 0.0
+
+    def test_max_empty_returns_zero(self):
+        assert max_mae([]) == 0.0
+
+    def test_mean_known_value(self):
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=15.0, mae=2.0),
+            TradeExcursion(pnl=-5.0, mfe=3.0, mae=8.0),
+            TradeExcursion(pnl=20.0, mfe=25.0, mae=5.0),
+        ]
+        assert mean_mae(trades) == pytest.approx(5.0)
+
+    def test_max_known_value(self):
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=15.0, mae=2.0),
+            TradeExcursion(pnl=-5.0, mfe=3.0, mae=8.0),
+            TradeExcursion(pnl=20.0, mfe=25.0, mae=5.0),
+        ]
+        assert max_mae(trades) == 8.0
+
+
+# ---------------------------------------------------------------------------
+# mean_mfe / max_mfe
+# ---------------------------------------------------------------------------
+
+
+class TestMFE:
+    def test_mean_empty_returns_zero(self):
+        assert mean_mfe([]) == 0.0
+
+    def test_max_empty_returns_zero(self):
+        assert max_mfe([]) == 0.0
+
+    def test_mean_known_value(self):
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=15.0, mae=2.0),
+            TradeExcursion(pnl=20.0, mfe=25.0, mae=5.0),
+        ]
+        assert mean_mfe(trades) == pytest.approx(20.0)
+
+    def test_max_known_value(self):
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=15.0, mae=2.0),
+            TradeExcursion(pnl=20.0, mfe=25.0, mae=5.0),
+        ]
+        assert max_mfe(trades) == 25.0
+
+
+# ---------------------------------------------------------------------------
+# edge_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeRatio:
+    def test_empty_returns_zero(self):
+        assert edge_ratio([]) == 0.0
+
+    def test_zero_mae_returns_zero(self):
+        # All trades with mae=0 → division would explode → 0.0 short-circuit.
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=15.0, mae=0.0),
+            TradeExcursion(pnl=20.0, mfe=25.0, mae=0.0),
+        ]
+        assert edge_ratio(trades) == 0.0
+
+    def test_known_value(self):
+        # mean MFE = 20, mean MAE = 5 → edge ratio 4.0.
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=15.0, mae=2.0),
+            TradeExcursion(pnl=20.0, mfe=25.0, mae=8.0),
+        ]
+        assert edge_ratio(trades) == pytest.approx(4.0)
+
+    def test_edge_below_one_means_more_pain_than_gain(self):
+        # MFE smaller than MAE on average — edge ratio < 1.
+        trades = [
+            TradeExcursion(pnl=-10.0, mfe=2.0, mae=15.0),
+            TradeExcursion(pnl=-5.0, mfe=3.0, mae=10.0),
+        ]
+        assert edge_ratio(trades) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# trade_efficiency
+# ---------------------------------------------------------------------------
+
+
+class TestTradeEfficiency:
+    def test_empty_returns_zero(self):
+        assert trade_efficiency([]) == 0.0
+
+    def test_no_winning_trades_returns_zero(self):
+        trades = [
+            TradeExcursion(pnl=-10.0, mfe=5.0, mae=12.0),
+            TradeExcursion(pnl=-5.0, mfe=2.0, mae=8.0),
+        ]
+        assert trade_efficiency(trades) == 0.0
+
+    def test_perfect_efficiency_one(self):
+        # pnl == mfe → exited at the high.
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=10.0, mae=0.0),
+            TradeExcursion(pnl=20.0, mfe=20.0, mae=2.0),
+        ]
+        assert trade_efficiency(trades) == pytest.approx(1.0)
+
+    def test_half_efficiency(self):
+        # pnl == 0.5 × mfe — gave back half.
+        trades = [
+            TradeExcursion(pnl=5.0, mfe=10.0, mae=2.0),
+            TradeExcursion(pnl=10.0, mfe=20.0, mae=3.0),
+        ]
+        assert trade_efficiency(trades) == pytest.approx(0.5)
+
+    def test_only_winning_trades_count(self):
+        # 1 win at perfect efficiency, 1 loss ignored.
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=10.0, mae=2.0),
+            TradeExcursion(pnl=-5.0, mfe=3.0, mae=8.0),
+        ]
+        assert trade_efficiency(trades) == pytest.approx(1.0)
+
+    def test_zero_mfe_winners_excluded(self):
+        # Winners with mfe=0 are degenerate and excluded.
+        trades = [
+            TradeExcursion(pnl=5.0, mfe=0.0, mae=1.0),
+        ]
+        assert trade_efficiency(trades) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# adverse_efficiency
+# ---------------------------------------------------------------------------
+
+
+class TestAdverseEfficiency:
+    def test_empty_returns_zero(self):
+        assert adverse_efficiency([]) == 0.0
+
+    def test_no_losing_trades_returns_zero(self):
+        trades = [TradeExcursion(pnl=10.0, mfe=15.0, mae=2.0)]
+        assert adverse_efficiency(trades) == 0.0
+
+    def test_stopped_at_worst_tick_returns_one(self):
+        # |pnl| == mae on every loss → adverse_efficiency = 1.0.
+        trades = [
+            TradeExcursion(pnl=-10.0, mfe=2.0, mae=10.0),
+            TradeExcursion(pnl=-5.0, mfe=1.0, mae=5.0),
+        ]
+        assert adverse_efficiency(trades) == pytest.approx(1.0)
+
+    def test_tight_stop_yields_lower_adverse(self):
+        # Loss only 50 % of MAE — exited before worst tick.
+        trades = [
+            TradeExcursion(pnl=-5.0, mfe=2.0, mae=10.0),
+            TradeExcursion(pnl=-5.0, mfe=1.0, mae=10.0),
+        ]
+        assert adverse_efficiency(trades) == pytest.approx(0.5)
+
+    def test_only_losing_trades_count(self):
+        trades = [
+            TradeExcursion(pnl=10.0, mfe=15.0, mae=2.0),
+            TradeExcursion(pnl=-10.0, mfe=2.0, mae=10.0),
+        ]
+        assert adverse_efficiency(trades) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

Pure-function helpers operating on a sequence of ``TradeExcursion`` records — one per closed trade carrying terminal pnl plus the most adverse (MAE) and most favourable (MFE) mark-to-market levels seen between entry and exit.

These metrics can't be derived from terminal pnl alone; they're the explicit follow-up flagged in ``engine.core.trade_stats:31`` (#346) as out-of-scope. Now shipped.

Adds gh#97 KPIs **64** (Maximum Adverse Excursion), **65** (Maximum Favourable Excursion), **66** (edge ratio), **67** (trade efficiency).

## What ships

- ``TradeExcursion`` — frozen dataclass with ``pnl``, ``mfe``, ``mae``. ``__post_init__`` rejects negative excursions (mfe and mae are positive magnitudes by construction).
- ``mean_mae`` / ``max_mae`` — average and worst single-trade adverse excursion.
- ``mean_mfe`` / ``max_mfe`` — average and best single-trade favourable excursion.
- ``edge_ratio(trades)`` — Sweeney's mean MFE / mean MAE. ``> 1`` means upside excursion bigger than downside; ``< 1`` means more pain than gain in flight.
- ``trade_efficiency(trades)`` — average ``pnl / mfe`` over winning trades. ``1.0`` = exited at the high; ``0.5`` = gave back half. Tells you how much of the favourable excursion the strategy captured.
- ``adverse_efficiency(trades)`` — bonus. Average ``|pnl| / mae`` over losing trades. ``1.0`` = stopped at worst tick; tighter stops yield lower values.

## Conventions

- ``mfe``, ``mae`` are positive magnitudes (no sign convention coupling to long/short).
- All helpers return ``0.0`` for empty input or for the degenerate cases described in their docstrings (e.g. zero MAE with positive MFE → edge ratio 0.0).
- Long vs short side encoded by the caller before constructing the DTO.

## Out of scope

- Bar-level path reconstruction (caller already collapses each trade to its (pnl, mfe, mae) summary).
- Time-to-MFE / time-to-MAE (separate slice — needs timestamps).
- Per-symbol / per-strategy rollups.

## Test plan

- [x] 28 new unit tests in ``tests/test_excursion_stats.py``:
  - ``TradeExcursion`` (5 cases incl. negative-rejection, frozen)
  - ``mean_mae`` / ``max_mae`` (4 cases)
  - ``mean_mfe`` / ``max_mfe`` (4 cases)
  - ``edge_ratio`` (4 cases incl. zero-MAE → 0.0, edge<1 detection)
  - ``trade_efficiency`` (5 cases incl. perfect=1.0, half=0.5, zero-MFE excluded)
  - ``adverse_efficiency`` (4 cases incl. stopped-at-worst=1.0, tight-stop=0.5)
- [x] Full local suite green: ``2554 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted suite: 28/28 pass in 0.07 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)