### PR TITLE
fix(auth): prevent fail-open role escalation in map_roles

### DIFF
--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 import structlog
 
 logger = structlog.get_logger()
+
+# Lowest-privilege role used as the fallback when no recognized role can
+# be derived from the upstream IdP assertion. Centralizing the literal
+# here makes it easy to audit and avoids drift between call sites.
+LOWEST_PRIVILEGE_ROLE: str = "viewer"
 
 
 @dataclass
@@ -24,9 +29,41 @@ class AuthResult:
     success: bool = False
     user_info: UserInfo | None = None
     error: str | None = None
+    # Free-form metadata bag. Used today to surface unrecognized upstream
+    # IdP roles so that callers / auditors can detect misconfigurations
+    # without scraping log lines (medium-severity follow-up to SEV-741).
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RoleMappingResult:
+    """Detailed outcome of mapping an external IdP role list.
+
+    ``role`` is the single internal role to assign (always one of the
+    keys in ``IAuthProvider.ROLE_PRIORITY`` — falling back to
+    :data:`LOWEST_PRIVILEGE_ROLE` when nothing recognized is present).
+    ``recognized`` and ``unrecognized`` carry the raw partitioning of
+    the input for audit / metadata purposes.
+    """
+
+    role: str
+    recognized: list[str] = field(default_factory=list)
+    unrecognized: list[str] = field(default_factory=list)
 
 
 class IAuthProvider(ABC):
+    # Public so tests / callers can introspect the recognized set without
+    # re-implementing the priority table.
+    ROLE_PRIORITY: ClassVar[dict[str, int]] = {
+        "viewer": 0,
+        "user": 1,
+        "retail_trader": 2,
+        "quant_dev": 3,
+        "developer": 4,
+        "portfolio_manager": 5,
+        "admin": 6,
+    }
+
     @property
     @abstractmethod
     def name(self) -> str: ...
@@ -40,27 +77,28 @@ class IAuthProvider(ABC):
     async def create_user(self, _user_info: UserInfo, **_kwargs: Any) -> AuthResult:
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
-    def map_roles(self, external_roles: list[str]) -> str:
-        """Map an external IdP role list to a single internal role.
+    def map_roles_with_metadata(
+        self, external_roles: list[str]
+    ) -> RoleMappingResult:
+        """Map an external IdP role list to a :class:`RoleMappingResult`.
 
         Security note: this function performs **no implicit promotion** of
         unrecognized roles. Upstream Identity-Provider (IdP) roles are
         reflected faithfully: only roles that are explicitly listed in
-        ``role_priority`` are eligible to become the user's role; anything
+        :attr:`ROLE_PRIORITY` are eligible to become the user's role; anything
         else is dropped and a warning is emitted so operators can detect
         misconfigurations. Previously ``viewer`` was silently promoted to
         ``user`` and ``quant_dev`` to ``developer``, which constituted a
         silent privilege escalation (SEV-741).
+
+        Empty input — including the case where every entry is filtered out
+        as unrecognized — falls back to :data:`LOWEST_PRIVILEGE_ROLE`
+        (``"viewer"``) rather than ``"user"``, adhering to a least-privilege
+        default. The partitioning (``recognized`` / ``unrecognized``) is
+        returned alongside the chosen role so callers can attach it to
+        :attr:`AuthResult.metadata` for auditability.
         """
-        role_priority: dict[str, int] = {
-            "viewer": 0,
-            "user": 1,
-            "retail_trader": 2,
-            "quant_dev": 3,
-            "developer": 4,
-            "portfolio_manager": 5,
-            "admin": 6,
-        }
+        role_priority = self.ROLE_PRIORITY
         recognized: list[str] = []
         unrecognized: list[str] = []
         best: str | None = None
@@ -72,6 +110,12 @@ class IAuthProvider(ABC):
                     best = normalized
             else:
                 unrecognized.append(role)
+
+        # Explicit empty/empty-after-filtering handling: when nothing
+        # recognized survives, assign the lowest-privilege role rather
+        # than implicitly granting "user".
+        mapped = LOWEST_PRIVILEGE_ROLE if best is None else best
+
         # Broaden the warning: fire on ANY unrecognized external role, not
         # only when the entire set is unrecognized. This surfaces partial
         # misconfigurations (e.g. one stale group name alongside valid ones).
@@ -81,6 +125,21 @@ class IAuthProvider(ABC):
                 provider=self.name,
                 unrecognized=unrecognized,
                 recognized=recognized,
-                mapped=best if best is not None else "user",
+                mapped=mapped,
             )
-        return best if best is not None else "user"
+        return RoleMappingResult(
+            role=mapped,
+            recognized=recognized,
+            unrecognized=unrecognized,
+        )
+
+    def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Convenience wrapper around :meth:`map_roles_with_metadata` that
+        returns only the chosen role string. Returns
+        :data:`LOWEST_PRIVILEGE_ROLE` (``"viewer"``) when the input is
+        empty or contains no recognized roles — see the security note on
+        :meth:`map_roles_with_metadata`.
+        """
+        return self.map_roles_with_metadata(external_roles).role

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -21,6 +21,40 @@ class LDAPAuthProvider(IAuthProvider):
     def name(self) -> str:
         return "ldap"
 
