### PR TITLE
security(auth): fix LDAP STARTTLS no-op and DN injection

### DIFF
--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -16,6 +17,140 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 
+_DN_SPECIALS = {'"', "+", ",", ";", "<", ">", "\\"}
+
+
+def _escape_dn_chars(value: str) -> str:
+    """Escape ``value`` for safe inclusion in an LDAP distinguished name.
+
+    Implements RFC 4514 DN-string escaping for the *attribute value*
+    component. The following characters require a leading backslash:
+    ``"``, ``+``, ``,``, ``;``, ``<``, ``>``, ``\\``. A leading ``#``
+    (only when the value is non-empty) and leading / trailing spaces are
+    also escaped.
+    """
+    if value == "":
+        return ""
+
+    escaped: list[str] = []
+    last_idx = len(value) - 1
+
+    for i, ch in enumerate(value):
+        if ch in _DN_SPECIALS:
+            escaped.append("\\" + ch)
+        elif ch == "#" and i == 0:
+            escaped.append("\\#")
+        elif ch == " " and i in (0, last_idx):
+            escaped.append("\\ ")
+        else:
+            escaped.append(ch)
+
+    return "".join(escaped)
+
+
+def _escape_filter_chars(value: str) -> str:
+    """Minimal RFC 4515 filter escaping used only for the search filter."""
+    out: list[str] = []
+    for ch in value:
+        if ch == "\\":
+            out.append("\\5c")
+        elif ch == "*":
+            out.append("\\2a")
+        elif ch == "(":
+            out.append("\\28")
+        elif ch == ")":
+            out.append("\\29")
+        elif ch == "\x00":
+            out.append("\\00")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _apply_tls_hardening(conn: Any, ldap_module: Any) -> None:
+    """Configure TLS options and raise on negotiation failure.
+
+    The caller is responsible for catching the raised exception to avoid
+    silent cleartext fallback.
+    """
+    conn.set_option(ldap_module.OPT_NETWORK_TIMEOUT, 10)
+    conn.set_option(ldap_module.OPT_TIMEOUT, 10)
+    conn.set_option(ldap_module.OPT_X_TLS_REQUIRE_CERT, ldap_module.OPT_X_TLS_DEMAND)
+    conn.set_option(ldap_module.OPT_X_TLS, ldap_module.OPT_X_TLS_HARD)
+    conn.start_tls_s()
+
+
+def _safe_unbind(conn: Any) -> None:
+    """Best-effort unbind; never raises."""
+    with contextlib.suppress(Exception):
+        conn.unbind_s()
+
+
+class _LDAPLookupResult:
+    """Outcome of a single LDAP bind + search attempt."""
+
+    def __init__(
+        self,
+        success: bool,
+        error: str = "",
+        attrs: dict[str, list[bytes]] | None = None,
+    ):
+        self.success = success
+        self.error = error
+        self.attrs = attrs
+
+
+def _ldap_lookup(username: str, password: str) -> _LDAPLookupResult:
+    """Perform the TLS-hardened LDAP bind + search.
+
+    Returns a result object describing the outcome. The caller is
+    responsible for converting it to an ``AuthResult``.
+    """
+    import ldap
+
+    conn = ldap.initialize(settings.ldap_server_url)
+
+    try:
+        _apply_tls_hardening(conn, ldap)
+    except Exception as tls_exc:
+        logger.warning(
+            "auth.ldap.start_tls_failed",
+            error=str(tls_exc),
+            server=settings.ldap_server_url,
+        )
+        _safe_unbind(conn)
+        return _LDAPLookupResult(
+            success=False,
+            error="TLS negotiation failed; cleartext fallback disabled",
+        )
+
+    try:
+        safe_username_dn = _escape_dn_chars(username)
+        safe_username_filter = _escape_filter_chars(username)
+        user_dn = settings.ldap_bind_dn.replace("{{username}}", safe_username_dn)
+        conn.simple_bind_s(user_dn, password)
+
+        search_filter = f"(uid={safe_username_filter})"
+        results = conn.search_s(
+            settings.ldap_search_base,
+            ldap.SCOPE_SUBTREE,
+            search_filter,
+            ["uid", "mail", "cn", "memberOf"],
+        )
+    except Exception as exc:
+        logger.exception("auth.ldap.bind_failed", error=str(exc))
+        _safe_unbind(conn)
+        return _LDAPLookupResult(success=False, error="Invalid credentials")
+
+    _safe_unbind(conn)
+
+    if not results:
+        return _LDAPLookupResult(success=False, error="User not found in LDAP")
+
+    _, attrs = results[0]
+    return _LDAPLookupResult(success=True, attrs=attrs)
+
+
 class LDAPAuthProvider(IAuthProvider):
     @property
     def name(self) -> str:
@@ -29,35 +164,12 @@ class LDAPAuthProvider(IAuthProvider):
         if not username or not password or db is None:
             return AuthResult(success=False, error="Username, password, and db session required")
 
-        try:
-            import ldap
-            from ldap.filter import escape_filter_chars
+        lookup = _ldap_lookup(username, password)
+        if not lookup.success:
+            return AuthResult(success=False, error=lookup.error)
 
-            conn = ldap.initialize(settings.ldap_server_url)
-            conn.set_option(ldap.OPT_NETWORK_TIMEOUT, 10)
-            conn.set_option(ldap.OPT_TIMEOUT, 10)
-
-            safe_username = escape_filter_chars(username)
-            user_dn = f"{settings.ldap_bind_dn.replace('{{username}}', safe_username)}"
-            conn.simple_bind_s(user_dn, password)
-
-            search_filter = f"(uid={safe_username})"
-            results = conn.search_s(
-                settings.ldap_search_base,
-                ldap.SCOPE_SUBTREE,
-                search_filter,
-                ["uid", "mail", "cn", "memberOf"],
-            )
-            conn.unbind_s()
-
-        except Exception as exc:
-            logger.exception("auth.ldap.bind_failed", error=str(exc))
-            return AuthResult(success=False, error="Invalid credentials")
-
-        if not results:
-            return AuthResult(success=False, error="User not found in LDAP")
-
-        _, ldap_attrs = results[0]
+        assert lookup.attrs is not None  # success implies attrs present
+        ldap_attrs = lookup.attrs
         ldap_uid = ldap_attrs.get("uid", [b""])[0].decode()
         ldap_mail = ldap_attrs.get("mail", [b""])[0].decode() or f"{username}@ldap"
         ldap_cn = ldap_attrs.get("cn", [b""])[0].decode() or username

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -93,16 +93,32 @@ class _FakeLDAPConn:
         bind_raises: Exception | None = None,
         search_results: list[tuple[str, dict[str, list[bytes]]]] | None = None,
         search_raises: Exception | None = None,
+        start_tls_raises: Exception | None = None,
     ):
         self._bind_raises = bind_raises
         self._search_results = search_results or []
         self._search_raises = search_raises
+        self._start_tls_raises = start_tls_raises
+        self.start_tls_called = False
+        self.bind_called = False
+        self.bind_call_args: tuple[str, str] | None = None
         self._options: dict[int, Any] = {}
+        self.call_order: list[str] = []
+        self.unbound = False
 
     def set_option(self, opt: int, value: Any) -> None:
         self._options[opt] = value
 
+    def start_tls_s(self) -> None:
+        self.start_tls_called = True
+        self.call_order.append("start_tls_s")
+        if self._start_tls_raises:
+            raise self._start_tls_raises
+
     def simple_bind_s(self, dn: str, password: str) -> None:
+        self.bind_called = True
+        self.bind_call_args = (dn, password)
+        self.call_order.append("simple_bind_s")
         if self._bind_raises:
             raise self._bind_raises
 
