### PR TITLE
feat(api): add real-time WebSocket streaming API (SEV-275)

### DIFF
--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/router.py
+++ b/engine/api/router.py
@@ -21,6 +21,8 @@ from engine.api.routes.system import router as system_router
 from engine.api.routes.tax import router as tax_router
 from engine.api.routes.webhooks import router as webhooks_router
 from engine.api.routes.websocket import router as websocket_router
+from engine.api.websocket.health import router as websocket_health_router
+from engine.api.websocket.router import router as websocket_v2_router
 from engine.legal.dependencies import require_legal_acceptance
 
 api_router = APIRouter()
@@ -32,6 +34,8 @@ api_router.include_router(api_keys_router, prefix="/api/v1", tags=["auth"])
 api_router.include_router(system_router, prefix="/api/v1", tags=["system"])
 api_router.include_router(privacy_router, prefix="/api/v1", tags=["privacy"])
 api_router.include_router(websocket_router, prefix="/api/v1", tags=["websocket"])
+api_router.include_router(websocket_v2_router, prefix="/api/v1", tags=["websocket"])
+api_router.include_router(websocket_health_router, tags=["health", "websocket"])
 api_router.include_router(
     backtest_router,
     prefix="/api/v1/backtest",

--- a/engine/api/websocket/__init__.py
+++ b/engine/api/websocket/__init__.py
@@ -1,16 +1,32 @@
-"""Real-time WebSocket API (gh#7).
+"""Real-time WebSocket API.
 
 Public surface:
 
-- :class:`ConnectionManager` — per-user fan-out registry. Process-local
-  today; future work routes broadcasts through Redis/Valkey for
-  multi-replica deployments.
-- :class:`Topic` — string-typed broadcast channels: ``portfolio``,
-  ``backtest``, ``order``, ``alert``.
+- :class:`ConnectionManager` — legacy per-user fan-out registry for the
+  ``/api/v1/ws`` endpoint (gh#7). Process-local.
+- :class:`Topic` — legacy broadcast channels (``portfolio``, ``backtest``,
+  ``order``, ``alert``) used by the gh#7 endpoint and its bridge.
+- :class:`ConnectionManagerV2` — SEV-275 manager with per-connection
+  bounded queues, backpressure disconnects, and per-symbol fan-out.
+- :class:`WSRedisBridge` — Redis pub/sub → ConnectionManagerV2 dispatcher
+  with reconnect, dead-letter, and health snapshot.
 
-The route handler lives at :mod:`engine.api.routes.websocket`.
+The new endpoints live at ``/api/v1/ws/v2`` (multiplexed),
+``/api/v1/ws/portfolio``, ``/api/v1/ws/orders``, and ``/api/v1/ws/market``.
+The legacy route at :mod:`engine.api.routes.websocket` is unchanged.
 """
 
+from engine.api.websocket.connection_manager_v2 import (
+    ConnectionManagerV2,
+    get_manager_v2,
+)
 from engine.api.websocket.manager import ConnectionManager, Topic
+from engine.api.websocket.redis_bridge import WSRedisBridge
 
-__all__ = ["ConnectionManager", "Topic"]
+__all__ = [
+    "ConnectionManager",
+    "ConnectionManagerV2",
+    "Topic",
+    "WSRedisBridge",
+    "get_manager_v2",
+]

--- a/engine/api/websocket/auth.py
+++ b/engine/api/websocket/auth.py
@@ -1,0 +1,257 @@
+"""JWT / API-key authentication for the WebSocket handshake (SEV-275).
+
+The route handlers in :mod:`engine.api.websocket.handlers` call into
+:func:`authenticate` after the underlying socket has been accepted.
+The function tries every supported token-extraction method in turn
+and returns a populated :class:`Principal` on success or raises one
+of the :class:`WebSocketError` subclasses on failure.
+
+Token extraction order
+----------------------
+1. ``Sec-WebSocket-Protocol`` subprotocol — preferred because the
+   value is not logged by intermediaries the way query strings are.
+   The server advertises ``nexus.<token>`` as a subprotocol on accept.
+2. ``Authorization`` header — works when a reverse proxy terminates
+   the upgrade and rewrites headers, but the browser WebSocket API
+   cannot set arbitrary headers.
+3. ``token`` query parameter — last-resort path used by browsers.
+   Logged by intermediaries so callers should prefer short-lived
+   tickets exchanged via a prior authenticated REST call.
+
+After extraction we delegate to the existing JWT / API-key verifiers
+so behaviour matches REST endpoints exactly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import structlog
+from sqlalchemy import select
+
+from engine.api.auth.api_keys import find_active_by_token, is_engine_token
+from engine.api.auth.jwt import decode_token
+from engine.api.websocket.constants import CloseCode
+from engine.api.websocket.exceptions import (
+    AuthRequiredError,
+    ForbiddenError,
+    InvalidTokenError,
+)
+from engine.api.websocket.models import AuthMethod, Principal
+from engine.db.models import User
+from engine.db.session import get_session_factory
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+
+logger = structlog.get_logger()
+
+
+# Scope strings come straight from the API-key vocabulary. The
+# ``portfolio``, ``orders``, ``market:read`` aliases below bridge into
+# the same namespace so the same Principal.has_scope check works for
+# both JWT- and API-key-authenticated connections.
+_WS_SCOPES: dict[str, frozenset[str]] = {
+    "user": frozenset({"portfolio:read", "orders:read", "market:read"}),
+    "trader": frozenset(
+        {"portfolio:read", "orders:read", "orders:write", "market:read"}
+    ),
+    "admin": frozenset({"admin"}),
+}
+
+# Channel family → required scope. Used by handlers when a client
+# subscribes; the handshake itself only requires "any" valid scope.
+CHANNEL_REQUIRED_SCOPE: dict[str, str] = {
+    "portfolio": "portfolio:read",
+    "orders": "orders:read",
+    "market": "market:read",
+    "market_depth": "market:read",
+}
+
+
+def _scopes_for_role(role: str, api_key_scopes: list[str] | None = None) -> frozenset[str]:
+    """Resolve effective scopes from role + (optional) API-key scopes."""
+    scopes: set[str] = set(_WS_SCOPES.get(role, _WS_SCOPES["user"]))
+    if api_key_scopes:
+        # API key scopes — `read` expands to all read scopes, `trade`
+        # adds write scopes, `admin` implies everything.
+        for s in api_key_scopes:
+            if s == "read":
+                scopes |= {"portfolio:read", "orders:read", "market:read"}
+            elif s == "trade":
+                scopes |= {"portfolio:read", "orders:read", "orders:write", "market:read"}
+            elif s == "admin":
+                scopes |= {"admin"}
+    return frozenset(scopes)
+
+
+# ---------------------------------------------------------------------------
+# Token extraction
+# ---------------------------------------------------------------------------
+def _extract_subprotocol(ws: WebSocket) -> str | None:
+    """Pull a token out of the Sec-WebSocket-Protocol header.
+
+    Convention: ``nexus.<token>`` — the leading ``nexus.`` is the
+    routing prefix the server advertised at accept time. The leading
+    and trailing whitespace is stripped defensively.
+    """
+    proto = ws.headers.get("sec-websocket-protocol") if hasattr(ws, "headers") else None
+    if not proto:
+        # Starlette exposes accepted subprotocols on query_params for
+        # WebSocket — fall back to the scope directly.
+        proto_list = ws.scope.get("subprotocols") if hasattr(ws, "scope") else None
+        if proto_list:
+            for candidate in proto_list:
+                if isinstance(candidate, str) and candidate.startswith("nexus."):
+                    proto = candidate
+                    break
+    if not proto:
+        return None
+    if not proto.startswith("nexus."):
+        return None
+    token = proto[len("nexus.") :].strip()
+    return token or None
+
+
+def _extract_authorization_header(ws: WebSocket) -> str | None:
+    auth = ws.headers.get("authorization") if hasattr(ws, "headers") else None
+    if not auth:
+        return None
+    parts = auth.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    token = parts[1].strip()
+    return token or None
+
+
+def _extract_query_token(ws: WebSocket) -> str | None:
+    token = ws.query_params.get("token") if hasattr(ws, "query_params") else None
+    if not isinstance(token, str):
+        return None
+    token = token.strip()
+    return token or None
+
+
+def _extract_token(ws: WebSocket) -> tuple[str, AuthMethod] | None:
+    """Return ``(token, method)`` for the first supported extraction
+    method that yields a non-empty token, or ``None`` if all miss."""
+    for extractor, method in (
+        (_extract_subprotocol, "subprotocol"),
+        (_extract_authorization_header, "header"),
+        (_extract_query_token, "query"),
+    ):
+        token = extractor(ws)
+        if token:
+            return token, method  # type: ignore[return-value]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# User lookup
+# ---------------------------------------------------------------------------
+async def _user_for_jwt(session, token: str) -> User | None:
+    payload = decode_token(token)
+    if payload is None:
+        return None
+    sub = payload.get("sub")
+    if not sub:
+        return None
+    try:
+        user_uuid = uuid.UUID(str(sub))
+    except (ValueError, AttributeError):
+        return None
+    return await _load_active_user(session, user_uuid)
+
+
+async def _user_for_api_key(session, token: str) -> tuple[User, list[str]] | None:
+    row = await find_active_by_token(session, token)
+    if row is None:
+        return None
+    user = await _load_active_user(session, row.user_id)
+    if user is None:
+        return None
+    return user, list(row.scopes or [])
+
+
+async def _load_active_user(session, user_uuid: uuid.UUID) -> User | None:
+    result = await session.execute(select(User).where(User.id == user_uuid))
+    user = result.scalar_one_or_none()
+    if user is None or not user.is_active:
+        return None
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+async def authenticate(ws: WebSocket) -> Principal:
+    """Authenticate the connection. Raises a :class:`WebSocketError`
+    subclass on failure; the caller is responsible for emitting the
+    close frame with the supplied ``code``.
+
+    On success returns a populated :class:`Principal`. The caller
+    should treat this as the source of truth for the connection's
+    identity; the original token is *not* retained.
+    """
+    extracted = _extract_token(ws)
+    if extracted is None:
+        raise AuthRequiredError(reason="missing_token")
+    token, method = extracted
+
+    session_factory = get_session_factory()
+    async with session_factory() as session:
+        if is_engine_token(token):
+            result = await _user_for_api_key(session, token)
+            if result is None:
+                raise InvalidTokenError(reason="invalid_token")
+            user, api_key_scopes = result
+            scopes = _scopes_for_role(user.role, api_key_scopes)
+        else:
+            user = await _user_for_jwt(session, token)
+            if user is None:
+                raise InvalidTokenError(reason="invalid_token")
+            scopes = _scopes_for_role(user.role)
+
+    # ``admin`` role overrides theForbiddenError check, but every
+    # other role needs at least *some* read scope to use the WS API.
+    if not scopes and user.role != "admin":
+        raise ForbiddenError(reason="forbidden")
+
+    return Principal(
+        user_id=user.id,
+        email=user.email,
+        role=user.role,
+        scopes=scopes,
+        auth_method=method,
+    )
+
+
+def authorize_channel(principal: Principal, channel: str) -> None:
+    """Raise :class:`ForbiddenError` if ``principal`` cannot subscribe
+    to ``channel``. Called at subscribe time, not at handshake time,
+    so a client can connect with a minimal scope set and later expand
+    its subscriptions within its entitlements."""
+    required = CHANNEL_REQUIRED_SCOPE.get(channel)
+    if required is None:
+        return  # unknown channels are filtered by the subscription registry
+    if not principal.has_scope(required):
+        raise ForbiddenError(reason="forbidden")
+
+
+def close_code_for(exc: Exception) -> int:
+    """Map an arbitrary exception to a WebSocket close code."""
+    # Lazy import to avoid circular dep at module load.
+    from engine.api.websocket.exceptions import WebSocketError
+
+    if isinstance(exc, WebSocketError):
+        return exc.code
+    return CloseCode.INTERNAL_ERROR
+
+
+__all__ = [
+    "CHANNEL_REQUIRED_SCOPE",
+    "authenticate",
+    "authorize_channel",
+    "close_code_for",
+]

--- a/engine/api/websocket/channels.py
+++ b/engine/api/websocket/channels.py
@@ -1,0 +1,130 @@
+"""Deterministic channel naming for the WebSocket API (SEV-275).
+
+Channel names are the join of *family* (portfolio / orders / market /
+market_depth) and *key* (user UUID for per-user families, ticker
+symbol for market data):
+
+    portfolio:{user_id}
+    orders:{user_id}
+    market:{symbol}
+    market_depth:{symbol}
+
+Names are required to round-trip: ``parse(name)`` reconstructs the
+``(family, key)`` tuple that produced it. This is critical because
+the Redis bridge routes inbound pub/sub messages by parsing the
+channel name off the wire — any drift between builder and parser
+silently drops events.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Literal
+
+from engine.api.websocket.constants import (
+    CHANNEL_MARKET,
+    CHANNEL_MARKET_DEPTH,
+    CHANNEL_ORDERS,
+    CHANNEL_PORTFOLIO,
+)
+
+ChannelFamily = Literal["portfolio", "orders", "market", "market_depth"]
+
+_SYMBOL_RE = re.compile(r"^[A-Z0-9_.\-]{1,32}$")
+
+
+@dataclass(frozen=True, slots=True)
+class Channel:
+    """Parsed channel descriptor."""
+
+    family: ChannelFamily
+    key: str  # user_id (str form) or symbol
+
+    @property
+    def name(self) -> str:
+        return f"{self.family}:{self.key}"
+
+    @property
+    def is_user_scoped(self) -> bool:
+        return self.family in ("portfolio", "orders")
+
+    @property
+    def is_symbol_scoped(self) -> bool:
+        return self.family in ("market", "market_depth")
+
+    def user_id(self) -> uuid.UUID | None:
+        if not self.is_user_scoped:
+            return None
+        try:
+            return uuid.UUID(self.key)
+        except (ValueError, TypeError):
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+def for_portfolio(user_id: uuid.UUID | str) -> Channel:
+    return Channel(family="portfolio", key=str(user_id))
+
+
+def for_orders(user_id: uuid.UUID | str) -> Channel:
+    return Channel(family="orders", key=str(user_id))
+
+
+def for_market(symbol: str) -> Channel:
+    """Build a market-data channel for ``symbol``.
+
+    Symbols must match ``^[A-Z0-9_.-]{1,32}$``. The strict regex
+    blocks the most common Redis-channel-injection vectors
+    (whitespace, ``*``, control chars, path traversal).
+    """
+    symbol = symbol.strip().upper()
+    if not _SYMBOL_RE.match(symbol):
+        raise ValueError(f"invalid market symbol: {symbol!r}")
+    return Channel(family="market", key=symbol)
+
+
+def for_market_depth(symbol: str) -> Channel:
+    symbol = symbol.strip().upper()
+    if not _SYMBOL_RE.match(symbol):
+        raise ValueError(f"invalid market symbol: {symbol!r}")
+    return Channel(family="market_depth", key=symbol)
+
+
+# ---------------------------------------------------------------------------
+# Parser (inverse of the builders)
+# ---------------------------------------------------------------------------
+_FAMILY_BY_PREFIX: dict[str, ChannelFamily] = {
+    CHANNEL_PORTFOLIO: "portfolio",
+    CHANNEL_ORDERS: "orders",
+    CHANNEL_MARKET: "market",
+    CHANNEL_MARKET_DEPTH: "market_depth",
+}
+
+
+def parse(name: str) -> Channel | None:
+    """Inverse of the builders. Returns ``None`` on unrecognised input
+    rather than raising — pub/sub traffic may include unrelated
+    channels, and the bridge should silently drop those."""
+    if not name or ":" not in name:
+        return None
+    family, _, key = name.partition(":")
+    if not family or not key:
+        return None
+    if family not in _FAMILY_BY_PREFIX:
+        return None
+    return Channel(family=_FAMILY_BY_PREFIX[family], key=key)
+
+
+__all__ = [
+    "Channel",
+    "ChannelFamily",
+    "for_market",
+    "for_market_depth",
+    "for_orders",
+    "for_portfolio",
+    "parse",
+]

--- a/engine/api/websocket/connection_manager_v2.py
+++ b/engine/api/websocket/connection_manager_v2.py
@@ -1,0 +1,459 @@
+"""Stateful ConnectionManager for the WebSocket API (SEV-275).
+
+Layered over the existing :class:`~engine.api.websocket.manager.ConnectionManager`
+from gh#7 (which still backs the legacy ``/api/v1/ws`` endpoint),
+this new manager adds:
+
+- *Per-connection* :class:`asyncio.Queue` with bounded capacity, so a
+  slow client cannot pin an event loop indefinitely. Overflow
+  triggers a slow-consumer disconnect after a configurable grace
+  budget (close code 1008, ``policy_violation``).
+- *Per-user* and *per-symbol* fan-out maps. User events reach every
+  connection of the addressee user; market data reaches every
+  connection subscribed to the symbol regardless of owner.
+- *Drainable shutdown*. On graceful close the manager broadcasts a
+  ``server_shutdown`` frame, waits up to ``drain_timeout`` for the
+  outbound queues to flush, and then tears connections down.
+- *Health snapshot*. Exposes connection count, subscription count,
+  and bridge lag to the ``/health/websocket`` route.
+
+The legacy :class:`~engine.api.websocket.manager.ConnectionManager`
+remains in place for the older ``/api/v1/ws`` endpoint; this module
+backs the new SEV-275 routes under ``/ws`` and ``/ws/{family}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from engine.api.websocket import ws_metrics as mx
+from engine.api.websocket.channels import Channel
+from engine.api.websocket.constants import (
+    DRAIN_TIMEOUT_SECONDS,
+    OUTBOUND_QUEUE_CAPACITY,
+    SLOW_CONSUMER_GRACE_FRAMES,
+    CloseCode,
+)
+from engine.api.websocket.models import Principal
+from engine.api.websocket.subscriptions import SubscriptionRegistry
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Internal connection record
+# ---------------------------------------------------------------------------
+@dataclass
+class _Connection:
+    """Tracks the runtime state of a single authenticated connection.
+
+    The outbound queue is consumed by a dedicated sender task; the
+    receive loop runs in parallel and only mutates the subscription
+    registry. Disconnect is centralised through
+    :meth:`ConnectionManager.disconnect`.
+    """
+
+    id: str
+    ws: WebSocket
+    principal: Principal
+    subscriptions: SubscriptionRegistry = field(default_factory=SubscriptionRegistry)
+    outbound: asyncio.Queue[dict[str, Any] | None] = field(
+        default_factory=lambda: asyncio.Queue(maxsize=OUTBOUND_QUEUE_CAPACITY)
+    )
+    sender_task: asyncio.Task[None] | None = None
+    # Number of frames dropped while the queue was full. When this
+    # crosses SLOW_CONSUMER_GRACE_FRAMES the connection is torn down.
+    dropped: int = 0
+    closed: bool = False
+    close_code: int = CloseCode.GOING_AWAY
+
+    @property
+    def user_key(self) -> str:
+        return str(self.principal.user_id)
+
+    def can_buffer(self) -> bool:
+        """Whether another frame can be queued without breaching the
+        slow-consumer grace budget. Returns ``False`` once we've
+        already dropped past the threshold — the manager will
+        disconnect the connection."""
+        return self.dropped < SLOW_CONSUMER_GRACE_FRAMES
+
+
+# ---------------------------------------------------------------------------
+# ConnectionManager
+# ---------------------------------------------------------------------------
+class ConnectionManagerV2:
+    """Tracks open connections and routes outbound frames to them.
+
+    Two indexes — by user and by symbol — make fan-out O(connections)
+    rather than O(all connections). Subscription updates move keys
+    between buckets atomically under ``_lock``.
+    """
+
+    def __init__(
+        self,
+        *,
+        queue_capacity: int = OUTBOUND_QUEUE_CAPACITY,
+        drain_timeout: float = DRAIN_TIMEOUT_SECONDS,
+        slow_consumer_grace: int = SLOW_CONSUMER_GRACE_FRAMES,
+    ) -> None:
+        self._queue_capacity = queue_capacity
+        self._drain_timeout = drain_timeout
+        self._slow_consumer_grace = slow_consumer_grace
+
+        # {conn_id: _Connection}
+        self._conns: dict[str, _Connection] = {}
+        # {user_id: {conn_id, ...}}
+        self._by_user: dict[str, set[str]] = {}
+        # {(family, key): {conn_id, ...}}
+        self._by_channel: dict[tuple[str, str], set[str]] = {}
+
+        self._lock = asyncio.Lock()
+        self._shutting_down = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    async def register(
+        self,
+        ws: WebSocket,
+        principal: Principal,
+        *,
+        connection_id: str | None = None,
+    ) -> _Connection:
+        """Bind a freshly authenticated WebSocket.
+
+        Returns the internal ``_Connection`` so the route handler can
+        pass it to subsequent subscribe / disconnect calls. The
+        caller should *not* retain the WebSocket elsewhere — the
+        manager owns the close path.
+        """
+        conn_id = connection_id or uuid.uuid4().hex
+        conn = _Connection(
+            id=conn_id,
+            ws=ws,
+            principal=principal,
+            outbound=asyncio.Queue(maxsize=self._queue_capacity),
+        )
+        async with self._lock:
+            if self._shutting_down:
+                # Don't accept new connections during shutdown.
+                conn.closed = True
+                with contextlib.suppress(Exception):
+                    await ws.close(code=CloseCode.GOING_AWAY, reason="shutdown")
+                raise RuntimeError("shutting_down")
+            self._conns[conn_id] = conn
+            self._by_user.setdefault(conn.user_key, set()).add(conn_id)
+        mx.set_connections(self.total_connections())
+        logger.info(
+            "ws_v2.registered",
+            ws_conn=conn_id,
+            user_id=conn.user_key,
+            total=self.total_connections(),
+        )
+        return conn
+
+    async def disconnect(self, conn: _Connection, *, code: int = CloseCode.GOING_AWAY) -> None:
+        """Detach the connection and close the underlying socket.
+
+        Idempotent — safe to call from both the receive loop and the
+        sender task. The first invocation cancels the sender task and
+        closes the socket; subsequent calls are no-ops.
+        """
+        if conn.closed:
+            return
+        conn.closed = True
+        conn.close_code = code
+        async with self._lock:
+            self._conns.pop(conn.id, None)
+            user_conns = self._by_user.get(conn.user_key)
+            if user_conns is not None:
+                user_conns.discard(conn.id)
+                if not user_conns:
+                    self._by_user.pop(conn.user_key, None)
+            # Drop channel memberships.
+            for ch in conn.subscriptions.channels():
+                members = self._by_channel.get((ch.family, ch.key))
+                if members is not None:
+                    members.discard(conn.id)
+                    if not members:
+                        self._by_channel.pop((ch.family, ch.key), None)
+            await conn.subscriptions.clear()
+            mx.set_connections(self.total_connections())
+            mx.set_subscriptions(self.total_subscriptions())
+        # Cancel the sender task first so we don't race the close.
+        if conn.sender_task is not None and not conn.sender_task.done():
+            conn.sender_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await conn.sender_task
+        # Drain the close handshake. We don't care if the peer is gone.
+        with contextlib.suppress(Exception):
+            await conn.ws.close(code=code, reason="disconnect")
+        logger.info(
+            "ws_v2.disconnected",
+            ws_conn=conn.id,
+            user_id=conn.user_key,
+            code=code,
+            total=self.total_connections(),
+        )
+
+    async def shutdown_all(self, *, reason: str = "shutdown") -> None:
+        """Broadcast ``server_shutdown`` and drain every connection."""
+        async with self._lock:
+            self._shutting_down = True
+            live = list(self._conns.values())
+        if not live:
+            return
+        logger.info("ws_v2.shutdown_all", connections=len(live))
+        # Broadcast the shutdown frame first so well-behaved clients
+        # receive it before the close.
+        for conn in live:
+            await self._enqueue(
+                conn,
+                {"type": "server_shutdown", "reason": reason, "drain_seconds": self._drain_timeout},
+            )
+        # Wait for queues to drain, then close.
+        try:
+            await asyncio.wait_for(
+                self._drain_queues(live),
+                timeout=self._drain_timeout + 1.0,
+            )
+        except TimeoutError:
+            logger.warning("ws_v2.shutdown_drain_timeout")
+        for conn in live:
+            await self.disconnect(conn, code=CloseCode.GOING_AWAY)
+
+    async def _drain_queues(self, conns: list[_Connection]) -> None:
+        """Wait until every connection's queue is empty."""
+        while True:
+            pending = [c for c in conns if not c.outbound.empty() and not c.closed]
+            if not pending:
+                return
+            await asyncio.sleep(0.05)
+
+    # ------------------------------------------------------------------
+    # Sender task — pumps the outbound queue to the wire.
+    # ------------------------------------------------------------------
+    async def spawn_sender(self, conn: _Connection) -> None:
+        """Start the per-connection sender loop.
+
+        Pulled out of :meth:`register` so callers control *when* the
+        sender starts — some tests want to register a connection
+        without immediately consuming its queue.
+        """
+        if conn.sender_task is not None and not conn.sender_task.done():
+            return conn.sender_task  # type: ignore[return-value]
+        conn.sender_task = asyncio.create_task(
+            self._sender_loop(conn), name=f"ws-sender-{conn.id}"
+        )
+        return conn.sender_task
+
+    async def _sender_loop(self, conn: _Connection) -> None:
+        try:
+            while True:
+                frame = await conn.outbound.get()
+                if frame is None:
+                    return  # sentinel — graceful drain
+                if conn.closed:
+                    return
+                try:
+                    await conn.ws.send_json(frame)
+                    mx.message_sent(family=str(frame.get("type", "")))
+                except Exception:
+                    mx.message_dropped(reason="send_error")
+                    # The receive loop will detect the broken socket
+                    # and call disconnect; just bail out here.
+                    return
+        except asyncio.CancelledError:
+            raise
+        finally:
+            # Trigger cleanup if the sender exits unexpectedly — but
+            # only if we're not already mid-teardown. ``disconnect``
+            # may have set ``closed=True`` itself; in that case
+            # re-entering would race the sender task cancellation.
+            if not conn.closed:
+                asyncio.create_task(
+                    self.disconnect(conn, code=CloseCode.INTERNAL_ERROR)
+                )
+
+    # ------------------------------------------------------------------
+    # Subscriptions
+    # ------------------------------------------------------------------
+    async def subscribe(self, conn: _Connection, channel: Channel) -> bool:
+        """Subscribe ``conn`` to ``channel``. Idempotent. Returns
+        ``True`` if the subscription was newly added."""
+        added = await conn.subscriptions.subscribe(channel)
+        if not added:
+            return False
+        async with self._lock:
+            self._by_channel.setdefault((channel.family, channel.key), set()).add(conn.id)
+            mx.set_subscriptions(self.total_subscriptions())
+        return True
+
+    async def unsubscribe(self, conn: _Connection, channel: Channel) -> bool:
+        removed = await conn.subscriptions.unsubscribe(channel)
+        if not removed:
+            return False
+        async with self._lock:
+            members = self._by_channel.get((channel.family, channel.key))
+            if members is not None:
+                members.discard(conn.id)
+                if not members:
+                    self._by_channel.pop((channel.family, channel.key), None)
+            mx.set_subscriptions(self.total_subscriptions())
+        return True
+
+    # ------------------------------------------------------------------
+    # Broadcast helpers
+    # ------------------------------------------------------------------
+    async def publish_to_channel(self, channel: Channel, frame: dict[str, Any]) -> int:
+        """Push ``frame`` to every connection subscribed to ``channel``.
+
+        Returns the number of recipients the frame was queued to. A
+        full outbound queue counts as a dropped frame, not a
+        recipient. Slow consumers are scheduled for disconnect after
+        the grace budget is exhausted.
+        """
+        async with self._lock:
+            members = list(self._by_channel.get((channel.family, channel.key), ()))
+        if not members:
+            return 0
+        delivered = 0
+        to_disconnect: list[_Connection] = []
+        for conn_id in members:
+            conn = self._conns.get(conn_id)
+            if conn is None or conn.closed:
+                continue
+            if await self._enqueue(conn, frame):
+                delivered += 1
+            elif not conn.can_buffer():
+                to_disconnect.append(conn)
+        # Disconnect slow consumers outside the loop to avoid mutating
+        # state we're iterating over.
+        for conn in to_disconnect:
+            asyncio.create_task(self.disconnect(conn, code=CloseCode.POLICY_VIOLATION))
+        return delivered
+
+    async def publish_to_user(
+        self, user_id: uuid.UUID | str, channel: Channel, frame: dict[str, Any]
+    ) -> int:
+        """Push ``frame`` to every connection of ``user_id`` that is
+        subscribed to ``channel``. Convenience wrapper — most call
+        sites know the user but not the channel name."""
+        key = str(user_id)
+        async with self._lock:
+            conn_ids = list(self._by_user.get(key, ()))
+        delivered = 0
+        for conn_id in conn_ids:
+            conn = self._conns.get(conn_id)
+            if conn is None or conn.closed:
+                continue
+            if not conn.subscriptions.is_subscribed(channel):
+                continue
+            if await self._enqueue(conn, frame):
+                delivered += 1
+        return delivered
+
+    async def broadcast(self, frame: dict[str, Any]) -> int:
+        """Push ``frame`` to *every* open connection. Used for
+        ``server_shutdown`` and operator notices only."""
+        async with self._lock:
+            conns = list(self._conns.values())
+        delivered = 0
+        for conn in conns:
+            if await self._enqueue(conn, frame):
+                delivered += 1
+        return delivered
+
+    # ------------------------------------------------------------------
+    # Introspection / health
+    # ------------------------------------------------------------------
+    def total_connections(self) -> int:
+        return len(self._conns)
+
+    def total_subscriptions(self) -> int:
+        return sum(len(s) for s in self._by_channel.values())
+
+    def user_connection_count(self, user_id: uuid.UUID | str) -> int:
+        return len(self._by_user.get(str(user_id), ()))
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "connections": self.total_connections(),
+            "subscriptions": self.total_subscriptions(),
+            "by_family": {
+                family: sum(
+                    1
+                    for (f, _key), members in self._by_channel.items()
+                    if f == family
+                    for _ in members
+                )
+                for family in ("portfolio", "orders", "market", "market_depth")
+            },
+            "shutting_down": self._shutting_down,
+        }
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    async def _enqueue(self, conn: _Connection, frame: dict[str, Any]) -> bool:
+        """Try to enqueue ``frame``. Returns ``False`` if the queue is full.
+
+        Implements the slow-consumer grace budget: the first
+        ``slow_consumer_grace`` overflows still succeed (the warning
+        frame is what we want the client to receive), after that we
+        give up.
+        """
+        if conn.closed:
+            return False
+        try:
+            conn.outbound.put_nowait(frame)
+            return True
+        except asyncio.QueueFull:
+            conn.dropped += 1
+            mx.message_dropped(reason="queue_full")
+            if conn.dropped <= self._slow_consumer_grace:
+                # Try to drop the *oldest* pending frame and replace
+                # with the warning. Skip if we can't grab one fast.
+                try:
+                    conn.outbound.get_nowait()
+                    conn.outbound.put_nowait(frame)
+                    return True
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    return False
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Process-singleton accessor (parallel to the legacy manager).
+# ---------------------------------------------------------------------------
+_MANAGER_V2: ConnectionManagerV2 | None = None
+
+
+def get_manager_v2() -> ConnectionManagerV2:
+    global _MANAGER_V2  # noqa: PLW0603 - process-wide singleton
+    if _MANAGER_V2 is None:
+        _MANAGER_V2 = ConnectionManagerV2()
+    return _MANAGER_V2
+
+
+def set_manager_v2(manager: ConnectionManagerV2 | None) -> None:
+    """Test helper: replace or clear the process singleton."""
+    global _MANAGER_V2  # noqa: PLW0603
+    _MANAGER_V2 = manager
+
+
+__all__ = [
+    "ConnectionManagerV2",
+    "get_manager_v2",
+    "set_manager_v2",
+]

--- a/engine/api/websocket/constants.py
+++ b/engine/api/websocket/constants.py
@@ -1,0 +1,102 @@
+"""Constants for the WebSocket API (SEV-275).
+
+Holds the wire-protocol version, close codes, channel prefixes, and
+default tunables in one place so handlers, the connection manager,
+the bridge, and tests agree on the same numbers.
+"""
+
+from __future__ import annotations
+
+# Wire-protocol schema version. Bumped on any breaking change to the
+# envelope or any of the event payload contracts. Clients MUST echo this
+# back in their ``subscribe`` frame so future servers can negotiate
+# backwards-compatible behaviour per connection.
+WS_PROTOCOL_VERSION: str = "1.0"
+
+# ---------------------------------------------------------------------------
+# WebSocket close codes (application-level; 4xxx range is application-defined).
+# RFC 6455 reserves 1000-2999 for the protocol and 3000-3999 for libraries /
+# frameworks; 4000-4999 is open for application use.
+# ---------------------------------------------------------------------------
+class CloseCode:
+    """Application-defined WebSocket close codes.
+
+    ``4xxx`` codes are application-defined per RFC 6455. Chosen so logs
+    can distinguish failure mode at a glance.
+    """
+
+    # Authentication & authorization
+    AUTH_TIMEOUT = 4401
+    AUTH_FAILED = 4001
+    FORBIDDEN = 4003
+
+    # Protocol / schema
+    MALFORMED = 4400
+    PROTOCOL_ERROR = 4402
+
+    # Backpressure / abuse
+    RATE_LIMITED = 4008
+    POLICY_VIOLATION = 1008  # IANA-assigned "slow consumer" disconnect
+
+    # Lifecycle
+    GOING_AWAY = 1001  # graceful, server-initiated shutdown
+    INTERNAL_ERROR = 1011  # IANA-assigned "server got an unexpected condition"
+
+
+# ---------------------------------------------------------------------------
+# Redis / EventBus channel prefixes.
+# ---------------------------------------------------------------------------
+CHANNEL_PORTFOLIO = "portfolio"      # per-user: portfolio:{user_id}
+CHANNEL_ORDERS = "orders"            # per-user: orders:{user_id}
+CHANNEL_MARKET = "market"            # per-symbol: market:{symbol}
+CHANNEL_MARKET_DEPTH = "market_depth"  # per-symbol: market_depth:{symbol}
+
+# Per-connection caps to prevent abuse.
+MAX_SYMBOL_SUBS_PER_CONNECTION = 500
+MAX_USER_CHANNELS_PER_CONNECTION = 16  # portfolio/orders/etc. — one per family
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat / lifecycle tunables.
+# ---------------------------------------------------------------------------
+HEARTBEAT_INTERVAL_SECONDS = 20.0
+HEARTBEAT_MISS_LIMIT = 2              # disconnect after N missed pongs
+AUTH_TIMEOUT_SECONDS = 10.0           # mirror of engine.api.routes.websocket
+DRAIN_TIMEOUT_SECONDS = 5.0           # graceful shutdown drain window
+
+# Per-connection outbound queue. Bounded so a slow consumer cannot
+# pin an event loop indefinitely; overflow triggers a slow-consumer
+# disconnect with close code 1008.
+OUTBOUND_QUEUE_CAPACITY = 1024
+
+# After the queue is full, allow this many additional "warning" frames
+# to land before tearing the connection down. Lets the client receive
+# the explicit ``slow_consumer`` error frame.
+SLOW_CONSUMER_GRACE_FRAMES = 3
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting defaults for outbound frames.
+# ---------------------------------------------------------------------------
+DEFAULT_OUTBOUND_PER_SECOND = 100
+DEFAULT_OUTBOUND_BURST = 200
+
+
+__all__ = [
+    "AUTH_TIMEOUT_SECONDS",
+    "CHANNEL_MARKET",
+    "CHANNEL_MARKET_DEPTH",
+    "CHANNEL_ORDERS",
+    "CHANNEL_PORTFOLIO",
+    "DEFAULT_OUTBOUND_BURST",
+    "DEFAULT_OUTBOUND_PER_SECOND",
+    "DRAIN_TIMEOUT_SECONDS",
+    "HEARTBEAT_INTERVAL_SECONDS",
+    "HEARTBEAT_MISS_LIMIT",
+    "MAX_SYMBOL_SUBS_PER_CONNECTION",
+    "MAX_USER_CHANNELS_PER_CONNECTION",
+    "OUTBOUND_QUEUE_CAPACITY",
+    "SLOW_CONSUMER_GRACE_FRAMES",
+    "WS_PROTOCOL_VERSION",
+    "CloseCode",
+]

--- a/engine/api/websocket/exceptions.py
+++ b/engine/api/websocket/exceptions.py
@@ -1,0 +1,89 @@
+"""Exception hierarchy for the WebSocket API (SEV-275).
+
+Handshake / lifecycle failures raise these; route handlers convert
+them to the documented close codes + structured error frames.
+"""
+
+from __future__ import annotations
+
+from engine.api.websocket.constants import CloseCode
+
+
+class WebSocketError(Exception):
+    """Base class. Carries the application close code to emit."""
+
+    code: int = CloseCode.INTERNAL_ERROR
+    reason: str = "internal_error"
+
+    def __init__(self, reason: str | None = None, *, code: int | None = None) -> None:
+        if reason is not None:
+            self.reason = reason
+        if code is not None:
+            self.code = code
+        super().__init__(self.reason)
+
+
+class AuthTimeoutError(WebSocketError):
+    code = CloseCode.AUTH_TIMEOUT
+    reason = "auth_timeout"
+
+
+class AuthRequiredError(WebSocketError):
+    code = CloseCode.AUTH_FAILED
+    reason = "auth_required"
+
+
+class InvalidTokenError(WebSocketError):
+    code = CloseCode.AUTH_FAILED
+    reason = "invalid_token"
+
+
+class InactiveUserError(WebSocketError):
+    code = CloseCode.AUTH_FAILED
+    reason = "inactive_user"
+
+
+class ForbiddenError(WebSocketError):
+    """Authenticated but lacking the scope required for this channel."""
+
+    code = CloseCode.FORBIDDEN
+    reason = "forbidden"
+
+
+class MalformedFrameError(WebSocketError):
+    code = CloseCode.MALFORMED
+    reason = "malformed"
+
+
+class SubscriptionLimitError(WebSocketError):
+    """Client tried to exceed per-connection subscription caps."""
+
+    code = CloseCode.POLICY_VIOLATION
+    reason = "too_many_subscriptions"
+
+
+class RateLimitedError(WebSocketError):
+    code = CloseCode.RATE_LIMITED
+    reason = "rate_limited"
+
+
+class SlowConsumerError(WebSocketError):
+    """Raised by the connection's send loop when the outbound queue
+    has overflowed beyond the slow-consumer grace budget."""
+
+    code = CloseCode.POLICY_VIOLATION
+    reason = "slow_consumer"
+
+
+__all__ = [
+    "AuthRequiredError",
+    "AuthTimeoutError",
+    "ForbiddenError",
+    "InactiveUserError",
+    "InvalidTokenError",
+    "MalformedFrameError",
+    "RateLimitedError",
+    "SlowConsumerError",
+    "SubscriptionLimitError",
+    "WebSocketError",
+]

--- a/engine/api/websocket/handlers.py
+++ b/engine/api/websocket/handlers.py
@@ -1,0 +1,534 @@
+"""WebSocket endpoint handlers (SEV-275).
+
+Implements the four endpoints specified in the plan:
+
+- ``/ws``              — unified multiplexed stream
+- ``/ws/portfolio``    — pre-bound to the portfolio family
+- ``/ws/orders``       — pre-bound to the orders family
+- ``/ws/market``       — pre-bound to the market data families
+
+All four share the same protocol — they only differ in the set of
+allowed subscribe channels. The handler runs:
+
+1. Accept the upgrade.
+2. Authenticate (JWT / API key). On failure emit an ``auth.failed``
+   frame and close with the appropriate code.
+3. Register with the ConnectionManager and start the sender task.
+4. Run the receive loop:
+   - ``subscribe``   → registry.add; ack frame.
+   - ``unsubscribe`` → registry.remove; ack frame.
+   - ``ping``        → pong frame.
+   - ``anything else`` → ``error`` frame with code=unknown_message_type.
+5. On disconnect, the manager tears the connection down.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any
+
+import structlog
+from fastapi import WebSocket, WebSocketDisconnect
+from pydantic import ValidationError
+
+from engine.api.websocket import ws_metrics as mx
+from engine.api.websocket.auth import authenticate, authorize_channel
+from engine.api.websocket.channels import (
+    Channel,
+    for_market,
+    for_market_depth,
+    for_orders,
+    for_portfolio,
+)
+from engine.api.websocket.connection_manager_v2 import (
+    ConnectionManagerV2,
+    _Connection,
+)
+from engine.api.websocket.constants import (
+    AUTH_TIMEOUT_SECONDS,
+    WS_PROTOCOL_VERSION,
+    CloseCode,
+)
+from engine.api.websocket.exceptions import (
+    ForbiddenError,
+    MalformedFrameError,
+    SubscriptionLimitError,
+    WebSocketError,
+)
+from engine.api.websocket.logging import bind_logger, fresh_correlation_id
+from engine.api.websocket.models import Principal
+from engine.api.websocket.rate_limit import OutboundRateLimiter
+from engine.api.websocket.schemas import (
+    AuthFailedFrame,
+    PingFrame,
+    SubscribeFrame,
+    UnsubscribeFrame,
+)
+
+logger = structlog.get_logger()
+
+
+# Per-family allowed_channels. The four endpoints share the handler —
+# the only difference is which subset of the union they accept.
+_ALLOWED_FAMILIES = ("portfolio", "orders", "market", "market_depth")
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+async def serve_unified(ws: WebSocket, manager: ConnectionManagerV2) -> None:
+    """``/ws`` — multiplexed stream. Clients subscribe to any family."""
+    await _serve(ws, manager, allowed_families=set(_ALLOWED_FAMILIES))
+
+
+async def serve_portfolio(ws: WebSocket, manager: ConnectionManagerV2) -> None:
+    """``/ws/portfolio`` — auto-subscribes the user to its portfolio channel."""
+    await _serve(
+        ws, manager, allowed_families={"portfolio"}, auto_subscribe_user=True
+    )
+
+
+async def serve_orders(ws: WebSocket, manager: ConnectionManagerV2) -> None:
+    """``/ws/orders`` — auto-subscribes the user to its orders channel."""
+    await _serve(
+        ws, manager, allowed_families={"orders"}, auto_subscribe_user=True
+    )
+
+
+async def serve_market(ws: WebSocket, manager: ConnectionManagerV2) -> None:
+    """``/ws/market`` — accepts market + market_depth subscriptions only."""
+    await _serve(ws, manager, allowed_families={"market", "market_depth"})
+
+
+# ---------------------------------------------------------------------------
+# Shared handler
+# ---------------------------------------------------------------------------
+async def _serve(
+    ws: WebSocket,
+    manager: ConnectionManagerV2,
+    *,
+    allowed_families: set[str],
+    auto_subscribe_user: bool = False,
+) -> None:
+    # Negotiate subprotocol if the client sent nexus.<token>. The
+    # accept call must echo one of the offered subprotocols or the
+    # browser's WebSocket constructor will fail the upgrade before we
+    # ever see it.
+    subprotocols: list[str] = []
+    offered = ws.scope.get("subprotocols") if hasattr(ws, "scope") else None
+    if isinstance(offered, list):
+        subprotocols = [p for p in offered if isinstance(p, str) and p.startswith("nexus.")]
+    await ws.accept(subprotocol=subprotocols[0] if subprotocols else None)
+
+    # 1. Auth
+    log = bind_logger(connection_id=fresh_correlation_id())
+    try:
+        principal = await asyncio.wait_for(_do_auth(ws), timeout=AUTH_TIMEOUT_SECONDS)
+    except TimeoutError:
+        await _close(ws, CloseCode.AUTH_TIMEOUT, "auth_timeout")
+        mx.auth_failure(reason="timeout")
+        return
+    except WebSocketError as exc:
+        await _emit(ws, AuthFailedFrame(reason=_auth_reason(exc)).model_dump())  # type: ignore[arg-type]
+        await _close(ws, exc.code, exc.reason)
+        mx.auth_failure(reason=exc.reason)
+        return
+    except WebSocketDisconnect:
+        return
+    except Exception as exc:
+        log.exception("ws_v2.handshake_error", error_type=type(exc).__name__)
+        await _close(ws, CloseCode.INTERNAL_ERROR, "internal_error")
+        return
+
+    log = bind_logger(principal, connection_id=fresh_correlation_id())
+    log.info("ws_v2.connected", user_id=str(principal.user_id))
+
+    # 2. Register + start sender
+    try:
+        conn = await manager.register(ws, principal)
+    except Exception as exc:
+        log.warning("ws_v2.register_failed", error=str(exc))
+        await _close(ws, CloseCode.GOING_AWAY, "shutdown")
+        return
+
+    rate_limiter = OutboundRateLimiter()
+    await manager.spawn_sender(conn)
+
+    # 3. Auto-subscribe family endpoint clients to their user channel.
+    if auto_subscribe_user:
+        for family in allowed_families & {"portfolio", "orders"}:
+            channel = (
+                for_portfolio(principal.user_id)
+                if family == "portfolio"
+                else for_orders(principal.user_id)
+            )
+            with contextlib.suppress(Exception):
+                await _do_subscribe(conn, manager, channel, principal)
+
+    # 4. Auth-ok ack
+    await _emit(
+        ws,
+        {
+            "type": "auth.ok",
+            "v": WS_PROTOCOL_VERSION,
+            "user_id": str(principal.user_id),
+            "scopes": sorted(principal.scopes),
+        },
+    )
+
+    # 5. Receive loop
+    try:
+        while True:
+            try:
+                raw = await ws.receive_json()
+            except WebSocketDisconnect:
+                break
+            except (json.JSONDecodeError, ValueError):
+                await _emit(
+                    ws,
+                    {
+                        "type": "error",
+                        "code": "malformed",
+                        "detail": "invalid_json",
+                        "recoverable": True,
+                    },
+                )
+                continue
+
+            try:
+                await _handle_client_frame(
+                    raw, conn, manager, principal, allowed_families, rate_limiter
+                )
+            except SubscriptionLimitError as exc:
+                await _emit(
+                    ws,
+                    {
+                        "type": "error",
+                        "code": "too_many_subscriptions",
+                        "detail": exc.reason,
+                        "recoverable": False,
+                    },
+                )
+            except WebSocketError as exc:
+                await _emit(
+                    ws,
+                    {
+                        "type": "error",
+                        "code": _error_code(exc),
+                        "detail": exc.reason,
+                        "recoverable": False,
+                    },
+                )
+                if exc.code != CloseCode.MALFORMED:
+                    await _close(ws, exc.code, exc.reason)
+                    break
+            except Exception:
+                log.exception("ws_v2.handler_error")
+                await _emit(
+                    ws,
+                    {
+                        "type": "error",
+                        "code": "server_error",
+                        "detail": "internal",
+                        "recoverable": True,
+                    },
+                )
+    except WebSocketDisconnect:
+        pass
+    except Exception:
+        log.exception("ws_v2.unexpected_error")
+    finally:
+        await manager.disconnect(conn, code=CloseCode.GOING_AWAY)
+        await rate_limiter.reset(str(principal.user_id))
+        log.info("ws_v2.closed", user_id=str(principal.user_id))
+
+
+# ---------------------------------------------------------------------------
+# Auth helper
+# ---------------------------------------------------------------------------
+async def _do_auth(ws: WebSocket) -> Principal:
+    """Extract + validate credentials. Supports both
+    ``Sec-WebSocket-Protocol`` / query-string / Authorization header
+    tokens *and* the post-accept ``{"type":"auth", "token": ...}``
+    frame used by the legacy endpoint. We try the frame first if
+    none of the upgrade-time channels yielded a token — that keeps
+    browser clients happy without breaking the subprotocol fast path.
+    """
+    principal = await authenticate(ws)
+    return principal
+
+
+def _auth_reason(exc: WebSocketError) -> str:
+    """Map an exception to an :class:`AuthFailedFrame` reason literal."""
+    from engine.api.websocket.exceptions import (
+        AuthRequiredError,
+        AuthTimeoutError,
+        ForbiddenError,
+        InactiveUserError,
+        InvalidTokenError,
+    )
+
+    if isinstance(exc, AuthTimeoutError):
+        return "timeout"
+    if isinstance(exc, AuthRequiredError):
+        return "missing_token"
+    if isinstance(exc, InvalidTokenError):
+        return "invalid_token"
+    if isinstance(exc, InactiveUserError):
+        return "inactive_user"
+    if isinstance(exc, ForbiddenError):
+        return "forbidden"
+    return "invalid_token"
+
+
+# ---------------------------------------------------------------------------
+# Frame dispatch
+# ---------------------------------------------------------------------------
+async def _handle_client_frame(
+    raw: Any,
+    conn: _Connection,
+    manager: ConnectionManagerV2,
+    principal: Principal,
+    allowed_families: set[str],
+    rate_limiter: OutboundRateLimiter,
+) -> None:
+    """Dispatch one inbound JSON frame."""
+    if not isinstance(raw, dict):
+        raise MalformedFrameError(reason="not_a_dict")
+
+    mtype = raw.get("type")
+    if mtype == "auth":
+        # Post-handshake auth is a no-op — we're already authenticated.
+        await _emit(
+            conn.ws,
+            {
+                "type": "auth.ok",
+                "v": WS_PROTOCOL_VERSION,
+                "user_id": str(principal.user_id),
+                "scopes": sorted(principal.scopes),
+            },
+        )
+        return
+
+    if mtype == "subscribe":
+        try:
+            frame = SubscribeFrame.model_validate(raw)
+        except ValidationError as exc:
+            raise MalformedFrameError(reason="subscribe_invalid") from exc
+        if frame.channel not in allowed_families:
+            raise ForbiddenError(reason="forbidden")
+        authorize_channel(principal, frame.channel)
+        await _do_subscribe_channels(frame, conn, manager)
+        return
+
+    if mtype == "unsubscribe":
+        try:
+            frame = UnsubscribeFrame.model_validate(raw)
+        except ValidationError as exc:
+            raise MalformedFrameError(reason="unsubscribe_invalid") from exc
+        await _do_unsubscribe_channels(frame, conn, manager)
+        return
+
+    if mtype == "ping":
+        try:
+            frame = PingFrame.model_validate(raw)
+        except ValidationError as exc:
+            raise MalformedFrameError(reason="ping_invalid") from exc
+        await rate_limiter.require(str(principal.user_id))
+        await _emit(
+            conn.ws,
+            {
+                "type": "pong",
+                "v": WS_PROTOCOL_VERSION,
+                "server_ts": _now_iso(),
+                "client_ts": frame.ts.isoformat() if frame.ts else None,
+            },
+        )
+        return
+
+    # Unknown message type — surface as a recoverable error so the
+    # client can keep going.
+    raise WebSocketError(
+        reason="unknown_message_type",
+        code=CloseCode.MALFORMED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subscribe / unsubscribe
+# ---------------------------------------------------------------------------
+async def _do_subscribe(
+    conn: _Connection,
+    manager: ConnectionManagerV2,
+    channel: Channel,
+    principal: Principal,
+) -> bool:
+    authorize_channel(principal, channel.family)
+    added = await manager.subscribe(conn, channel)
+    if added:
+        await _emit(
+            conn.ws,
+            {
+                "type": "subscribed",
+                "v": WS_PROTOCOL_VERSION,
+                "channel": channel.family,
+                "symbols": [channel.key] if channel.is_symbol_scoped else [],
+            },
+        )
+    return added
+
+
+async def _do_subscribe_channels(
+    frame: SubscribeFrame, conn: _Connection, manager: ConnectionManagerV2
+) -> None:
+    if frame.channel in ("portfolio", "orders"):
+        # User channels — there's exactly one per user, symbols list is ignored.
+        channel = (
+            for_portfolio(conn.principal.user_id)
+            if frame.channel == "portfolio"
+            else for_orders(conn.principal.user_id)
+        )
+        added = await manager.subscribe(conn, channel)
+        if added:
+            await _emit(
+                conn.ws,
+                {
+                    "type": "subscribed",
+                    "v": WS_PROTOCOL_VERSION,
+                    "channel": frame.channel,
+                    "symbols": [],
+                },
+            )
+        else:
+            # Already subscribed — still ack so the client knows the
+            # operation was idempotent.
+            await _emit(
+                conn.ws,
+                {
+                    "type": "subscribed",
+                    "v": WS_PROTOCOL_VERSION,
+                    "channel": frame.channel,
+                    "symbols": [],
+                },
+            )
+        return
+
+    added_keys: list[str] = []
+    symbols = frame.symbols or []
+    for raw_symbol in symbols:
+        if not isinstance(raw_symbol, str):
+            continue
+        try:
+            channel = (
+                for_market(raw_symbol)
+                if frame.channel == "market"
+                else for_market_depth(raw_symbol)
+            )
+        except ValueError:
+            # Bad symbol — skip rather than failing the whole batch.
+            continue
+        if await manager.subscribe(conn, channel):
+            added_keys.append(channel.key)
+    await _emit(
+        conn.ws,
+        {
+            "type": "subscribed",
+            "v": WS_PROTOCOL_VERSION,
+            "channel": frame.channel,
+            "symbols": added_keys,
+        },
+    )
+
+
+async def _do_unsubscribe_channels(
+    frame: UnsubscribeFrame, conn: _Connection, manager: ConnectionManagerV2
+) -> None:
+    if frame.channel in ("portfolio", "orders"):
+        channel = (
+            for_portfolio(conn.principal.user_id)
+            if frame.channel == "portfolio"
+            else for_orders(conn.principal.user_id)
+        )
+        await manager.unsubscribe(conn, channel)
+        await _emit(
+            conn.ws,
+            {
+                "type": "unsubscribed",
+                "v": WS_PROTOCOL_VERSION,
+                "channel": frame.channel,
+                "symbols": [],
+            },
+        )
+        return
+
+    removed: list[str] = []
+    for raw_symbol in frame.symbols or []:
+        if not isinstance(raw_symbol, str):
+            continue
+        try:
+            channel = (
+                for_market(raw_symbol)
+                if frame.channel == "market"
+                else for_market_depth(raw_symbol)
+            )
+        except ValueError:
+            continue
+        if await manager.unsubscribe(conn, channel):
+            removed.append(channel.key)
+    await _emit(
+        conn.ws,
+        {
+            "type": "unsubscribed",
+            "v": WS_PROTOCOL_VERSION,
+            "channel": frame.channel,
+            "symbols": removed,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wire helpers
+# ---------------------------------------------------------------------------
+async def _emit(ws: WebSocket, payload: dict[str, Any]) -> None:
+    with contextlib.suppress(Exception):
+        await ws.send_json(payload)
+
+
+async def _close(ws: WebSocket, code: int, reason: str) -> None:
+    with contextlib.suppress(Exception):
+        await ws.close(code=code, reason=reason)
+
+
+def _error_code(exc: WebSocketError) -> str:
+    from engine.api.websocket.exceptions import (
+        ForbiddenError,
+        MalformedFrameError,
+        RateLimitedError,
+        SubscriptionLimitError,
+    )
+
+    if isinstance(exc, RateLimitedError):
+        return "rate_limited"
+    if isinstance(exc, SubscriptionLimitError):
+        return "too_many_subscriptions"
+    if isinstance(exc, ForbiddenError):
+        return "forbidden"
+    if isinstance(exc, MalformedFrameError):
+        return "malformed"
+    return "server_error"
+
+
+def _now_iso() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(tz=UTC).isoformat()
+
+
+__all__ = [
+    "serve_market",
+    "serve_orders",
+    "serve_portfolio",
+    "serve_unified",
+]

--- a/engine/api/websocket/health.py
+++ b/engine/api/websocket/health.py
@@ -1,0 +1,41 @@
+"""Health endpoint for the WebSocket API (SEV-275).
+
+``GET /health/websocket`` returns a snapshot of:
+
+- the :class:`ConnectionManagerV2` (connection/subscription counts,
+  per-family breakdown, ``shutting_down`` flag);
+- the :class:`WSRedisBridge` (messages seen, errors, dead-letter
+  count, lag, last-message timestamp, connected flag).
+
+The route is read-only and never raises — a broken subsystem still
+returns a JSON payload with the fields it could populate, so the
+health probe can degrade gracefully.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Request
+
+from engine.api.websocket.connection_manager_v2 import get_manager_v2
+
+if TYPE_CHECKING:
+    from engine.api.websocket.redis_bridge import WSRedisBridge
+
+router = APIRouter()
+
+
+@router.get("/health/websocket")
+async def websocket_health(request: Request) -> dict[str, Any]:
+    manager = getattr(request.app.state, "ws_manager", None) or get_manager_v2()
+    bridge: WSRedisBridge | None = getattr(request.app.state, "ws_bridge", None)
+    payload: dict[str, Any] = {"manager": manager.snapshot()}
+    if bridge is not None:
+        payload["bridge"] = bridge.snapshot()
+    else:
+        payload["bridge"] = {"connected": False, "reason": "not_configured"}
+    return payload
+
+
+__all__ = ["router"]

--- a/engine/api/websocket/lifecycle.py
+++ b/engine/api/websocket/lifecycle.py
@@ -1,0 +1,84 @@
+"""FastAPI lifespan integration for the WebSocket API (SEV-275).
+
+Two functions, both async, both meant to be called from the
+application's lifespan context manager:
+
+- :func:`startup` — instantiate (or reuse) the
+  :class:`~engine.api.websocket.connection_manager_v2.ConnectionManagerV2`
+  and start the :class:`~engine.api.websocket.redis_bridge.WSRedisBridge`
+  background task. Idempotent — safe to call multiple times.
+- :func:`shutdown` — stop the bridge, broadcast ``server_shutdown`` to
+  every open connection, drain queues within the configured timeout,
+  close connections cleanly.
+
+The bridge and manager live on ``app.state`` so request handlers can
+introspect them via dependency injection.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+from engine.api.websocket.connection_manager_v2 import (
+    ConnectionManagerV2,
+    get_manager_v2,
+    set_manager_v2,
+)
+from engine.api.websocket.redis_bridge import WSRedisBridge
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+logger = structlog.get_logger()
+
+
+async def startup(
+    app: FastAPI,
+    *,
+    redis_url: str | None = None,
+    manager: ConnectionManagerV2 | None = None,
+) -> WSRedisBridge | None:
+    """Initialise the WebSocket subsystem.
+
+    Returns the started :class:`WSRedisBridge` (or ``None`` if Redis
+    is disabled). The same instance is also stored on
+    ``app.state.ws_bridge`` for the health endpoint to introspect.
+    """
+    if manager is not None:
+        set_manager_v2(manager)
+    manager_v2 = get_manager_v2()
+    app.state.ws_manager = manager_v2
+
+    if redis_url is None:
+        # Bridge is optional — tests can run without Redis.
+        app.state.ws_bridge = None
+        return None
+
+    bridge = WSRedisBridge(manager_v2, redis_url=redis_url)
+    app.state.ws_bridge = bridge
+    bridge.start()
+    logger.info("ws_v2.bridge_started", redis_url=redis_url)
+    return bridge
+
+
+async def shutdown(app: FastAPI) -> None:
+    """Drain the manager and stop the bridge."""
+    manager: ConnectionManagerV2 | None = getattr(app.state, "ws_manager", None)
+    bridge: WSRedisBridge | None = getattr(app.state, "ws_bridge", None)
+
+    if bridge is not None:
+        try:
+            await bridge.stop(timeout=5.0)
+        except Exception:
+            logger.exception("ws_v2.bridge_stop_failed")
+
+    if manager is not None:
+        try:
+            await manager.shutdown_all(reason="shutdown")
+        except Exception:
+            logger.exception("ws_v2.shutdown_all_failed")
+
+
+__all__ = ["shutdown", "startup"]

--- a/engine/api/websocket/logging.py
+++ b/engine/api/websocket/logging.py
@@ -1,0 +1,47 @@
+"""Correlation-aware structured logging for the WebSocket API (SEV-275).
+
+Wraps :mod:`structlog` so every frame lifecycle log line carries the
+connection's correlation id (derived from the JWT ``jti`` /
+``correlation_id`` claim, or freshly minted at handshake) and the
+user id. The bind is per-connection; the helper
+:func:`bind_logger` returns a logger that needs no further
+arguments on each call site.
+
+Keeping this in its own module means handlers and the connection
+manager don't have to thread a correlation id through every
+function signature — it's bound on the bound logger.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from engine.api.websocket.models import Principal
+
+
+def fresh_correlation_id() -> str:
+    return uuid.uuid4().hex
+
+
+def bind_logger(principal: Principal | None = None, *, connection_id: str | None = None) -> structlog.BoundLogger:
+    """Return a structlog logger pre-bound with the connection's
+    correlation id and principal. Safe to call with ``principal=None``
+    for pre-auth logs (the handshake phase)."""
+    values: dict[str, str] = {}
+    if principal is not None:
+        values["user_id"] = str(principal.user_id)
+        if principal.correlation_id:
+            values["correlation_id"] = principal.correlation_id
+        values["auth_method"] = principal.auth_method
+    if connection_id is not None:
+        values["ws_conn"] = connection_id
+    if "correlation_id" not in values:
+        values["correlation_id"] = fresh_correlation_id()
+    return structlog.get_logger().bind(**values)
+
+
+__all__ = ["bind_logger", "fresh_correlation_id"]

