### PR TITLE
fix(auth): preserve user roles on login and warn on downgrades

### DIFF
--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -21,6 +21,78 @@ class LDAPAuthProvider(IAuthProvider):
     def name(self) -> str:
         return "ldap"
 
+    @staticmethod
+    def _ldap_fetch(username: str, password: str) -> dict[str, Any] | None:
+        """Bind to LDAP and return the user's attributes, or None when absent."""
+        import ldap
+        from ldap.filter import escape_filter_chars
+
+        conn = ldap.initialize(settings.ldap_server_url)
+        conn.set_option(ldap.OPT_NETWORK_TIMEOUT, 10)
+        conn.set_option(ldap.OPT_TIMEOUT, 10)
+
+        safe_username = escape_filter_chars(username)
+        user_dn = settings.ldap_bind_dn.replace("{{username}}", safe_username)
+        conn.simple_bind_s(user_dn, password)
+
+        search_filter = f"(uid={safe_username})"
+        results = conn.search_s(
+            settings.ldap_search_base,
+            ldap.SCOPE_SUBTREE,
+            search_filter,
+            ["uid", "mail", "cn", "memberOf"],
+        )
+        conn.unbind_s()
+        if not results:
+            return None
+        _, ldap_attrs = results[0]
+        return ldap_attrs
+
+    @staticmethod
+    def _map_ldap_groups_to_roles(ldap_groups: list[str]) -> list[str]:
+        role_mapping = json.loads(settings.ldap_role_mapping) if settings.ldap_role_mapping else {}
+        mapped_roles: list[str] = []
+        for group_dn in ldap_groups:
+            for ldap_group, nexus_role in role_mapping.items():
+                if ldap_group in group_dn:
+                    mapped_roles.append(nexus_role)
+        return mapped_roles or ["user"]
+
+    async def _maybe_overwrite_role(
+        self, db: AsyncSession, user: User, mapped_role: str
+    ) -> None:
+        if user.role == mapped_role:
+            return
+        # Role overwrite on login is gated on
+        # ``settings.auth_overwrite_role_on_login`` (defaults to False —
+        # SEV-741). When the mapped role is *lower* than the user's
+        # current role we always emit an explicit warning so operators
+        # can detect attempted downgrades (whether or not overwrite is
+        # enabled), and skip the write when overwrite is disabled.
+        role_priority = {
+            "viewer": 0,
+            "user": 1,
+            "retail_trader": 2,
+            "quant_dev": 3,
+            "developer": 4,
+            "portfolio_manager": 5,
+            "admin": 6,
+        }
+        current_priority = role_priority.get(user.role, -1)
+        mapped_priority = role_priority.get(mapped_role, -1)
+        if mapped_priority < current_priority:
+            logger.warning(
+                "auth.ldap.role_downgrade_on_login",
+                provider=self.name,
+                user_id=str(getattr(user, "id", "")),
+                current_role=user.role,
+                mapped_role=mapped_role,
+                overwrite_enabled=settings.auth_overwrite_role_on_login,
+            )
+        if settings.auth_overwrite_role_on_login:
+            user.role = mapped_role
+            await db.flush()
+
     async def authenticate(self, **kwargs: Any) -> AuthResult:
         username = kwargs.get("username", "")
         password = kwargs.get("password", "")
@@ -30,52 +102,20 @@ class LDAPAuthProvider(IAuthProvider):
             return AuthResult(success=False, error="Username, password, and db session required")
 
         try:
-            import ldap
-            from ldap.filter import escape_filter_chars
-
-            conn = ldap.initialize(settings.ldap_server_url)
-            conn.set_option(ldap.OPT_NETWORK_TIMEOUT, 10)
-            conn.set_option(ldap.OPT_TIMEOUT, 10)
-
-            safe_username = escape_filter_chars(username)
-            user_dn = f"{settings.ldap_bind_dn.replace('{{username}}', safe_username)}"
-            conn.simple_bind_s(user_dn, password)
-
-            search_filter = f"(uid={safe_username})"
-            results = conn.search_s(
-                settings.ldap_search_base,
-                ldap.SCOPE_SUBTREE,
-                search_filter,
-                ["uid", "mail", "cn", "memberOf"],
-            )
-            conn.unbind_s()
-
+            ldap_attrs = self._ldap_fetch(username, password)
         except Exception as exc:
             logger.exception("auth.ldap.bind_failed", error=str(exc))
             return AuthResult(success=False, error="Invalid credentials")
 
-        if not results:
+        if ldap_attrs is None:
             return AuthResult(success=False, error="User not found in LDAP")
 