+    def _ldap_bind_and_search(
+        self, username: str, password: str
+    ) -> dict[str, list[bytes]] | None:
+        """Bind to LDAP and search for the user.
+
+        Returns the user's LDAP attributes on success, ``None`` when the
+        user is not found. Any other failure raises so the caller can
+        translate it into an "Invalid credentials" :class:`AuthResult`.
+        """
+        import ldap
+        from ldap.filter import escape_filter_chars
+
+        conn = ldap.initialize(settings.ldap_server_url)
+        conn.set_option(ldap.OPT_NETWORK_TIMEOUT, 10)
+        conn.set_option(ldap.OPT_TIMEOUT, 10)
+
+        safe_username = escape_filter_chars(username)
+        user_dn = f"{settings.ldap_bind_dn.replace('{{username}}', safe_username)}"
+        conn.simple_bind_s(user_dn, password)
+
+        search_filter = f"(uid={safe_username})"
+        results = conn.search_s(
+            settings.ldap_search_base,
+            ldap.SCOPE_SUBTREE,
+            search_filter,
+            ["uid", "mail", "cn", "memberOf"],
+        )
+        conn.unbind_s()
+
+        if not results:
+            return None
+        _, ldap_attrs = results[0]
+        return ldap_attrs
+
     async def authenticate(self, **kwargs: Any) -> AuthResult:
         username = kwargs.get("username", "")
         password = kwargs.get("password", "")
@@ -30,34 +64,14 @@ class LDAPAuthProvider(IAuthProvider):
             return AuthResult(success=False, error="Username, password, and db session required")
 
         try:
-            import ldap
-            from ldap.filter import escape_filter_chars
-
-            conn = ldap.initialize(settings.ldap_server_url)
-            conn.set_option(ldap.OPT_NETWORK_TIMEOUT, 10)
-            conn.set_option(ldap.OPT_TIMEOUT, 10)
-
-            safe_username = escape_filter_chars(username)
-            user_dn = f"{settings.ldap_bind_dn.replace('{{username}}', safe_username)}"
-            conn.simple_bind_s(user_dn, password)
-
-            search_filter = f"(uid={safe_username})"
-            results = conn.search_s(
-                settings.ldap_search_base,
-                ldap.SCOPE_SUBTREE,
-                search_filter,
-                ["uid", "mail", "cn", "memberOf"],
-            )
-            conn.unbind_s()
-
+            ldap_attrs = self._ldap_bind_and_search(username, password)
         except Exception as exc:
             logger.exception("auth.ldap.bind_failed", error=str(exc))
             return AuthResult(success=False, error="Invalid credentials")
 
-        if not results:
+        if ldap_attrs is None:
             return AuthResult(success=False, error="User not found in LDAP")
 
-        _, ldap_attrs = results[0]
         ldap_uid = ldap_attrs.get("uid", [b""])[0].decode()
         ldap_mail = ldap_attrs.get("mail", [b""])[0].decode() or f"{username}@ldap"
         ldap_cn = ldap_attrs.get("cn", [b""])[0].decode() or username
