### PR TITLE
security(auth): default empty roles to viewer not user

### DIFF
--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -26,6 +26,75 @@ class AuthResult:
     error: str | None = None
 
 
+# ---------------------------------------------------------------------------
+# Role-priority table
+# ---------------------------------------------------------------------------
+#
+# ``_ROLE_PRIORITY`` is the single source of truth for the internal role
+# hierarchy used by :meth:`IAuthProvider.map_roles`. The keys **must** be
+# lowercase because :meth:`map_roles` normalizes incoming IdP role strings
+# via ``str.lower().strip()`` before lookup; mixing cases here would
+# silently break that normalization. The module-level ``assert`` below
+# enforces this invariant at import time so a future contributor adding
+# a role cannot accidentally introduce a key that would never match.
+#
+# ``viewer`` is the lowest-privilege role and is also used as the
+# "floor" (default fallback) when no recognized role is supplied —
+# returning the lowest possible privilege is the safer default than
+# the historical ``user`` fallback, which granted more capability than
+# appropriate for an unrecognized identity.
+_ROLE_PRIORITY: dict[str, int] = {
+    "viewer": 0,
+    "user": 1,
+    "retail_trader": 2,
+    "quant_dev": 3,
+    "developer": 4,
+    "portfolio_manager": 5,
+    "admin": 6,
+}
+# Future-proofing guard: every key in the priority table must be
+# lowercase. Without this, map_roles' lower().strip() normalization
+# would silently fail to match any upper-case entry, causing every
+# caller to fall through to the ``viewer`` floor and masking the bug.
+assert all(k == k.lower() for k in _ROLE_PRIORITY), (
+    "_ROLE_PRIORITY keys must be lowercase; map_roles normalizes "
+    "incoming roles via str.lower() and would never match an "
+    "upper-/mixed-case key."
+)
+# ``_ROLE_FLOOR`` is the role returned when no recognized role is
+# supplied. It is intentionally the lowest-privilege entry in
+# ``_ROLE_PRIORITY``.
+_ROLE_FLOOR: str = min(_ROLE_PRIORITY, key=_ROLE_PRIORITY.get)  # type: ignore[arg-type]
+assert _ROLE_PRIORITY[_ROLE_FLOOR] == 0, (
+    "_ROLE_FLOOR must be the lowest-privilege role (priority 0)."
+)
+
+
+@dataclass(frozen=True)
+class RoleMappingResult:
+    """Structured result of :meth:`IAuthProvider.map_roles_detailed`.
+
+    Callers that need to make policy decisions based on which upstream
+    roles were unrecognized (e.g. alerting, audit logging, access
+    denial on partial misconfiguration) should use
+    :meth:`map_roles_detailed` instead of :meth:`map_roles`.
+
+    Attributes:
+        role: The highest-priority recognized role from
+            ``external_roles``. If no role was recognized this is
+            ``"viewer"`` — the lowest-privilege floor.
+        recognized: Every recognized role that appeared in the input,
+            normalized to lowercase, in the order it was supplied.
+        unrecognized: Every unrecognized raw role string that appeared
+            in the input, in the order it was supplied. Useful for
+            surfacing misconfigurations to operators.
+    """
+
+    role: str
+    recognized: list[str]
+    unrecognized: list[str]
+
+
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,44 +112,65 @@ class IAuthProvider(ABC):
     def map_roles(self, external_roles: list[str]) -> str:
         """Map an external IdP role list to a single internal role.
 
-        Security note: this function performs **no implicit promotion** of
-        unrecognized roles. Upstream Identity-Provider (IdP) roles are
-        reflected faithfully: only roles that are explicitly listed in
-        ``role_priority`` are eligible to become the user's role; anything
-        else is dropped and a warning is emitted so operators can detect
-        misconfigurations. Previously ``viewer`` was silently promoted to
-        ``user`` and ``quant_dev`` to ``developer``, which constituted a
-        silent privilege escalation (SEV-741).
+        Returns the highest-priority **recognized** role as-is, with no
+        implicit promotion. If no role in ``external_roles`` is
+        recognized (including the empty-list case) the function
+        returns ``"viewer"`` — the lowest-privilege floor — rather
+        than ``"user"`` (the historical default, which granted more
+        capability than appropriate for an unrecognized identity).
+
+        Security note: this function performs **no implicit promotion**
+        of unrecognized roles. Upstream Identity-Provider (IdP) roles
+        are reflected faithfully: only roles that are explicitly
+        listed in :data:`_ROLE_PRIORITY` are eligible to become the
+        user's role; anything else is dropped and a warning is emitted
+        so operators can detect misconfigurations. Previously
+        ``viewer`` was silently promoted to ``user`` and ``quant_dev``
+        to ``developer``, which constituted a silent privilege
+        escalation (SEV-741).
+
+        Callers that need visibility into which roles were
+        unrecognized should call :meth:`map_roles_detailed` instead.
         """