-        _, ldap_attrs = results[0]
         ldap_uid = ldap_attrs.get("uid", [b""])[0].decode()
         ldap_mail = ldap_attrs.get("mail", [b""])[0].decode() or f"{username}@ldap"
         ldap_cn = ldap_attrs.get("cn", [b""])[0].decode() or username
+        ldap_groups = [g.decode() for g in ldap_attrs.get("memberOf", [])]
 
-        member_of_raw = ldap_attrs.get("memberOf", [])
-        ldap_groups = [g.decode() for g in member_of_raw]
-
-        role_mapping = json.loads(settings.ldap_role_mapping) if settings.ldap_role_mapping else {}
-        mapped_roles: list[str] = []
-        for group_dn in ldap_groups:
-            for ldap_group, nexus_role in role_mapping.items():
-                if ldap_group in group_dn:
-                    mapped_roles.append(nexus_role)
-
-        if not mapped_roles:
-            mapped_roles = ["user"]
-
-        mapped_role = self.map_roles(mapped_roles)
+        mapped_role = self.map_roles(self._map_ldap_groups_to_roles(ldap_groups))
 
         result = await db.execute(
             select(User).where(User.auth_provider == "ldap", User.external_id == ldap_uid)
@@ -102,9 +142,8 @@ class LDAPAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.ldap.user_created", user_id=str(user.id))
-        elif user.role != mapped_role:
-            user.role = mapped_role
-            await db.flush()
+        else:
+            await self._maybe_overwrite_role(db, user, mapped_role)
 
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -404,6 +404,12 @@ class TestLDAPAuthenticateExistingUser:
     ):
         from engine.db.models import User
 
+        # Overwrite-on-login is gated on
+        # ``auth_overwrite_role_on_login`` (SEV-741, defaults to False);
+        # opt in explicitly here to preserve the original contract this
+        # test pins.
+        mock_settings.auth_overwrite_role_on_login = True
+
         attrs = _make_ldap_attrs(
             member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
         )
@@ -434,6 +440,340 @@ class TestLDAPAuthenticateExistingUser:
         assert result.success is True
         assert existing_user.role == "admin"
         mock_db.flush.assert_called()