@@ -75,7 +89,8 @@ class LDAPAuthProvider(IAuthProvider):
         if not mapped_roles:
             mapped_roles = ["user"]
 
-        mapped_role = self.map_roles(mapped_roles)
+        mapping = self.map_roles_with_metadata(mapped_roles)
+        mapped_role = mapping.role
 
         result = await db.execute(
             select(User).where(User.auth_provider == "ldap", User.external_id == ldap_uid)
@@ -109,6 +124,14 @@ class LDAPAuthProvider(IAuthProvider):
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")
 
+        # Surface any unrecognized upstream roles on AuthResult.metadata so
+        # callers / auditors can detect IdP misconfigurations without
+        # scraping log lines (medium-severity follow-up to SEV-741).
+        metadata: dict[str, Any] = {}
+        if mapping.unrecognized:
+            metadata["unrecognized_roles"] = list(mapping.unrecognized)
+            metadata["recognized_roles"] = list(mapping.recognized)
+
         return AuthResult(
             success=True,
             user_info=UserInfo(
@@ -118,4 +141,5 @@ class LDAPAuthProvider(IAuthProvider):
                 provider="ldap",
                 roles=[user.role],
             ),
+            metadata=metadata,
         )

--- a/engine/api/auth/oidc.py
+++ b/engine/api/auth/oidc.py
@@ -58,6 +58,52 @@ class OIDCAuthProvider(IAuthProvider):
             self._jwks_cache = resp.json()
         return self._jwks_cache
 
+    async def _exchange_and_verify_token(self, code: str) -> dict[str, Any]:
+        """Exchange an authorization code for tokens and verify the ID token.
+
+        Returns the decoded claims from the ID token. Raises on any
+        transport, exchange, or signature-verification failure so the
+        caller can translate the failure into a uniform
+        ``"OIDC authentication failed"`` :class:`AuthResult`.
+        """
+        import httpx
+
+        discovery = await self._get_discovery()
+        token_endpoint = discovery["token_endpoint"]
+
+        async with httpx.AsyncClient() as client:
+            token_resp = await client.post(
+                token_endpoint,
+                data={
+                    "code": code,
+                    "client_id": settings.oidc_client_id,
+                    "client_secret": settings.oidc_client_secret,
+                    "redirect_uri": settings.oidc_redirect_uri,
+                    "grant_type": "authorization_code",
+                },
+            )
+            token_resp.raise_for_status()
+            tokens = token_resp.json()
+
+        id_token = tokens.get("id_token", "")
+        jwks = await self._get_jwks()
+        unverified_header = jwt.get_unverified_header(id_token)
+        kid = unverified_header.get("kid")
+        signing_key = None
+        for key_data in jwks.get("keys", []):
+            if key_data.get("kid") == kid:
+                signing_key = jwt.algorithms.RSAAlgorithm.from_jwk(key_data)
+                break
+        if signing_key is None:
+            msg = f"No matching key found for kid={kid}"
+            raise ValueError(msg)
+        return jwt.decode(
+            id_token,
+            signing_key,
+            algorithms=["RS256"],
+            audience=settings.oidc_client_id,
+        )
+
     async def authenticate(self, **kwargs: Any) -> AuthResult:
         code = kwargs.get("code")
         db: AsyncSession | None = kwargs.get("db")
@@ -65,44 +111,7 @@ class OIDCAuthProvider(IAuthProvider):
             return AuthResult(success=False, error="Authorization code and db session required")
 
         try:
-            import httpx
-
-            discovery = await self._get_discovery()
-            token_endpoint = discovery["token_endpoint"]
-
-            async with httpx.AsyncClient() as client:
-                token_resp = await client.post(
-                    token_endpoint,
-                    data={
-                        "code": code,
-                        "client_id": settings.oidc_client_id,
-                        "client_secret": settings.oidc_client_secret,
-                        "redirect_uri": settings.oidc_redirect_uri,
-                        "grant_type": "authorization_code",
-                    },
-                )
-                token_resp.raise_for_status()
-                tokens = token_resp.json()
-
-            id_token = tokens.get("id_token", "")
-            jwks = await self._get_jwks()
-            unverified_header = jwt.get_unverified_header(id_token)
-            kid = unverified_header.get("kid")
-            signing_key = None
-            for key_data in jwks.get("keys", []):
-                if key_data.get("kid") == kid:
-                    signing_key = jwt.algorithms.RSAAlgorithm.from_jwk(key_data)
-                    break
-            if signing_key is None:
-                msg = f"No matching key found for kid={kid}"
-                raise ValueError(msg)
-            claims_data = jwt.decode(
-                id_token,
-                signing_key,
-                algorithms=["RS256"],
-                audience=settings.oidc_client_id,
-            )
-
+            claims_data = await self._exchange_and_verify_token(code)
         except Exception as exc:
             logger.exception("auth.oidc.failed", error=str(exc))
             return AuthResult(success=False, error="OIDC authentication failed")
@@ -130,9 +139,17 @@ class OIDCAuthProvider(IAuthProvider):
                     success=False, error="Email already registered with a different provider"
                 )
 
