### PR TITLE
feat(metrics): alpha/beta + capture ratios (gh#97)

### DIFF
--- a/engine/core/benchmark_comparison.py
+++ b/engine/core/benchmark_comparison.py
@@ -1,0 +1,227 @@
+"""Alpha / beta / capture ratio helpers (gh#97 follow-up).
+
+Pure-function helpers for CAPM-style benchmark-relative metrics.
+Complements the variance decomposition in
+``engine.core.portfolio_concentration`` (#341) and the active-return
+streams in ``engine.core.cumulative_returns`` (#349) by adding the
+single-number alpha / beta / capture-ratio summaries that benchmark
+comparison reports surface.
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 36  Alpha (Jensen)               — ``jensen_alpha``
+- 37  Beta                         — ``beta``
+- 75  Up-market capture ratio      — ``up_capture_ratio``
+- 76  Down-market capture ratio    — ``down_capture_ratio``
+- 77  Capture ratio (up/down)      — ``capture_ratio``
+
+Conventions:
+
+- All inputs are *period* returns (e.g. daily). The caller passes an
+  annualisation factor (default 252) so we can produce annualised
+  alpha. Beta is unit-less.
+- Length-mismatched inputs raise ``ValueError``.
+- Empty inputs / fewer-than-2 points / zero-variance benchmark return
+  ``0.0``.
+
+Out of scope:
+- Treynor-Mazuy / Henriksson-Merton timing alpha.
+- Multi-factor (Fama-French) decomposition — separate slice.
+- Rolling alpha / beta — analogous slice when needed.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+def _mean(xs: Sequence[float]) -> float:
+    return sum(xs) / len(xs)
+
+
+def beta(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+) -> float:
+    """OLS slope of portfolio on benchmark returns.
+
+    Returns ``0.0`` when fewer than 2 points, length mismatch, or
+    benchmark has zero variance. A market-neutral portfolio returns
+    ``0.0``; an inverse-correlated portfolio returns negative.
+    """
+    if len(portfolio_returns) != len(benchmark_returns):
+        raise ValueError(
+            f"length mismatch: {len(portfolio_returns)} "
+            f"vs {len(benchmark_returns)}"
+        )
+    n = len(portfolio_returns)
+    if n < 2:
+        return 0.0
+    mp = _mean(portfolio_returns)
+    mb = _mean(benchmark_returns)
+    cov = (
+        sum((p - mp) * (b - mb) for p, b in zip(portfolio_returns, benchmark_returns))
+        / n
+    )
+    var_b = sum((b - mb) ** 2 for b in benchmark_returns) / n
+    # Guard against float-precision residuals from constant-input series
+    # (e.g. mean-subtracted [0.05, 0.05, 0.05] leaves ~1e-17 bits).
+    if var_b < 1e-20:
+        return 0.0
+    return cov / var_b
+
+
+def jensen_alpha(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+    *,
+    risk_free_rate: float = 0.0,
+    annualisation_factor: int = 252,
+) -> float:
+    """Annualised Jensen's alpha.
+
+    ``α = (E[Rp] - Rf) - β · (E[Rb] - Rf)`` in per-period units, then
+    multiplied by ``annualisation_factor``. Returns ``0.0`` for empty /
+    too-short inputs.
+    """
+    if annualisation_factor <= 0:
+        raise ValueError("annualisation_factor must be > 0")
+    if len(portfolio_returns) != len(benchmark_returns):
+        raise ValueError(
+            f"length mismatch: {len(portfolio_returns)} "
+            f"vs {len(benchmark_returns)}"
+        )
+    n = len(portfolio_returns)
+    if n < 2:
+        return 0.0
+    rf_period = risk_free_rate / annualisation_factor
+    b = beta(portfolio_returns, benchmark_returns)
+    excess_p = _mean(portfolio_returns) - rf_period
+    excess_b = _mean(benchmark_returns) - rf_period
+    return (excess_p - b * excess_b) * annualisation_factor
+
+
+def _compounded_return(returns: Sequence[float]) -> float:
+    """Compounded return: ``∏(1 + r) - 1``."""
+    product = 1.0
+    for r in returns:
+        product *= 1.0 + r
+    return product - 1.0
+
+
+def up_capture_ratio(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+) -> float:
+    """Compounded portfolio return / compounded benchmark return on up bars.
+
+    Filters to bars where ``benchmark > 0`` and compounds both streams.
+    Returns ``0.0`` when no up bars exist or the benchmark up-period
+    return is zero. ``> 1`` means the portfolio captured more than 100 %
+    of the up move.
+    """
+    if len(portfolio_returns) != len(benchmark_returns):
+        raise ValueError(
+            f"length mismatch: {len(portfolio_returns)} "
+            f"vs {len(benchmark_returns)}"
+        )
+    pairs = [
+        (p, b)
+        for p, b in zip(portfolio_returns, benchmark_returns)
+        if b > 0
+    ]
+    if not pairs:
+        return 0.0
+    p_compound = _compounded_return([p for p, _ in pairs])
+    b_compound = _compounded_return([b for _, b in pairs])
+    if b_compound == 0.0:
+        return 0.0
+    return p_compound / b_compound
+
+
+def down_capture_ratio(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+) -> float:
+    """Compounded portfolio return / compounded benchmark return on down bars.
+
+    Filters to bars where ``benchmark < 0``. ``< 1`` means the
+    portfolio fell less than the benchmark on down days (a good
+    defensive signal); ``> 1`` means it amplified the loss.
+    """
+    if len(portfolio_returns) != len(benchmark_returns):
+        raise ValueError(
+            f"length mismatch: {len(portfolio_returns)} "
+            f"vs {len(benchmark_returns)}"
+        )
+    pairs = [
+        (p, b)
+        for p, b in zip(portfolio_returns, benchmark_returns)
+        if b < 0
+    ]
+    if not pairs:
+        return 0.0
+    p_compound = _compounded_return([p for p, _ in pairs])
+    b_compound = _compounded_return([b for _, b in pairs])
+    if b_compound == 0.0:
+        return 0.0
+    return p_compound / b_compound
+
+
+def capture_ratio(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+) -> float:
+    """Up-capture / down-capture.
+
+    A single-number summary: ``> 1`` means asymmetric upside (great);
+    ``< 1`` means more downside than upside (bad). Returns ``0.0`` when
+    down-capture is zero (mathematically infinite — caller decides
+    display).
+    """
+    up = up_capture_ratio(portfolio_returns, benchmark_returns)
+    down = down_capture_ratio(portfolio_returns, benchmark_returns)
+    if down == 0.0:
+        return 0.0
+    return up / down
+
+
+def correlation(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+) -> float:
+    """Pearson correlation of portfolio and benchmark.
+
+    Bounded ``[-1, 1]``. Returns ``0.0`` for empty / single-point /
+    length-mismatch / zero-variance inputs.
+    """
+    if len(portfolio_returns) != len(benchmark_returns):
+        raise ValueError(
+            f"length mismatch: {len(portfolio_returns)} "
+            f"vs {len(benchmark_returns)}"
+        )
+    n = len(portfolio_returns)
+    if n < 2:
+        return 0.0
+    mp = _mean(portfolio_returns)
+    mb = _mean(benchmark_returns)
+    num = sum(
+        (p - mp) * (b - mb)
+        for p, b in zip(portfolio_returns, benchmark_returns)
+    )
+    dp = math.sqrt(sum((p - mp) ** 2 for p in portfolio_returns))
+    db = math.sqrt(sum((b - mb) ** 2 for b in benchmark_returns))
+    if dp == 0.0 or db == 0.0:
+        return 0.0
+    return num / (dp * db)
+
+
+__all__ = [
+    "beta",
+    "capture_ratio",
+    "correlation",
+    "down_capture_ratio",
+    "jensen_alpha",
+    "up_capture_ratio",
+]

--- a/tests/test_benchmark_comparison.py
+++ b/tests/test_benchmark_comparison.py
@@ -1,0 +1,219 @@
+"""Tests for alpha/beta + capture ratio helpers (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.benchmark_comparison import (
+    beta,
+    capture_ratio,
+    correlation,
+    down_capture_ratio,
+    jensen_alpha,
+    up_capture_ratio,
+)
+
+
+# ---------------------------------------------------------------------------
+# beta
+# ---------------------------------------------------------------------------
+
+
+class TestBeta:
+    def test_empty_returns_zero(self):
+        assert beta([], []) == 0.0
+
+    def test_single_point_returns_zero(self):
+        assert beta([0.01], [0.01]) == 0.0
+
+    def test_zero_variance_benchmark_returns_zero(self):
+        assert beta([0.01, 0.02, 0.03], [0.05, 0.05, 0.05]) == 0.0
+
+    def test_perfect_correlation_unit_beta(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = list(bench)
+        assert beta(port, bench) == pytest.approx(1.0)
+
+    def test_amplified_beta_two(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [2 * b for b in bench]
+        assert beta(port, bench) == pytest.approx(2.0)
+
+    def test_inverse_correlation_negative_beta(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [-b for b in bench]
+        assert beta(port, bench) == pytest.approx(-1.0)
+
+    def test_orthogonal_zero_beta(self):
+        bench = [1.0, -1.0, 1.0, -1.0]
+        port = [1.0, 1.0, -1.0, -1.0]
+        assert beta(port, bench) == pytest.approx(0.0, abs=1e-12)
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            beta([0.01, 0.02], [0.01, 0.02, 0.03])
+
+
+# ---------------------------------------------------------------------------
+# jensen_alpha
+# ---------------------------------------------------------------------------
+
+
+class TestJensenAlpha:
+    def test_empty_returns_zero(self):
+        assert jensen_alpha([], []) == 0.0
+
+    def test_single_point_returns_zero(self):
+        assert jensen_alpha([0.01], [0.01]) == 0.0
+
+    def test_perfect_replicator_zero_alpha(self):
+        # Portfolio = benchmark with rf=0 → α = 0.
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = list(bench)
+        assert jensen_alpha(port, bench) == pytest.approx(0.0, abs=1e-12)
+
+    def test_outperformance_positive_alpha(self):
+        # Portfolio = benchmark + 0.001/day on every bar.
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [b + 0.001 for b in bench]
+        assert jensen_alpha(port, bench) > 0
+
+    def test_underperformance_negative_alpha(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [b - 0.001 for b in bench]
+        assert jensen_alpha(port, bench) < 0
+
+    def test_annualisation_scales_alpha(self):
+        # Doubling annualisation factor doubles annual alpha.
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [b + 0.001 for b in bench]
+        a252 = jensen_alpha(port, bench, annualisation_factor=252)
+        a504 = jensen_alpha(port, bench, annualisation_factor=504)
+        assert a504 == pytest.approx(2 * a252, rel=1e-9)
+
+    def test_zero_annualisation_rejected(self):
+        with pytest.raises(ValueError, match="annualisation_factor"):
+            jensen_alpha([0.01, 0.02], [0.01, 0.02], annualisation_factor=0)
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            jensen_alpha([0.01], [0.01, 0.02])
+
+
+# ---------------------------------------------------------------------------
+# up_capture_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestUpCaptureRatio:
+    def test_empty_returns_zero(self):
+        assert up_capture_ratio([], []) == 0.0
+
+    def test_no_up_bars_returns_zero(self):
+        # All benchmark bars non-positive — no up market exists.
+        out = up_capture_ratio([0.01, 0.02], [-0.01, -0.02])
+        assert out == 0.0
+
+    def test_perfect_replicator_unit_capture(self):
+        out = up_capture_ratio([0.01, 0.02, -0.01], [0.01, 0.02, -0.01])
+        assert out == pytest.approx(1.0)
+
+    def test_outperforms_in_up_market(self):
+        # Portfolio doubles benchmark on up bars.
+        out = up_capture_ratio([0.02, 0.04, -0.01], [0.01, 0.02, -0.01])
+        assert out > 1.0
+
+    def test_underperforms_in_up_market(self):
+        out = up_capture_ratio([0.005, 0.01, -0.01], [0.01, 0.02, -0.01])
+        assert 0.0 < out < 1.0
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            up_capture_ratio([0.01], [0.01, 0.02])
+
+
+# ---------------------------------------------------------------------------
+# down_capture_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestDownCaptureRatio:
+    def test_empty_returns_zero(self):
+        assert down_capture_ratio([], []) == 0.0
+
+    def test_no_down_bars_returns_zero(self):
+        out = down_capture_ratio([0.01, 0.02], [0.01, 0.02])
+        assert out == 0.0
+
+    def test_perfect_replicator_unit_capture(self):
+        out = down_capture_ratio([-0.01, -0.02, 0.01], [-0.01, -0.02, 0.01])
+        assert out == pytest.approx(1.0)
+
+    def test_defensive_lower_capture(self):
+        # Portfolio falls less than benchmark on down days — defensive.
+        out = down_capture_ratio([-0.005, -0.01, 0.01], [-0.01, -0.02, 0.01])
+        assert 0.0 < out < 1.0
+
+    def test_amplified_drawdown(self):
+        out = down_capture_ratio([-0.02, -0.04, 0.01], [-0.01, -0.02, 0.01])
+        assert out > 1.0
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            down_capture_ratio([0.01], [0.01, 0.02])
+
+
+# ---------------------------------------------------------------------------
+# capture_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureRatio:
+    def test_empty_returns_zero(self):
+        assert capture_ratio([], []) == 0.0
+
+    def test_no_down_bars_returns_zero(self):
+        # Down capture undefined → capture_ratio 0.0 short-circuit.
+        out = capture_ratio([0.02, 0.03], [0.01, 0.02])
+        assert out == 0.0
+
+    def test_perfect_replicator_one(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        out = capture_ratio(bench, bench)
+        assert out == pytest.approx(1.0)
+
+    def test_asymmetric_upside_above_one(self):
+        # Up capture 1.5, down capture 0.5 → ratio 3.0.
+        bench = [0.10, -0.10]
+        port = [0.15, -0.05]  # capture 150% on up, 50% on down.
+        out = capture_ratio(port, bench)
+        assert out > 1.0
+
+
+# ---------------------------------------------------------------------------
+# correlation
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelation:
+    def test_empty_returns_zero(self):
+        assert correlation([], []) == 0.0
+
+    def test_single_point_returns_zero(self):
+        assert correlation([0.01], [0.01]) == 0.0
+
+    def test_perfect_correlation_one(self):
+        out = correlation([1.0, 2.0, 3.0], [2.0, 4.0, 6.0])
+        assert out == pytest.approx(1.0)
+
+    def test_perfect_anti_correlation(self):
+        out = correlation([1.0, 2.0, 3.0], [3.0, 2.0, 1.0])
+        assert out == pytest.approx(-1.0)
+
+    def test_zero_variance_input_zero(self):
+        out = correlation([1.0, 1.0, 1.0], [1.0, 2.0, 3.0])
+        assert out == 0.0
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            correlation([0.01], [0.01, 0.02])


### PR DESCRIPTION
## Summary

Pure-function helpers for CAPM-style benchmark-relative metrics. Complements ``variance_decomposition`` from #341 (which returns beta inside a CAPM split) and the active-return streams in ``cumulative_returns`` (#349) by adding the single-number alpha / beta / capture-ratio summaries that benchmark comparison reports surface.

Adds gh#97 KPIs **36** (Jensen's alpha), **37** (beta), **75** (up-capture), **76** (down-capture), **77** (capture ratio).

## What ships

- ``beta(portfolio, benchmark)`` — OLS slope. Inverse-correlated → negative; market-neutral → 0.
- ``jensen_alpha(portfolio, benchmark, *, risk_free_rate=0.0, annualisation_factor=252)`` — annualised ``α = (E[Rp] - Rf) - β · (E[Rb] - Rf)``.
- ``up_capture_ratio`` — compounded portfolio / benchmark on bars where benchmark > 0. ``> 1`` = captured more than 100 % of upside.
- ``down_capture_ratio`` — same on bars where benchmark < 0. ``< 1`` = defensive.
- ``capture_ratio`` — up/down. Single-number asymmetry summary.
- ``correlation`` — Pearson; ``[-1, 1]`` bounded.

## Bug-fix during development

Initial ``beta`` impl produced ``0.083`` instead of ``0.0`` on benchmark series ``[0.05, 0.05, 0.05]`` due to float-precision residuals from mean-subtraction (``0.05 - 0.05000000000000001 ≈ -1.4e-17``). Added a ``var_b < 1e-20`` epsilon guard so constant benchmarks short-circuit cleanly.

## Conventions

- Length-mismatched inputs raise ``ValueError``.
- Empty / single-point / zero-variance benchmark → ``0.0``.
- ``risk_free_rate`` is the *annualised* rate; converted per-period internally.
- ``capture_ratio`` returns ``0.0`` when down-capture is zero (mathematically infinite — caller decides display).

## Out of scope

- Treynor-Mazuy / Henriksson-Merton timing alpha.
- Multi-factor (Fama-French) decomposition — separate slice.
- Rolling alpha / beta — analogous slice when needed.

## Test plan

- [x] 38 new unit tests in ``tests/test_benchmark_comparison.py``:
  - ``beta`` (8 cases incl. perfect correlation, β=2, β=-1, orthogonal=0, zero-variance benchmark)
  - ``jensen_alpha`` (7 cases incl. perfect-replicator=0, outperformance>0, annualisation scaling)
  - ``up_capture_ratio`` (6 cases incl. no-up-bars, perfect-replicator=1, outperforms>1, underperforms<1)
  - ``down_capture_ratio`` (6 cases incl. defensive<1, amplified>1)
  - ``capture_ratio`` (4 cases incl. no-down-bars, asymmetric upside>1)
  - ``correlation`` (6 cases incl. ±1, zero-variance, validation)
- [x] Full local suite green: ``2634 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted suite: 38/38 pass in 0.07 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)