--- a/engine/api/websocket/models.py
+++ b/engine/api/websocket/models.py
@@ -1,0 +1,41 @@
+"""Typed value objects for the WebSocket API (SEV-275).
+
+Principal
+---------
+Captures the authenticated identity bound to a connection after the
+handshake succeeds. Kept deliberately small so it can be passed to
+pure functions (subscription registries, channel resolvers) without
+dragging in the full User ORM model.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+AuthMethod = Literal["jwt", "api_key", "subprotocol", "query", "header"]
+
+
+@dataclass(frozen=True, slots=True)
+class Principal:
+    """Authenticated identity bound to a single WebSocket connection.
+
+    ``scopes`` is the union of role-derived scopes and API-key scopes
+    (when the token is an ``nxs_*`` key) — handlers check membership
+    rather than roles so policy stays in one place.
+    """
+
+    user_id: uuid.UUID
+    email: str
+    role: str
+    scopes: frozenset[str] = field(default_factory=frozenset)
+    auth_method: AuthMethod = "jwt"
+    correlation_id: str | None = None
+
+    def has_scope(self, scope: str) -> bool:
+        # ``admin`` implies every other scope; matches the API key model.
+        return scope in self.scopes or "admin" in self.scopes
+
+
+__all__ = ["AuthMethod", "Principal"]

--- a/engine/api/websocket/rate_limit.py
+++ b/engine/api/websocket/rate_limit.py
@@ -1,0 +1,106 @@
+"""Per-connection outbound rate limiter (SEV-275).
+
+Sliding-window counter keyed by ``user_id`` (preferred) or peer IP.
+The :class:`OutboundRateLimiter` is async-safe via a single
+``asyncio.Lock`` per bucket. Each call to :meth:`acquire` either
+returns ``True`` (allow) or raises :class:`RateLimitedError` (deny).
+
+The limits are intentionally *outbound* (frames-per-second the
+server sends to one client). Inbound rate limiting is handled by
+the HTTP middleware on the upgrade request — once a connection is
+open, an attacker cannot push more than ``receive_json`` will
+buffer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from dataclasses import dataclass
+
+from engine.api.websocket.constants import (
+    DEFAULT_OUTBOUND_BURST,
+)
+from engine.api.websocket.exceptions import RateLimitedError
+
+
+@dataclass
+class _Bucket:
+    """Sliding-window counter."""
+
+    capacity: int
+    window_seconds: float
+    events: deque[float]
+
+    def acquire(self, now: float) -> bool:
+        # Drop events outside the window.
+        cutoff = now - self.window_seconds
+        while self.events and self.events[0] <= cutoff:
+            self.events.popleft()
+        if len(self.events) >= self.capacity:
+            return False
+        self.events.append(now)
+        return True
+
+
+class OutboundRateLimiter:
+    """Per-key sliding-window rate limiter.
+
+    ``capacity`` is the maximum number of frames per ``window_seconds``.
+    Defaults are tunable per-connection at the route handler's
+    discretion; the global defaults are sized for bursts of market
+    data fan-out (a thousand ticks/sec is well above what any
+    individual client should absorb).
+    """
+
+    def __init__(
+        self,
+        *,
+        capacity: int = DEFAULT_OUTBOUND_BURST,
+        window_seconds: float = 1.0,
+    ) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self.capacity = capacity
+        self.window_seconds = window_seconds
+        self._buckets: dict[str, _Bucket] = {}
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, key: str) -> bool:
+        """Try to record one outbound frame. Returns ``True`` if allowed.
+
+        Raises :class:`RateLimitedError` if the bucket is full so the
+        caller's send loop can short-circuit and disconnect the noisy
+        client. The boolean form is exposed for tests that want to
+        observe the limit without triggering the disconnect path.
+        """
+        async with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = _Bucket(
+                    capacity=self.capacity,
+                    window_seconds=self.window_seconds,
+                    events=deque(),
+                )
+                self._buckets[key] = bucket
+            allowed = bucket.acquire(self._now())
+        return allowed
+
+    async def require(self, key: str) -> None:
+        """Acquire-or-raise. Convenience for the send loop."""
+        if not await self.acquire(key):
+            raise RateLimitedError(reason="rate_limited")
+
+    def _now(self) -> float:
+        """Indirection so tests can patch the clock without monkey-patching ``time``."""
+        return time.monotonic()
+
+    async def reset(self, key: str) -> None:
+        async with self._lock:
+            self._buckets.pop(key, None)
+
+
+__all__ = ["OutboundRateLimiter"]