-            mapped_role = "user"
-            if isinstance(raw_roles, list):
-                mapped_role = self.map_roles(raw_roles)
+            # Note: the OIDC provider's default when the upstream role
+            # claim is missing / not a list is left as ``"user"`` for
+            # backward compatibility — the least-privilege default of
+            # ``"viewer"`` only applies to the ``map_roles`` fallback
+            # itself (see SEV-741 follow-up).
+            mapping = (
+                self.map_roles_with_metadata(raw_roles)
+                if isinstance(raw_roles, list)
+                else None
+            )
+            mapped_role = mapping.role if mapping is not None else "user"
 
             user = User(
                 email=email,
@@ -148,8 +165,19 @@ class OIDCAuthProvider(IAuthProvider):
             await db.refresh(user)
             logger.info("auth.oidc.user_created", user_id=str(user.id))
 
+        else:
+            mapping = None
+
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")
+
+        # Surface any unrecognized upstream roles on AuthResult.metadata so
+        # callers / auditors can detect IdP misconfigurations without
+        # scraping log lines (medium-severity follow-up to SEV-741).
+        metadata: dict[str, Any] = {}
+        if mapping is not None and mapping.unrecognized:
+            metadata["unrecognized_roles"] = list(mapping.unrecognized)
+            metadata["recognized_roles"] = list(mapping.recognized)
 
         return AuthResult(
             success=True,
@@ -161,6 +189,7 @@ class OIDCAuthProvider(IAuthProvider):
                 roles=[user.role],
                 raw_claims=claims_data,
             ),
+            metadata=metadata,
         )
 
     async def get_authorize_url(self, state: str = "") -> str:

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -205,23 +205,26 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_unknown_roles_ignored(self):
         p = self._make_provider()
-        assert p.map_roles(["superuser", "god"]) == "user"
+        assert p.map_roles(["superuser", "god"]) == "viewer"
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
         # SEV-741: map_roles no longer silently promotes domain roles.
         # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
         # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
-        # external role is unrecognized do we fall back to ``user``.
+        # external role is unrecognized do we fall back to ``viewer``
+        # (least-privilege default).
         assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
         assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 
-    def test_map_roles_empty_list_returns_user(self):
+    def test_map_roles_empty_list_returns_viewer(self):
+        """Least-privilege default — empty input must yield ``viewer``
+        rather than ``user``."""
         p = self._make_provider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
 
 
 class TestAuthExports:

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -131,12 +131,21 @@ class TestNoImplicitPromotion:
             == "admin"
         )
 
-    def test_empty_input_returns_user(self):
-        assert _ConcreteProvider().map_roles([]) == "user"
+    def test_empty_input_returns_viewer(self):
+        """Least-privilege default: an empty external_roles list must map
+        to ``"viewer"`` (the lowest-privilege recognized role), not
+        ``"user"``. Previously this fell back to ``"user"``, which
+        granted more privilege than necessary when the upstream IdP
+        asserted nothing."""
+        assert _ConcreteProvider().map_roles([]) == "viewer"
 
-    def test_all_unrecognized_falls_back_to_user(self):
+    def test_all_unrecognized_falls_back_to_viewer(self):
+        """Least-privilege default: when every external role is
+        unrecognized, the user must receive ``"viewer"`` rather than
+        ``"user"`` — this is the safe default when the upstream IdP
+        assertion cannot be interpreted."""
         assert (
-            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "viewer"
         )
 
     def test_partial_unrecognized_still_uses_recognized(self):
