### PR TITLE
feat(metrics): rolling alpha/beta + IR/TE time series (gh#97)

### DIFF
--- a/engine/core/rolling_benchmark.py
+++ b/engine/core/rolling_benchmark.py
@@ -1,0 +1,197 @@
+"""Rolling alpha / beta / IR / tracking-error time series (gh#97 follow-up).
+
+Pure-function helpers producing the *full* rolling series of CAPM-style
+benchmark-relative metrics. Complements the full-period helpers in
+``engine.core.benchmark_comparison`` (#350) and the single-series rolling
+metrics in ``engine.core.rolling_metrics`` (#343).
+
+Coverage (numbers from gh#97 taxonomy):
+
+- 56c Rolling alpha            — ``rolling_alpha``
+- 56d Rolling beta             — ``rolling_beta``
+- 56e Rolling Information Rat. — ``rolling_information_ratio``
+- 72b Rolling tracking error   — ``rolling_tracking_error``
+
+Output convention follows ``engine.core.rolling_metrics`` (#343):
+same-length output with ``None`` for the first ``window - 1`` indices.
+
+Out of scope:
+- Rolling Treynor-Mazuy timing alpha — separate slice.
+- Rolling capture ratios — caller can compose via filter+rolling.
+- Multi-factor rolling regression.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+DEFAULT_ANNUALISATION = 252
+
+
+def _validate_window(window: int) -> None:
+    if window < 2:
+        raise ValueError("window must be >= 2")
+
+
+def _validate_pair(
+    a: Sequence[float], b: Sequence[float]
+) -> None:
+    if len(a) != len(b):
+        raise ValueError(f"length mismatch: {len(a)} vs {len(b)}")
+
+
+def _beta_window(
+    port: Sequence[float], bench: Sequence[float]
+) -> float:
+    """OLS slope of portfolio on benchmark over one window. ``0.0`` if degenerate."""
+    n = len(port)
+    if n < 2:
+        return 0.0
+    mp = sum(port) / n
+    mb = sum(bench) / n
+    cov = sum((p - mp) * (b - mb) for p, b in zip(port, bench)) / n
+    var_b = sum((b - mb) ** 2 for b in bench) / n
+    if var_b < 1e-20:
+        return 0.0
+    return cov / var_b
+
+
+def rolling_beta(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+    window: int,
+) -> list[float | None]:
+    """Rolling OLS slope of portfolio on benchmark.
+
+    ``None`` for the first ``window - 1`` indices. ``0.0`` for windows
+    where the benchmark has zero variance.
+    """
+    _validate_window(window)
+    _validate_pair(portfolio_returns, benchmark_returns)
+    n = len(portfolio_returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    for i in range(window - 1, n):
+        out[i] = _beta_window(
+            portfolio_returns[i - window + 1 : i + 1],
+            benchmark_returns[i - window + 1 : i + 1],
+        )
+    return out
+
+
+def rolling_alpha(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+    window: int,
+    *,
+    risk_free_rate: float = 0.0,
+    annualisation_factor: int = DEFAULT_ANNUALISATION,
+) -> list[float | None]:
+    """Rolling annualised Jensen's alpha.
+
+    Per-window: ``α = (E[Rp] - Rf) - β · (E[Rb] - Rf)`` × ``ann``.
+    """
+    _validate_window(window)
+    if annualisation_factor <= 0:
+        raise ValueError("annualisation_factor must be > 0")
+    _validate_pair(portfolio_returns, benchmark_returns)
+    n = len(portfolio_returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    rf_period = risk_free_rate / annualisation_factor
+    for i in range(window - 1, n):
+        port = portfolio_returns[i - window + 1 : i + 1]
+        bench = benchmark_returns[i - window + 1 : i + 1]
+        b = _beta_window(port, bench)
+        excess_p = sum(port) / window - rf_period
+        excess_b = sum(bench) / window - rf_period
+        out[i] = (excess_p - b * excess_b) * annualisation_factor
+    return out
+
+
+def _stdev(xs: Sequence[float], *, ddof: int = 1) -> float:
+    n = len(xs)
+    if n - ddof <= 0:
+        return 0.0
+    m = sum(xs) / n
+    var = sum((x - m) ** 2 for x in xs) / (n - ddof)
+    return math.sqrt(var)
+
+
+def rolling_tracking_error(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+    window: int,
+    *,
+    annualisation_factor: int = DEFAULT_ANNUALISATION,
+) -> list[float | None]:
+    """Rolling annualised stdev of active returns.
+
+    ``TE = stdev(active) × √(annualisation_factor)``. Constant-active
+    windows (zero variance) return ``0.0``.
+    """
+    _validate_window(window)
+    if annualisation_factor <= 0:
+        raise ValueError("annualisation_factor must be > 0")
+    _validate_pair(portfolio_returns, benchmark_returns)
+    n = len(portfolio_returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    sqrt_ann = math.sqrt(annualisation_factor)
+    for i in range(window - 1, n):
+        active = [
+            p - b
+            for p, b in zip(
+                portfolio_returns[i - window + 1 : i + 1],
+                benchmark_returns[i - window + 1 : i + 1],
+            )
+        ]
+        out[i] = _stdev(active) * sqrt_ann
+    return out
+
+
+def rolling_information_ratio(
+    portfolio_returns: Sequence[float],
+    benchmark_returns: Sequence[float],
+    window: int,
+    *,
+    annualisation_factor: int = DEFAULT_ANNUALISATION,
+) -> list[float | None]:
+    """Rolling annualised Information Ratio.
+
+    ``IR = (E[Rp] - E[Rb]) / stdev(active) × √(ann)``. Returns ``0.0``
+    for zero-variance active streams (degenerate constant excess).
+    """
+    _validate_window(window)
+    if annualisation_factor <= 0:
+        raise ValueError("annualisation_factor must be > 0")
+    _validate_pair(portfolio_returns, benchmark_returns)
+    n = len(portfolio_returns)
+    out: list[float | None] = [None] * n
+    if n < window:
+        return out
+    sqrt_ann = math.sqrt(annualisation_factor)
+    for i in range(window - 1, n):
+        port = portfolio_returns[i - window + 1 : i + 1]
+        bench = benchmark_returns[i - window + 1 : i + 1]
+        active = [p - b for p, b in zip(port, bench)]
+        sd = _stdev(active)
+        if sd == 0.0:
+            out[i] = 0.0
+        else:
+            mean_active = sum(active) / window
+            out[i] = mean_active / sd * sqrt_ann
+    return out
+
+
+__all__ = [
+    "DEFAULT_ANNUALISATION",
+    "rolling_alpha",
+    "rolling_beta",
+    "rolling_information_ratio",
+    "rolling_tracking_error",
+]

--- a/tests/test_rolling_benchmark.py
+++ b/tests/test_rolling_benchmark.py
@@ -1,0 +1,222 @@
+"""Tests for rolling alpha/beta + IR/TE time series (gh#97 follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.core.rolling_benchmark import (
+    DEFAULT_ANNUALISATION,
+    rolling_alpha,
+    rolling_beta,
+    rolling_information_ratio,
+    rolling_tracking_error,
+)
+
+
+# ---------------------------------------------------------------------------
+# rolling_beta
+# ---------------------------------------------------------------------------
+
+
+class TestRollingBeta:
+    def test_empty_returns_empty(self):
+        assert rolling_beta([], [], 3) == []
+
+    def test_window_too_large_all_none(self):
+        assert rolling_beta([0.01, 0.02], [0.01, 0.02], 5) == [None, None]
+
+    def test_first_indices_none(self):
+        out = rolling_beta(
+            [0.01, 0.02, 0.03, 0.04, 0.05],
+            [0.01, 0.02, 0.03, 0.04, 0.05],
+            3,
+        )
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_unit_beta_for_replicator(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = list(bench)
+        out = rolling_beta(port, bench, 3)
+        for v in out[2:]:
+            assert v == pytest.approx(1.0)
+
+    def test_amplified_beta_two(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [2 * b for b in bench]
+        out = rolling_beta(port, bench, 3)
+        for v in out[2:]:
+            assert v == pytest.approx(2.0)
+
+    def test_inverse_beta_negative(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [-b for b in bench]
+        out = rolling_beta(port, bench, 3)
+        for v in out[2:]:
+            assert v == pytest.approx(-1.0)
+
+    def test_constant_benchmark_zero_beta(self):
+        out = rolling_beta(
+            [0.01, 0.02, 0.03], [0.05, 0.05, 0.05], 3
+        )
+        assert out[2] == 0.0
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            rolling_beta([0.01, 0.02], [0.01, 0.02, 0.03], 2)
+
+    def test_window_one_rejected(self):
+        with pytest.raises(ValueError, match="window must be"):
+            rolling_beta([0.01, 0.02], [0.01, 0.02], 1)
+
+
+# ---------------------------------------------------------------------------
+# rolling_alpha
+# ---------------------------------------------------------------------------
+
+
+class TestRollingAlpha:
+    def test_empty_returns_empty(self):
+        assert rolling_alpha([], [], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_alpha(
+            [0.01, 0.02, 0.03], [0.01, 0.02, 0.03], 3
+        )
+        assert out[:2] == [None, None]
+
+    def test_perfect_replicator_zero_alpha(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = list(bench)
+        out = rolling_alpha(port, bench, 3)
+        for v in out[2:]:
+            assert v == pytest.approx(0.0, abs=1e-12)
+
+    def test_outperformance_positive_alpha(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [b + 0.001 for b in bench]
+        out = rolling_alpha(port, bench, 3)
+        for v in out[2:]:
+            assert v > 0
+
+    def test_underperformance_negative_alpha(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = [b - 0.001 for b in bench]
+        out = rolling_alpha(port, bench, 3)
+        for v in out[2:]:
+            assert v < 0
+
+    def test_zero_annualisation_rejected(self):
+        with pytest.raises(ValueError, match="annualisation_factor"):
+            rolling_alpha([0.01, 0.02], [0.01, 0.02], 2, annualisation_factor=0)
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            rolling_alpha([0.01], [0.01, 0.02], 2)
+
+    def test_default_annualisation(self):
+        assert DEFAULT_ANNUALISATION == 252
+
+
+# ---------------------------------------------------------------------------
+# rolling_tracking_error
+# ---------------------------------------------------------------------------
+
+
+class TestRollingTrackingError:
+    def test_empty_returns_empty(self):
+        assert rolling_tracking_error([], [], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_tracking_error(
+            [0.01, 0.02, 0.03], [0.01, 0.02, 0.03], 3
+        )
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_perfect_replicator_zero_te(self):
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = list(bench)
+        out = rolling_tracking_error(port, bench, 3)
+        for v in out[2:]:
+            assert v == pytest.approx(0.0, abs=1e-12)
+
+    def test_constant_active_zero_te(self):
+        # Constant excess return → no variance → TE 0.
+        out = rolling_tracking_error(
+            [0.05, 0.05, 0.05, 0.05],
+            [0.02, 0.02, 0.02, 0.02],
+            3,
+        )
+        for v in out[2:]:
+            assert v == pytest.approx(0.0, abs=1e-12)
+
+    def test_non_constant_active_positive_te(self):
+        out = rolling_tracking_error(
+            [0.10, -0.05, 0.10, -0.05],
+            [0.05, 0.05, 0.05, 0.05],
+            3,
+        )
+        for v in out[2:]:
+            assert v > 0
+
+    def test_zero_annualisation_rejected(self):
+        with pytest.raises(ValueError, match="annualisation_factor"):
+            rolling_tracking_error(
+                [0.01, 0.02], [0.01, 0.02], 2, annualisation_factor=0
+            )
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            rolling_tracking_error([0.01], [0.01, 0.02], 2)
+
+
+# ---------------------------------------------------------------------------
+# rolling_information_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestRollingInformationRatio:
+    def test_empty_returns_empty(self):
+        assert rolling_information_ratio([], [], 3) == []
+
+    def test_first_indices_none(self):
+        out = rolling_information_ratio(
+            [0.01, 0.02, 0.03], [0.01, 0.02, 0.03], 3
+        )
+        assert out[:2] == [None, None]
+        assert out[2] is not None
+
+    def test_perfect_replicator_zero_ir(self):
+        # Active is all zero → constant → SD 0 → IR 0 short-circuit.
+        bench = [0.01, -0.02, 0.03, -0.01, 0.02]
+        port = list(bench)
+        out = rolling_information_ratio(port, bench, 3)
+        for v in out[2:]:
+            assert v == 0.0
+
+    def test_consistent_outperformance_zero_ir(self):
+        # Constant active → zero variance → IR 0.0 (degenerate).
+        out = rolling_information_ratio(
+            [0.02, 0.02, 0.02, 0.02],
+            [0.01, 0.01, 0.01, 0.01],
+            3,
+        )
+        for v in out[2:]:
+            assert v == 0.0
+
+    def test_volatile_outperformance_positive_ir(self):
+        # Uniformly above benchmark with varying excess → every window
+        # has positive mean active and non-zero SD → IR > 0.
+        out = rolling_information_ratio(
+            [0.06, 0.04, 0.05, 0.07, 0.06],
+            [0.01, 0.01, 0.01, 0.01, 0.01],
+            3,
+        )
+        for v in out[2:]:
+            assert v is not None
+            assert v > 0
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            rolling_information_ratio([0.01], [0.01, 0.02], 2)


### PR DESCRIPTION
## Summary

Pure-function helpers producing the *full* rolling series of CAPM-style benchmark-relative metrics. Complements the full-period helpers in ``engine.core.benchmark_comparison`` (#350) and the single-series rolling metrics in ``engine.core.rolling_metrics`` (#343).

Adds gh#97 KPIs **56c** (rolling alpha), **56d** (rolling beta), **56e** (rolling Information Ratio), **72b** (rolling tracking error).

## What ships

- ``rolling_beta(portfolio, benchmark, window)`` — rolling OLS slope. ``0.0`` for constant-benchmark windows (with 1e-20 epsilon guard against float residuals, same convention as the full-period helper).
- ``rolling_alpha(portfolio, benchmark, window, *, risk_free_rate=0.0, annualisation_factor=252)`` — annualised Jensen alpha per window.
- ``rolling_tracking_error(portfolio, benchmark, window, *, annualisation_factor=252)`` — annualised stdev of active returns.
- ``rolling_information_ratio(portfolio, benchmark, window, *, annualisation_factor=252)`` — annualised IR. ``0.0`` for zero-variance active streams (degenerate constant excess).

## Output convention

Same as ``engine.core.rolling_metrics`` (#343): same-length output with ``None`` for the first ``window - 1`` indices so callers can distinguish "not enough data yet" from "zero".

## Out of scope

- Rolling Treynor-Mazuy timing alpha — separate slice.
- Rolling capture ratios — caller can compose via filter+rolling.
- Multi-factor rolling regression.

## Test plan

- [x] 30 new unit tests in ``tests/test_rolling_benchmark.py``:
  - ``rolling_beta`` (9 cases incl. perfect/inverse/amplified replication, constant-benchmark guard)
  - ``rolling_alpha`` (8 cases incl. perfect-replicator=0, outperformance>0, underperformance<0)
  - ``rolling_tracking_error`` (7 cases incl. constant-active=0, validation)
  - ``rolling_information_ratio`` (6 cases incl. perfect-replicator=0, constant-outperformance=0 degenerate, volatile-outperformance>0)
- [x] Full local suite green: ``2664 passed, 9 skipped`` (the 55 errors are the pre-existing ``test_security_sev507`` / ``test_legal_qa`` DB-required baseline that depends on the CI Postgres service)
- [x] Targeted suite: 30/30 pass in 0.07 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)