-        role_priority: dict[str, int] = {
-            "viewer": 0,
-            "user": 1,
-            "retail_trader": 2,
-            "quant_dev": 3,
-            "developer": 4,
-            "portfolio_manager": 5,
-            "admin": 6,
-        }
+        return self.map_roles_detailed(external_roles).role
+
+    def map_roles_detailed(self, external_roles: list[str]) -> RoleMappingResult:
+        """Structured variant of :meth:`map_roles`.
+
+        Returns a :class:`RoleMappingResult` containing the mapped
+        role plus the full lists of recognized and unrecognized input
+        roles, so callers can make policy decisions (e.g. deny login
+        when the unrecognized set is non-empty, audit-log the raw IdP
+        group names, alert on drift, etc.).
+
+        See :meth:`map_roles` for normalization and security
+        semantics; both methods share the same implementation.
+        """
         recognized: list[str] = []
         unrecognized: list[str] = []
         best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority:
+            if normalized in _ROLE_PRIORITY:
                 recognized.append(normalized)
-                if best is None or role_priority[normalized] > role_priority[best]:
+                if best is None or _ROLE_PRIORITY[normalized] > _ROLE_PRIORITY[best]:
                     best = normalized
             else:
                 unrecognized.append(role)
-        # Broaden the warning: fire on ANY unrecognized external role, not
-        # only when the entire set is unrecognized. This surfaces partial
-        # misconfigurations (e.g. one stale group name alongside valid ones).
+        # Broaden the warning: fire on ANY unrecognized external role,
+        # not only when the entire set is unrecognized. This surfaces
+        # partial misconfigurations (e.g. one stale group name
+        # alongside valid ones).
         if unrecognized:
             logger.warning(
                 "auth.map_roles.unrecognized_roles",
                 provider=self.name,
                 unrecognized=unrecognized,
                 recognized=recognized,
-                mapped=best if best is not None else "user",
+                mapped=best if best is not None else _ROLE_FLOOR,
             )
-        return best if best is not None else "user"
+        return RoleMappingResult(
+            role=best if best is not None else _ROLE_FLOOR,
+            recognized=recognized,
+            unrecognized=unrecognized,
+        )

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -205,23 +205,27 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_unknown_roles_ignored(self):
         p = self._make_provider()
-        assert p.map_roles(["superuser", "god"]) == "user"
+        assert p.map_roles(["superuser", "god"]) == "viewer"
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
         # SEV-741: map_roles no longer silently promotes domain roles.
         # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
         # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
-        # external role is unrecognized do we fall back to ``user``.
+        # external role is unrecognized do we fall back to ``viewer``
+        # (the lowest-privilege floor).
         assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
         assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 
-    def test_map_roles_empty_list_returns_user(self):
+    def test_map_roles_empty_list_returns_viewer_floor(self):
+        """Empty external_roles returns the lowest-privilege floor
+        (``viewer``) rather than ``user`` — minimal capability for
+        unrecognized identities."""
         p = self._make_provider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
 
 
 class TestAuthExports:

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -131,12 +131,20 @@ class TestNoImplicitPromotion:
             == "admin"
         )
 