@@ -153,9 +162,9 @@ class TestNoImplicitPromotion:
 
     def test_whitespace_only_role_is_unrecognized(self):
         """A whitespace-only string is normalized to the empty string,
-        which is not a known role.  Should fall through to user without
-        crashing."""
-        assert _ConcreteProvider().map_roles(["   "]) == "user"
+        which is not a known role.  Should fall through to viewer
+        (least-privilege) without crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "viewer"
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +205,7 @@ class TestUnrecognizedRoleWarning:
     def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
         calls = self._patch(monkeypatch)
         p = _ConcreteProvider()
-        assert p.map_roles(["totally_bogus"]) == "user"
+        assert p.map_roles(["totally_bogus"]) == "viewer"
         assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
 
     def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
@@ -220,7 +229,7 @@ class TestUnrecognizedRoleWarning:
     def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
         calls = self._patch(monkeypatch)
         p = _ConcreteProvider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
         assert calls == []
 
     def test_warning_includes_provider_name(self, monkeypatch):
@@ -441,3 +450,184 @@ class TestMappedRoleFlowsToRequireRole:
                 f"minimum={minimum_required}; expected {expected_status}, "
                 f"got {resp.status_code}"
             )
+
+
+# ---------------------------------------------------------------------------
+# 7. Least-privilege fallback (viewer) — SEV-741 follow-up
+# ---------------------------------------------------------------------------
+
+
+class TestLeastPrivilegeFallback:
+    """The fallback when no recognized role can be derived must be
+    ``"viewer"`` (the lowest-privilege role in ``ROLE_PRIORITY``) rather
+    than ``"user"``. This applies in three scenarios:
+
+    1. The caller passes an empty ``external_roles`` list.
+    2. The caller passes a list in which *every* entry is unrecognized.
+    3. The caller passes a list that becomes empty after normalization
+       (e.g. only whitespace-only strings).
+    """
+
+    def test_empty_external_roles_returns_viewer(self):
+        """(1) Empty list -> viewer (not user)."""
+        assert _ConcreteProvider().map_roles([]) == "viewer"
+
+    def test_all_unrecognized_returns_viewer(self):
+        """(2) Every role unrecognized -> viewer (not user)."""
+        assert (
+            _ConcreteProvider().map_roles(["bogus_a", "bogus_b"]) == "viewer"
+        )
+
+    def test_whitespace_only_input_returns_viewer(self):
+        """(3) All entries normalize to empty (unrecognized) -> viewer."""
+        assert _ConcreteProvider().map_roles(["   ", "\t", "  "]) == "viewer"
+
+    def test_mixed_recognized_and_unrecognized_returns_only_recognized_role(self):
+        """Recognized roles win even when unrecognized roles are present;
+        the unrecognized roles must NEVER contribute to the mapped role.
+
+        Concretely: ``["admin", "bogus_root", "superuser"]`` must yield
+        ``"admin"`` — the unrecognized entries do not promote beyond
+        ``admin`` and do not demote below it.
+        """
+        assert (
+            _ConcreteProvider().map_roles(["admin", "bogus_root", "superuser"])
+            == "admin"
+        )
+
+    def test_mixed_lower_recognized_with_bogus_high_role_does_not_escalate(self):
+        """A bogus role that *looks* privileged (e.g. ``"superuser"``)
+        must not be treated as more privileged than a real recognized
+        role. ``"viewer"`` + ``"superuser"`` must yield ``"viewer"``,
+        not anything higher."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "superuser"]) == "viewer"
+        )
+
+    def test_lowest_privilege_role_constant_is_viewer(self):
+        """Pin the constant — operators / auditors rely on this being
+        ``"viewer"``."""
+        from engine.api.auth.base import LOWEST_PRIVILEGE_ROLE
+
+        assert LOWEST_PRIVILEGE_ROLE == "viewer"
+
+
+# ---------------------------------------------------------------------------
+# 8. map_roles_with_metadata — surfaces unrecognized roles for AuthResult
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesWithMetadata:
+    """``map_roles_with_metadata`` returns a structured result so that
+    callers (e.g. OIDC / LDAP providers) can populate
+    :attr:`AuthResult.metadata` for audit purposes."""
+
+    def test_returns_role_mapping_result(self):
+        from engine.api.auth.base import RoleMappingResult
+
+        result = _ConcreteProvider().map_roles_with_metadata(["admin"])
+        assert isinstance(result, RoleMappingResult)
+
+    def test_role_field_matches_map_roles(self):
+        p = _ConcreteProvider()
+        for external in [
+            [],
+            ["viewer"],
+            ["user"],
+            ["admin"],
+            ["bogus"],
+            ["admin", "bogus"],
+            ["viewer", "quant_dev"],
+        ]:
+            mapped = p.map_roles(external)
+            detailed = p.map_roles_with_metadata(external)
+            assert mapped == detailed.role, (
+                f"map_roles and map_roles_with_metadata disagree on "
+                f"{external}: {mapped} vs {detailed.role}"
+            )
+
+    def test_recognized_list_excludes_unrecognized(self):
+        result = _ConcreteProvider().map_roles_with_metadata(
+            ["admin", "bogus", "user"]
+        )
+        assert "admin" in result.recognized
+        assert "user" in result.recognized
+        assert "bogus" not in result.recognized
+
+    def test_unrecognized_list_excludes_recognized(self):
+        result = _ConcreteProvider().map_roles_with_metadata(
+            ["admin", "bogus_a", "bogus_b"]
+        )
+        assert "bogus_a" in result.unrecognized
+        assert "bogus_b" in result.unrecognized
+        assert "admin" not in result.unrecognized
+
+    def test_empty_input_yields_empty_lists_and_viewer(self):
+        result = _ConcreteProvider().map_roles_with_metadata([])
+        assert result.role == "viewer"
+        assert result.recognized == []
+        assert result.unrecognized == []
+
+    def test_all_unrecognized_yields_viewer_and_populated_unrecognized(self):
+        result = _ConcreteProvider().map_roles_with_metadata(
+            ["weird1", "weird2"]
+        )
+        assert result.role == "viewer"
+        assert result.recognized == []
+        assert result.unrecognized == ["weird1", "weird2"]
+
+    def test_preserves_unrecognized_role_original_casing(self):
+        """The unrecognized list keeps the original raw string (with
+        original casing) so operators can correlate with upstream IdP
+        logs."""
+        result = _ConcreteProvider().map_roles_with_metadata(
+            ["Admin", "WeirdRole", "Quant_Dev"]
+        )
+        # "Admin" and "Quant_Dev" are recognized (case-insensitively);
+        # "WeirdRole" stays with its original casing in unrecognized.
+        assert result.unrecognized == ["WeirdRole"]
+        assert result.recognized == ["admin", "quant_dev"]
+
+
+# ---------------------------------------------------------------------------
+# 9. AuthResult.metadata surfacing — medium-severity follow-up
+# ---------------------------------------------------------------------------
+
+
+class TestAuthResultMetadataField:
+    """``AuthResult`` must expose a ``metadata`` dict so that callers can
+    propagate structured audit information (notably, unrecognized roles)
+    without scraping log lines."""
+
+    def test_auth_result_has_metadata_default(self):
+        r = AuthResult()
+        assert hasattr(r, "metadata")
+        assert r.metadata == {}
+
+    def test_auth_result_metadata_can_be_provided(self):
+        r = AuthResult(metadata={"unrecognized_roles": ["bogus"]})
+        assert r.metadata == {"unrecognized_roles": ["bogus"]}
+
+    def test_each_auth_result_has_independent_metadata(self):
+        """Default factory must yield a fresh dict per instance
+        (no shared mutable state)."""
+        a = AuthResult()
+        b = AuthResult()
+        a.metadata["foo"] = "bar"
+        assert "foo" not in b.metadata
+
+    def test_map_roles_with_metadata_can_drive_authresult_metadata(self):
+        """End-to-end: the result of ``map_roles_with_metadata`` can be
+        used to populate ``AuthResult.metadata`` — exactly the pattern
+        the LDAP/OIDC providers use."""
+        p = _ConcreteProvider()
+        mapping = p.map_roles_with_metadata(
+            ["admin", "bogus_a", "bogus_b"]
+        )
+        metadata: dict[str, object] = {}
+        if mapping.unrecognized:
+            metadata["unrecognized_roles"] = list(mapping.unrecognized)
+            metadata["recognized_roles"] = list(mapping.recognized)
+        r = AuthResult(success=True, metadata=metadata)
+        assert r.metadata["unrecognized_roles"] == ["bogus_a", "bogus_b"]
+        assert r.metadata["recognized_roles"] == ["admin"]

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -559,8 +559,12 @@ class TestLDAPInheritedMethods:
     def test_map_roles_developer(self, ldap_provider):
         assert ldap_provider.map_roles(["developer"]) == "developer"
 
-    def test_map_roles_unknown_defaults_user(self, ldap_provider):
-        assert ldap_provider.map_roles(["unknown_role"]) == "user"
+    def test_map_roles_unknown_defaults_viewer(self, ldap_provider):
+        """Least-privilege default: unrecognized external roles must fall
+        back to ``"viewer"`` (not ``"user"``)."""
+        assert ldap_provider.map_roles(["unknown_role"]) == "viewer"
 
     def test_map_roles_empty_list(self, ldap_provider):
-        assert ldap_provider.map_roles([]) == "user"
+        """Least-privilege default: an empty external_roles list must
+        yield ``"viewer"``."""
+        assert ldap_provider.map_roles([]) == "viewer"

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -650,10 +650,14 @@ class TestOIDCRoleMapping:
         assert oidc_provider.map_roles(["user"]) == "user"
 
     def test_map_roles_unknown_role(self, oidc_provider):
-        assert oidc_provider.map_roles(["unknown_role"]) == "user"
+        """Least-privilege default: an unrecognized external role must
+        fall back to ``"viewer"`` (not ``"user"``)."""
+        assert oidc_provider.map_roles(["unknown_role"]) == "viewer"
 
     def test_map_roles_empty_list(self, oidc_provider):
-        assert oidc_provider.map_roles([]) == "user"
+        """Least-privilege default: an empty external_roles list must
+        yield ``"viewer"``."""
+        assert oidc_provider.map_roles([]) == "viewer"
 
     def test_map_roles_case_insensitive(self, oidc_provider):
         assert oidc_provider.map_roles(["ADMIN"]) == "admin"

--- a/tests/test_recent_code_comprehensive.py
+++ b/tests/test_recent_code_comprehensive.py
@@ -461,6 +461,11 @@ class TestOIDCAuthenticateEdgeCases:
     async def test_new_user_creation_with_no_roles(
         self, oidc_provider, mock_settings, rsa_keys
     ):
+        """When the upstream IdP asserts no roles (empty list / claim
+        missing), the new user must receive the least-privilege
+        ``"viewer"`` role rather than ``"user"``. This is the
+        ``map_roles`` least-privilege fallback flowing through the
+        OIDC provider end-to-end."""
         client = _full_client(
             rsa_keys,
             {"sub": "no-role-user", "email": "norole@test.com", "name": "No Role"},
@@ -480,7 +485,7 @@ class TestOIDCAuthenticateEdgeCases:
 
         assert result.success is True
         assert len(created) == 1
-        assert created[0].role == "user"
+        assert created[0].role == "viewer"
 
     async def test_custom_role_claim(self, monkeypatch, rsa_keys):
         _settings(monkeypatch, oidc_role_claim="groups")
@@ -561,11 +566,11 @@ class TestIAuthProviderBase:
 
     def test_map_roles_empty_list(self):
         p = _ConcreteProvider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
 
     def test_map_roles_unknown_roles(self):
         p = _ConcreteProvider()
-        assert p.map_roles(["superadmin", "guest"]) == "user"
+        assert p.map_roles(["superadmin", "guest"]) == "viewer"
 
     def test_map_roles_case_insensitive(self):
         p = _ConcreteProvider()


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix HIGH severity fail-open privilege escalation in engine/api/auth/base.py map_roles — default to 'viewer' or deny when no recognized roles present instead of granting 'user' role

Closes #801
