### PR TITLE
feat(metrics): cumulative returns + return-stream comparison (gh#97)

### DIFF
--- a/engine/core/cumulative_returns.py
+++ b/engine/core/cumulative_returns.py
@@ -1,0 +1,170 @@
+"""Cumulative return + return-stream comparison helpers (gh#97 follow-up).
+
+Pure-function helpers operating on flat sequences of period returns
+(or equity curves). Provides the per-bar compounded series, log-return
+conversion, equity reconstruction, and pairwise comparison primitives
+that the chart layer needs without instantiating a full report.
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 1   Total cumulative return       — ``cumulative_returns`` last bar
+- 2   Cumulative return series      — ``cumulative_returns``
+- 3   Equity from returns           — ``equity_curve_from_returns``
+- 70  Log returns                   — ``log_returns``
+- 71  Active return series          — ``active_returns``
+- 72  Tracking-error stream         — ``tracking_error``
+- 73  Beating-benchmark hit rate    — ``beating_benchmark_pct``
+
+Conventions:
+
+- ``cumulative_returns(returns)`` returns a list the same length as
+  the input. Each element is the compounded return up to and including
+  that bar (so the first bar equals ``returns[0]``).
+- All helpers return ``[]`` or ``0.0`` for empty input rather than
+  raising.
+- Length-mismatched comparison helpers raise ``ValueError``.
+
+Out of scope:
+- Calendar-period rollups (already in ``engine.core.time_metrics``).
+- Rolling-window metrics (already in ``engine.core.rolling_metrics``).
+- Drawdown analytics (already in ``engine.core.drawdown_analytics``).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+def cumulative_returns(returns: Sequence[float]) -> list[float]:
+    """Per-bar compounded cumulative return.
+
+    ``cumulative[i] = ∏(1 + r_j) - 1`` for ``j ≤ i``. Empty input → ``[]``.
+    """
+    if not returns:
+        return []
+    out: list[float] = []
+    product = 1.0
+    for r in returns:
+        product *= 1.0 + r
+        out.append(product - 1.0)
+    return out
+
+
+def equity_curve_from_returns(
+    returns: Sequence[float], *, initial_value: float = 1.0
+) -> list[float]:
+    """Reconstruct equity curve from period returns.
+
+    Returns a list of length ``len(returns) + 1``. The first element
+    is ``initial_value``; subsequent bars compound forward. Empty
+    returns → ``[initial_value]``.
+    """
+    if initial_value <= 0:
+        raise ValueError(f"initial_value must be > 0; got {initial_value}")
+    out = [initial_value]
+    for r in returns:
+        out.append(out[-1] * (1.0 + r))
+    return out
+
+
+def log_returns(returns: Sequence[float]) -> list[float]:
+    """Convert simple returns to log returns via ``ln(1 + r)``.
+
+    Returns matching length. Inputs ``r <= -1`` raise ``ValueError``
+    (would imply equity went to ≤ 0; log undefined).
+    """
+    out: list[float] = []
+    for r in returns:
+        if r <= -1.0:
+            raise ValueError(
+                f"return must be > -1 (equity > 0); got {r}"
+            )
+        out.append(math.log(1.0 + r))
+    return out
+
+
+def returns_from_equity(equity: Sequence[float]) -> list[float]:
+    """Compute per-bar simple returns from an equity curve.
+
+    Returns a list of length ``len(equity) - 1``. Empty / single-point
+    input → ``[]``. Non-positive previous bars yield ``0.0`` (avoids
+    divide-by-zero) so this works on stub data.
+    """
+    n = len(equity)
+    if n < 2:
+        return []
+    out: list[float] = []
+    for i in range(1, n):
+        prev = equity[i - 1]
+        if prev <= 0:
+            out.append(0.0)
+        else:
+            out.append((equity[i] - prev) / prev)
+    return out
+
+
+def active_returns(
+    portfolio: Sequence[float], benchmark: Sequence[float]
+) -> list[float]:
+    """Per-bar excess return over a benchmark.
+
+    Both inputs must have identical length; mismatch raises
+    ``ValueError``. Empty inputs → ``[]``.
+    """
+    if len(portfolio) != len(benchmark):
+        raise ValueError(
+            f"length mismatch: {len(portfolio)} vs {len(benchmark)}"
+        )
+    return [p - b for p, b in zip(portfolio, benchmark)]
+
+
+def tracking_error(
+    portfolio: Sequence[float],
+    benchmark: Sequence[float],
+    *,
+    annualisation_factor: int = 252,
+) -> float:
+    """Annualised standard deviation of active returns.
+
+    ``TE = stdev(active) × √(annualisation_factor)``. Returns ``0.0``
+    for fewer than 2 points. ``annualisation_factor <= 0`` rejected.
+    """
+    if annualisation_factor <= 0:
+        raise ValueError("annualisation_factor must be > 0")
+    active = active_returns(portfolio, benchmark)
+    n = len(active)
+    if n < 2:
+        return 0.0
+    m = sum(active) / n
+    var = sum((x - m) ** 2 for x in active) / (n - 1)
+    return math.sqrt(var) * math.sqrt(annualisation_factor)
+
+
+def beating_benchmark_pct(
+    portfolio: Sequence[float], benchmark: Sequence[float]
+) -> float:
+    """Fraction of bars where portfolio strictly beats benchmark.
+
+    Empty input → ``0.0``. Length mismatch → ``ValueError``. Ties
+    (``p == b``) are *not* counted as beating.
+    """
+    if len(portfolio) != len(benchmark):
+        raise ValueError(
+            f"length mismatch: {len(portfolio)} vs {len(benchmark)}"
+        )
+    if not portfolio:
+        return 0.0
+    wins = sum(1 for p, b in zip(portfolio, benchmark) if p > b)
+    return wins / len(portfolio)
+
+
+__all__ = [
+    "active_returns",
+    "beating_benchmark_pct",
+    "cumulative_returns",
+    "equity_curve_from_returns",
+    "log_returns",
+    "returns_from_equity",
+    "tracking_error",
+]

--- a/tests/test_cumulative_returns.py
+++ b/tests/test_cumulative_returns.py
@@ -1,0 +1,253 @@
+"""Tests for cumulative returns + return-stream comparison (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.cumulative_returns import (
+    active_returns,
+    beating_benchmark_pct,
+    cumulative_returns,
+    equity_curve_from_returns,
+    log_returns,
+    returns_from_equity,
+    tracking_error,
+)
+
+
+# ---------------------------------------------------------------------------
+# cumulative_returns
+# ---------------------------------------------------------------------------
+
+
+class TestCumulativeReturns:
+    def test_empty_returns_empty(self):
+        assert cumulative_returns([]) == []
+
+    def test_first_bar_equals_first_return(self):
+        out = cumulative_returns([0.05, 0.10, -0.02])
+        assert out[0] == pytest.approx(0.05)
+
+    def test_compounding_known_value(self):
+        # Three +1 % bars → (1.01)^3 - 1 ≈ 0.030301.
+        out = cumulative_returns([0.01, 0.01, 0.01])
+        assert out[-1] == pytest.approx(0.030301, rel=1e-9)
+
+    def test_loss_then_recovery(self):
+        # -10% then +10% → -0.01.
+        out = cumulative_returns([-0.10, 0.10])
+        assert out[-1] == pytest.approx(-0.01, rel=1e-9)
+
+    def test_output_length_matches_input(self):
+        out = cumulative_returns([0.01, 0.02, 0.03, 0.04, 0.05])
+        assert len(out) == 5
+
+
+# ---------------------------------------------------------------------------
+# equity_curve_from_returns
+# ---------------------------------------------------------------------------
+
+
+class TestEquityCurveFromReturns:
+    def test_empty_returns_initial_only(self):
+        assert equity_curve_from_returns([]) == [1.0]
+
+    def test_default_initial_one(self):
+        out = equity_curve_from_returns([0.10])
+        assert out == [1.0, pytest.approx(1.10)]
+
+    def test_custom_initial(self):
+        out = equity_curve_from_returns([0.10, -0.05], initial_value=100.0)
+        # 100 → 110 → 104.5
+        assert out[0] == 100.0
+        assert out[1] == pytest.approx(110.0)
+        assert out[2] == pytest.approx(104.5)
+
+    def test_zero_initial_rejected(self):
+        with pytest.raises(ValueError, match="initial_value"):
+            equity_curve_from_returns([0.10], initial_value=0.0)
+
+    def test_negative_initial_rejected(self):
+        with pytest.raises(ValueError, match="initial_value"):
+            equity_curve_from_returns([0.10], initial_value=-100.0)
+
+    def test_length_is_returns_plus_one(self):
+        out = equity_curve_from_returns([0.01] * 5)
+        assert len(out) == 6
+
+
+# ---------------------------------------------------------------------------
+# log_returns
+# ---------------------------------------------------------------------------
+
+
+class TestLogReturns:
+    def test_empty_returns_empty(self):
+        assert log_returns([]) == []
+
+    def test_zero_input_zero_output(self):
+        out = log_returns([0.0, 0.0, 0.0])
+        for v in out:
+            assert v == pytest.approx(0.0)
+
+    def test_known_value(self):
+        # ln(1.10) ≈ 0.09531.
+        out = log_returns([0.10])
+        assert out[0] == pytest.approx(math.log(1.10))
+
+    def test_minus_one_rejected(self):
+        with pytest.raises(ValueError, match="return must be"):
+            log_returns([-1.0])
+
+    def test_below_minus_one_rejected(self):
+        with pytest.raises(ValueError, match="return must be"):
+            log_returns([0.05, -1.5])
+
+    def test_log_returns_sum_to_log_of_total(self):
+        # Identity: sum(log_returns) == ln(1 + total_compounded_return).
+        simple = [0.01, -0.02, 0.03, -0.01]
+        logs = log_returns(simple)
+        compounded = 1.0
+        for r in simple:
+            compounded *= 1.0 + r
+        assert sum(logs) == pytest.approx(math.log(compounded), rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# returns_from_equity
+# ---------------------------------------------------------------------------
+
+
+class TestReturnsFromEquity:
+    def test_empty_returns_empty(self):
+        assert returns_from_equity([]) == []
+
+    def test_single_point_returns_empty(self):
+        assert returns_from_equity([100.0]) == []
+
+    def test_known_values(self):
+        # 100 → 110 → 104.5 → returns 0.10, -0.05.
+        out = returns_from_equity([100.0, 110.0, 104.5])
+        assert out == [pytest.approx(0.10), pytest.approx(-0.05)]
+
+    def test_length_is_equity_minus_one(self):
+        out = returns_from_equity([100.0, 105.0, 110.0, 115.0])
+        assert len(out) == 3
+
+    def test_zero_previous_yields_zero(self):
+        # Stub-safe: zero previous bar yields 0.0 instead of divide error.
+        out = returns_from_equity([0.0, 100.0, 110.0])
+        assert out[0] == 0.0
+        assert out[1] == pytest.approx(0.10)
+
+    def test_negative_previous_yields_zero(self):
+        # Defensive — should never happen in real data but must not crash.
+        out = returns_from_equity([-100.0, 100.0])
+        assert out[0] == 0.0
+
+    def test_round_trip_with_equity_curve(self):
+        # Inverse of equity_curve_from_returns.
+        original = [0.01, -0.02, 0.03, -0.01]
+        equity = equity_curve_from_returns(original, initial_value=100.0)
+        recovered = returns_from_equity(equity)
+        for o, r in zip(original, recovered):
+            assert r == pytest.approx(o, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# active_returns
+# ---------------------------------------------------------------------------
+
+
+class TestActiveReturns:
+    def test_empty_returns_empty(self):
+        assert active_returns([], []) == []
+
+    def test_known_values(self):
+        out = active_returns([0.10, 0.05], [0.08, 0.06])
+        assert out == [pytest.approx(0.02), pytest.approx(-0.01)]
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            active_returns([0.01, 0.02], [0.01, 0.02, 0.03])
+
+    def test_zero_active_when_identical(self):
+        out = active_returns([0.01, 0.02, 0.03], [0.01, 0.02, 0.03])
+        assert all(v == pytest.approx(0.0) for v in out)
+
+
+# ---------------------------------------------------------------------------
+# tracking_error
+# ---------------------------------------------------------------------------
+
+
+class TestTrackingError:
+    def test_empty_returns_zero(self):
+        assert tracking_error([], []) == 0.0
+
+    def test_single_point_returns_zero(self):
+        assert tracking_error([0.01], [0.01]) == 0.0
+
+    def test_identical_streams_zero_te(self):
+        out = tracking_error([0.01, 0.02, 0.03], [0.01, 0.02, 0.03])
+        assert out == pytest.approx(0.0, abs=1e-12)
+
+    def test_constant_active_zero_te(self):
+        # Constant excess return → no variance → TE 0.
+        out = tracking_error(
+            [0.05, 0.05, 0.05, 0.05], [0.02, 0.02, 0.02, 0.02]
+        )
+        assert out == pytest.approx(0.0, abs=1e-12)
+
+    def test_non_constant_active_positive_te(self):
+        out = tracking_error(
+            [0.10, -0.05, 0.10, -0.05], [0.05, 0.05, 0.05, 0.05]
+        )
+        assert out > 0
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            tracking_error([0.01], [0.01, 0.02])
+
+    def test_zero_annualisation_rejected(self):
+        with pytest.raises(ValueError, match="annualisation_factor"):
+            tracking_error([0.01, 0.02], [0.01, 0.02], annualisation_factor=0)
+
+    def test_negative_annualisation_rejected(self):
+        with pytest.raises(ValueError, match="annualisation_factor"):
+            tracking_error([0.01, 0.02], [0.01, 0.02], annualisation_factor=-1)
+
+
+# ---------------------------------------------------------------------------
+# beating_benchmark_pct
+# ---------------------------------------------------------------------------
+
+
+class TestBeatingBenchmarkPct:
+    def test_empty_returns_zero(self):
+        assert beating_benchmark_pct([], []) == 0.0
+
+    def test_all_beat(self):
+        out = beating_benchmark_pct([0.05, 0.06, 0.07], [0.01, 0.02, 0.03])
+        assert out == pytest.approx(1.0)
+
+    def test_none_beat(self):
+        out = beating_benchmark_pct([0.01, 0.02, 0.03], [0.05, 0.06, 0.07])
+        assert out == pytest.approx(0.0)
+
+    def test_mixed(self):
+        # 2 of 4 beat.
+        out = beating_benchmark_pct(
+            [0.10, 0.01, 0.10, 0.01], [0.05, 0.05, 0.05, 0.05]
+        )
+        assert out == pytest.approx(0.5)
+
+    def test_ties_not_counted_as_beating(self):
+        out = beating_benchmark_pct([0.05, 0.05], [0.05, 0.05])
+        assert out == pytest.approx(0.0)
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            beating_benchmark_pct([0.01], [0.01, 0.02])


### PR DESCRIPTION
## Summary

Pure-function helpers operating on flat sequences of period returns (or equity curves). Provides per-bar compounded series, log-return conversion, equity reconstruction, and pairwise comparison primitives — the chart-layer foundation for return-vs-benchmark plots without instantiating a full report.

Adds gh#97 KPIs **1** (total cumulative return), **2** (cumulative return series), **3** (equity from returns), **70** (log returns), **71** (active return series), **72** (tracking error), **73** (beating-benchmark hit rate).

## What ships

- ``cumulative_returns(returns)`` — per-bar ``∏(1 + r_j) - 1``. Same length as input.
- ``equity_curve_from_returns(returns, *, initial_value=1.0)`` — reconstructs equity. Length N+1; starts at ``initial_value``; rejects non-positive ``initial_value``.
- ``log_returns(returns)`` — ``ln(1 + r)`` per bar; rejects ``r <= -1`` (equity → 0).
- ``returns_from_equity(equity)`` — inverse of ``equity_curve_from_returns``. Zero / negative previous bars yield ``0.0`` (stub-safe).
- ``active_returns(portfolio, benchmark)`` — per-bar excess.
- ``tracking_error(portfolio, benchmark, *, annualisation_factor=252)`` — annualised stdev of active returns.
- ``beating_benchmark_pct(portfolio, benchmark)`` — fraction of bars where portfolio strictly beats benchmark; ties not counted as beating.

## Round-trip identity

``returns_from_equity(equity_curve_from_returns(r)) == r`` (within float tolerance) — covered by an explicit test.

## Out of scope

- Calendar-period rollups (already in ``engine.core.time_metrics``).
- Rolling-window metrics (already in ``engine.core.rolling_metrics``).
- Drawdown analytics (already in ``engine.core.drawdown_analytics``).

## Test plan

- [x] 42 new unit tests in ``tests/test_cumulative_returns.py``:
  - ``cumulative_returns`` (5 cases incl. compounding identity, loss-then-recovery)
  - ``equity_curve_from_returns`` (6 cases incl. zero/negative initial rejection)
  - ``log_returns`` (6 cases incl. ``r <= -1`` rejection, sum-to-log-of-total identity)
  - ``returns_from_equity`` (7 cases incl. round-trip identity, stub-safe zero/negative previous)
  - ``active_returns`` (4 cases)
  - ``tracking_error`` (8 cases incl. constant-active=0, length validation, annualisation validation)
  - ``beating_benchmark_pct`` (6 cases incl. ties-not-counted)
- [x] Full local suite green: ``2596 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted suite: 42/42 pass in 0.08 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)