-    def test_empty_input_returns_user(self):
-        assert _ConcreteProvider().map_roles([]) == "user"
+    def test_empty_input_returns_viewer_floor(self):
+        """With no recognized roles supplied the caller must receive
+        ``viewer`` — the lowest-privilege floor — rather than the
+        historical ``user`` default which granted excess capability
+        for an unrecognized identity."""
+        assert _ConcreteProvider().map_roles([]) == "viewer"
 
-    def test_all_unrecognized_falls_back_to_user(self):
+    def test_all_unrecognized_falls_back_to_viewer(self):
+        """When every external role is unrecognized, the lowest-
+        privilege floor (``viewer``) must be returned rather than
+        ``user`` — granting minimal capability to unrecognized
+        identities."""
         assert (
-            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "viewer"
         )
 
     def test_partial_unrecognized_still_uses_recognized(self):
@@ -153,9 +161,9 @@ class TestNoImplicitPromotion:
 
     def test_whitespace_only_role_is_unrecognized(self):
         """A whitespace-only string is normalized to the empty string,
-        which is not a known role.  Should fall through to user without
-        crashing."""
-        assert _ConcreteProvider().map_roles(["   "]) == "user"
+        which is not a known role.  Should fall through to the
+        ``viewer`` floor without crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "viewer"
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +204,7 @@ class TestUnrecognizedRoleWarning:
     def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
         calls = self._patch(monkeypatch)
         p = _ConcreteProvider()
-        assert p.map_roles(["totally_bogus"]) == "user"
+        assert p.map_roles(["totally_bogus"]) == "viewer"
         assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
 
     def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
@@ -220,7 +228,7 @@ class TestUnrecognizedRoleWarning:
     def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
         calls = self._patch(monkeypatch)
         p = _ConcreteProvider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
         assert calls == []
 
     def test_warning_includes_provider_name(self, monkeypatch):

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -559,8 +559,8 @@ class TestLDAPInheritedMethods:
     def test_map_roles_developer(self, ldap_provider):
         assert ldap_provider.map_roles(["developer"]) == "developer"
 
-    def test_map_roles_unknown_defaults_user(self, ldap_provider):
-        assert ldap_provider.map_roles(["unknown_role"]) == "user"
+    def test_map_roles_unknown_defaults_viewer(self, ldap_provider):
+        assert ldap_provider.map_roles(["unknown_role"]) == "viewer"
 
     def test_map_roles_empty_list(self, ldap_provider):
-        assert ldap_provider.map_roles([]) == "user"
+        assert ldap_provider.map_roles([]) == "viewer"

