### PR TITLE
fix(auth): prevent privilege escalation via role alias mapping

### DIFF
--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -22,12 +22,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -52,9 +46,13 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        # Fail-secure: unknown / empty input collapses to the lowest-privilege
+        # role ("viewer"). We intentionally do NOT alias any external role
+        # names to internal ones — only roles actually present in the input
+        # are considered, and the highest-priority one wins.
+        best = "viewer"
         for role in external_roles:
             normalized = role.lower().strip()
             if normalized in role_priority and role_priority[normalized] > role_priority[best]:
                 best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+        return best

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -203,21 +203,42 @@ class TestBaseProviderMapRoles:
         p = self._make_provider()
         assert p.map_roles(["user", "admin", "developer"]) == "admin"
 
-    def test_map_roles_unknown_roles_ignored(self):
+    def test_map_roles_unknown_roles_default_to_viewer(self):
+        # Fail-secure: unrecognized roles must collapse to the lowest-privilege
+        # role ("viewer") — never to "user" or anything else.
         p = self._make_provider()
-        assert p.map_roles(["superuser", "god"]) == "user"
+        assert p.map_roles(["superuser", "god"]) == "viewer"
 
     def test_map_roles_new_domain_roles(self):
+        # No silent role promotion: each input role is returned at its own
+        # priority level. quant_dev is no longer aliased up to "developer",
+        # and viewer is no longer aliased up to "user".
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 
-    def test_map_roles_empty_list_returns_user(self):
+    def test_map_roles_empty_list_returns_viewer(self):
+        # Fail-secure: empty input must default to the lowest-privilege role.
         p = self._make_provider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
+
+    def test_map_roles_no_silent_role_promotion(self):
+        # Regression guard: quant_dev must never silently promote to developer,
+        # and viewer must never silently promote to user. Only roles actually
+        # present in the input are eligible, selected by ROLE_HIERARCHY priority.
+        p = self._make_provider()
+        assert p.map_roles(["quant_dev"]) == "quant_dev"
+        assert p.map_roles(["quant_dev"]) != "developer"
+        assert p.map_roles(["viewer"]) == "viewer"
+        assert p.map_roles(["viewer"]) != "user"
+        # Mixed input: even when a higher-priority *internal* role would be
+        # reachable via the old alias, we must select only from what was
+        # actually provided.
+        assert p.map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        assert p.map_roles(["viewer", "quant_dev"]) != "developer"
 
 
 class TestAuthExports:

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,8 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles only selects from roles actually present in the
+input (no silent aliasing / promotion) and require_role checks work
+end-to-end.
 """
 
 from __future__ import annotations
@@ -24,16 +26,18 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_quant_dev_resource(self):
         app = FastAPI()
 
-        @app.get("/dev-only")
-        async def handler(user: User = Depends(require_role("developer"))):
+        @app.get("/qd-only")
+        async def handler(user: User = Depends(require_role("quant_dev"))):
             return {"role": user.role}
 
         provider = _ConcreteProvider()
+        # No silent promotion to "developer": quant_dev is selected at its
+        # own priority level.
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -51,10 +55,13 @@ class TestRequireRoleEnforcement:
 
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            resp = await ac.get("/dev-only")
+            resp = await ac.get("/qd-only")
             assert resp.status_code == 200
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_not_promoted_to_user(self):
+        # No silent promotion: viewer stays viewer and cannot reach a
+        # require_role("user") endpoint. The map_roles result must be
+        # "viewer", and the downstream dependency must reject it.
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +70,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +89,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -559,8 +559,10 @@ class TestLDAPInheritedMethods:
     def test_map_roles_developer(self, ldap_provider):
         assert ldap_provider.map_roles(["developer"]) == "developer"
 
-    def test_map_roles_unknown_defaults_user(self, ldap_provider):
-        assert ldap_provider.map_roles(["unknown_role"]) == "user"
+    def test_map_roles_unknown_defaults_viewer(self, ldap_provider):
+        # Fail-secure: unrecognized roles collapse to the lowest-privilege role.
+        assert ldap_provider.map_roles(["unknown_role"]) == "viewer"
 
     def test_map_roles_empty_list(self, ldap_provider):
-        assert ldap_provider.map_roles([]) == "user"
+        # Fail-secure: empty input collapses to the lowest-privilege role.
+        assert ldap_provider.map_roles([]) == "viewer"

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -650,10 +650,12 @@ class TestOIDCRoleMapping:
         assert oidc_provider.map_roles(["user"]) == "user"
 
     def test_map_roles_unknown_role(self, oidc_provider):
-        assert oidc_provider.map_roles(["unknown_role"]) == "user"
+        # Fail-secure: unrecognized roles collapse to the lowest-privilege role.
+        assert oidc_provider.map_roles(["unknown_role"]) == "viewer"
 
     def test_map_roles_empty_list(self, oidc_provider):
-        assert oidc_provider.map_roles([]) == "user"
+        # Fail-secure: empty input collapses to the lowest-privilege role.
+        assert oidc_provider.map_roles([]) == "viewer"
 
     def test_map_roles_case_insensitive(self, oidc_provider):
         assert oidc_provider.map_roles(["ADMIN"]) == "admin"

--- a/tests/test_recent_code_comprehensive.py
+++ b/tests/test_recent_code_comprehensive.py
@@ -480,7 +480,9 @@ class TestOIDCAuthenticateEdgeCases:
 
         assert result.success is True
         assert len(created) == 1
-        assert created[0].role == "user"
+        # Fail-secure: a brand-new user with no roles in the ID token is
+        # assigned the lowest-privilege role ("viewer"), not "user".
+        assert created[0].role == "viewer"
 
     async def test_custom_role_claim(self, monkeypatch, rsa_keys):
         _settings(monkeypatch, oidc_role_claim="groups")
@@ -561,11 +563,11 @@ class TestIAuthProviderBase:
 
     def test_map_roles_empty_list(self):
         p = _ConcreteProvider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
 
     def test_map_roles_unknown_roles(self):
         p = _ConcreteProvider()
-        assert p.map_roles(["superadmin", "guest"]) == "user"
+        assert p.map_roles(["superadmin", "guest"]) == "viewer"
 
     def test_map_roles_case_insensitive(self):
         p = _ConcreteProvider()


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Resolve critical privilege escalation in engine/api/auth/base.py: remove _EXTERNAL_ROLE_ALIASES mapping that silently promotes quant_dev→developer and viewer→user, change fail-open default from 'user' to 'viewer', and restore the regressed test assertion in test_auth_rbac_roles.py

Closes #772