+
+
+class TestLDAPRoleOverwriteOnLoginGate:
+    """SEV-741: role overwrite on federated login is gated on
+    ``settings.auth_overwrite_role_on_login`` (defaults to False) and
+    emits an explicit warning when the mapped role is a downgrade."""
+
+    async def test_overwrite_skipped_when_setting_disabled(
+        self, ldap_provider, mock_settings
+    ):
+        """With ``auth_overwrite_role_on_login=False`` (the default) a
+        returning user's existing role must be preserved even when the
+        IdP now asserts a different role."""
+        from engine.db.models import User
+
+        mock_settings.auth_overwrite_role_on_login = False
+
+        attrs = _make_ldap_attrs(
+            member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
+        )
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=promoted,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="keepadmin@example.com",
+            display_name="Existing Admin",
+            is_active=True,
+            role="user",
+            auth_provider="ldap",
+            external_id="keepadmin",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="keepadmin", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        # Role should remain unchanged because overwrite is disabled.
+        assert existing_user.role == "user"
+        mock_db.flush.assert_not_called()
+
+    async def test_overwrite_applied_when_setting_enabled(
+        self, ldap_provider, mock_settings
+    ):
+        from engine.db.models import User
+
+        mock_settings.auth_overwrite_role_on_login = True
+
+        attrs = _make_ldap_attrs(
+            member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
+        )
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=upgrade,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="upgrade@example.com",
+            display_name="Upgrading User",
+            is_active=True,
+            role="user",
+            auth_provider="ldap",
+            external_id="upgrade",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="upgrade", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        assert existing_user.role == "admin"
+        mock_db.flush.assert_called()
+
+    async def test_downgrade_warning_fires_when_overwrite_disabled(
+        self, ldap_provider, mock_settings
+    ):
+        """A downgrade attempt must emit a warning even when overwrite
+        is disabled, so operators can detect attempted privilege
+        reductions."""
+        from engine.db.models import User
+
+        mock_settings.auth_overwrite_role_on_login = False
+
+        attrs = _make_ldap_attrs(member_of=[])  # maps to "user"
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=downgrade,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="admin@example.com",
+            display_name="Existing Admin",
+            is_active=True,
+            role="admin",
+            auth_provider="ldap",
+            external_id="downgrade",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        calls: list[dict[str, object]] = []
+
+        class _StubLogger:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def exception(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        with (
+            patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}),
+            patch("engine.api.auth.ldap.logger", _StubLogger()),
+        ):
+            result = await ldap_provider.authenticate(
+                username="downgrade", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        # Role unchanged because overwrite disabled.
+        assert existing_user.role == "admin"
+        # But the downgrade warning must still fire.
+        assert any(
+            c["event"] == "auth.ldap.role_downgrade_on_login" for c in calls
+        ), f"Expected role_downgrade_on_login warning, got: {calls}"
+        downgrade_calls = [
+            c for c in calls if c["event"] == "auth.ldap.role_downgrade_on_login"
+        ]
+        assert downgrade_calls[0]["current_role"] == "admin"
+        assert downgrade_calls[0]["mapped_role"] == "user"
+        assert downgrade_calls[0]["overwrite_enabled"] is False
+
+    async def test_downgrade_warning_fires_when_overwrite_enabled(
+        self, ldap_provider, mock_settings
+    ):
+        """When overwrite is enabled and the mapped role is a downgrade,
+        the warning fires AND the role is actually written."""
+        from engine.db.models import User
+
+        mock_settings.auth_overwrite_role_on_login = True
+
+        attrs = _make_ldap_attrs(member_of=[])
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=down2,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="down2@example.com",
+            display_name="Existing Dev",
+            is_active=True,
+            role="developer",
+            auth_provider="ldap",
+            external_id="down2",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        calls: list[dict[str, object]] = []
+
+        class _StubLogger:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def exception(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        with (
+            patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}),
+            patch("engine.api.auth.ldap.logger", _StubLogger()),
+        ):
+            result = await ldap_provider.authenticate(
+                username="down2", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        # Overwrite enabled → role actually downgraded.
+        assert existing_user.role == "user"
+        # And the warning fired with the correct payload.
+        downgrade_calls = [
+            c for c in calls if c["event"] == "auth.ldap.role_downgrade_on_login"
+        ]
+        assert downgrade_calls, f"Expected downgrade warning, got: {calls}"
+        assert downgrade_calls[0]["current_role"] == "developer"
+        assert downgrade_calls[0]["mapped_role"] == "user"
+        assert downgrade_calls[0]["overwrite_enabled"] is True
+
+    async def test_no_warning_when_role_unchanged(
+        self, ldap_provider, mock_settings
+    ):
+        """When mapped role equals existing role there is nothing to
+        warn about and no flush should happen regardless of the
+        overwrite setting."""
+        from engine.db.models import User
+
+        mock_settings.auth_overwrite_role_on_login = True
+
+        attrs = _make_ldap_attrs(
+            member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
+        )
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=same,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="same@example.com",
+            display_name="Same Role",
+            is_active=True,
+            role="admin",
+            auth_provider="ldap",
+            external_id="same",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        calls: list[dict[str, object]] = []
+
+        class _StubLogger:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def exception(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        with (
+            patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}),
+            patch("engine.api.auth.ldap.logger", _StubLogger()),
+        ):
+            result = await ldap_provider.authenticate(
+                username="same", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        assert existing_user.role == "admin"
+        assert not any(
+            c["event"] == "auth.ldap.role_downgrade_on_login" for c in calls
+        )
+        mock_db.flush.assert_not_called()
+
+    async def test_no_warning_on_upgrade_when_overwrite_enabled(
+        self, ldap_provider, mock_settings
+    ):
+        """Upgrade (mapped > current) does not trigger the downgrade
+        warning, but the role is still written because overwrite is
+        opted-in."""
+        from engine.db.models import User
+
+        mock_settings.auth_overwrite_role_on_login = True
+
+        attrs = _make_ldap_attrs(
+            member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
+        )
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=up,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="up@example.com",
+            display_name="Promotion",
+            is_active=True,
+            role="viewer",
+            auth_provider="ldap",
+            external_id="up",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        calls: list[dict[str, object]] = []
+
+        class _StubLogger:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def exception(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        with (
+            patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}),
+            patch("engine.api.auth.ldap.logger", _StubLogger()),
+        ):
+            result = await ldap_provider.authenticate(
+                username="up", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        assert existing_user.role == "admin"
+        assert not any(
+            c["event"] == "auth.ldap.role_downgrade_on_login" for c in calls
+        )
+
+    async def test_overwrite_disabled_by_default_in_settings(self):
+        """Defense-in-depth: ``auth_overwrite_role_on_login`` must
+        default to False on a fresh Settings instance."""
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
 
 
 class TestLDAPAuthenticateEmailConflict:


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Resolve remaining HIGH severity review findings in engine/api/auth/base.py: (1) flip auth_overwrite_role_on_login default to False so existing user roles are preserved on login instead of silently overwritten, (2) add warning-level log when a role downgrade is detected (new_role priority < previous_role), distinct from generic info log, (3) emit warning on ANY unrecognized external role not just when all are unrecognized

Closes #779