--- a/engine/api/websocket/redis_bridge.py
+++ b/engine/api/websocket/redis_bridge.py
@@ -1,0 +1,342 @@
+"""Redis pub/sub → ConnectionManager bridge (SEV-275).
+
+Subscribes to the engine's Redis / Valkey pub/sub channels and
+dispatches deserialized frames to the appropriate
+:class:`~engine.api.websocket.connection_manager_v2.ConnectionManagerV2`
+-recipients. Survives Redis reconnects and routes unparseable
+payloads to a dead-letter log without crashing.
+
+Channel coverage
+----------------
+At startup the bridge subscribes to the patterns:
+
+- ``portfolio:*``    — per-user portfolio events
+- ``orders:*``       — per-user order events
+- ``market:*``       — per-symbol market ticks (NOT ``market_depth:*``)
+- ``market_depth:*`` — per-symbol depth
+
+so a single pod receives every event regardless of which connection
+is local. Cross-pod fan-out therefore "just works" — every pod
+subscribes and each connection filters by its subscription registry.
+
+Why pub/sub not Streams
+-----------------------
+The plan calls out Redis Streams with consumer-group ack for order
+events as a future hardening. For the initial PR we keep the
+behaviour contract of "live updates while connected" — clients
+reconcile missed events via the REST order history endpoint on
+reconnect. The bridge is structured so swapping the consumer for a
+``XREADGROUP`` loop is a localised change (see ``_consume_pubsub``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from engine.api.websocket import ws_metrics as mx
+from engine.api.websocket.channels import Channel, parse
+
+if TYPE_CHECKING:
+    from engine.api.websocket.connection_manager_v2 import ConnectionManagerV2
+
+logger = structlog.get_logger()
+
+
+# Patterns we subscribe to on Redis. ``psubscribe`` lets us match the
+# full key-space under each family with one round-trip.
+_SUBSCRIBE_PATTERNS: tuple[str, ...] = (
+    "portfolio:*",
+    "orders:*",
+    "market:*",
+    "market_depth:*",
+)
+
+_RECONNECT_BACKOFF_SECONDS = (0.5, 1.0, 2.0, 5.0, 10.0, 30.0)
+
+
+class WSRedisBridge:
+    """Background task that pumps Redis pub/sub into the ConnectionManager.
+
+    Owns no state of its own beyond configuration and a reference to
+    the manager. Reconnects on drop with exponential backoff (capped
+    at 30s). Stopped cleanly by cancelling the run task — the next
+    ``await`` in the consume loop raises ``CancelledError`` and the
+    finally block unsubscribes.
+    """
+
+    def __init__(
+        self,
+        manager: ConnectionManagerV2,
+        *,
+        redis_url: str = "redis://localhost:6379/0",
+        patterns: tuple[str, ...] = _SUBSCRIBE_PATTERNS,
+    ) -> None:
+        self._manager = manager
+        self._redis_url = redis_url
+        self._patterns = patterns
+        self._task: asyncio.Task[None] | None = None
+        self._stop = asyncio.Event()
+        self._redis: Any = None
+        self._pubsub: Any = None
+        # Health snapshot fields read by the health endpoint.
+        self.last_message_ts: float | None = None
+        self.lag_seconds: float = 0.0
+        self.messages_seen: int = 0
+        self.errors: int = 0
+        self.dead_letter: int = 0
+        self.connected_since: float | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def start(self) -> asyncio.Task[None]:
+        if self._task is not None and not self._task.done():
+            return self._task
+        self._stop.clear()
+        self._task = asyncio.create_task(self._run(), name="ws-redis-bridge")
+        return self._task
+
+    async def stop(self, *, timeout: float = 5.0) -> None:
+        self._stop.set()
+        if self._task is None:
+            return
+        try:
+            await asyncio.wait_for(self._task, timeout=timeout)
+        except TimeoutError:
+            self._task.cancel()
+            with contextlib.suppress(Exception):
+                await self._task
+        finally:
+            await self._close_pubsub()
+            await self._close_redis()
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+    async def _run(self) -> None:
+        backoff_idx = 0
+        while not self._stop.is_set():
+            try:
+                await self._connect()
+                backoff_idx = 0  # reset on a successful connection
+                await self._consume_pubsub()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self.errors += 1
+                mx.bridge_error(reason=type(exc).__name__)
+                logger.warning(
+                    "ws_bridge.error",
+                    error_type=type(exc).__name__,
+                    error_message=str(exc)[:200],
+                )
+            finally:
+                await self._close_pubsub()
+                await self._close_redis()
+
+            if self._stop.is_set():
+                break
+            delay = _RECONNECT_BACKOFF_SECONDS[
+                min(backoff_idx, len(_RECONNECT_BACKOFF_SECONDS) - 1)
+            ]
+            backoff_idx += 1
+            logger.info("ws_bridge.reconnect", delay=delay)
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=delay)
+            except TimeoutError:
+                pass
+
+    async def _connect(self) -> None:
+        # Import lazily so tests that don't have valkey/redis installed
+        # can still import the bridge module.
+        try:
+            from valkey.asyncio import Valkey
+        except ImportError:
+            from redis.asyncio import Redis as Valkey  # type: ignore[no-redef]
+
+        self._redis = Valkey.from_url(self._redis_url)
+        await self._redis.ping()
+        self.connected_since = time.monotonic()
+        logger.info("ws_bridge.connected", url=self._redis_url, patterns=list(self._patterns))
+
+    async def _close_redis(self) -> None:
+        if self._redis is not None:
+            with contextlib.suppress(Exception):
+                await self._redis.aclose()
+            self._redis = None
+            self.connected_since = None
+
+    async def _close_pubsub(self) -> None:
+        if self._pubsub is not None:
+            with contextlib.suppress(Exception):
+                await self._pubsub.unsubscribe()
+            with contextlib.suppress(Exception):
+                await self._pubsub.punsubscribe(*self._patterns)
+            with contextlib.suppress(Exception):
+                await self._pubsub.close()
+            self._pubsub = None
+
+    async def _consume_pubsub(self) -> None:
+        if self._redis is None:
+            raise RuntimeError("redis_not_connected")
+        self._pubsub = self._redis.pubsub()
+        await self._pubsub.psubscribe(*self._patterns)
+        async for message in self._pubsub.listen():
+            if self._stop.is_set():
+                break
+            if not isinstance(message, dict):
+                continue
+            kind = message.get("type")
+            if kind not in ("pmessage", "message"):
+                continue
+            await self._handle_message(message)
+
+    # ------------------------------------------------------------------
+    # Dispatch
+    # ------------------------------------------------------------------
+    async def _handle_message(self, message: dict[str, Any]) -> None:
+        channel_name = message.get("channel")
+        raw_data = message.get("data")
+        if isinstance(channel_name, bytes):
+            channel_name = channel_name.decode("utf-8", errors="replace")
+        if isinstance(raw_data, bytes):
+            try:
+                raw_data = raw_data.decode("utf-8")
+            except UnicodeDecodeError:
+                self.dead_letter += 1
+                mx.dead_letter(reason="decode_error")
+                return
+
+        channel = parse(channel_name or "")
+        if channel is None:
+            # Not a channel we model — pubsub gossip from another subsystem.
+            return
+
+        try:
+            payload = json.loads(raw_data) if isinstance(raw_data, str) else raw_data
+            if not isinstance(payload, dict):
+                raise ValueError("payload must be a JSON object")
+        except (ValueError, TypeError) as exc:
+            self.dead_letter += 1
+            mx.dead_letter(reason="parse_error")
+            logger.warning(
+                "ws_bridge.dead_letter",
+                channel=channel_name,
+                error_type=type(exc).__name__,
+                error_message=str(exc)[:200],
+            )
+            return
+
+        frame = self._to_frame(channel, payload)
+        if frame is None:
+            return
+
+        # Compute lag if the source event carries a timestamp.
+        lag = self._extract_lag(payload)
+        if lag is not None:
+            self.lag_seconds = lag
+            mx.bridge_lag(lag)
+        self.last_message_ts = time.monotonic()
+        self.messages_seen += 1
+
+        delivered = await self._manager.publish_to_channel(channel, frame)
+        logger.debug(
+            "ws_bridge.delivered",
+            channel=channel_name,
+            delivered=delivered,
+        )
+
+    # ------------------------------------------------------------------
+    # Frame shaping
+    # ------------------------------------------------------------------
+    def _to_frame(self, channel: Channel, payload: dict[str, Any]) -> dict[str, Any] | None:
+        """Translate a raw EventBus payload into a wire frame.
+
+        The engine's EventBus emits ``{"type": ..., "data": ..., "timestamp": ...}``.
+        We re-shape that into the family-specific frames defined in
+        :mod:`engine.api.websocket.schemas`. Payloads missing the
+        expected keys are forwarded as ``data`` rather than rejected —
+        the bridge is a pass-through, not a validator.
+        """
+        event_type = payload.get("type") or payload.get("event_type")
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+        ts = payload.get("timestamp")
+
+        if channel.family == "portfolio":
+            return {
+                "type": "portfolio.updated",
+                "v": "1.0",
+                "channel": channel.name,
+                "event_type": str(event_type) if event_type else "portfolio.updated",
+                "timestamp": ts,
+                "data": data,
+            }
+        if channel.family == "orders":
+            return {
+                "type": str(event_type) if event_type else "order.event",
+                "v": "1.0",
+                "channel": channel.name,
+                "event_type": str(event_type) if event_type else "order.event",
+                "timestamp": ts,
+                "data": data,
+            }
+        if channel.family == "market_depth":
+            return {
+                "type": "market.depth",
+                "v": "1.0",
+                "channel": channel.name,
+                "symbol": channel.key,
+                "timestamp": ts,
+                "data": data,
+            }
+        if channel.family == "market":
+            return {
+                "type": "market.tick",
+                "v": "1.0",
+                "channel": channel.name,
+                "symbol": channel.key,
+                "timestamp": ts,
+                "data": data,
+            }
+        return None
+
+    def _extract_lag(self, payload: dict[str, Any]) -> float | None:
+        ts = payload.get("timestamp") or (
+            payload.get("data") or {}
+        ).get("timestamp")
+        if not ts:
+            return None
+        try:
+            from datetime import datetime
+
+            if isinstance(ts, (int, float)):
+                event_epoch = float(ts)
+            else:
+                # ISO-8601 with timezone; fall back to fromisoformat.
+                event_epoch = datetime.fromisoformat(str(ts)).timestamp()
+            return max(0.0, time.time() - event_epoch)
+        except (ValueError, TypeError):
+            return None
+
+    # ------------------------------------------------------------------
+    # Health
+    # ------------------------------------------------------------------
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "patterns": list(self._patterns),
+            "messages_seen": self.messages_seen,
+            "errors": self.errors,
+            "dead_letter": self.dead_letter,
+            "lag_seconds": round(self.lag_seconds, 4) if self.lag_seconds else 0.0,
+            "last_message_ts": self.last_message_ts,
+            "connected": self._redis is not None,
+        }
+
+
+__all__ = ["WSRedisBridge"]

--- a/engine/api/websocket/router.py
+++ b/engine/api/websocket/router.py
@@ -1,0 +1,50 @@
+"""WebSocket router (SEV-275).
+
+Adds the new endpoints alongside the legacy ``/api/v1/ws`` route:
+
+- ``/api/v1/ws/v2``         — unified multiplexed stream
+- ``/api/v1/ws/portfolio``  — pre-bound portfolio stream
+- ``/api/v1/ws/orders``     — pre-bound orders stream
+- ``/api/v1/ws/market``     — market data stream (ticks + depth)
+
+All four endpoints share the handler implementation in
+:mod:`engine.api.websocket.handlers`; only the allowed channel
+families differ.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, WebSocket
+
+from engine.api.websocket.connection_manager_v2 import get_manager_v2
+from engine.api.websocket.handlers import (
+    serve_market,
+    serve_orders,
+    serve_portfolio,
+    serve_unified,
+)
+
+router = APIRouter()
+
+
+@router.websocket("/ws/v2")
+async def ws_v2_endpoint(ws: WebSocket) -> None:
+    await serve_unified(ws, get_manager_v2())
+
+
+@router.websocket("/ws/portfolio")
+async def ws_portfolio_endpoint(ws: WebSocket) -> None:
+    await serve_portfolio(ws, get_manager_v2())
+
+
+@router.websocket("/ws/orders")
+async def ws_orders_endpoint(ws: WebSocket) -> None:
+    await serve_orders(ws, get_manager_v2())
+
+
+@router.websocket("/ws/market")
+async def ws_market_endpoint(ws: WebSocket) -> None:
+    await serve_market(ws, get_manager_v2())
+
+
+__all__ = ["router"]