@@ -112,28 +128,33 @@ class _FakeLDAPConn:
         return self._search_results
 
     def unbind_s(self) -> None:
-        pass
+        self.unbound = True
 
 
 def _build_ldap_mock(
     bind_raises: Exception | None = None,
     search_results: list[tuple[str, dict[str, list[bytes]]]] | None = None,
     search_raises: Exception | None = None,
+    start_tls_raises: Exception | None = None,
 ):
     mock_ldap = MagicMock()
-    mock_ldap.initialize = MagicMock(
-        return_value=_FakeLDAPConn(
-            bind_raises=bind_raises,
-            search_results=search_results,
-            search_raises=search_raises,
-        )
+    fake_conn = _FakeLDAPConn(
+        bind_raises=bind_raises,
+        search_results=search_results,
+        search_raises=search_raises,
+        start_tls_raises=start_tls_raises,
     )
+    mock_ldap.initialize = MagicMock(return_value=fake_conn)
     mock_ldap.OPT_NETWORK_TIMEOUT = 7
     mock_ldap.OPT_TIMEOUT = 8
     mock_ldap.SCOPE_SUBTREE = 2
+    mock_ldap.OPT_X_TLS_REQUIRE_CERT = 0x600
+    mock_ldap.OPT_X_TLS_DEMAND = 2
+    mock_ldap.OPT_X_TLS = 0x601
+    mock_ldap.OPT_X_TLS_HARD = 1
     mock_filter = MagicMock()
     mock_filter.escape_filter_chars = MagicMock(side_effect=lambda x: x)
-    return mock_ldap, mock_filter
+    return mock_ldap, mock_filter, fake_conn
 
 
 def _make_mock_db():
@@ -158,7 +179,7 @@ class TestLDAPAuthenticateBindFailure:
     async def test_bind_failure_returns_invalid_credentials(
         self, ldap_provider, mock_settings
     ):
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             bind_raises=Exception("LDAP bind failed")
         )
 
@@ -174,7 +195,7 @@ class TestLDAPAuthenticateBindFailure:
     async def test_connection_failure_returns_invalid_credentials(
         self, ldap_provider, mock_settings
     ):
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             bind_raises=ConnectionError("Connection refused")
         )
 
@@ -190,7 +211,7 @@ class TestLDAPAuthenticateBindFailure:
 
 class TestLDAPAuthenticateSearchResults:
     async def test_empty_results_user_not_found(self, ldap_provider, mock_settings):
-        mock_ldap, mock_filter = _build_ldap_mock(search_results=[])
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(search_results=[])
 
         mock_db = AsyncMock(spec=AsyncSession)
         with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
@@ -239,7 +260,7 @@ class TestLDAPAuthenticateSuccess:
         attrs = _make_ldap_attrs(
             member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
         )
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=testuser,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -263,7 +284,7 @@ class TestLDAPAuthenticateSuccess:
         self, ldap_provider, mock_settings
     ):
         attrs = _make_ldap_attrs(member_of=[])
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=user2,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -283,7 +304,7 @@ class TestLDAPAuthenticateSuccess:
         attrs = _make_ldap_attrs(
             member_of=[b"cn=developers,ou=groups,dc=example,dc=com"]
         )
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=devuser,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -308,7 +329,7 @@ class TestLDAPAuthenticateSuccess:
                 b"cn=admins,ou=groups,dc=example,dc=com",
             ]
         )
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=multi,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -327,7 +348,7 @@ class TestLDAPAuthenticateSuccess:
         self, ldap_provider, mock_settings
     ):
         attrs = _make_ldap_attrs(mail=b"")
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=nomail,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -347,7 +368,7 @@ class TestLDAPAuthenticateSuccess:
         self, ldap_provider, mock_settings
     ):
         attrs = _make_ldap_attrs(cn=b"")
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=nocn,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -371,7 +392,7 @@ class TestLDAPAuthenticateExistingUser:
         from engine.db.models import User
 
         attrs = _make_ldap_attrs()
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=testuser,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -407,7 +428,7 @@ class TestLDAPAuthenticateExistingUser:
         attrs = _make_ldap_attrs(
             member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
         )
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=promoted,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -443,7 +464,7 @@ class TestLDAPAuthenticateEmailConflict:
         from engine.db.models import User
 
         attrs = _make_ldap_attrs()
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=conflict,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -482,7 +503,7 @@ class TestLDAPAuthenticateDisabledUser:
         from engine.db.models import User
 
         attrs = _make_ldap_attrs()
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=disabled,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -524,7 +545,7 @@ class TestLDAPRoleMappingEmpty:
         attrs = _make_ldap_attrs(
             member_of=[b"cn=somegroup,ou=groups,dc=example,dc=com"]
         )
