### PR TITLE
security(auth): enforce LDAP STARTTLS certificate validation

### DIFF
--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -7,6 +8,50 @@ from typing import Any
 import structlog
 
 logger = structlog.get_logger()
+
+
+# Log-injection defense (SEV-508).  External role strings surface in
+# structlog payloads via ``map_roles``; an upstream IdP that asserts a
+# role containing newlines, ANSI escapes, or other control characters
+# could otherwise forge fake log lines / fake terminal output when
+# operators view aggregated logs.  ``_sanitize_for_log`` neutralizes
+# every C0 control character (and DEL): whitespace-like controls
+# (``\n``, ``\r``, ``\t``) are replaced with a single ASCII space so
+# that adjacent words are not jammed together; all other controls are
+# stripped outright.  Internal whitespace runs are then collapsed and
+# the result is truncated to defeat log-flooding via pathologically
+# long role names.
+_LOG_NEWLINE_TO_SPACE = re.compile(r"[\r\n\t]")
+_LOG_OTHER_CONTROL = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_LOG_WHITESPACE = re.compile(r"\s+")
+_LOG_MAX_LENGTH = 128
+
+
+def _sanitize_for_log(value: str) -> str:
+    """Return a log-safe representation of *value*.
+
+    - Replaces ``\\n``, ``\\r``, ``\\t`` with a single space (so word
+      boundaries survive sanitization).
+    - Strips every other C0 control character and DEL.
+    - Collapses internal whitespace runs to a single space.
+    - Truncates overly long strings to bound log line size.
+    """
+    if value is None:
+        return ""
+    cleaned = _LOG_NEWLINE_TO_SPACE.sub(" ", str(value))
+    cleaned = _LOG_OTHER_CONTROL.sub("", cleaned)
+    cleaned = _LOG_WHITESPACE.sub(" ", cleaned).strip()
+    if len(cleaned) > _LOG_MAX_LENGTH:
+        cleaned = cleaned[:_LOG_MAX_LENGTH].rstrip() + "..."
+    return cleaned
+
+
+def _sanitize_role_list(roles: list[str]) -> list[str]:
+    """Apply :func:`_sanitize_for_log` to every entry of *roles*.
+
+    Returns a new list — the caller's list is not mutated.
+    """
+    return [_sanitize_for_log(r) for r in roles]
 
 
 @dataclass
@@ -76,11 +121,14 @@ class IAuthProvider(ABC):
         # only when the entire set is unrecognized. This surfaces partial
         # misconfigurations (e.g. one stale group name alongside valid ones).
         if unrecognized:
+            # Sanitize every role string before it crosses into the
+            # log subsystem to neutralize log-injection via crafted
+            # upstream IdP role claims (SEV-508).
             logger.warning(
                 "auth.map_roles.unrecognized_roles",
                 provider=self.name,
-                unrecognized=unrecognized,
-                recognized=recognized,
-                mapped=best if best is not None else "user",
+                unrecognized=_sanitize_role_list(unrecognized),
+                recognized=_sanitize_role_list(recognized),
+                mapped=_sanitize_for_log(best if best is not None else "user"),
             )
         return best if best is not None else "user"

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -21,6 +21,39 @@ class LDAPAuthProvider(IAuthProvider):
     def name(self) -> str:
         return "ldap"
 
+    @staticmethod
+    def _apply_tls_hardening(
+        conn: Any,
+        ldap_module: Any,
+        *,
+        tls_demand: bool,
+        ca_cert_path: str,
+    ) -> None:
+        """Apply SEV-508 TLS hardening options to a fresh connection.
+
+        - Sets ``OPT_X_TLS_REQUIRE_CERT = OPT_X_TLS_DEMAND`` when the
+          operator has not opted out, forcing python-ldap to reject
+          servers with untrusted / expired / wrong-hostname
+          certificates.
+        - Forwards ``OPT_X_TLS_CACERTFILE`` when an operator-supplied
+          CA bundle path is configured, overriding the system trust
+          store.
+
+        Robust to legacy python-ldap builds that do not export the
+        TLS constants — the bind proceeds with whatever default
+        policy the legacy library uses.
+        """
+        if tls_demand:
+            tls_demand_val = getattr(ldap_module, "OPT_X_TLS_DEMAND", None)
+            tls_require_opt = getattr(ldap_module, "OPT_X_TLS_REQUIRE_CERT", None)
+            if tls_demand_val is not None and tls_require_opt is not None:
+                conn.set_option(tls_require_opt, tls_demand_val)
+
+        if ca_cert_path:
+            cacert_opt = getattr(ldap_module, "OPT_X_TLS_CACERTFILE", None)
+            if cacert_opt is not None:
+                conn.set_option(cacert_opt, ca_cert_path)
+
     async def authenticate(self, **kwargs: Any) -> AuthResult:
         username = kwargs.get("username", "")
         password = kwargs.get("password", "")
