### PR TITLE
fix(tests): override legal_acceptance dependency for all databases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,15 @@ from engine.app import create_app
 from engine.config import settings
 from engine.db.models import Base, User
 from engine.deps import get_db
+from engine.legal.dependencies import require_legal_acceptance
+
+
+async def _noop_legal_acceptance() -> None:
+    """Test stub that replaces ``require_legal_acceptance`` so route-level
+    consent enforcement never touches the (test) DB. Some test fixtures
+    only create a subset of tables — bypassing the dependency keeps them
+    from blowing up on ``legal_documents`` queries."""
+    return
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -76,6 +85,7 @@ def _bypass_auth(request, monkeypatch):
     def patched_init(self, *args, **kwargs):
         original_init(self, *args, **kwargs)
         self.dependency_overrides[get_current_user] = lambda: fake
+        self.dependency_overrides[require_legal_acceptance] = _noop_legal_acceptance
 
     monkeypatch.setattr(FastAPI, "__init__", patched_init)
 
@@ -84,6 +94,7 @@ def _bypass_auth(request, monkeypatch):
 async def client() -> AsyncIterator[AsyncClient]:
     app = create_app()
     app.dependency_overrides[get_current_user] = _fake_authenticated_user
+    app.dependency_overrides[require_legal_acceptance] = _noop_legal_acceptance
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
@@ -154,6 +165,7 @@ async def db_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
 
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_current_user] = _fake_authenticated_user
+    app.dependency_overrides[require_legal_acceptance] = _noop_legal_acceptance
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac

--- a/tests/test_auth_e2e.py
+++ b/tests/test_auth_e2e.py
@@ -120,7 +120,13 @@ async def e2e_client(e2e_db: AsyncSession) -> AsyncIterator[AsyncClient]:
     async def override_get_db():
         yield e2e_db
 
+    async def _noop_legal_acceptance():
+        return None
+
+    from engine.legal.dependencies import require_legal_acceptance
+
     app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_legal_acceptance] = _noop_legal_acceptance
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix 62 failing tests by properly overriding the legal_acceptance dependency in conftest.py for ALL test databases (SQLite and PostgreSQL)

Closes #752