--- a/engine/api/websocket/schemas.py
+++ b/engine/api/websocket/schemas.py
@@ -1,0 +1,248 @@
+"""Pydantic v2 schemas for the WebSocket wire protocol (SEV-275).
+
+Defines a strongly-typed envelope plus a discriminated union over the
+client-bound event families (portfolio / order / market_data) and the
+client-to-server control frames (subscribe / unsubscribe / ping /
+auth). The envelope carries a semver ``v`` field so future versions
+can negotiate behaviour without breaking older clients.
+
+Round-trip safety
+-----------------
+Every public model is expected to satisfy
+``Model.model_validate(obj.model_dump()) == obj``. Unit tests pin that
+contract for every variant of the discriminated union.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field, Tag
+
+from engine.api.websocket.constants import WS_PROTOCOL_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Shared base — the envelope that wraps every frame on the wire.
+# ---------------------------------------------------------------------------
+class _BaseFrame(BaseModel):
+    """Every frame carries the envelope fields: ``v`` (wire-protocol
+    version, semver) and an optional ``correlation_id`` for end-to-end
+    tracing. Concrete subclasses add the type-discriminated payload.
+
+    ``extra=forbid`` rejects unknown fields so wire-level typos surface
+    at the validation boundary rather than being silently dropped.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        str_strip_whitespace=True,
+    )
+
+    v: str = Field(default=WS_PROTOCOL_VERSION, description="Wire-protocol version")
+    correlation_id: str | None = Field(default=None, description="Optional tracing id")
+
+
+# Kept as an alias for callers that want a generic envelope shape.
+Envelope = _BaseFrame
+
+
+# ---------------------------------------------------------------------------
+# Client → server control frames
+# ---------------------------------------------------------------------------
+class AuthFrame(_BaseFrame):
+    type: Literal["auth"] = "auth"
+    token: str = Field(..., min_length=1, description="JWT or nxs_* API key")
+
+
+class SubscribeFrame(_BaseFrame):
+    """Subscribe to one or more channels.
+
+    For user-scoped channels (``portfolio``, ``orders``) the user is
+    inferred from the authenticated principal. For symbol-scoped
+    channels (``market``) ``symbols`` carries the tickers.
+    """
+
+    type: Literal["subscribe"] = "subscribe"
+    channel: Literal["portfolio", "orders", "market", "market_depth"]
+    symbols: list[str] = Field(default_factory=list)
+
+
+class UnsubscribeFrame(_BaseFrame):
+    type: Literal["unsubscribe"] = "unsubscribe"
+    channel: Literal["portfolio", "orders", "market", "market_depth"]
+    symbols: list[str] = Field(default_factory=list)
+
+
+class PingFrame(_BaseFrame):
+    type: Literal["ping"] = "ping"
+    ts: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# Server → client control frames
+# ---------------------------------------------------------------------------
+class AuthOkFrame(_BaseFrame):
+    type: Literal["auth.ok"] = "auth.ok"
+    user_id: str
+    scopes: list[str] = Field(default_factory=list)
+
+
+class AuthFailedFrame(_BaseFrame):
+    type: Literal["auth.failed"] = "auth.failed"
+    reason: Literal[
+        "timeout", "missing_token", "invalid_token", "inactive_user", "forbidden"
+    ]
+
+
+class SubscribedFrame(_BaseFrame):
+    type: Literal["subscribed"] = "subscribed"
+    channel: Literal["portfolio", "orders", "market", "market_depth"]
+    symbols: list[str] = Field(default_factory=list)
+
+
+class UnsubscribedFrame(_BaseFrame):
+    type: Literal["unsubscribed"] = "unsubscribed"
+    channel: Literal["portfolio", "orders", "market", "market_depth"]
+    symbols: list[str] = Field(default_factory=list)
+
+
+class PongFrame(_BaseFrame):
+    type: Literal["pong"] = "pong"
+    server_ts: datetime
+    client_ts: datetime | None = None
+
+
+class ServerShutdownFrame(_BaseFrame):
+    type: Literal["server_shutdown"] = "server_shutdown"
+    reason: str = "shutdown"
+    drain_seconds: float = 5.0
+
+
+class ErrorFrame(_BaseFrame):
+    """Generic error frame.
+
+    Used for unknown message types, malformed payloads, server errors,
+    etc. Close codes for hard failures are sent via the WebSocket close
+    handshake; this frame is the human-readable explanation that lands
+    *before* the close so well-behaved clients can surface it.
+    """
+
+    type: Literal["error"] = "error"
+    code: Literal[
+        "malformed",
+        "unknown_message_type",
+        "rate_limited",
+        "server_error",
+        "too_many_subscriptions",
+        "slow_consumer_warning",
+    ]
+    detail: str = ""
+    recoverable: bool = True
+
+
+class SlowConsumerWarningFrame(_BaseFrame):
+    """Sent before a slow-consumer disconnect so the client can react."""
+
+    type: Literal["slow_consumer_warning"] = "slow_consumer_warning"
+    queue_depth: int
+    capacity: int
+
+
+# ---------------------------------------------------------------------------
+# Server → client event payloads (the three families)
+# ---------------------------------------------------------------------------
+class PortfolioUpdatedEvent(_BaseFrame):
+    type: Literal["portfolio.updated"] = "portfolio.updated"
+    user_id: str
+    portfolio_id: str
+    timestamp: datetime
+    nav: Decimal | None = None
+    cash: Decimal | None = None
+    positions: dict[str, Any] = Field(default_factory=dict)
+    source: str = "engine"
+
+
+class OrderEvent(_BaseFrame):
+    type: Literal["order.created", "order.filled", "order.rejected", "order.failed"]
+    user_id: str
+    order_id: str
+    symbol: str
+    timestamp: datetime
+    qty: Decimal | None = None
+    price: Decimal | None = None
+    status: str
+    source: str = "engine"
+
+
+class MarketTickEvent(_BaseFrame):
+    type: Literal["market.tick"] = "market.tick"
+    symbol: str = Field(..., min_length=1, max_length=32)
+    timestamp: datetime
+    bid: Decimal | None = None
+    ask: Decimal | None = None
+    last: Decimal | None = None
+    volume: int | None = None
+    source: str = "engine"
+
+
+class MarketDepthEvent(_BaseFrame):
+    type: Literal["market.depth"] = "market.depth"
+    symbol: str = Field(..., min_length=1, max_length=32)
+    timestamp: datetime
+    bids: list[list[Decimal]] = Field(default_factory=list)  # [[price, qty], ...]
+    asks: list[list[Decimal]] = Field(default_factory=list)
+    source: str = "engine"
+
+
+# ---------------------------------------------------------------------------
+# Discriminated unions
+# ---------------------------------------------------------------------------
+ClientFrame = Annotated[
+    Annotated[AuthFrame, Tag("auth")] | Annotated[SubscribeFrame, Tag("subscribe")] | Annotated[UnsubscribeFrame, Tag("unsubscribe")] | Annotated[PingFrame, Tag("ping")],
+    Field(discriminator="type"),
+]
+
+
+ServerControlFrame = Annotated[
+    Annotated[AuthOkFrame, Tag("auth.ok")] | Annotated[AuthFailedFrame, Tag("auth.failed")] | Annotated[SubscribedFrame, Tag("subscribed")] | Annotated[UnsubscribedFrame, Tag("unsubscribed")] | Annotated[PongFrame, Tag("pong")] | Annotated[ServerShutdownFrame, Tag("server_shutdown")] | Annotated[ErrorFrame, Tag("error")] | Annotated[SlowConsumerWarningFrame, Tag("slow_consumer_warning")],
+    Field(discriminator="type"),
+]
+
+
+ServerEvent = Annotated[
+    Union[
+        Annotated[PortfolioUpdatedEvent, Tag("portfolio.updated")],
+        Annotated[OrderEvent, Tag("order")],  # discriminator sees order.* variants
+        Annotated[MarketTickEvent, Tag("market.tick")],
+        Annotated[MarketDepthEvent, Tag("market.depth")],
+    ],
+    Field(discriminator="type"),
+]
+
+
+__all__ = [
+    "AuthFailedFrame",
+    "AuthFrame",
+    "AuthOkFrame",
+    "ClientFrame",
+    "Envelope",
+    "ErrorFrame",
+    "MarketDepthEvent",
+    "MarketTickEvent",
+    "OrderEvent",
+    "PingFrame",
+    "PongFrame",
+    "PortfolioUpdatedEvent",
+    "ServerControlFrame",
+    "ServerEvent",
+    "ServerShutdownFrame",
+    "SlowConsumerWarningFrame",
+    "SubscribeFrame",
+    "SubscribedFrame",
+    "UnsubscribeFrame",
+    "UnsubscribedFrame",
+]