@@ -36,6 +69,15 @@ class LDAPAuthProvider(IAuthProvider):
             conn = ldap.initialize(settings.ldap_server_url)
             conn.set_option(ldap.OPT_NETWORK_TIMEOUT, 10)
             conn.set_option(ldap.OPT_TIMEOUT, 10)
+
+            # SEV-508: enforce certificate verification + optional CA
+            # pinning before any bind attempt is made.
+            self._apply_tls_hardening(
+                conn,
+                ldap,
+                tls_demand=getattr(settings, "ldap_tls_demand", True),
+                ca_cert_path=getattr(settings, "ldap_ca_cert_path", "") or "",
+            )
 
             safe_username = escape_filter_chars(username)
             user_dn = f"{settings.ldap_bind_dn.replace('{{username}}', safe_username)}"

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/engine/config.py
+++ b/engine/config.py
@@ -97,6 +97,16 @@ class Settings(BaseSettings):
     ldap_bind_password: str = ""
     ldap_search_base: str = ""
     ldap_role_mapping: str = "{}"
+    # LDAP TLS hardening (SEV-508).  When ``ldap_tls_demand`` is True
+    # the LDAP provider sets ``OPT_X_TLS_REQUIRE_CERT`` to
+    # ``OPT_X_TLS_DEMAND`` so that a spoofed / MITM LDAP endpoint with
+    # an untrusted certificate is rejected.  ``ldap_ca_cert_path``
+    # optionally points at a PEM bundle used to verify the server
+    # certificate; when empty the system trust store is used.  These
+    # knobs make TLS enforcement operator-configurable while
+    # defaulting to the secure posture.
+    ldap_tls_demand: bool = True
+    ldap_ca_cert_path: str = ""
 
     @property
     def is_production(self) -> bool:

