### PR TITLE
fix(lint): add S108 ignore for test files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ select = [
 ignore = ["S101", "TRY003", "PLR0913"]
 
 [tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S108"]
 "engine/api/routes/*.py" = ["B008", "B904", "S105", "PLC0415", "TC001", "TC002", "TC003", "ARG001", "TRY300", "TRY301", "PLR2004", "RUF013", "E501", "PLW0603", "PT028"]
 "engine/api/auth/dependency.py" = ["B008"]
 "engine/api/auth/google.py" = ["S105", "PLC0415", "TC002"]

--- a/tests/test_sandbox_security.py
+++ b/tests/test_sandbox_security.py
@@ -106,7 +106,7 @@ class _FileWriteStrategy:
     version = "1.0.0"
 
     def on_bar(self, _state: Any, _portfolio: Any) -> list[Any]:
-        with open("/tmp/sandbox_write_test", "w") as f:  # noqa: S108
+        with open("/tmp/sandbox_write_test", "w") as f:
             f.write("pwned")
         return []
 


### PR DESCRIPTION
Fixes remaining lint errors so quality gate passes clean.