### PR TITLE
fix(auth): prevent silent role downgrade and log unmatched roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,19 +14,8 @@ edit this file by hand — it is regenerated as part of every release PR.
 
 ### Internal
 - (write_tests) Write tests for the most recently changed code to break the loop
-
-
-### Internal
-- (write_tests) Write tests for the most recently changed code to break the loop
-
-
-### Internal
-- (write_tests) Write tests for the most recently changed code to break the loop
-
-
-### Internal
-- (write_tests) Write tests for the most recently changed code to break the loop
 - (subagent) SEV-267 — Plugin Sandbox with Security Isolation (Phase 2, Lane B)
+- (auth) Gate external-provider role resync behind `auth_overwrite_role_on_login` setting and warn on unrecognized roles
 
 
 The initial public 0.1.0 release line. Entries below this point are appended

--- a/alembic/versions/002_normalize_legacy_roles.py
+++ b/alembic/versions/002_normalize_legacy_roles.py
@@ -1,0 +1,49 @@
+"""normalize legacy role aliases (viewer -> user, quant_dev -> developer)
+
+Revision ID: 002_normalize_legacy_roles
+Revises: 001_tax_lots
+Create Date: 2026-06-04 13:30:00.000000
+
+One-time audit/migration that rewrites any user.role value that was set via
+the old role aliases ("viewer", "quant_dev") to their canonical equivalent.
+The Python-side ``IAuthProvider.map_roles`` rewrites these on the fly for
+newly-mapped claims, but rows that pre-date the promotion table (or were
+hand-edited by an operator) could still carry the legacy literal — which
+breaks role-hierarchy comparisons elsewhere in the codebase.
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy import text
+
+from alembic import op
+
+revision: str = "002_normalize_legacy_roles"
+down_revision: str | None = "001_tax_lots"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_LEGACY_TO_CANONICAL: dict[str, str] = {
+    "viewer": "user",
+    "quant_dev": "developer",
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for legacy, canonical in _LEGACY_TO_CANONICAL.items():
+        bind.execute(
+            text(
+                "UPDATE users SET role = :canonical "
+                "WHERE role = :legacy"
+            ),
+            {"canonical": canonical, "legacy": legacy},
+        )
+
+
+def downgrade() -> None:
+    # Downgrade is intentionally a no-op: we cannot recover the original
+    # legacy alias from a canonical role, and reverting would risk silently
+    # downgrading accounts that were genuinely promoted.
+    pass

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
 
 @dataclass
 class UserInfo:
@@ -26,6 +28,9 @@ _ROLE_PROMOTIONS: dict[str, str] = {
     "viewer": "user",
     "quant_dev": "developer",
 }
+
+
+logger = structlog.get_logger()
 
 
 class IAuthProvider(ABC):
@@ -53,8 +58,22 @@ class IAuthProvider(ABC):
             "admin": 6,
         }
         best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        if external_roles and not recognized:
+            logger.warning(
+                "auth.roles.unrecognized",
+                provider=self.name,
+                external_roles=list(external_roles),
+                fallback_role=best,
+                recognized_roles=sorted(role_priority.keys()),
+            )
         return _ROLE_PROMOTIONS.get(best, best)

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -102,7 +102,13 @@ class LDAPAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.ldap.user_created", user_id=str(user.id))
-        elif user.role != mapped_role:
+        elif user.role != mapped_role and settings.auth_overwrite_role_on_login:
+            logger.info(
+                "auth.ldap.role_resync",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
             user.role = mapped_role
             await db.flush()
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,11 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, external providers (LDAP/OIDC) resync the stored user.role
+    # from the upstream role claim on every login. Set to False to preserve
+    # the role assigned at first login (useful if operators hand-edit roles
+    # in the DB or if upstream groups are temporarily incorrect).
+    auth_overwrite_role_on_login: bool = True
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -219,6 +219,43 @@ class TestBaseProviderMapRoles:
         p = self._make_provider()
         assert p.map_roles([]) == "user"
 
+    def test_map_roles_warns_when_all_unrecognized(self):
+        from unittest.mock import patch
+
+        from engine.api.auth import base as base_mod
+
+        p = self._make_provider()
+        with patch.object(base_mod, "logger") as mock_logger:
+            result = p.map_roles(["superuser", "god"])
+        assert result == "user"
+        mock_logger.warning.assert_called_once()
+        kwargs = mock_logger.warning.call_args.kwargs
+        assert mock_logger.warning.call_args.args[0] == "auth.roles.unrecognized"
+        assert kwargs["provider"] == "test"
+        assert kwargs["external_roles"] == ["superuser", "god"]
+        assert kwargs["fallback_role"] == "user"
+
+    def test_map_roles_no_warning_when_recognized_present(self):
+        from unittest.mock import patch
+
+        from engine.api.auth import base as base_mod
+
+        p = self._make_provider()
+        with patch.object(base_mod, "logger") as mock_logger:
+            p.map_roles(["user", "admin"])
+            p.map_roles(["unknown_role", "developer"])
+        mock_logger.warning.assert_not_called()
+
+    def test_map_roles_no_warning_on_empty_list(self):
+        from unittest.mock import patch
+
+        from engine.api.auth import base as base_mod
+
+        p = self._make_provider()
+        with patch.object(base_mod, "logger") as mock_logger:
+            p.map_roles([])
+        mock_logger.warning.assert_not_called()
+
 
 class TestAuthExports:
     def test_require_auth_importable(self):

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -435,6 +435,45 @@ class TestLDAPAuthenticateExistingUser:
         assert existing_user.role == "admin"
         mock_db.flush.assert_called()
 
+    async def test_existing_user_role_preserved_when_resync_disabled(
+        self, ldap_provider, mock_settings
+    ):
+        """When auth_overwrite_role_on_login=False, role must not be touched."""
+        from engine.db.models import User
+
+        mock_settings.auth_overwrite_role_on_login = False
+
+        attrs = _make_ldap_attrs(
+            member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
+        )
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=locked,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="locked@example.com",
+            display_name="Locked Role",
+            is_active=True,
+            role="user",
+            auth_provider="ldap",
+            external_id="locked",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="locked", password="correctpass", db=mock_db
+            )
+
+        assert result.success is True
+        assert existing_user.role == "user", "role must not be resynced when setting is off"
+        mock_db.flush.assert_not_called()
+
 
 class TestLDAPAuthenticateEmailConflict:
     async def test_email_registered_with_different_provider(


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Resolve HIGH severity review findings from PR #741: (1) auth role mapping silent downgrade risk in engine/api/auth/base.py — add migration audit or prove authenticate() doesn't overwrite existing user roles from map_roles(), (2) add structured warning logging when external_roles produces no recognized match, (3) clean up corrupted CHANGELOG.md duplicate Internal sections

Closes #741