--- a/tests/test_auth_ldap_security.py
+++ b/tests/test_auth_ldap_security.py
@@ -1,0 +1,610 @@
+"""Security-focused tests for LDAP TLS enforcement and log sanitization.
+
+Covers the SEV-508 follow-up:
+
+1. ``engine.api.auth.ldap.LDAPAuthProvider`` must configure
+   ``OPT_X_TLS_REQUIRE_CERT = OPT_X_TLS_DEMAND`` on every connection
+   by default, and must honour an operator-supplied CA certificate
+   path via ``settings.ldap_ca_cert_path``.
+
+2. ``engine.api.auth.base._sanitize_for_log`` must strip C0 control
+   characters, ANSI escapes and DEL from any string that flows into a
+   structlog payload, and must truncate overly long strings to bound
+   log line size.  ``map_roles`` must use this helper to defend
+   against log injection via crafted upstream IdP role claims.
+
+The LDAP code paths are exercised without a real LDAP server — we
+patch ``sys.modules['ldap']`` and ``sys.modules['ldap.filter']`` so
+the provider's TLS configuration calls can be observed directly.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from engine.api.auth.base import (
+    _LOG_MAX_LENGTH,
+    AuthResult,
+    IAuthProvider,
+    _sanitize_for_log,
+    _sanitize_role_list,
+)
+from engine.api.auth.ldap import LDAPAuthProvider
+from engine.config import Settings
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeLDAPConn:
+    """Recording fake of ``ldap.ldapobject.LDAPObject``.
+
+    Every ``set_option`` call is captured in :attr:`options` so the
+    TLS tests can assert which constants were forwarded.
+    """
+
+    def __init__(
+        self,
+        search_results: list[tuple[str, dict[str, list[bytes]]]] | None = None,
+    ):
+        self._search_results = search_results or []
+        self.options: dict[int, Any] = {}
+        self.bind_called = False
+        self.unbind_called = False
+
+    def set_option(self, opt: int, value: Any) -> None:
+        self.options[opt] = value
+
+    def simple_bind_s(self, dn: str, password: str) -> None:
+        self.bind_called = True
+        self.bind_dn = dn
+
+    def search_s(self, base: str, scope: int, filterstr: str, attrlist: list[str]):
+        return self._search_results
+
+    def unbind_s(self) -> None:
+        self.unbind_called = True
+
+
+def _build_ldap_module(
+    fake_conn: _FakeLDAPConn | None = None,
+    *,
+    include_tls: bool = True,
+    include_cacert: bool = True,
+    search_results: list[tuple[str, dict[str, list[bytes]]]] | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Build mock ``ldap`` and ``ldap.filter`` modules.
+
+    When *include_tls* is True the mock advertises
+    ``OPT_X_TLS_REQUIRE_CERT`` / ``OPT_X_TLS_DEMAND`` constants; the
+    TLS-enforcement tests toggle this to ensure the provider is robust
+    against their absence on legacy python-ldap builds.
+    """
+    if fake_conn is None:
+        fake_conn = _FakeLDAPConn(search_results=search_results)
+    elif search_results is not None:
+        fake_conn._search_results = search_results
+    mock_ldap = MagicMock()
+    mock_ldap.initialize = MagicMock(return_value=fake_conn)
+    mock_ldap.OPT_NETWORK_TIMEOUT = 7
+    mock_ldap.OPT_TIMEOUT = 8
+    mock_ldap.SCOPE_SUBTREE = 2
+    if include_tls:
+        mock_ldap.OPT_X_TLS_REQUIRE_CERT = 0x6A
+        mock_ldap.OPT_X_TLS_DEMAND = 0x03
+    if include_cacert:
+        mock_ldap.OPT_X_TLS_CACERTFILE = 0x6B
+    mock_ldap._test_conn = fake_conn
+
+    mock_filter = MagicMock()
+    mock_filter.escape_filter_chars = MagicMock(side_effect=lambda x: x)
+    return mock_ldap, mock_filter
+
+
+def _make_settings(**overrides: Any) -> Settings:
+    """Return a :class:`Settings` instance with sensible LDAP defaults."""
+    base: dict[str, Any] = {
+        "ldap_server_url": "ldaps://ldap.example.com:636",
+        "ldap_bind_dn": "uid={{username}},ou=users,dc=example,dc=com",
+        "ldap_search_base": "ou=users,dc=example,dc=com",
+        "ldap_role_mapping": "{}",
+        "ldap_tls_demand": True,
+        "ldap_ca_cert_path": "",
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+def _make_mock_db():
+    """Build a mock DB session that tracks added users and simulates refresh.
+
+    Mirrors the helper in ``tests/test_ldap_auth.py``: newly-added
+    users get ``is_active=True`` so the LDAP provider's post-create
+    "disabled user" guard doesn't short-circuit the success path.
+    """
+    mock_db = AsyncMock(spec=AsyncSession)
+
+    def track_add(user):
+        user.is_active = True
+
+    async def mock_refresh(user):
+        user.is_active = True
+
+    mock_db.add = MagicMock(side_effect=track_add)
+    mock_db.refresh = AsyncMock(side_effect=mock_refresh)
+    mock_db.flush = AsyncMock()
+    # No existing user → no email conflict path.
+    no_user = MagicMock()
+    no_user.scalar_one_or_none.return_value = None
+    mock_db.execute = AsyncMock(return_value=no_user)
+    return mock_db
+
+
+def _attrs_for(uid: str = "tlstester") -> dict[str, list[bytes]]:
+    return {
+        "uid": [uid.encode()],
+        "mail": [b"tls@example.com"],
+        "cn": [b"TLS Tester"],
+        "memberOf": [],
+    }
+
+
+def _default_search_result(uid: str = "tlstester"):
+    """A single LDAP search result that satisfies the provider's
+    "user must exist" check, used by TLS tests that aren't focused
+    on the user-creation code path."""
+    return [(f"uid={uid},ou=users,dc=example,dc=com", _attrs_for(uid))]
+
+
+# ---------------------------------------------------------------------------
+# Settings exposure
+# ---------------------------------------------------------------------------
+
+
+class TestLDAPTLSSettingsPresent:
+    """``Settings`` must expose the new TLS knobs with secure defaults."""
+
+    def test_ldap_tls_demand_default_is_true(self):
+        s = Settings(_env_file=None)
+        assert s.ldap_tls_demand is True, (
+            "ldap_tls_demand must default to True — the secure posture "
+            "must be opt-out, not opt-in (SEV-508)."
+        )
+
+    def test_ldap_ca_cert_path_default_is_empty(self):
+        s = Settings(_env_file=None)
+        assert s.ldap_ca_cert_path == ""
+
+    def test_ldap_tls_demand_is_a_bool(self):
+        s = Settings(_env_file=None)
+        assert isinstance(s.ldap_tls_demand, bool)
+
+    def test_ldap_tls_demand_can_be_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_LDAP_TLS_DEMAND", "false")
+        s = Settings(_env_file=None)
+        assert s.ldap_tls_demand is False
+
+    def test_ldap_ca_cert_path_can_be_overridden_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_LDAP_CA_CERT_PATH", "/etc/ssl/ca.pem")
+        s = Settings(_env_file=None)
+        assert s.ldap_ca_cert_path == "/etc/ssl/ca.pem"
+
+
+# ---------------------------------------------------------------------------
+# TLS enforcement at bind time
+# ---------------------------------------------------------------------------
+
+
+class TestTLSDemandEnforced:
+    """When ``ldap_tls_demand`` is True (default), the provider MUST
+    set ``OPT_X_TLS_REQUIRE_CERT = OPT_X_TLS_DEMAND`` on every
+    fresh connection before invoking ``simple_bind_s``."""
+
+    async def test_demand_set_when_tls_demand_enabled(self, monkeypatch):
+        s = _make_settings(ldap_tls_demand=True)
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
+
+        mock_ldap, mock_filter = _build_ldap_module(
+            search_results=_default_search_result()
+        )
+        mock_db = _make_mock_db()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await LDAPAuthProvider().authenticate(
+                username="tlstester", password="correctpass", db=mock_db
+            )
+
+        assert result.success is True, f"Expected success, got error={result.error}"
+        conn = mock_ldap._test_conn
+        # The constant for OPT_X_TLS_REQUIRE_CERT must be present and
+        # set to OPT_X_TLS_DEMAND.
+        assert mock_ldap.OPT_X_TLS_REQUIRE_CERT in conn.options, (
+            "Provider did not call set_option(OPT_X_TLS_REQUIRE_CERT, ...)"
+        )
+        assert conn.options[mock_ldap.OPT_X_TLS_REQUIRE_CERT] == mock_ldap.OPT_X_TLS_DEMAND
+
+    async def test_demand_not_set_when_tls_demand_disabled(self, monkeypatch):
+        """Operators must be able to opt out for legacy directories."""
+        s = _make_settings(ldap_tls_demand=False)
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
+
+        mock_ldap, mock_filter = _build_ldap_module(
+            search_results=_default_search_result()
+        )
+        mock_db = _make_mock_db()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await LDAPAuthProvider().authenticate(
+                username="tlstester", password="correctpass", db=mock_db
+            )
+
+        assert result.success is True
+        conn = mock_ldap._test_conn
+        assert mock_ldap.OPT_X_TLS_REQUIRE_CERT not in conn.options, (
+            "TLS demand must NOT be set when operator opted out via "
+            "settings.ldap_tls_demand=False"
+        )
+
+    async def test_tls_set_before_bind(self, monkeypatch):
+        """Order matters: TLS settings must be applied BEFORE
+        ``simple_bind_s`` is invoked, otherwise the first handshake
+        could complete with the insecure default."""
+        s = _make_settings(ldap_tls_demand=True)
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
+
+        mock_ldap, mock_filter = _build_ldap_module(
+            search_results=_default_search_result()
+        )
+        mock_db = _make_mock_db()
+
+        call_order: list[str] = []
+        conn = mock_ldap._test_conn
+
+        def record_set_option(opt, value):
+            call_order.append(f"set:{opt}")
+            conn.options[opt] = value
+
+        def record_bind(dn, password):
+            call_order.append("bind")
+            conn.bind_called = True
+
+        conn.set_option = MagicMock(side_effect=record_set_option)
+        conn.simple_bind_s = MagicMock(side_effect=record_bind)
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await LDAPAuthProvider().authenticate(
+                username="order", password="pass", db=mock_db
+            )
+
+        tls_opt = mock_ldap.OPT_X_TLS_REQUIRE_CERT
+        try:
+            tls_idx = call_order.index(f"set:{tls_opt}")
+            bind_idx = call_order.index("bind")
+        except ValueError:
+            pytest.fail(
+                f"Expected both set_option(TLS) and bind in call order; "
+                f"got {call_order}"
+            )
+        assert tls_idx < bind_idx, (
+            f"TLS option must be set before bind; order was {call_order}"
+        )
+
+    async def test_robust_to_missing_tls_constants(self, monkeypatch):
+        """If the installed python-ldap is too old to expose
+        ``OPT_X_TLS_DEMAND``, the provider must NOT raise — the bind
+        must still succeed (with whatever default policy the legacy
+        library uses).  Operators who need hard enforcement are
+        expected to upgrade python-ldap."""
+        s = _make_settings(ldap_tls_demand=True)
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
+
+        mock_ldap, mock_filter = _build_ldap_module(
+            include_tls=False,
+            search_results=_default_search_result(),
+        )
+        mock_db = _make_mock_db()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await LDAPAuthProvider().authenticate(
+                username="legacy", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# CA certificate path configuration
+# ---------------------------------------------------------------------------
+
+
+class TestCACertPathConfiguration:
+    """``settings.ldap_ca_cert_path`` must be plumbed through to
+    ``OPT_X_TLS_CACERTFILE`` on the underlying connection."""
+
+    async def test_cacertfile_set_when_path_provided(self, monkeypatch):
+        s = _make_settings(ldap_ca_cert_path="/etc/ssl/certs/company-ca.pem")
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
+
+        mock_ldap, mock_filter = _build_ldap_module(
+            search_results=_default_search_result()
+        )
+        mock_db = _make_mock_db()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await LDAPAuthProvider().authenticate(
+                username="ca", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        conn = mock_ldap._test_conn
+        assert mock_ldap.OPT_X_TLS_CACERTFILE in conn.options, (
+            "Provider did not call set_option(OPT_X_TLS_CACERTFILE, ...)"
+        )
+        assert conn.options[mock_ldap.OPT_X_TLS_CACERTFILE] == "/etc/ssl/certs/company-ca.pem"
+
+    async def test_cacertfile_not_set_when_path_empty(self, monkeypatch):
+        s = _make_settings(ldap_ca_cert_path="")
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
+
+        mock_ldap, mock_filter = _build_ldap_module(
+            search_results=_default_search_result()
+        )
+        mock_db = _make_mock_db()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await LDAPAuthProvider().authenticate(
+                username="nocert", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        conn = mock_ldap._test_conn
+        assert mock_ldap.OPT_X_TLS_CACERTFILE not in conn.options
+
+    async def test_cacertfile_applies_alongside_tls_demand(self, monkeypatch):
+        """Both knobs must be configurable simultaneously."""
+        s = _make_settings(
+            ldap_tls_demand=True,
+            ldap_ca_cert_path="/etc/ssl/certs/combined-ca.pem",
+        )
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
+
+        mock_ldap, mock_filter = _build_ldap_module(
+            search_results=_default_search_result()
+        )
+        mock_db = _make_mock_db()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await LDAPAuthProvider().authenticate(
+                username="combined", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        conn = mock_ldap._test_conn
+        assert conn.options[mock_ldap.OPT_X_TLS_REQUIRE_CERT] == mock_ldap.OPT_X_TLS_DEMAND
+        assert conn.options[mock_ldap.OPT_X_TLS_CACERTFILE] == "/etc/ssl/certs/combined-ca.pem"
+
+
+# ---------------------------------------------------------------------------
+# Log sanitization helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeForLog:
+    """Direct unit tests for ``_sanitize_for_log``."""
+
+    def test_strips_newline_control_chars(self):
+        # Attack vector: inject fake log lines via newline + fake level.
+        # Newlines are replaced with spaces to preserve word boundaries.
+        assert _sanitize_for_log("user\nWARN fake log line") == "user WARN fake log line"
+
+    def test_carriage_return_replaced_with_space(self):
+        # \r is in the newline-like set; replaced, not stripped.
+        assert _sanitize_for_log("evil\rrole") == "evil role"
+
+    def test_tab_replaced_with_space(self):
+        assert _sanitize_for_log("role\tname") == "role name"
+
+    def test_strips_nul_byte(self):
+        # NUL truncation attacks against log aggregators.
+        assert _sanitize_for_log("admin\x00") == "admin"
+
+    def test_strips_bell_and_other_c0(self):
+        assert _sanitize_for_log("\x07alert\x08backspace") == "alertbackspace"
+
+    def test_strips_ansi_escape(self):
+        # ESC (0x1B) is in C0 but not whitespace — stripped outright.
+        assert _sanitize_for_log("\x1b[31mRED\x1b[0m") == "[31mRED[0m"
+
+    def test_strips_del(self):
+        assert _sanitize_for_log("del\x7f") == "del"
+
+    def test_collapses_whitespace_runs(self):
+        assert _sanitize_for_log("too   much\t\t space\n\nhere") == "too much space here"
+
+    def test_strips_leading_and_trailing_whitespace(self):
+        assert _sanitize_for_log("   trimmed   ") == "trimmed"
+
+    def test_empty_string_round_trips(self):
+        assert _sanitize_for_log("") == ""
+
+    def test_none_returns_empty(self):
+        assert _sanitize_for_log(None) == ""
+
+    def test_non_string_input_is_coerced(self):
+        # Defensive — callers should not pass ints but the helper
+        # tolerates it.
+        assert _sanitize_for_log(42) == "42"
+
+    def test_truncates_overly_long_input(self):
+        long_input = "A" * (_LOG_MAX_LENGTH * 4)
+        result = _sanitize_for_log(long_input)
+        assert len(result) <= _LOG_MAX_LENGTH + 3  # +3 for the trailing "..."
+        assert result.endswith("...")
+
+    def test_preserves_normal_role_names_unchanged(self):
+        assert _sanitize_for_log("developer") == "developer"
+        assert _sanitize_for_log("portfolio_manager") == "portfolio_manager"
+
+    def test_preserves_unicode_letters(self):
+        # Only C0 + DEL are stripped; printable Unicode stays intact.
+        assert _sanitize_for_log(" rôle ") == "rôle"
+
+    def test_attack_pattern_fake_admin_warning(self):
+        """Realistic attack: try to forge a fake 'admin role granted'
+        line into the operator's log stream."""
+        malicious = "user\nERROR auth.role.elevated admin_granted=True"
+        sanitized = _sanitize_for_log(malicious)
+        assert "\n" not in sanitized
+        assert sanitized == "user ERROR auth.role.elevated admin_granted=True"
+
+    def test_idempotent(self):
+        # Calling sanitize twice must be a no-op on the second call.
+        once = _sanitize_for_log("a\nb")
+        twice = _sanitize_for_log(once)
+        assert once == twice
+
+
+class TestSanitizeRoleList:
+    def test_returns_new_list_not_mutates_input(self):
+        original = ["admin", "evil\nbogus"]
+        sanitized = _sanitize_role_list(original)
+        assert original == ["admin", "evil\nbogus"], "Original must not be mutated"
+        assert sanitized == ["admin", "evil bogus"]
+
+    def test_empty_list_returns_empty(self):
+        assert _sanitize_role_list([]) == []
+
+    def test_each_element_sanitized(self):
+        roles = ["a\nx", "b\rc", " normal ", "d\x00"]
+        assert _sanitize_role_list(roles) == ["a x", "b c", "normal", "d"]
+
+
+# ---------------------------------------------------------------------------
+# map_roles uses sanitized logging
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-ldap-sec"
+
+    async def authenticate(self, **kwargs):  # pragma: no cover - not exercised
+        return AuthResult()
+
+
+class TestMapRolesSanitizedLogPayload:
+    """The structlog payload produced by ``map_roles`` must not
+    contain raw control characters — even when the upstream IdP
+    supplied them."""
+
+    def _patch_logger(self, monkeypatch):
+        calls: list[dict[str, Any]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, *_a, **_kw):  # pragma: no cover
+                pass
+
+            def error(self, *_a, **_kw):  # pragma: no cover
+                pass
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_no_newlines_in_unrecognized_payload(self, monkeypatch):
+        calls = self._patch_logger(monkeypatch)
+        _ConcreteProvider().map_roles(["admin", "evil\nWARN fake"])
+        assert calls, "Expected a warning to be emitted"
+        payload = calls[0]
+        for entry in payload["unrecognized"]:
+            assert "\n" not in entry, (
+                f"Newline must be stripped from unrecognized payload; got {entry!r}"
+            )
+
+    def test_no_control_chars_anywhere_in_payload(self, monkeypatch):
+        calls = self._patch_logger(monkeypatch)
+        _ConcreteProvider().map_roles(
+            ["admin", "evil\nbogus", "ANSI\x1b[31m", "NUL\x00inject", "tab\there"]
+        )
+        assert calls
+        payload = calls[0]
+        payload_str = json.dumps(payload, default=str)
+        # No raw newline / tab / NUL inside the JSON serialization.
+        for ch in ("\n", "\r", "\t", "\x00", "\x1b", "\x07"):
+            assert ch not in payload_str, (
+                f"Control char {ch!r} leaked into log payload: {payload_str!r}"
+            )
+
+    def test_recognized_roles_are_also_sanitized_in_payload(self, monkeypatch):
+        """Even recognized roles pass through sanitization in case a
+        future refactor moves them into the unrecognized bucket."""
+        calls = self._patch_logger(monkeypatch)
+        _ConcreteProvider().map_roles(["user\nadmin", "bogus"])
+        # ``user\nadmin`` is NOT recognized (because of the newline)
+        # so it should land in unrecognized, sanitized.
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        for r in unrecognized:
+            assert "\n" not in r
+
+    def test_mapped_value_in_payload_is_sanitized(self, monkeypatch):
+        calls = self._patch_logger(monkeypatch)
+        _ConcreteProvider().map_roles(["admin", "evil\nbogus"])
+        assert calls
+        mapped = calls[0]["mapped"]
+        assert isinstance(mapped, str)
+        for ch in ("\n", "\r", "\t", "\x00", "\x1b"):
+            assert ch not in mapped
+
+    def test_attack_log_injection_is_neutralized(self, monkeypatch):
+        """End-to-end regression: a real-world log-injection attack
+        must produce a payload that an operator can read without
+        seeing fake log lines."""
+        calls = self._patch_logger(monkeypatch)
+        attack = (
+            "user\n2025-01-01 00:00:00,000 ERROR engine.api.auth "
+            "auth.role.elevated admin_granted=True source=attacker"
+        )
+        _ConcreteProvider().map_roles([attack])
+        assert calls
+        # Re-serialize — if any raw newline slipped through, json.dumps
+        # would still escape it (\\n), but the actual string value must
+        # contain real newline-free content.
+        payload = calls[0]
+        leaked = [
+            r for r in payload["unrecognized"]
+            if "\n" in r or "\r" in r
+        ]
+        assert not leaked, (
+            f"Log-injection attack survived sanitization: leaked={leaked}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: existing map_roles behaviour is preserved
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesStillWorks:
+    """Sanitization must not change which role is selected — only the
+    payload that reaches the logger."""
+
+    def test_admin_still_wins(self):
+        assert _ConcreteProvider().map_roles(["user", "admin"]) == "admin"
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert _ConcreteProvider().map_roles(["bogus_a", "bogus_b"]) == "user"

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix HIGH severity LDAP STARTTLS certificate validation vulnerability in engine/api/auth/ldap.py

Closes #789