--- a/tests/test_map_roles_viewer_floor.py
+++ b/tests/test_map_roles_viewer_floor.py
@@ -1,0 +1,299 @@
+"""Targeted tests for the ``map_roles`` viewer-floor + structured-return
+hardening.
+
+Background
+----------
+Two related changes were made to :meth:`IAuthProvider.map_roles`:
+
+1. **Viewer-as-floor**: when no recognized role is supplied (empty
+   list, all-unrecognized, or whitespace-only entries) the function
+   now returns ``"viewer"`` — the lowest-privilege role — instead of
+   the historical ``"user"`` default. Granting the lowest possible
+   privilege to an unrecognized identity is the safer default.
+
+2. **Structured return**: a new ``map_roles_detailed`` method
+   complements ``map_roles`` by returning a :class:`RoleMappingResult`
+   containing both the mapped role and the full ``recognized`` /
+   ``unrecognized`` lists, so callers can make policy decisions
+   (e.g. deny login when any unrecognized role is present).
+
+3. **Lowercase guard**: a module-level ``assert`` enforces that
+   ``_ROLE_PRIORITY`` keys are all lowercase, since ``map_roles``
+   normalizes incoming IdP role strings via ``str.lower().strip()``
+   and would silently fail to match a mixed-/upper-case entry.
+
+These tests pin each of those behaviors and the future-proofing
+guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import (
+    _ROLE_FLOOR,
+    _ROLE_PRIORITY,
+    AuthResult,
+    IAuthProvider,
+    RoleMappingResult,
+)
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-viewer-floor"
+
+    async def authenticate(self, **kwargs):  # pragma: no cover
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. viewer is the floor — empty / unrecognized input must return viewer
+# ---------------------------------------------------------------------------
+
+
+class TestViewerIsTheFloor:
+    """``map_roles`` returns the lowest-privilege role when no
+    recognized role is present. This is the security hardening that
+    replaces the old ``user`` default."""
+
+    def test_empty_external_roles_returns_viewer(self):
+        """Empty input — no roles to consider — defaults to viewer."""
+        assert _ConcreteProvider().map_roles([]) == "viewer"
+
+    def test_all_unrecognized_returns_viewer(self):
+        """When every external role is unrecognized, the lowest-
+        privilege floor (viewer) is returned rather than ``user``."""
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus", "nope", "fake_role"]) == "viewer"
+
+    def test_whitespace_only_input_returns_viewer(self):
+        """A whitespace-only string normalizes to empty, which is not
+        a known role — must fall through to viewer."""
+        assert _ConcreteProvider().map_roles(["   ", "\t", " "]) == "viewer"
+
+    def test_viewer_floor_is_lowest_privilege(self):
+        """Sanity: ``viewer`` must have priority 0 (the lowest)."""
+        assert _ROLE_PRIORITY["viewer"] == 0
+        assert _ROLE_FLOOR == "viewer"
+        # ``viewer`` must be strictly less-privileged than ``user``.
+        assert _ROLE_PRIORITY["viewer"] < _ROLE_PRIORITY["user"]
+
+    def test_viewer_floor_strictly_below_all_other_known_roles(self):
+        """viewer is the lowest-privilege role — every other role in
+        the table must outrank it."""
+        for role, prio in _ROLE_PRIORITY.items():
+            if role == "viewer":
+                continue
+            assert prio > _ROLE_PRIORITY["viewer"], (
+                f"role {role!r} has priority {prio} which does not "
+                f"outrank viewer ({_ROLE_PRIORITY['viewer']}); viewer "
+                f"is supposed to be the floor."
+            )
+
+    def test_mixed_recognized_and_unrecognized_returns_recognized(self):
+        """Mix of recognized + unrecognized — recognized one wins
+        (and the unrecognized ones are dropped, not promoted)."""
+        p = _ConcreteProvider()
+        assert p.map_roles(["viewer", "bogus_x", "bogus_y"]) == "viewer"
+        assert p.map_roles(["admin", "bogus_z"]) == "admin"
+        assert p.map_roles(["developer", "l33t_h4x0r"]) == "developer"
+
+    def test_floor_only_used_when_nothing_recognized(self):
+        """Sanity: as soon as one recognized role is present, the
+        floor is NOT used; the highest-priority recognized role wins."""
+        p = _ConcreteProvider()
+        # viewer is recognized here, so result is viewer (not because
+        # of the floor, but because viewer is the highest recognized).
+        assert p.map_roles(["viewer"]) == "viewer"
+        # user outranks viewer — result must be user, not viewer.
+        assert p.map_roles(["user"]) == "user"
+        assert p.map_roles(["viewer", "user"]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 2. Structured return — map_roles_detailed
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesDetailed:
+    """``map_roles_detailed`` returns a :class:`RoleMappingResult`
+    with the mapped role plus the full recognized/unrecognized
+    lists, so callers can implement policy decisions on top."""
+
+    def test_returns_role_mapping_result_instance(self):
+        result = _ConcreteProvider().map_roles_detailed(["admin"])
+        assert isinstance(result, RoleMappingResult)
+
+    def test_role_field_matches_map_roles(self):
+        """The ``role`` attribute must agree with what plain
+        ``map_roles`` returns."""
+        p = _ConcreteProvider()
+        cases = [
+            ["admin"],
+            ["user", "developer"],
+            ["viewer"],
+            ["quant_dev"],
+            [],
+            ["bogus"],
+            ["admin", "bogus"],
+        ]
+        for external in cases:
+            detailed = p.map_roles_detailed(external)
+            assert detailed.role == p.map_roles(external), (
+                f"map_roles_detailed().role must equal map_roles() for "
+                f"input {external!r}"
+            )
+
+    def test_recognized_list_contains_all_recognized(self):
+        """The ``recognized`` list must include every recognized role
+        from the input (normalized to lowercase), in input order."""
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed(["ADMIN", "user", "  developer  "])
+        assert result.recognized == ["admin", "user", "developer"]
+
+    def test_recognized_list_empty_when_all_unrecognized(self):
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed(["bogus_a", "bogus_b"])
+        assert result.recognized == []
+
+    def test_recognized_list_empty_for_empty_input(self):
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed([])
+        assert result.recognized == []
+
+    def test_unrecognized_list_contains_raw_unrecognized(self):
+        """``unrecognized`` must contain the *raw* (un-normalized)
+        unrecognized strings in input order, so operators can audit
+        the exact IdP-supplied group/role names."""
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed(
+            ["admin", "StaleGroup", "  WeirdRole  ", "developer"]
+        )
+        assert result.unrecognized == ["StaleGroup", "  WeirdRole  "]
+
+    def test_unrecognized_list_empty_when_all_recognized(self):
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed(["admin", "user"])
+        assert result.unrecognized == []
+
+    def test_unrecognized_list_empty_for_empty_input(self):
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed([])
+        assert result.unrecognized == []
+
+    def test_floor_returned_in_role_when_nothing_recognized(self):
+        """When nothing is recognized, ``role`` is the viewer floor
+        and both recognized/unrecognized are populated correctly."""
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed(["foo", "bar"])
+        assert result.role == "viewer"
+        assert result.recognized == []
+        assert result.unrecognized == ["foo", "bar"]
+
+    def test_floor_returned_for_empty_input(self):
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed([])
+        assert result.role == "viewer"
+        assert result.recognized == []
+        assert result.unrecognized == []
+
+    def test_callers_can_implement_deny_if_unrecognized_policy(self):
+        """Demonstrates a caller-side policy: deny if any role is
+        unrecognized. This is the structured-return use case."""
+        p = _ConcreteProvider()
+
+        def deny_if_unrecognized(external: list[str]) -> str | None:
+            """Return the mapped role, or None to deny login when
+            any unrecognized role is present."""
+            r = p.map_roles_detailed(external)
+            if r.unrecognized:
+                return None
+            return r.role
+
+        # All-recognized: policy passes, role returned.
+        assert deny_if_unrecognized(["admin", "user"]) == "admin"
+        # Mixed: policy denies.
+        assert deny_if_unrecognized(["admin", "weird"]) is None
+        # All-unrecognized: policy denies (and floor not exposed).
+        assert deny_if_unrecognized(["weird"]) is None
+
+    def test_result_is_hashable_via_frozen_dataclass(self):
+        """RoleMappingResult is a frozen dataclass — it should be
+        hashable so it can be used as a dict key / set member by
+        callers tracking mapping outcomes."""
+        p = _ConcreteProvider()
+        r = p.map_roles_detailed(["admin"])
+        # frozen=True + list fields: lists are not hashable, but the
+        # dataclass itself raises FrozenInstanceError on mutation.
+        # Verify immutability contract.
+        with pytest.raises(Exception):  # noqa: B017 (any FrozenInstanceError attr)
+            r.role = "viewer"
+
+    def test_role_field_is_viewer_floor_when_input_is_unrecognized(self):
+        """Direct test of the viewer floor through the structured
+        API."""
+        p = _ConcreteProvider()
+        result = p.map_roles_detailed(["totally_unknown"])
+        assert result.role == "viewer"
+
+
+# ---------------------------------------------------------------------------
+# 3. Lowercase-guard on _ROLE_PRIORITY
+# ---------------------------------------------------------------------------
+
+
+class TestRolePriorityLowercaseGuard:
+    """The module-level ``assert`` ensures every key in
+    ``_ROLE_PRIORITY`` is lowercase, because ``map_roles`` normalizes
+    incoming IdP roles via ``str.lower().strip()`` — an upper- or
+    mixed-case key would silently never match."""
+
+    def test_all_keys_are_lowercase(self):
+        """Static guard: every key must already be lowercase."""
+        for key in _ROLE_PRIORITY:
+            assert key == key.lower(), (
+                f"_ROLE_PRIORITY key {key!r} must be lowercase; "
+                f"map_roles normalizes via str.lower() and would "
+                f"never match a mixed-/upper-case key."
+            )
+
+    def test_no_duplicate_priorities_among_adjacent_ranks(self):
+        """Sanity: every priority value is unique (no two roles tied
+        for the same rank) so that the max-priority lookup is
+        deterministic."""
+        priorities = list(_ROLE_PRIORITY.values())
+        assert len(set(priorities)) == len(priorities), (
+            "Every role must have a distinct priority; ties would "
+            "make map_roles' max-priority lookup non-deterministic."
+        )
+
+    def test_viewer_is_minimum_priority(self):
+        """The viewer floor must have the minimum priority value."""
+        min_priority = min(_ROLE_PRIORITY.values())
+        assert _ROLE_PRIORITY["viewer"] == min_priority
+
+    def test_normalization_would_match_every_known_role(self):
+        """Round-trip: ``role.lower().strip()`` of every key must
+        still be present as a key. (Trivially true when keys are
+        already lowercase + stripped, but this pins the contract.)"""
+        for key in _ROLE_PRIORITY:
+            normalized = key.lower().strip()
+            assert normalized in _ROLE_PRIORITY, (
+                f"Normalized form {normalized!r} of key {key!r} is "
+                f"missing from _ROLE_PRIORITY; map_roles would fail "
+                f"to match the normalized form."
+            )
+
+    def test_module_reimport_does_not_raise_assertion(self):
+        """Re-importing the module must succeed — i.e. the assert
+        is not currently tripping on bad data."""
+        import importlib
+
+        from engine.api.auth import base
+
+        importlib.reload(base)
+        # If we got here, the module-level assert did not fire.
+        assert hasattr(base, "_ROLE_PRIORITY")
+        assert hasattr(base, "_ROLE_FLOOR")

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -650,10 +650,10 @@ class TestOIDCRoleMapping:
         assert oidc_provider.map_roles(["user"]) == "user"
 
     def test_map_roles_unknown_role(self, oidc_provider):
-        assert oidc_provider.map_roles(["unknown_role"]) == "user"
+        assert oidc_provider.map_roles(["unknown_role"]) == "viewer"
 
     def test_map_roles_empty_list(self, oidc_provider):
-        assert oidc_provider.map_roles([]) == "user"
+        assert oidc_provider.map_roles([]) == "viewer"
 
     def test_map_roles_case_insensitive(self, oidc_provider):
         assert oidc_provider.map_roles(["ADMIN"]) == "admin"

--- a/tests/test_recent_code_comprehensive.py
+++ b/tests/test_recent_code_comprehensive.py
@@ -480,7 +480,9 @@ class TestOIDCAuthenticateEdgeCases:
 
         assert result.success is True
         assert len(created) == 1
-        assert created[0].role == "user"
+        # When no upstream role is asserted, the OIDC provider falls
+        # back to the lowest-privilege floor (``viewer``).
+        assert created[0].role == "viewer"
 
     async def test_custom_role_claim(self, monkeypatch, rsa_keys):
         _settings(monkeypatch, oidc_role_claim="groups")
@@ -561,11 +563,11 @@ class TestIAuthProviderBase:
 
     def test_map_roles_empty_list(self):
         p = _ConcreteProvider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
 
     def test_map_roles_unknown_roles(self):
         p = _ConcreteProvider()
-        assert p.map_roles(["superadmin", "guest"]) == "user"
+        assert p.map_roles(["superadmin", "guest"]) == "viewer"
 
     def test_map_roles_case_insensitive(self):
         p = _ConcreteProvider()


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix HIGH severity fail-open privilege escalation in engine/api/auth/base.py map_roles() — when external_roles is empty or all roles unrecognized, it defaults to 'user' (priority 1) instead of 'viewer' (priority 0) or denial

Closes #803