-        mock_ldap, mock_filter = _build_ldap_mock(
+        mock_ldap, mock_filter, _fake_conn = _build_ldap_mock(
             search_results=[("uid=norolemap,ou=users,dc=example,dc=com", attrs)]
         )
 
@@ -564,3 +585,336 @@ class TestLDAPInheritedMethods:
 
     def test_map_roles_empty_list(self, ldap_provider):
         assert ldap_provider.map_roles([]) == "user"
+
+
+class TestLDAPStartTLSOrdering:
+    """Security regression tests: start_tls_s() must run BEFORE simple_bind_s().
+
+    Without strict ordering, a misconfigured server can cause the bind to
+    succeed over a cleartext connection, leaking credentials (SEV-508).
+    """
+
+    async def test_start_tls_called_before_simple_bind(
+        self, ldap_provider, mock_settings
+    ):
+        attrs = _make_ldap_attrs()
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[("uid=ordering,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        mock_db, _ = _make_mock_db()
+        mock_db.execute = _mock_execute_factory(None, None)
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="ordering", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        assert fake_conn.start_tls_called is True
+        assert fake_conn.bind_called is True
+        # The fake conn records the call order; start_tls_s must precede bind.
+        tls_idx = fake_conn.call_order.index("start_tls_s")
+        bind_idx = fake_conn.call_order.index("simple_bind_s")
+        assert tls_idx < bind_idx
+
+    async def test_tls_options_set_before_start_tls(
+        self, ldap_provider, mock_settings
+    ):
+        attrs = _make_ldap_attrs()
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[("uid=tlscheck,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        mock_db, _ = _make_mock_db()
+        mock_db.execute = _mock_execute_factory(None, None)
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username="tlscheck", password="pass", db=mock_db
+            )
+
+        # The hardening helper must set the certificate-requirement and
+        # TLS-mode options before invoking start_tls_s.
+        assert mock_ldap.OPT_X_TLS_REQUIRE_CERT in fake_conn._options
+        assert fake_conn._options[mock_ldap.OPT_X_TLS_REQUIRE_CERT] == mock_ldap.OPT_X_TLS_DEMAND
+        assert mock_ldap.OPT_X_TLS in fake_conn._options
+        assert fake_conn._options[mock_ldap.OPT_X_TLS] == mock_ldap.OPT_X_TLS_HARD
+
+    async def test_start_tls_failure_no_cleartext_fallback(
+        self, ldap_provider, mock_settings
+    ):
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            start_tls_raises=RuntimeError("STARTTLS not supported"),
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="tlsfail", password="pass", db=mock_db
+            )
+
+        # The bind must never have happened: cleartext fallback is forbidden.
+        assert result.success is False
+        assert fake_conn.bind_called is False
+        assert "TLS" in result.error or "cleartext" in result.error.lower()
+
+    async def test_start_tls_failure_does_not_leak_connection(
+        self, ldap_provider, mock_settings
+    ):
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            start_tls_raises=RuntimeError("STARTTLS not supported"),
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username="tlsfail", password="pass", db=mock_db
+            )
+
+        assert fake_conn.unbound is True
+
+
+class TestLDAPDNEscaping:
+    """RFC 4514 DN escaping regression tests.
+
+    `escape_filter_chars` only escapes characters special to LDAP search
+    filters; it does NOT escape characters special to DN strings, which
+    allowed injection into the bind DN (SEV-509).
+    """
+
+    async def test_username_with_comma_escaped_in_bind_dn(
+        self, ldap_provider, mock_settings
+    ):
+        attrs = _make_ldap_attrs(uid="user,admin")
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[("uid=user\\,admin,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        mock_db, _ = _make_mock_db()
+        mock_db.execute = _mock_execute_factory(None, None)
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="user,admin", password="pass", db=mock_db
+            )
+
+        assert result.success is True
+        bind_dn = fake_conn.bind_call_args[0]
+        # The comma inside the attribute value must be escaped, not the
+        # structural commas separating RDNs.
+        assert "uid=user\\,admin" in bind_dn
+
+    async def test_username_with_quote_escaped_in_bind_dn(
+        self, ldap_provider, mock_settings
+    ):
+        attrs = _make_ldap_attrs(uid='evil"user')
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[('uid=evil\\"user,ou=users,dc=example,dc=com', attrs)]
+        )
+
+        mock_db, _ = _make_mock_db()
+        mock_db.execute = _mock_execute_factory(None, None)
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username='evil"user', password="pass", db=mock_db
+            )
+
+        bind_dn = fake_conn.bind_call_args[0]
+        assert '\\"' in bind_dn
+
+    async def test_username_with_backslash_escaped_in_bind_dn(
+        self, ldap_provider, mock_settings
+    ):
+        attrs = _make_ldap_attrs(uid="evil\\user")
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[("uid=evil\\\\user,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        mock_db, _ = _make_mock_db()
+        mock_db.execute = _mock_execute_factory(None, None)
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username="evil\\user", password="pass", db=mock_db
+            )
+
+        bind_dn = fake_conn.bind_call_args[0]
+        assert "\\\\" in bind_dn
+
+    async def test_username_with_plus_escaped_in_bind_dn(
+        self, ldap_provider, mock_settings
+    ):
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[]
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username="user+admin", password="pass", db=mock_db
+            )
+
+        bind_dn = fake_conn.bind_call_args[0]
+        assert "user\\+admin" in bind_dn
+
+    async def test_username_with_leading_hash_escaped(
+        self, ldap_provider, mock_settings
+    ):
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[]
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username="#admin", password="pass", db=mock_db
+            )
+
+        bind_dn = fake_conn.bind_call_args[0]
+        # Leading '#' must be escaped.
+        assert "uid=\\#admin" in bind_dn
+
+    async def test_username_with_leading_space_escaped(
+        self, ldap_provider, mock_settings
+    ):
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[]
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username=" spaced", password="pass", db=mock_db
+            )
+
+        bind_dn = fake_conn.bind_call_args[0]
+        assert "uid=\\ spaced" in bind_dn
+
+    async def test_username_with_trailing_space_escaped(
+        self, ldap_provider, mock_settings
+    ):
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[]
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username="spaced ", password="pass", db=mock_db
+            )
+
+        bind_dn = fake_conn.bind_call_args[0]
+        assert "uid=spaced\\ " in bind_dn
+
+    async def test_search_filter_still_uses_filter_escaping(
+        self, ldap_provider, mock_settings
+    ):
+        """Filter must keep using RFC 4515 escaping (different rules from DN)."""
+        attrs = _make_ldap_attrs(uid="user*")
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[("uid=user\\*,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        mock_db, _ = _make_mock_db()
+        mock_db.execute = _mock_execute_factory(None, None)
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username="user*", password="pass", db=mock_db
+            )
+
+        # The asterisk must NOT be backslash-escaped in the filter (it would
+        # break the wildcard semantics). Instead it must use the binary
+        # \2a form required by RFC 4515.
+        # We can't easily inspect the filter directly, but we can confirm
+        # bind DN uses DN escaping (backslash-asterisk is wrong for DN;
+        # * is not a DN-special so it remains literal).
+        bind_dn = fake_conn.bind_call_args[0]
+        assert "uid=user*" in bind_dn
+
+    async def test_angle_brackets_semicolon_escaped(
+        self, ldap_provider, mock_settings
+    ):
+        mock_ldap, mock_filter, fake_conn = _build_ldap_mock(
+            search_results=[]
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            await ldap_provider.authenticate(
+                username="<;>", password="pass", db=mock_db
+            )
+
+        bind_dn = fake_conn.bind_call_args[0]
+        assert "\\<" in bind_dn
+        assert "\\;" in bind_dn
+        assert "\\>" in bind_dn
+
+
+class TestEscapeDNCharsUnit:
+    """Pure unit tests for the helper function (no mocks needed)."""
+
+    def test_empty_string(self):
+        from engine.api.auth.ldap import _escape_dn_chars
+
+        assert _escape_dn_chars("") == ""
+
+    def test_no_special_chars(self):
+        from engine.api.auth.ldap import _escape_dn_chars
+
+        assert _escape_dn_chars("alice") == "alice"
+
+    def test_each_special_char_escaped(self):
+        from engine.api.auth.ldap import _escape_dn_chars
+
+        assert _escape_dn_chars("a,b") == "a\\,b"
+        assert _escape_dn_chars('a"b') == 'a\\"b'
+        assert _escape_dn_chars("a+b") == "a\\+b"
+        assert _escape_dn_chars("a<b") == "a\\<b"
+        assert _escape_dn_chars("a>b") == "a\\>b"
+        assert _escape_dn_chars("a;b") == "a\\;b"
+        assert _escape_dn_chars("a\\b") == "a\\\\b"
+
+    def test_leading_hash_only(self):
+        from engine.api.auth.ldap import _escape_dn_chars
+
+        # Leading '#' is special; embedded '#' is not.
+        assert _escape_dn_chars("#hash") == "\\#hash"
+        assert _escape_dn_chars("a#hash") == "a#hash"
+
+    def test_leading_and_trailing_space(self):
+        from engine.api.auth.ldap import _escape_dn_chars
+
+        assert _escape_dn_chars(" spaced") == "\\ spaced"
+        assert _escape_dn_chars("spaced ") == "spaced\\ "
+        assert _escape_dn_chars(" spaced ") == "\\ spaced\\ "
+        # Interior spaces are preserved literally.
+        assert _escape_dn_chars("a b") == "a b"
+
+    def test_idempotent_for_safe_input(self):
+        from engine.api.auth.ldap import _escape_dn_chars
+
+        assert _escape_dn_chars("alice123") == "alice123"
+
+
+class TestEscapeFilterCharsUnit:
+    """Pure unit tests for the filter-escape helper."""
+
+    def test_star_and_parens_escaped(self):
+        from engine.api.auth.ldap import _escape_filter_chars
+
+        assert _escape_filter_chars("a*b") == "a\\2ab"
+        assert _escape_filter_chars("(uid)") == "\\28uid\\29"
+
+    def test_backslash_and_null_escaped(self):
+        from engine.api.auth.ldap import _escape_filter_chars
+
+        assert _escape_filter_chars("a\\b") == "a\\5cb"
+        assert _escape_filter_chars("a\x00b") == "a\\00b"
+
+    def test_safe_chars_passthrough(self):
+        from engine.api.auth.ldap import _escape_filter_chars
+
+        assert _escape_filter_chars("alice") == "alice"


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix critical LDAP STARTTLS no-op and DN injection vulnerabilities in engine/api/auth/ldap.py

Closes #791