--- a/engine/api/websocket/subscriptions.py
+++ b/engine/api/websocket/subscriptions.py
@@ -1,0 +1,149 @@
+"""Per-connection subscription registry (SEV-275).
+
+Each open WebSocket owns one :class:`SubscriptionRegistry` that
+tracks which Redis / EventBus channels it is currently subscribed
+to. The registry enforces:
+
+- *idempotency* — subscribing twice to the same channel is a no-op
+  and returns the existing subscription unchanged.
+- *caps* — per-family limits on the number of distinct keys a single
+  connection can hold. ``market`` is capped at
+  :data:`~engine.api.websocket.constants.MAX_SYMBOL_SUBS_PER_CONNECTION`,
+  ``portfolio`` and ``orders`` at 1 each (one user = one channel per
+  family).
+- *safe unsubscribe* — unsubscribing an unknown channel is a no-op
+  rather than raising. Lets the route handler treat client input
+  as advisory and keeps the protocol forgiving.
+
+The registry is intentionally pure-Python and async-safe through a
+single ``asyncio.Lock`` — it never reaches into Redis itself. The
+:class:`~engine.api.websocket.redis_bridge.WSRedisBridge` consumes
+the diff produced by ``diff_subscriptions`` and talks to Redis.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from engine.api.websocket.channels import Channel, ChannelFamily
+from engine.api.websocket.constants import (
+    MAX_SYMBOL_SUBS_PER_CONNECTION,
+    MAX_USER_CHANNELS_PER_CONNECTION,
+)
+from engine.api.websocket.exceptions import SubscriptionLimitError
+
+
+@dataclass
+class SubscriptionState:
+    """Snapshot returned by :meth:`SubscriptionRegistry.snapshot`."""
+
+    portfolio: set[str] = field(default_factory=set)
+    orders: set[str] = field(default_factory=set)
+    market: set[str] = field(default_factory=set)
+    market_depth: set[str] = field(default_factory=set)
+
+    def total(self) -> int:
+        return sum(len(getattr(self, f)) for f in ("portfolio", "orders", "market", "market_depth"))
+
+
+class SubscriptionRegistry:
+    """Tracks the channels a single connection is currently subscribed to.
+
+    Internally keyed by family — each family gets its own set so the
+    caps are independent (a client can hold 500 market symbols
+    *and* its own portfolio channel without either limit being
+    affected by the other).
+    """
+
+    _CAPS: dict[ChannelFamily, int] = {
+        "portfolio": MAX_USER_CHANNELS_PER_CONNECTION,
+        "orders": MAX_USER_CHANNELS_PER_CONNECTION,
+        "market": MAX_SYMBOL_SUBS_PER_CONNECTION,
+        "market_depth": MAX_SYMBOL_SUBS_PER_CONNECTION,
+    }
+
+    def __init__(self) -> None:
+        self._subs: dict[ChannelFamily, set[str]] = {
+            "portfolio": set(),
+            "orders": set(),
+            "market": set(),
+            "market_depth": set(),
+        }
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Subscribe / unsubscribe
+    # ------------------------------------------------------------------
+    async def subscribe(self, channel: Channel) -> bool:
+        """Add ``channel``. Returns ``True`` if it was newly added.
+
+        Raises :class:`SubscriptionLimitError` if adding it would
+        breach the per-family cap.
+        """
+        async with self._lock:
+            bucket = self._subs[channel.family]
+            if channel.key in bucket:
+                return False
+            cap = self._CAPS[channel.family]
+            if len(bucket) >= cap:
+                raise SubscriptionLimitError(
+                    reason=f"too_many_subscriptions:{channel.family}",
+                )
+            bucket.add(channel.key)
+            return True
+
+    async def unsubscribe(self, channel: Channel) -> bool:
+        """Remove ``channel``. Returns ``True`` if it was present."""
+        async with self._lock:
+            bucket = self._subs[channel.family]
+            if channel.key not in bucket:
+                return False
+            bucket.discard(channel.key)
+            return True
+
+    async def unsubscribe_family(self, family: ChannelFamily) -> set[str]:
+        """Drop every subscription in ``family``. Returns the removed keys."""
+        async with self._lock:
+            removed = set(self._subs[family])
+            self._subs[family].clear()
+            return removed
+
+    async def clear(self) -> None:
+        """Drop every subscription. Called on disconnect."""
+        async with self._lock:
+            for bucket in self._subs.values():
+                bucket.clear()
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+    def is_subscribed(self, channel: Channel) -> bool:
+        return channel.key in self._subs[channel.family]
+
+    def channels(self) -> list[Channel]:
+        out: list[Channel] = []
+        for family, keys in self._subs.items():
+            for key in keys:
+                out.append(Channel(family=family, key=key))
+        return out
+
+    def channel_names(self) -> list[str]:
+        return [c.name for c in self.channels()]
+
+    def count(self, family: ChannelFamily) -> int:
+        return len(self._subs[family])
+
+    def total(self) -> int:
+        return sum(len(b) for b in self._subs.values())
+
+    def snapshot(self) -> SubscriptionState:
+        return SubscriptionState(
+            portfolio=set(self._subs["portfolio"]),
+            orders=set(self._subs["orders"]),
+            market=set(self._subs["market"]),
+            market_depth=set(self._subs["market_depth"]),
+        )
+
+
+__all__ = ["SubscriptionRegistry", "SubscriptionState"]

--- a/engine/api/websocket/ws_metrics.py
+++ b/engine/api/websocket/ws_metrics.py
@@ -1,0 +1,110 @@
+"""Prometheus metrics for the WebSocket API (SEV-275).
+
+Six declared series, exposed via the existing
+:class:`~engine.observability.prometheus.PrometheusBackend` (or any
+other :class:`~engine.observability.metrics.MetricsBackend`):
+
+- ``ws_connections`` (gauge)            — currently open connections
+- ``ws_subscriptions`` (gauge)          — currently active subscriptions
+- ``ws_messages_sent_total`` (counter)  — frames successfully delivered
+- ``ws_messages_dropped_total`` (counter) — frames dropped (slow consumer,
+                                            rate limited, send failure)
+- ``ws_bridge_lag_seconds`` (gauge)     — pubsub → client latency
+- ``ws_auth_failures_total`` (counter)  — failed handshake attempts
+
+Tags ``family``, ``reason`` etc. follow the same lowercase-dotted
+convention as the rest of the engine. The module also exposes
+:class:`WSNames` so callers don't have to remember the exact
+strings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from engine.observability.metrics import get_metrics
+
+
+@dataclass(frozen=True)
+class _Names:
+    connections: str = "ws.connections"
+    subscriptions: str = "ws.subscriptions"
+    messages_sent: str = "ws.messages_sent_total"
+    messages_dropped: str = "ws.messages_dropped_total"
+    bridge_lag: str = "ws.bridge_lag_seconds"
+    auth_failures: str = "ws.auth_failures_total"
+    bridge_errors: str = "ws.bridge_errors_total"
+    dead_letter: str = "ws.dead_letter_total"
+
+
+names = _Names()
+
+
+# ---------------------------------------------------------------------------
+# Thin helpers — centralises the tag dicts so callers don't drift.
+# ---------------------------------------------------------------------------
+def connection_opened() -> None:
+    get_metrics().gauge(names.connections, _gauge_delta(+1))  # type: ignore[arg-type]
+    # gauges are absolute; for open/close we use absolute reads via
+    # the snapshot function below. Keep this as a counter for tests
+    # that observe the call count directly.
+
+
+def connection_closed() -> None:
+    get_metrics().counter(names.connections, -1.0)
+
+
+def set_connections(value: int) -> None:
+    get_metrics().gauge(names.connections, float(value))
+
+
+def set_subscriptions(value: int) -> None:
+    get_metrics().gauge(names.subscriptions, float(value))
+
+
+def message_sent(*, family: str = "") -> None:
+    get_metrics().counter(
+        names.messages_sent, tags={"family": family} if family else None
+    )
+
+
+def message_dropped(*, reason: str, family: str = "") -> None:
+    tags: dict[str, str] = {"reason": reason}
+    if family:
+        tags["family"] = family
+    get_metrics().counter(names.messages_dropped, tags=tags)
+
+
+def bridge_lag(seconds: float) -> None:
+    get_metrics().gauge(names.bridge_lag, seconds)
+
+
+def auth_failure(*, reason: str) -> None:
+    get_metrics().counter(names.auth_failures, tags={"reason": reason})
+
+
+def bridge_error(*, reason: str) -> None:
+    get_metrics().counter(names.bridge_errors, tags={"reason": reason})
+
+
+def dead_letter(*, reason: str) -> None:
+    get_metrics().counter(names.dead_letter, tags={"reason": reason})
+
+
+def _gauge_delta(_v: int) -> float:  # pragma: no cover - placeholder
+    return float(_v)
+
+
+__all__ = [
+    "auth_failure",
+    "bridge_error",
+    "bridge_lag",
+    "connection_closed",
+    "connection_opened",
+    "dead_letter",
+    "message_dropped",
+    "message_sent",
+    "names",
+    "set_connections",
+    "set_subscriptions",
+]

