### PR TITLE
test: mock legal_acceptance dependency in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,17 @@ from engine.app import create_app
 from engine.config import settings
 from engine.db.models import Base, User
 from engine.deps import get_db
+from engine.legal.dependencies import require_legal_acceptance
+
+
+async def _noop_legal_acceptance() -> None:
+    """Test stand-in for ``require_legal_acceptance``.
+
+    The real dependency queries the ``legal_documents`` table, which many
+    test DBs (SQLite in-memory, minimal Postgres schemas) don't have. Tests
+    don't exercise legal re-acceptance flows, so we short-circuit it here.
+    """
+    return
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -63,9 +74,24 @@ def _bypass_auth(request, monkeypatch):
     """Globally bypass Bearer-token auth in tests. Patches FastAPI so every
     new app gets a dependency_override for get_current_user, covering tests
     that build their own isolated FastAPI instances. Tests in test_auth*
-    opt out so they exercise real auth behavior."""
+    opt out so they exercise real auth behavior.
+
+    Also always overrides ``require_legal_acceptance`` — the legal documents
+    table is not guaranteed to exist in every test DB, and consent flows
+    are not exercised by the suite."""
     nodeid = request.node.nodeid
     if "test_auth" in nodeid or "_requires_auth" in nodeid:
+        # Still override legal acceptance even for auth tests — those tests
+        # don't care about legal_documents, and the table may not exist.
+        from fastapi import FastAPI
+
+        original_init = FastAPI.__init__
+
+        def patched_init_auth(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+            self.dependency_overrides[require_legal_acceptance] = _noop_legal_acceptance
+
+        monkeypatch.setattr(FastAPI, "__init__", patched_init_auth)
         return
 
     from fastapi import FastAPI
@@ -76,6 +102,7 @@ def _bypass_auth(request, monkeypatch):
     def patched_init(self, *args, **kwargs):
         original_init(self, *args, **kwargs)
         self.dependency_overrides[get_current_user] = lambda: fake
+        self.dependency_overrides[require_legal_acceptance] = _noop_legal_acceptance
 
     monkeypatch.setattr(FastAPI, "__init__", patched_init)
 
@@ -84,6 +111,7 @@ def _bypass_auth(request, monkeypatch):
 async def client() -> AsyncIterator[AsyncClient]:
     app = create_app()
     app.dependency_overrides[get_current_user] = _fake_authenticated_user
+    app.dependency_overrides[require_legal_acceptance] = _noop_legal_acceptance
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
@@ -154,6 +182,7 @@ async def db_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
 
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_current_user] = _fake_authenticated_user
+    app.dependency_overrides[require_legal_acceptance] = _noop_legal_acceptance
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac

--- a/tests/test_legal_acceptance_bypass.py
+++ b/tests/test_legal_acceptance_bypass.py
@@ -1,0 +1,74 @@
+"""Regression tests for the global ``require_legal_acceptance`` test bypass.
+
+The conftest autouse fixture overrides ``require_legal_acceptance`` on every
+FastAPI app so that tests don't need a ``legal_documents`` table. These tests
+lock that contract in — if the override is ever removed, the protected routes
+would 500 against a schema-less test DB and these tests will catch it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from engine.api.router import api_router
+from engine.legal.dependencies import require_legal_acceptance
+
+
+async def _bypass_was_installed() -> bool:
+    """Build a throwaway app and confirm the override is wired."""
+    app = FastAPI()
+    app.include_router(api_router)
+    return require_legal_acceptance in app.dependency_overrides
+
+
+@pytest.mark.asyncio
+async def test_conftest_overrides_require_legal_acceptance() -> None:
+    """The autouse conftest fixture must register an override on every new app."""
+    assert await _bypass_was_installed(), (
+        "require_legal_acceptance was not overridden — tests will hit the "
+        "legal_documents table which doesn't exist in minimal test DBs."
+    )
+
+
+@pytest.mark.asyncio
+async def test_protected_route_does_not_query_legal_documents() -> None:
+    """Hit a route protected by require_legal_acceptance via the public client
+    fixture and assert no legal_documents-related error surfaces.
+
+    This is the regression that previously produced 62 failures (OperationalError:
+    no such table: legal_documents) across test_health and test_auth_e2e.
+    """
+    # Build a fresh app the same way the `client` fixture does — the autouse
+    # _bypass_auth / legal override must already be attached.
+    import uuid as _uuid
+
+    from engine.api.auth.dependency import get_current_user
+    from engine.app import create_app
+    from engine.db.models import User
+
+    app = create_app()
+    # Confirm override survived create_app's middleware/router wiring.
+    assert require_legal_acceptance in app.dependency_overrides
+
+    fake_user = User(
+        id=_uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        email="regression@example.com",
+        display_name="Regress",
+        is_active=True,
+        role="admin",
+        auth_provider="local",
+    )
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # The marketplace router has require_legal_acceptance applied; without
+        # the override this 500s against an empty SQLite DB.
+        resp = await ac.get("/api/v1/marketplace/browse")
+        # 200 or any non-5xx/non-451 response means legal_acceptance didn't fire.
+        assert resp.status_code != 451, "require_legal_acceptance was not bypassed"
+        assert resp.status_code < 500, (
+            f"Protected route errored out — legal override likely missing: {resp.status_code} {resp.text}"
+        )


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Resolve 62 failing tests caused by missing legal_documents table by mocking/overriding the legal_acceptance FastAPI dependency in the root test conftest

Closes #742