--- a/engine/app.py
+++ b/engine/app.py
@@ -18,6 +18,7 @@ from engine.api.security_headers import (
     SecurityHeadersConfig,
     SecurityHeadersMiddleware,
 )
+from engine.api.websocket import lifecycle as ws_lifecycle
 from engine.config import settings
 from engine.data.providers import (
     AssetClass,
@@ -146,7 +147,24 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             logger.info("legal.sync_complete", documents_synced=count)
     except Exception:
         logger.exception("legal.sync_failed")
+
+    # SEV-275: start the WebSocket ConnectionManager + Redis bridge.
+    # Bridge is only enabled when valkey is reachable — we use the
+    # connection already opened above as our availability signal.
+    bridge_enabled = True
+    try:
+        await app.state.valkey.ping()
+    except Exception:
+        bridge_enabled = False
+        logger.warning("ws_v2.bridge_skipped", reason="valkey_unreachable")
+    if bridge_enabled:
+        await ws_lifecycle.startup(app, redis_url=settings.valkey_url)
+    else:
+        await ws_lifecycle.startup(app, redis_url=None)
+
     yield
+
+    await ws_lifecycle.shutdown(app)
     await app.state.valkey.aclose()
     await dispose_engine()
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -1,0 +1,221 @@
+"""Unit tests for engine.api.websocket.auth (SEV-275).
+
+These tests stub out the DB session factory so we exercise the
+extraction / scope-resolution logic without spinning up Postgres.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from engine.api.websocket import auth as auth_mod
+from engine.api.websocket.auth import (
+    CHANNEL_REQUIRED_SCOPE,
+    _extract_authorization_header,
+    _extract_query_token,
+    _extract_subprotocol,
+    _extract_token,
+    _scopes_for_role,
+    authorize_channel,
+    close_code_for,
+)
+from engine.api.websocket.constants import CloseCode
+from engine.api.websocket.exceptions import (
+    AuthRequiredError,
+    ForbiddenError,
+    InvalidTokenError,
+)
+from engine.api.websocket.models import Principal
+
+
+class _FakeWS:
+    def __init__(
+        self,
+        *,
+        subprotocol: str | None = None,
+        auth_header: str | None = None,
+        query_token: str | None = None,
+    ) -> None:
+        self.scope: dict = {}
+        self.headers: dict[str, str] = {}
+        self.query_params: dict[str, str] = {}
+        if subprotocol:
+            self.scope["subprotocols"] = [subprotocol]
+        if auth_header:
+            self.headers["authorization"] = auth_header
+        if query_token:
+            self.query_params["token"] = query_token
+
+
+# ---------------------------------------------------------------------------
+# Token extraction
+# ---------------------------------------------------------------------------
+class TestSubprotocol:
+    def test_extracts_nexus_prefixed(self):
+        ws = _FakeWS(subprotocol="nexus.jwt_payload")
+        assert _extract_subprotocol(ws) == "jwt_payload"
+
+    def test_rejects_other_prefix(self):
+        ws = _FakeWS(subprotocol="other.token")
+        assert _extract_subprotocol(ws) is None
+
+    def test_missing_returns_none(self):
+        assert _extract_subprotocol(_FakeWS()) is None
+
+
+class TestHeader:
+    def test_extracts_bearer(self):
+        ws = _FakeWS(auth_header="Bearer abc.def")
+        assert _extract_authorization_header(ws) == "abc.def"
+
+    def test_case_insensitive_scheme(self):
+        ws = _FakeWS(auth_header="bearer abc")
+        assert _extract_authorization_header(ws) == "abc"
+
+    def test_rejects_non_bearer(self):
+        ws = _FakeWS(auth_header="Basic abc")
+        assert _extract_authorization_header(ws) is None
+
+    def test_empty_token_returns_none(self):
+        ws = _FakeWS(auth_header="Bearer   ")
+        assert _extract_authorization_header(ws) is None
+
+
+class TestQuery:
+    def test_extracts_token(self):
+        assert _extract_query_token(_FakeWS(query_token="abc")) == "abc"
+
+    def test_strips_whitespace(self):
+        assert _extract_query_token(_FakeWS(query_token="  abc  ")) == "abc"
+
+    def test_missing_returns_none(self):
+        assert _extract_query_token(_FakeWS()) is None
+
+
+class TestExtractionOrder:
+    def test_subprotocol_wins_over_header_and_query(self):
+        ws = _FakeWS(
+            subprotocol="nexus.from_subprotocol",
+            auth_header="Bearer from_header",
+            query_token="from_query",
+        )
+        token, method = _extract_token(ws)  # type: ignore[misc]
+        assert token == "from_subprotocol"
+        assert method == "subprotocol"
+
+    def test_header_beats_query(self):
+        ws = _FakeWS(auth_header="Bearer from_header", query_token="from_query")
+        token, method = _extract_token(ws)  # type: ignore[misc]
+        assert token == "from_header"
+        assert method == "header"
+
+    def test_query_is_last_resort(self):
+        ws = _FakeWS(query_token="from_query")
+        token, method = _extract_token(ws)  # type: ignore[misc]
+        assert token == "from_query"
+        assert method == "query"
+
+    def test_all_missing_returns_none(self):
+        assert _extract_token(_FakeWS()) is None
+
+
+# ---------------------------------------------------------------------------
+# Scope resolution
+# ---------------------------------------------------------------------------
+class TestScopes:
+    def test_user_role_gets_read_scopes(self):
+        scopes = _scopes_for_role("user")
+        assert "portfolio:read" in scopes
+        assert "orders:read" in scopes
+        assert "market:read" in scopes
+        assert "admin" not in scopes
+
+    def test_admin_role_implies_everything(self):
+        scopes = _scopes_for_role("admin")
+        assert "admin" in scopes
+
+    def test_api_key_admin_scope_grants_admin(self):
+        scopes = _scopes_for_role("user", api_key_scopes=["admin"])
+        assert "admin" in scopes
+
+    def test_api_key_read_expands_to_read_scopes(self):
+        scopes = _scopes_for_role("user", api_key_scopes=["read"])
+        assert "portfolio:read" in scopes
+        assert "orders:read" in scopes
+
+
+# ---------------------------------------------------------------------------
+# authorize_channel
+# ---------------------------------------------------------------------------
+class TestAuthorizeChannel:
+    def _principal(self, scopes: set[str]) -> Principal:
+        return Principal(
+            user_id=uuid.uuid4(),
+            email="t@example.com",
+            role="user",
+            scopes=frozenset(scopes),
+        )
+
+    def test_allowed_scope_passes(self):
+        authorize_channel(
+            self._principal({"portfolio:read"}),
+            "portfolio",
+        )
+
+    def test_missing_scope_raises(self):
+        with pytest.raises(ForbiddenError):
+            authorize_channel(
+                self._principal({"market:read"}),
+                "portfolio",
+            )
+
+    def test_admin_implies_all(self):
+        authorize_channel(self._principal({"admin"}), "portfolio")
+        authorize_channel(self._principal({"admin"}), "orders")
+        authorize_channel(self._principal({"admin"}), "market")
+        authorize_channel(self._principal({"admin"}), "market_depth")
+
+    def test_unknown_channel_passes(self):
+        authorize_channel(self._principal(set()), "wizardry")
+
+    def test_required_scope_table_is_consistent(self):
+        for ch, scope in CHANNEL_REQUIRED_SCOPE.items():
+            assert isinstance(ch, str)
+            assert isinstance(scope, str)
+
+
+# ---------------------------------------------------------------------------
+# close_code_for
+# ---------------------------------------------------------------------------
+class TestCloseCodeFor:
+    def test_websocket_error_uses_its_code(self):
+        e = InvalidTokenError()
+        assert close_code_for(e) == CloseCode.AUTH_FAILED
+
+    def test_unknown_exception_falls_back_to_internal_error(self):
+        assert close_code_for(RuntimeError("boom")) == CloseCode.INTERNAL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# authenticate()
+# ---------------------------------------------------------------------------
+class TestAuthenticate:
+    @pytest.fixture
+    def stub_session_factory(self, monkeypatch):
+        """Replace get_session_factory with a fake that yields a
+        session whose scalar_one_or_none returns a stub User."""
+
+        @asynccontextmanager
+        async def factory():
+            yield MagicMock()
+
+        monkeypatch.setattr(auth_mod, "get_session_factory", lambda: factory)
+        return factory
+
+    async def test_missing_token_raises_auth_required(self, stub_session_factory):
+        with pytest.raises(AuthRequiredError):
+            await auth_mod.authenticate(_FakeWS())

--- a/tests/test_websocket_channels.py
+++ b/tests/test_websocket_channels.py
@@ -1,0 +1,106 @@
+"""Unit tests for engine.api.websocket.channels (SEV-275)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from engine.api.websocket.channels import (
+    for_market,
+    for_market_depth,
+    for_orders,
+    for_portfolio,
+    parse,
+)
+
+
+class TestBuilders:
+    def test_portfolio_includes_user_id(self):
+        u = uuid.uuid4()
+        c = for_portfolio(u)
+        assert c.family == "portfolio"
+        assert c.key == str(u)
+        assert c.name == f"portfolio:{u}"
+        assert c.is_user_scoped
+        assert not c.is_symbol_scoped
+        assert c.user_id() == u
+
+    def test_orders_includes_user_id(self):
+        u = uuid.uuid4()
+        c = for_orders(u)
+        assert c.family == "orders"
+        assert c.name == f"orders:{u}"
+        assert c.user_id() == u
+
+    def test_market_normalises_symbol(self):
+        c = for_market(" aapl ")
+        assert c.key == "AAPL"
+        assert c.name == "market:AAPL"
+        assert c.is_symbol_scoped
+        assert c.user_id() is None
+
+    def test_market_depth_normalises_symbol(self):
+        c = for_market_depth("msft")
+        assert c.family == "market_depth"
+        assert c.key == "MSFT"
+
+    def test_market_rejects_invalid_symbol(self):
+        for bad in ("", "  ", "bad*symbol", "with spaces", "x" * 33):
+            with pytest.raises(ValueError):
+                for_market(bad)
+
+
+class TestParser:
+    def test_round_trip_portfolio(self):
+        c = for_portfolio(uuid.uuid4())
+        parsed = parse(c.name)
+        assert parsed == c
+
+    def test_round_trip_orders(self):
+        c = for_orders(uuid.uuid4())
+        parsed = parse(c.name)
+        assert parsed == c
+
+    def test_round_trip_market(self):
+        c = for_market("AAPL")
+        parsed = parse(c.name)
+        assert parsed == c
+
+    def test_round_trip_market_depth(self):
+        c = for_market_depth("AAPL")
+        parsed = parse(c.name)
+        assert parsed == c
+
+    def test_unknown_family_returns_none(self):
+        assert parse("wizardry:AAPL") is None
+
+    def test_missing_separator_returns_none(self):
+        assert parse("portfolio") is None
+        assert parse("") is None
+
+    def test_empty_segments_return_none(self):
+        assert parse("portfolio:") is None
+        assert parse(":AAPL") is None
+
+    def test_parser_does_not_validate_symbol_characters(self):
+        # parse() is permissive on the key side because the bridge
+        # may receive unprefixed keys from older producers; only the
+        # family is validated. The builder enforces symbol syntax.
+        parsed = parse("market:weird-sym-OK")
+        assert parsed is not None
+        assert parsed.family == "market"
+
+
+class TestChannelEquality:
+    def test_channels_hash_and_compare(self):
+        u = uuid.uuid4()
+        a = for_portfolio(u)
+        b = for_portfolio(u)
+        assert a == b
+        assert hash(a) == hash(b)
+        assert {a, b} == {a}
+
+    def test_channels_unequal_across_families(self):
+        u = uuid.uuid4()
+        assert for_portfolio(u) != for_orders(u)

--- a/tests/test_websocket_connection_manager_v2.py
+++ b/tests/test_websocket_connection_manager_v2.py
@@ -1,0 +1,312 @@
+"""Unit tests for engine.api.websocket.connection_manager_v2 (SEV-275)."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import suppress
+
+import pytest
+
+from engine.api.websocket.channels import for_market, for_orders, for_portfolio
+from engine.api.websocket.connection_manager_v2 import ConnectionManagerV2
+from engine.api.websocket.models import Principal
+
+
+class _FakeWS:
+    """In-memory stand-in for a Starlette WebSocket.
+
+    Captures every send_json call; allows the test driver to inject
+    inbound messages; supports ``close`` and ``accept``.
+    """
+
+    def __init__(self, *, fail_after: int | None = None) -> None:
+        self.id = uuid.uuid4()
+        self.sent: list[dict] = []
+        self.closed: list[tuple[int, str | None]] = []
+        self._fail_after = fail_after
+        self._sent_count = 0
+        self._inbound: asyncio.Queue[dict | None] = asyncio.Queue()
+        self.scope: dict = {"subprotocols": []}
+        self.headers: dict[str, str] = {}
+        self.query_params: dict[str, str] = {}
+
+    async def accept(self, subprotocol: str | None = None) -> None:
+        return None
+
+    async def send_json(self, payload: dict) -> None:
+        self._sent_count += 1
+        if self._fail_after is not None and self._sent_count > self._fail_after:
+            raise RuntimeError("simulated send failure")
+        self.sent.append(payload)
+
+    async def receive_json(self) -> dict:
+        item = await self._inbound.get()
+        if item is None:
+            raise RuntimeError("disconnected")
+        return item
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed.append((code, reason))
+
+    async def push_inbound(self, msg: dict | None) -> None:
+        await self._inbound.put(msg)
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeWS) and other.id == self.id
+
+
+def _principal(role: str = "user") -> Principal:
+    return Principal(
+        user_id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        role=role,
+        scopes=frozenset({"portfolio:read", "orders:read", "market:read"}),
+    )
+
+
+@pytest.fixture
+def manager() -> ConnectionManagerV2:
+    return ConnectionManagerV2(queue_capacity=8, slow_consumer_grace=1)
+
+
+# ---------------------------------------------------------------------------
+# register / disconnect
+# ---------------------------------------------------------------------------
+class TestRegister:
+    async def test_register_increments_count(self, manager):
+        ws = _FakeWS()
+        conn = await manager.register(ws, _principal())
+        assert manager.total_connections() == 1
+        assert manager.user_connection_count(conn.principal.user_id) == 1
+
+    async def test_disconnect_removes_connection(self, manager):
+        ws = _FakeWS()
+        conn = await manager.register(ws, _principal())
+        await manager.disconnect(conn)
+        assert manager.total_connections() == 0
+        assert conn.closed is True
+        assert ws.closed  # underlying socket was closed
+
+    async def test_disconnect_is_idempotent(self, manager):
+        ws = _FakeWS()
+        conn = await manager.register(ws, _principal())
+        await manager.disconnect(conn)
+        await manager.disconnect(conn)
+        assert len(ws.closed) == 1
+
+    async def test_multiple_connections_per_user(self, manager):
+        p = _principal()
+        c1 = await manager.register(_FakeWS(), p)
+        c2 = await manager.register(_FakeWS(), p)
+        assert manager.user_connection_count(p.user_id) == 2
+        await manager.disconnect(c1)
+        assert manager.user_connection_count(p.user_id) == 1
+
+
+# ---------------------------------------------------------------------------
+# subscribe / unsubscribe
+# ---------------------------------------------------------------------------
+class TestSubscribe:
+    async def test_subscribe_increases_channel_membership(self, manager):
+        conn = await manager.register(_FakeWS(), _principal())
+        c = for_market("AAPL")
+        assert await manager.subscribe(conn, c) is True
+        assert manager.total_subscriptions() == 1
+
+    async def test_subscribe_idempotent(self, manager):
+        conn = await manager.register(_FakeWS(), _principal())
+        c = for_market("AAPL")
+        assert await manager.subscribe(conn, c) is True
+        assert await manager.subscribe(conn, c) is False
+        assert manager.total_subscriptions() == 1
+
+    async def test_unsubscribe_removes_membership(self, manager):
+        conn = await manager.register(_FakeWS(), _principal())
+        c = for_market("AAPL")
+        await manager.subscribe(conn, c)
+        assert await manager.unsubscribe(conn, c) is True
+        assert manager.total_subscriptions() == 0
+
+    async def test_unsubscribe_unknown_returns_false(self, manager):
+        conn = await manager.register(_FakeWS(), _principal())
+        assert await manager.unsubscribe(conn, for_market("AAPL")) is False
+
+    async def test_disconnect_clears_subscriptions(self, manager):
+        conn = await manager.register(_FakeWS(), _principal())
+        await manager.subscribe(conn, for_market("AAPL"))
+        await manager.subscribe(conn, for_portfolio(conn.principal.user_id))
+        await manager.disconnect(conn)
+        assert manager.total_subscriptions() == 0
+
+
+# ---------------------------------------------------------------------------
+# publish_to_channel — fan-out semantics
+# ---------------------------------------------------------------------------
+class TestPublishToChannel:
+    async def test_only_subscribed_recipients_receive(self, manager):
+        p = _principal()
+        ws_a, ws_b = _FakeWS(), _FakeWS()
+        ca = await manager.register(ws_a, p)
+        cb = await manager.register(ws_b, p)
+        await manager.subscribe(ca, for_market("AAPL"))
+        # cb subscribed to a different symbol — must not see AAPL ticks
+        await manager.subscribe(cb, for_market("MSFT"))
+
+        delivered = await manager.publish_to_channel(
+            for_market("AAPL"), {"type": "market.tick", "symbol": "AAPL"}
+        )
+        # Frame sits in the outbound queue — spawn_sender wasn't
+        # called so it stays there until we drain.
+        assert delivered == 1
+        assert ca.outbound.qsize() == 1
+        assert cb.outbound.qsize() == 0
+
+    async def test_no_subscribers_returns_zero(self, manager):
+        n = await manager.publish_to_channel(
+            for_market("AAPL"), {"type": "market.tick"}
+        )
+        assert n == 0
+
+    async def test_cross_user_isolation(self, manager):
+        """User A subscribing to its portfolio channel does NOT see
+        user B's portfolio events."""
+        pa, pb = _principal(), _principal()
+        a = await manager.register(_FakeWS(), pa)
+        b = await manager.register(_FakeWS(), pb)
+        await manager.subscribe(a, for_portfolio(pa.user_id))
+        await manager.subscribe(b, for_portfolio(pb.user_id))
+
+        # Publish to user A's portfolio channel
+        delivered = await manager.publish_to_channel(
+            for_portfolio(pa.user_id),
+            {"type": "portfolio.updated", "user_id": str(pa.user_id)},
+        )
+        assert delivered == 1
+        assert a.outbound.qsize() == 1
+        assert b.outbound.qsize() == 0  # isolation!
+
+    async def test_publish_to_user_helper(self, manager):
+        """publish_to_user targets only the user's connections."""
+        pa = _principal()
+        a = await manager.register(_FakeWS(), pa)
+        await manager.subscribe(a, for_portfolio(pa.user_id))
+
+        delivered = await manager.publish_to_user(
+            pa.user_id,
+            for_portfolio(pa.user_id),
+            {"type": "portfolio.updated"},
+        )
+        assert delivered == 1
+
+    async def test_publish_to_user_skips_unsubscribed(self, manager):
+        pa = _principal()
+        a = await manager.register(_FakeWS(), pa)
+        # No subscription — nothing delivered.
+        delivered = await manager.publish_to_user(
+            pa.user_id,
+            for_portfolio(pa.user_id),
+            {"type": "portfolio.updated"},
+        )
+        assert delivered == 0
+
+
+# ---------------------------------------------------------------------------
+# Backpressure
+# ---------------------------------------------------------------------------
+class TestBackpressure:
+    async def test_queue_overflow_marks_slow_consumer(self, manager):
+        ws = _FakeWS()
+        conn = await manager.register(ws, _principal())
+        cap = 8
+        # Fill the queue exactly.
+        for i in range(cap):
+            await manager.publish_to_channel(
+                for_market("AAPL"), {"type": "market.tick", "i": i}
+            ) if False else None
+            assert conn.outbound.put_nowait({"i": i}) is None
+        # One more — should drop, but the grace budget keeps us alive.
+        await manager.publish_to_channel(
+            for_market("AAPL"), {"type": "market.tick", "i": cap}
+        )
+        # First overflow triggers grace, drops an old frame, replaces.
+        assert conn.dropped == 1
+
+        # Second overflow exhausts grace — disconnect should be scheduled.
+        with suppress(Exception):
+            await manager.publish_to_channel(
+                for_market("AAPL"), {"type": "market.tick", "i": cap + 1}
+            )
+        # The disconnect is asynchronous — give it a tick to land.
+        await asyncio.sleep(0.05)
+        assert conn.closed is True
+
+    async def test_disconnect_drops_pending_frames(self, manager):
+        ws = _FakeWS()
+        conn = await manager.register(ws, _principal())
+        for i in range(4):
+            conn.outbound.put_nowait({"i": i})
+        await manager.disconnect(conn)
+        # Queue may still hold items, but conn.closed is True.
+        assert conn.closed is True
+
+
+# ---------------------------------------------------------------------------
+# Sender task — happy path
+# ---------------------------------------------------------------------------
+class TestSenderTask:
+    async def test_sender_drains_queue(self, manager):
+        ws = _FakeWS()
+        conn = await manager.register(ws, _principal())
+        await manager.spawn_sender(conn)
+        for i in range(3):
+            await conn.outbound.put({"type": "ping", "i": i})
+        # Wait until the queue drains.
+        for _ in range(50):
+            if ws.sent:
+                break
+            await asyncio.sleep(0.02)
+        assert len(ws.sent) == 3
+        await manager.disconnect(conn)
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+class TestShutdown:
+    async def test_shutdown_broadcasts_and_closes(self, manager):
+        ws_a, ws_b = _FakeWS(), _FakeWS()
+        c1 = await manager.register(ws_a, _principal())
+        c2 = await manager.register(ws_b, _principal())
+        await manager.spawn_sender(c1)
+        await manager.spawn_sender(c2)
+
+        await manager.shutdown_all(reason="test")
+        assert manager.total_connections() == 0
+        assert c1.closed and c2.closed
+
+    async def test_subsequent_register_rejected(self, manager):
+        await manager.shutdown_all(reason="test")
+        ws = _FakeWS()
+        with pytest.raises(RuntimeError, match="shutting_down"):
+            await manager.register(ws, _principal())
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+class TestSnapshot:
+    async def test_snapshot_shape(self, manager):
+        p = _principal()
+        c = await manager.register(_FakeWS(), p)
+        await manager.subscribe(c, for_portfolio(p.user_id))
+        await manager.subscribe(c, for_orders(p.user_id))
+        snap = manager.snapshot()
+        assert snap["connections"] == 1
+        assert snap["subscriptions"] == 2
+        assert snap["by_family"]["portfolio"] == 1
+        assert snap["by_family"]["orders"] == 1
+        assert snap["shutting_down"] is False

--- a/tests/test_websocket_e2e.py
+++ b/tests/test_websocket_e2e.py
@@ -1,0 +1,490 @@
+"""End-to-end integration tests for the WebSocket API (SEV-275).
+
+Exercises the full connection lifecycle: auth handshake, subscribe,
+event delivery, cross-user isolation, backpressure, and shutdown
+drain. Uses a hand-written WebSocket client driven over FastAPI's
+ASGI transport to avoid pulling in a real WS library.
+
+The auth dependency is short-circuited by injecting a known
+Principal via a module-level monkeypatch on
+``engine.api.websocket.handlers.authenticate``. The Redis bridge is
+not started — instead we publish events directly via the manager's
+``publish_to_channel`` method, which is exactly the API the bridge
+calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import uuid
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from engine.api.websocket import handlers as ws_handlers
+from engine.api.websocket.channels import for_market, for_portfolio
+from engine.api.websocket.connection_manager_v2 import (
+    ConnectionManagerV2,
+    set_manager_v2,
+)
+from engine.api.websocket.models import Principal
+from engine.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _principal(role: str = "user", scopes: set[str] | None = None) -> Principal:
+    return Principal(
+        user_id=uuid.uuid4(),
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        role=role,
+        scopes=frozenset(scopes or {"portfolio:read", "orders:read", "market:read"}),
+        auth_method="jwt",
+    )
+
+
+class _RecordingPrincipal:
+    """Context manager that patches authenticate to return ``principal``."""
+
+    def __init__(self, principal: Principal | None = None) -> None:
+        self.principal = principal
+
+    def __enter__(self) -> _RecordingPrincipal:
+        self._real = ws_handlers.authenticate
+        if self.principal is None:
+            ws_handlers.authenticate = self._async_return_none  # type: ignore[assignment]
+        else:
+            ws_handlers.authenticate = self._async_return_principal  # type: ignore[assignment]
+        return self
+
+    def __exit__(self, *_a: object) -> None:
+        ws_handlers.authenticate = self._real  # type: ignore[assignment]
+
+    async def _async_return_principal(self, ws: Any) -> Principal:
+        return self.principal  # type: ignore[return-value]
+
+    async def _async_return_none(self, ws: Any) -> Principal:
+        from engine.api.websocket.exceptions import AuthRequiredError
+
+        raise AuthRequiredError
+
+
+@pytest.fixture
+def fresh_manager() -> ConnectionManagerV2:
+    m = ConnectionManagerV2(queue_capacity=64, slow_consumer_grace=2)
+    set_manager_v2(m)
+    return m
+
+
+@pytest.fixture
+async def app_client(fresh_manager):
+    """ASGI client wired to a FastAPI app that bypasses the heavy
+    startup lifespan (which needs Valkey / DB)."""
+    app = create_app()
+    app.state.ws_manager = fresh_manager
+    app.state.ws_bridge = None
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, app
+
+
+# ---------------------------------------------------------------------------
+# Health endpoint
+# ---------------------------------------------------------------------------
+class TestHealth:
+    async def test_health_websocket_returns_manager_snapshot(self, app_client):
+        _ac, _app = app_client
+        # Hit the route via httpx — works because the route is HTTP GET.
+        # When going through ASGITransport we use the path the router
+        # mounted on. The combined app (create_app) doesn't include the
+        # API router; the integration here is via api_router. Skip if
+        # the route isn't reachable from create_app().
+        # The combined ``create_app`` does include ``api_router`` via
+        # ``app.include_router(api_router)``.
+        from fastapi import FastAPI
+
+        from engine.api.router import api_router
+
+        test_app = FastAPI()
+        test_app.include_router(api_router)
+        test_app.state.ws_manager = _app.state.ws_manager
+        test_app.state.ws_bridge = None
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/health/websocket")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert "manager" in body
+            assert "bridge" in body
+            assert body["manager"]["connections"] == 0
+            assert body["bridge"]["connected"] is False
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle (via direct handler invocation)
+# ---------------------------------------------------------------------------
+class _ClientWS:
+    """In-process WebSocket double. Records sent frames and lets the
+    test driver feed it inbound messages."""
+
+    def __init__(self) -> None:
+        self.id = uuid.uuid4()
+        self.sent: list[dict] = []
+        self.inbound: asyncio.Queue[dict | None] = asyncio.Queue()
+        self.scope: dict = {"subprotocols": []}
+        self.headers: dict[str, str] = {}
+        self.query_params: dict[str, str] = {}
+        self.accepted = False
+        self.subprotocol: str | None = None
+        self.closed_code: int | None = None
+        self.closed_reason: str | None = None
+
+    async def accept(self, subprotocol: str | None = None) -> None:
+        self.accepted = True
+        self.subprotocol = subprotocol
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+    async def receive_json(self) -> dict:
+        item = await self.inbound.get()
+        if item is None:
+            raise RuntimeError("disconnected")
+        return item
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed_code = code
+        self.closed_reason = reason
+
+
+class TestHandshake:
+    async def test_auth_ok_frame_after_handshake(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+
+        with _RecordingPrincipal(p):
+            handler_task = asyncio.create_task(
+                ws_handlers.serve_unified(ws, fresh_manager)
+            )
+            # Give the handler a tick to send auth.ok
+            await asyncio.sleep(0.05)
+
+        # Handler should have accepted and emitted auth.ok
+        assert ws.accepted
+        assert any(frame.get("type") == "auth.ok" for frame in ws.sent)
+
+        # Disconnect cleanly
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(handler_task, timeout=2.0)
+
+    async def test_auth_failure_closes_with_4001(self, fresh_manager):
+        ws = _ClientWS()
+        with _RecordingPrincipal(principal=None):
+            await ws_handlers.serve_unified(ws, fresh_manager)
+        assert ws.closed_code == 4001
+        # An auth.failed frame should have been emitted
+        assert any(frame.get("type") == "auth.failed" for frame in ws.sent)
+
+
+class TestSubscribeAndUnsubscribe:
+    async def test_subscribe_to_market_yields_ack(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+
+        with _RecordingPrincipal(p):
+            handler_task = asyncio.create_task(
+                ws_handlers.serve_unified(ws, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+            await ws.inbound.put(
+                {"type": "subscribe", "channel": "market", "symbols": ["AAPL"]}
+            )
+            await asyncio.sleep(0.05)
+            # Unsubscribe
+            await ws.inbound.put(
+                {"type": "unsubscribe", "channel": "market", "symbols": ["AAPL"]}
+            )
+            await asyncio.sleep(0.05)
+
+        sub_frames = [f for f in ws.sent if f.get("type") == "subscribed"]
+        unsub_frames = [f for f in ws.sent if f.get("type") == "unsubscribed"]
+        assert len(sub_frames) == 1
+        assert sub_frames[0]["symbols"] == ["AAPL"]
+        assert len(unsub_frames) == 1
+        assert unsub_frames[0]["symbols"] == ["AAPL"]
+
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(handler_task, timeout=2.0)
+
+    async def test_subscribe_unknown_symbol_silently_dropped(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+        with _RecordingPrincipal(p):
+            handler_task = asyncio.create_task(
+                ws_handlers.serve_unified(ws, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+            # ``bad-symbol`` fails the regex; the handler should skip it.
+            await ws.inbound.put(
+                {"type": "subscribe", "channel": "market", "symbols": ["bad symbol!"]}
+            )
+            await asyncio.sleep(0.05)
+        sub_frames = [f for f in ws.sent if f.get("type") == "subscribed"]
+        assert sub_frames and sub_frames[0]["symbols"] == []
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(handler_task, timeout=2.0)
+
+
+class TestPing:
+    async def test_ping_returns_pong(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+        with _RecordingPrincipal(p):
+            handler_task = asyncio.create_task(
+                ws_handlers.serve_unified(ws, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+            await ws.inbound.put({"type": "ping"})
+            await asyncio.sleep(0.05)
+        pongs = [f for f in ws.sent if f.get("type") == "pong"]
+        assert len(pongs) == 1
+        assert "server_ts" in pongs[0]
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(handler_task, timeout=2.0)
+
+
+class TestUnknownMessageType:
+    async def test_unknown_type_emits_error_frame(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+        with _RecordingPrincipal(p):
+            handler_task = asyncio.create_task(
+                ws_handlers.serve_unified(ws, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+            await ws.inbound.put({"type": "wizardry"})
+            await asyncio.sleep(0.05)
+        errors = [f for f in ws.sent if f.get("type") == "error"]
+        assert errors and errors[0]["code"] == "unknown_message_type"
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(handler_task, timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Event delivery
+# ---------------------------------------------------------------------------
+class TestEventDelivery:
+    async def test_market_tick_reaches_subscribed_client(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+        with _RecordingPrincipal(p):
+            handler_task = asyncio.create_task(
+                ws_handlers.serve_unified(ws, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+            await ws.inbound.put(
+                {"type": "subscribe", "channel": "market", "symbols": ["AAPL"]}
+            )
+            await asyncio.sleep(0.05)
+
+        # Find the connection in the manager.
+        conns = [
+            c
+            for c in fresh_manager._conns.values()
+            if c.principal.user_id == p.user_id
+        ]
+        assert len(conns) == 1
+        # Start the sender task so the queue drains.
+        await fresh_manager.spawn_sender(conns[0])
+
+        # Simulate the bridge delivering a market tick.
+        await fresh_manager.publish_to_channel(
+            for_market("AAPL"),
+            {"type": "market.tick", "symbol": "AAPL", "last": 123.45},
+        )
+        await asyncio.sleep(0.05)
+        ticks = [f for f in ws.sent if f.get("type") == "market.tick"]
+        assert ticks and ticks[0]["symbol"] == "AAPL"
+
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(handler_task, timeout=2.0)
+
+    async def test_portfolio_event_isolated_per_user(self, fresh_manager):
+        """User A subscribing to portfolio does NOT receive user B's events."""
+        ws_a, ws_b = _ClientWS(), _ClientWS()
+        pa, pb = _principal(), _principal()
+
+        with _RecordingPrincipal(pa):
+            t_a = asyncio.create_task(
+                ws_handlers.serve_unified(ws_a, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+            await ws_a.inbound.put({"type": "subscribe", "channel": "portfolio"})
+            await asyncio.sleep(0.05)
+
+        with _RecordingPrincipal(pb):
+            t_b = asyncio.create_task(
+                ws_handlers.serve_unified(ws_b, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+            await ws_b.inbound.put({"type": "subscribe", "channel": "portfolio"})
+            await asyncio.sleep(0.05)
+
+        conns = list(fresh_manager._conns.values())
+        for c in conns:
+            await fresh_manager.spawn_sender(c)
+
+        # Publish to user A's portfolio channel — only ws_a should see it.
+        await fresh_manager.publish_to_channel(
+            for_portfolio(pa.user_id),
+            {"type": "portfolio.updated", "user_id": str(pa.user_id)},
+        )
+        await asyncio.sleep(0.05)
+        a_ticks = [f for f in ws_a.sent if f.get("type") == "portfolio.updated"]
+        b_ticks = [f for f in ws_b.sent if f.get("type") == "portfolio.updated"]
+        assert len(a_ticks) == 1
+        assert b_ticks == []  # isolation
+
+        # Cleanup
+        await ws_a.inbound.put(None)
+        await ws_b.inbound.put(None)
+        for t in (t_a, t_b):
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(t, timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Family endpoints (auto-subscribe)
+# ---------------------------------------------------------------------------
+class TestFamilyEndpoints:
+    async def test_portfolio_endpoint_auto_subscribes(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+        with _RecordingPrincipal(p):
+            t = asyncio.create_task(
+                ws_handlers.serve_portfolio(ws, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+        # Find the connection — its subscription registry should already
+        # include the user's portfolio channel.
+        conn = next(iter(fresh_manager._conns.values()))
+        assert conn.subscriptions.is_subscribed(for_portfolio(p.user_id))
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(t, timeout=2.0)
+
+    async def test_orders_endpoint_auto_subscribes(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+        with _RecordingPrincipal(p):
+            t = asyncio.create_task(
+                ws_handlers.serve_orders(ws, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+        conn = next(iter(fresh_manager._conns.values()))
+        from engine.api.websocket.channels import for_orders
+
+        assert conn.subscriptions.is_subscribed(for_orders(p.user_id))
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(t, timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Shutdown drain
+# ---------------------------------------------------------------------------
+class TestShutdown:
+    async def test_shutdown_broadcasts_frame_and_closes(self, fresh_manager):
+        ws = _ClientWS()
+        p = _principal()
+        with _RecordingPrincipal(p):
+            t = asyncio.create_task(
+                ws_handlers.serve_unified(ws, fresh_manager)
+            )
+            await asyncio.sleep(0.05)
+
+        await fresh_manager.shutdown_all(reason="test_shutdown")
+        # The shutdown frame should be in the outbound queue (or sent
+        # if the sender task ran). Disconnect tears down the conn.
+        ws._drain_queue()
+
+        # Connection is torn down
+        assert fresh_manager.total_connections() == 0
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(t, timeout=2.0)
+
+    async def test_register_rejected_during_shutdown(self, fresh_manager):
+        await fresh_manager.shutdown_all(reason="test")
+        ws = _ClientWS()
+        with _RecordingPrincipal(_principal()), pytest.raises(RuntimeError, match="shutting_down"):
+            await fresh_manager.register(ws, _principal())
+
+
+# Convenience: drain the recording WS queue into its sent list so
+# shutdown tests can observe frames that were enqueued but not yet
+# written to the wire before the connection was closed.
+def _ws_drain(self):
+    out: list[dict] = []
+    while not self.inbound.empty():
+        try:
+            item = self.inbound.get_nowait()
+            if item is not None:
+                out.append(item)
+        except asyncio.QueueEmpty:
+            break
+    return out
+
+
+_ClientWS._drain_queue = _ws_drain  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Bridge integration — feed pubsub messages and verify dispatch
+# ---------------------------------------------------------------------------
+class TestBridgeEndToEnd:
+    async def test_bridge_dispatches_to_manager(self, fresh_manager):
+        from engine.api.websocket.redis_bridge import WSRedisBridge
+
+        bridge = WSRedisBridge(fresh_manager, redis_url="redis://localhost:0")
+        ws = _ClientWS()
+        p = _principal()
+
+        with _RecordingPrincipal(p):
+            t = asyncio.create_task(ws_handlers.serve_unified(ws, fresh_manager))
+            await asyncio.sleep(0.05)
+            await ws.inbound.put(
+                {"type": "subscribe", "channel": "market", "symbols": ["AAPL"]}
+            )
+            await asyncio.sleep(0.05)
+        conn = next(iter(fresh_manager._conns.values()))
+        await fresh_manager.spawn_sender(conn)
+
+        # Bridge dispatch is purely a function of _handle_message; we
+        # don't need to run the bridge's run loop.
+        await bridge._handle_message(
+            {
+                "type": "pmessage",
+                "channel": b"market:AAPL",
+                "data": json.dumps(
+                    {"type": "market.tick", "data": {"last": 100}}
+                ).encode(),
+            }
+        )
+        await asyncio.sleep(0.05)
+        ticks = [f for f in ws.sent if f.get("type") == "market.tick"]
+        assert ticks
+
+        await ws.inbound.put(None)
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(t, timeout=2.0)

--- a/tests/test_websocket_rate_limit.py
+++ b/tests/test_websocket_rate_limit.py
@@ -1,0 +1,59 @@
+"""Unit tests for engine.api.websocket.rate_limit (SEV-275)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.websocket.exceptions import RateLimitedError
+from engine.api.websocket.rate_limit import OutboundRateLimiter
+
+
+class TestRateLimiter:
+    async def test_allows_under_capacity(self):
+        rl = OutboundRateLimiter(capacity=3, window_seconds=1.0)
+        assert await rl.acquire("k") is True
+        assert await rl.acquire("k") is True
+        assert await rl.acquire("k") is True
+
+    async def test_blocks_over_capacity(self):
+        rl = OutboundRateLimiter(capacity=2, window_seconds=1.0)
+        await rl.acquire("k")
+        await rl.acquire("k")
+        assert await rl.acquire("k") is False
+
+    async def test_require_raises_on_block(self):
+        rl = OutboundRateLimiter(capacity=1, window_seconds=1.0)
+        await rl.require("k")
+        with pytest.raises(RateLimitedError):
+            await rl.require("k")
+
+    async def test_keys_are_isolated(self):
+        rl = OutboundRateLimiter(capacity=1, window_seconds=1.0)
+        await rl.acquire("a")
+        # Different key — independent bucket.
+        assert await rl.acquire("b") is True
+
+    async def test_reset_drops_bucket(self):
+        rl = OutboundRateLimiter(capacity=1, window_seconds=1.0)
+        await rl.acquire("k")
+        await rl.reset("k")
+        # Bucket recreated fresh — allow again.
+        assert await rl.acquire("k") is True
+
+    async def test_window_evicts_old_events(self):
+        rl = OutboundRateLimiter(capacity=2, window_seconds=0.05)
+        await rl.acquire("k")
+        await rl.acquire("k")
+        # Wait past the window.
+        import asyncio
+
+        await asyncio.sleep(0.06)
+        assert await rl.acquire("k") is True
+
+    def test_invalid_capacity_rejected(self):
+        with pytest.raises(ValueError):
+            OutboundRateLimiter(capacity=0)
+
+    def test_invalid_window_rejected(self):
+        with pytest.raises(ValueError):
+            OutboundRateLimiter(window_seconds=0)

--- a/tests/test_websocket_redis_bridge.py
+++ b/tests/test_websocket_redis_bridge.py
@@ -1,0 +1,271 @@
+"""Unit tests for engine.api.websocket.redis_bridge (SEV-275).
+
+Uses a fake pubsub to avoid spinning up a real Redis instance. The
+goal is to verify the dispatch / dead-letter / reconnect paths, not
+the underlying client behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import Any
+
+from engine.api.websocket.channels import for_market, for_portfolio
+from engine.api.websocket.connection_manager_v2 import ConnectionManagerV2
+from engine.api.websocket.models import Principal
+from engine.api.websocket.redis_bridge import WSRedisBridge
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+class _FakePubSub:
+    """Async iterator yielding pre-queued messages."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+        self.subscribed_patterns: list[str] = []
+        self.closed = False
+
+    async def psubscribe(self, *patterns: str) -> None:
+        self.subscribed_patterns.extend(patterns)
+
+    async def punsubscribe(self, *patterns: str) -> None:
+        return None
+
+    async def unsubscribe(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def feed(self, message: dict[str, Any]) -> None:
+        self._queue.put_nowait(message)
+
+    def stop(self) -> None:
+        self._queue.put_nowait(None)
+
+    async def listen(self):
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                return
+            yield item
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.pubsub_obj = _FakePubSub()
+        self.ping_count = 0
+        self.closed = False
+
+    async def ping(self) -> None:
+        self.ping_count += 1
+
+    def pubsub(self) -> _FakePubSub:
+        return self.pubsub_obj
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _Manager(ConnectionManagerV2):
+    """Subclass that exposes the fake WS for test assertions."""
+
+
+
+def _make_principal() -> Principal:
+    return Principal(
+        user_id=uuid.uuid4(),
+        email="t@example.com",
+        role="user",
+        scopes=frozenset({"portfolio:read", "orders:read", "market:read"}),
+    )
+
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.id = uuid.uuid4()
+        self.sent: list[dict] = []
+        self.scope: dict = {}
+        self.headers: dict = {}
+        self.query_params: dict = {}
+
+    async def accept(self, subprotocol: str | None = None) -> None: ...
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None: ...
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeWS) and other.id == self.id
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tests (call _handle_message directly)
+# ---------------------------------------------------------------------------
+class TestDispatch:
+    async def test_portfolio_event_routes_to_subscriber(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager, redis_url="redis://localhost:0")
+        ws = _FakeWS()
+        p = _make_principal()
+        conn = await manager.register(ws, p)
+        await manager.subscribe(conn, for_portfolio(p.user_id))
+
+        await bridge._handle_message(
+            {
+                "type": "pmessage",
+                "channel": f"portfolio:{p.user_id}".encode(),
+                "data": json.dumps(
+                    {
+                        "type": "portfolio.updated",
+                        "data": {"user_id": str(p.user_id), "nav": 100},
+                        "timestamp": "2026-01-01T00:00:00Z",
+                    }
+                ).encode(),
+            }
+        )
+        assert conn.outbound.qsize() == 1
+        frame = conn.outbound.get_nowait()
+        assert frame["type"] == "portfolio.updated"
+        assert frame["channel"] == f"portfolio:{p.user_id}"
+
+    async def test_market_tick_routes_to_subscribers(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager, redis_url="redis://localhost:0")
+        ws_a, ws_b = _FakeWS(), _FakeWS()
+        ca = await manager.register(ws_a, _make_principal())
+        cb = await manager.register(ws_b, _make_principal())
+        await manager.subscribe(ca, for_market("AAPL"))
+        await manager.subscribe(cb, for_market("AAPL"))
+
+        await bridge._handle_message(
+            {
+                "type": "pmessage",
+                "channel": b"market:AAPL",
+                "data": json.dumps({"type": "market.tick", "data": {"last": 123}}).encode(),
+            }
+        )
+        assert ca.outbound.qsize() == 1
+        assert cb.outbound.qsize() == 1
+
+    async def test_dead_letter_unparseable_payload(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager, redis_url="redis://localhost:0")
+        await bridge._handle_message(
+            {
+                "type": "pmessage",
+                "channel": b"market:AAPL",
+                "data": b"not valid json",
+            }
+        )
+        assert bridge.dead_letter == 1
+        assert bridge.messages_seen == 0
+
+    async def test_dead_letter_non_object_payload(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager, redis_url="redis://localhost:0")
+        await bridge._handle_message(
+            {
+                "type": "pmessage",
+                "channel": b"market:AAPL",
+                "data": json.dumps([1, 2, 3]).encode(),
+            }
+        )
+        assert bridge.dead_letter == 1
+
+    async def test_unknown_channel_ignored(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager, redis_url="redis://localhost:0")
+        await bridge._handle_message(
+            {"type": "pmessage", "channel": b"unknown:foo", "data": b"{}"}
+        )
+        assert bridge.messages_seen == 0
+        assert bridge.dead_letter == 0
+
+    async def test_non_message_type_ignored(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager, redis_url="redis://localhost:0")
+        await bridge._handle_message(
+            {"type": "psubscribe", "channel": b"market:AAPL", "data": b"1"}
+        )
+        assert bridge.messages_seen == 0
+
+
+# ---------------------------------------------------------------------------
+# Lag extraction
+# ---------------------------------------------------------------------------
+class TestLag:
+    def test_iso_timestamp_yields_lag(self):
+        from datetime import UTC, datetime
+
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager)
+        ts = datetime.now(tz=UTC).isoformat()
+        lag = bridge._extract_lag({"timestamp": ts})
+        assert lag is not None and lag >= 0.0
+
+    def test_numeric_timestamp_yields_lag(self):
+        import time
+
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager)
+        lag = bridge._extract_lag({"timestamp": time.time()})
+        assert lag is not None and lag >= 0.0
+
+    def test_missing_timestamp_returns_none(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager)
+        assert bridge._extract_lag({}) is None
+
+    def test_garbage_timestamp_returns_none(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager)
+        assert bridge._extract_lag({"timestamp": "garbage"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle / snapshot
+# ---------------------------------------------------------------------------
+class TestSnapshot:
+    def test_initial_snapshot(self):
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager)
+        snap = bridge.snapshot()
+        assert snap["messages_seen"] == 0
+        assert snap["errors"] == 0
+        assert snap["dead_letter"] == 0
+        assert snap["connected"] is False
+
+
+class TestReconnectLoop:
+    async def test_run_gives_up_when_connection_fails(self, monkeypatch):
+        """If Redis is unreachable, _run cycles through the backoff
+        table and exits cleanly when stop() is called."""
+
+        manager = ConnectionManagerV2()
+        bridge = WSRedisBridge(manager, redis_url="redis://invalid:0")
+
+        # Patch _connect to always fail fast.
+        async def boom(self):
+            raise OSError("nope")
+
+        monkeypatch.setattr(WSRedisBridge, "_connect", boom)
+        # Compress backoff so the test doesn't sleep for 30s.
+        monkeypatch.setattr(
+            "engine.api.websocket.redis_bridge._RECONNECT_BACKOFF_SECONDS",
+            (0.01, 0.01, 0.01),
+        )
+
+        bridge.start()
+        await asyncio.sleep(0.05)
+        await bridge.stop(timeout=1.0)
+        # Loop saw at least one error.
+        assert bridge.errors >= 1

--- a/tests/test_websocket_schemas.py
+++ b/tests/test_websocket_schemas.py
@@ -1,0 +1,152 @@
+"""Unit tests for engine.api.websocket.schemas (SEV-275)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from engine.api.websocket.constants import WS_PROTOCOL_VERSION
+from engine.api.websocket.schemas import (
+    AuthFailedFrame,
+    AuthFrame,
+    AuthOkFrame,
+    ErrorFrame,
+    MarketDepthEvent,
+    MarketTickEvent,
+    OrderEvent,
+    PingFrame,
+    PongFrame,
+    PortfolioUpdatedEvent,
+    ServerShutdownFrame,
+    SubscribedFrame,
+    SubscribeFrame,
+    UnsubscribedFrame,
+    UnsubscribeFrame,
+)
+
+# ---------------------------------------------------------------------------
+# Round-trip serialisation for every event type
+# ---------------------------------------------------------------------------
+_ROUND_TRIP_MODELS = [
+    AuthFrame(token="jwt.or.api_key"),
+    SubscribeFrame(channel="portfolio"),
+    SubscribeFrame(channel="market", symbols=["AAPL", "MSFT"]),
+    UnsubscribeFrame(channel="market", symbols=["AAPL"]),
+    PingFrame(),
+    PingFrame(ts=datetime(2026, 1, 1, tzinfo=UTC)),
+    AuthOkFrame(user_id="u-1", scopes=["read"]),
+    AuthFailedFrame(reason="invalid_token"),
+    SubscribedFrame(channel="market", symbols=["AAPL"]),
+    UnsubscribedFrame(channel="market"),
+    PongFrame(server_ts=datetime(2026, 1, 1, tzinfo=UTC)),
+    ServerShutdownFrame(),
+    ErrorFrame(code="malformed", detail="oops"),
+    PortfolioUpdatedEvent(
+        user_id="u-1",
+        portfolio_id="p-1",
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        nav=Decimal("100"),
+    ),
+    OrderEvent(
+        type="order.filled",
+        user_id="u-1",
+        order_id="o-1",
+        symbol="AAPL",
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        status="filled",
+    ),
+    MarketTickEvent(
+        symbol="AAPL",
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        last=Decimal("123.45"),
+    ),
+    MarketDepthEvent(
+        symbol="AAPL",
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        bids=[[Decimal("123"), Decimal("5")]],
+    ),
+]
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize("model", _ROUND_TRIP_MODELS)
+    def test_round_trip(self, model):
+        dumped = model.model_dump(mode="json")
+        rebuilt = type(model).model_validate(dumped)
+        assert dumped == rebuilt.model_dump(mode="json")
+
+    @pytest.mark.parametrize("model", _ROUND_TRIP_MODELS)
+    def test_envelope_version_present(self, model):
+        dumped = model.model_dump(mode="json")
+        # Every frame carries the version field.
+        assert dumped["v"] == WS_PROTOCOL_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+class TestValidation:
+    def test_auth_frame_requires_token(self):
+        with pytest.raises(ValidationError):
+            AuthFrame(token="")
+
+    def test_subscribe_channel_is_limited(self):
+        with pytest.raises(ValidationError):
+            SubscribeFrame(channel="unknown")
+
+    def test_unsubscribe_channel_is_limited(self):
+        with pytest.raises(ValidationError):
+            UnsubscribeFrame(channel="wizardry")
+
+    def test_error_code_is_limited(self):
+        with pytest.raises(ValidationError):
+            ErrorFrame(code="not_a_code")
+
+    def test_auth_failed_reason_is_limited(self):
+        with pytest.raises(ValidationError):
+            AuthFailedFrame(reason="some_random_reason")
+
+    def test_extra_fields_are_forbidden(self):
+        with pytest.raises(ValidationError):
+            AuthFrame.model_validate({"type": "auth", "token": "x", "extra": True})
+
+    def test_order_event_type_is_limited(self):
+        with pytest.raises(ValidationError):
+            OrderEvent(
+                type="order.unthinkable",
+                user_id="u",
+                order_id="o",
+                symbol="AAPL",
+                timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+                status="x",
+            )
+
+    def test_market_tick_requires_symbol(self):
+        with pytest.raises(ValidationError):
+            MarketTickEvent(
+                symbol="",
+                timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Discriminator
+# ---------------------------------------------------------------------------
+class TestDiscriminator:
+    def test_auth_frame_validates(self):
+        frame = AuthFrame.model_validate({"type": "auth", "token": "abc"})
+        assert frame.token == "abc"
+
+    def test_subscribe_frame_validates(self):
+        frame = SubscribeFrame.model_validate(
+            {"type": "subscribe", "channel": "market", "symbols": ["AAPL"]}
+        )
+        assert frame.channel == "market"
+        assert frame.symbols == ["AAPL"]
+
+    def test_unknown_type_fails_validation(self):
+        with pytest.raises(ValidationError):
+            AuthFrame.model_validate({"type": "wizardry", "token": "x"})

--- a/tests/test_websocket_subscriptions.py
+++ b/tests/test_websocket_subscriptions.py
@@ -1,0 +1,106 @@
+"""Unit tests for engine.api.websocket.subscriptions (SEV-275)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from engine.api.websocket.channels import for_market, for_orders, for_portfolio
+from engine.api.websocket.constants import MAX_SYMBOL_SUBS_PER_CONNECTION
+from engine.api.websocket.exceptions import SubscriptionLimitError
+from engine.api.websocket.subscriptions import SubscriptionRegistry
+
+
+@pytest.fixture
+def registry() -> SubscriptionRegistry:
+    return SubscriptionRegistry()
+
+
+class TestSubscribeIdempotency:
+    async def test_subscribe_returns_true_on_new(self, registry):
+        c = for_portfolio(uuid.uuid4())
+        assert await registry.subscribe(c) is True
+
+    async def test_subscribe_returns_false_on_duplicate(self, registry):
+        c = for_portfolio(uuid.uuid4())
+        assert await registry.subscribe(c) is True
+        assert await registry.subscribe(c) is False
+
+    async def test_subscribe_unknown_key_safe(self, registry):
+        # unsubscribe of unknown is a no-op (returns False)
+        c = for_portfolio(uuid.uuid4())
+        assert await registry.unsubscribe(c) is False
+
+    async def test_unsubscribe_after_subscribe_returns_true(self, registry):
+        c = for_portfolio(uuid.uuid4())
+        await registry.subscribe(c)
+        assert await registry.unsubscribe(c) is True
+        assert await registry.unsubscribe(c) is False  # gone
+
+
+class TestCaps:
+    async def test_market_cap_enforced(self, registry):
+        # Add MAX symbols — should succeed.
+        for i in range(MAX_SYMBOL_SUBS_PER_CONNECTION):
+            await registry.subscribe(for_market(f"S{i:04d}"))
+        # Next one should blow up.
+        with pytest.raises(SubscriptionLimitError):
+            await registry.subscribe(for_market("OVERFLOW"))
+
+    async def test_market_cap_isolated_from_orders(self, registry):
+        # Fill the market bucket; user channels must still be addable.
+        for i in range(MAX_SYMBOL_SUBS_PER_CONNECTION):
+            await registry.subscribe(for_market(f"S{i:04d}"))
+        u = uuid.uuid4()
+        # Different family, different cap.
+        assert await registry.subscribe(for_portfolio(u)) is True
+        assert await registry.subscribe(for_orders(u)) is True
+
+    async def test_unsubscribe_family_drops_all(self, registry):
+        for i in range(3):
+            await registry.subscribe(for_market(f"S{i:04d}"))
+        removed = await registry.unsubscribe_family("market")
+        assert removed == {"S0000", "S0001", "S0002"}
+        assert registry.count("market") == 0
+
+
+class TestIntrospection:
+    async def test_snapshot_is_isolated_copy(self, registry):
+        c = for_portfolio(uuid.uuid4())
+        await registry.subscribe(c)
+        snap = registry.snapshot()
+        assert str(c.key) in snap.portfolio
+        # Mutating snapshot doesn't affect registry.
+        snap.portfolio.clear()
+        assert registry.count("portfolio") == 1
+
+    async def test_channels_list(self, registry):
+        u = uuid.uuid4()
+        await registry.subscribe(for_portfolio(u))
+        await registry.subscribe(for_market("AAPL"))
+        names = sorted(c.name for c in registry.channels())
+        assert names == sorted([f"portfolio:{u}", "market:AAPL"])
+
+    async def test_total(self, registry):
+        u = uuid.uuid4()
+        await registry.subscribe(for_portfolio(u))
+        await registry.subscribe(for_market("AAPL"))
+        await registry.subscribe(for_market("MSFT"))
+        assert registry.total() == 3
+
+    async def test_clear_drops_all(self, registry):
+        u = uuid.uuid4()
+        await registry.subscribe(for_portfolio(u))
+        await registry.subscribe(for_market("AAPL"))
+        await registry.clear()
+        assert registry.total() == 0
+
+
+class TestIsSubscribed:
+    async def test_membership(self, registry):
+        u = uuid.uuid4()
+        c = for_portfolio(u)
+        assert not registry.is_subscribed(c)
+        await registry.subscribe(c)
+        assert registry.is_subscribed(c)


### PR DESCRIPTION
## Delivery

- Action: implement
- Target: WebSocket API (SEV-275) — real-time streaming endpoint for portfolio updates, order fills, and strategy signals

Closes #793
