### PR TITLE
fix(auth): apply SEV-741 least-privilege and log injection fixes

### DIFF
--- a/docs/operations/load-testing.md
+++ b/docs/operations/load-testing.md
@@ -74,11 +74,12 @@ The baseline thresholds are deliberately a bit tighter than the SLOs
 in [`slos.md`](slos.md): we want this test to fail before the SLO
 budget is consumed, not after.
 
-| Threshold (baseline)                              | Related SLO                  |
-|---------------------------------------------------|------------------------------|
-| `http_req_failed < 0.5%`                          | API availability (99.5%)     |
-| `http_req_duration{portfolio_list} p(95) < 800ms` | API latency (99% < 1.0s)     |
-| `http_req_duration{backtest_submit} p(95) < 1.5s` | Backtest submit (99%)        |
+| Threshold (baseline)                                | Related SLO                  |
+|-----------------------------------------------------|------------------------------|
+| `http_req_failed < 0.5%`                            | API availability (99.5%)     |
+| `http_req_duration{portfolio_list} p(95) < 800ms`   | API latency (99% < 1.0s)     |
+| `http_req_duration{reference_suggest} p(95) < 400ms`| Cache read latency (99%)     |
+| `http_req_duration{backtest_submit} p(95) < 1500ms` | Backtest submit (99%)        |
 
 If you tighten or relax a threshold in the scripts, update this table
 in the same PR.
@@ -103,7 +104,8 @@ in the same PR.
   intentionally hit the flat `/login` path; an MFA-enabled user will
   get an `mfa_required: true` response. Disable MFA on the test user.
 - **Backtest endpoint returns 422** — the Pydantic model changed.
-  Update `BACKTEST_BODY` in `tests/load/api-baseline.js` to match.
+  Update `BACKTEST_BODY` in `tests/load/api-baseline.js` to match
+  the current `BacktestRequest` in `engine/api/routes/backtest.py`.
 - **`Frontend Lint` fails on the JS** — lint scope intentionally
   doesn't include `tests/load/`. If you see this, check the lint
   config wasn't accidentally widened.

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -7,6 +8,49 @@ from typing import Any
 import structlog
 
 logger = structlog.get_logger()
+
+
+# Maximum length, in characters, of a single sanitized role value emitted
+# in log records. Anything beyond this is truncated to bound log size and
+# to defeat log-injection via arbitrarily long role names.
+_SANITIZED_ROLE_MAX_LENGTH = 128
+
+# Pattern matching ASCII control characters (0x00-0x1F and 0x7F) plus the
+# C1 control range (0x80-0x9F). These are stripped before logging to
+# prevent log-injection / terminal escape-sequence attacks.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def sanitize_role(role: str) -> str:
+    """Sanitize a single external role string before it is logged.
+
+    This performs two transformations:
+
+    1. **Strip control characters.** ASCII control characters (including
+       ``\\r``, ``\\n``, ``\\t``, ``BEL``, terminal escape introducers,
+       and the C1 control range) are removed. Without this, a malicious
+       or misconfigured upstream IdP could embed line breaks / escape
+       sequences in role names and forge log lines or affect terminals
+       rendering the log stream (CWE-117 / CWE-93).
+
+    2. **Cap length.** The result is truncated to
+       :data:`_SANITIZED_ROLE_MAX_LENGTH` characters. This bounds the
+       size of any single log payload and defeats trivial
+       log-blowing-by-INPUT attacks where an attacker submits a
+       multi-megabyte role name.
+
+    The original ``role`` value is never used as-is in log output; the
+    sanitized form should always be used for the ``unrecognized`` list
+    in :meth:`IAuthProvider.map_roles`.
+    """
+    if not isinstance(role, str):
+        # Defensive: callers should pass strings, but coerce anything
+        # else via repr to avoid crashing the auth path on bad input.
+        role = str(role)
+    stripped = _CONTROL_CHARS_RE.sub("", role)
+    if len(stripped) > _SANITIZED_ROLE_MAX_LENGTH:
+        return stripped[:_SANITIZED_ROLE_MAX_LENGTH]
+    return stripped
 
 
 @dataclass
@@ -43,14 +87,24 @@ class IAuthProvider(ABC):
     def map_roles(self, external_roles: list[str]) -> str:
         """Map an external IdP role list to a single internal role.
 
-        Security note: this function performs **no implicit promotion** of
-        unrecognized roles. Upstream Identity-Provider (IdP) roles are
-        reflected faithfully: only roles that are explicitly listed in
-        ``role_priority`` are eligible to become the user's role; anything
-        else is dropped and a warning is emitted so operators can detect
-        misconfigurations. Previously ``viewer`` was silently promoted to
-        ``user`` and ``quant_dev`` to ``developer``, which constituted a
-        silent privilege escalation (SEV-741).
+        Security notes:
+
+        * **No implicit promotion** of unrecognized roles. Upstream
+          Identity-Provider (IdP) roles are reflected faithfully: only
+          roles that are explicitly listed in ``role_priority`` are
+          eligible to become the user's role; anything else is dropped
+          and a warning is emitted so operators can detect
+          misconfigurations. Previously ``viewer`` was silently promoted
+          to ``user`` and ``quant_dev`` to ``developer``, which
+          constituted a silent privilege escalation (SEV-741).
+
+        * **Least-privilege fallback.** When no recognized role is
+          present (empty input, all-unrecognized, or whitespace-only
+          inputs), the function falls back to ``viewer`` — the lowest
+          privileged internal role. Previously the fallback was
+          ``user`` which grants trading privileges by default; an
+          unrecognized role claim should not silently confer trading
+          capabilities (defense-in-depth, SEV-741 follow-up).
         """
         role_priority: dict[str, int] = {
             "viewer": 0,
@@ -79,8 +133,8 @@ class IAuthProvider(ABC):
             logger.warning(
                 "auth.map_roles.unrecognized_roles",
                 provider=self.name,
-                unrecognized=unrecognized,
+                unrecognized=[sanitize_role(r) for r in unrecognized],
                 recognized=recognized,
-                mapped=best if best is not None else "user",
+                mapped=best if best is not None else "viewer",
             )
-        return best if best is not None else "user"
+        return best if best is not None else "viewer"

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -29,6 +29,40 @@ class LDAPAuthProvider(IAuthProvider):
         if not username or not password or db is None:
             return AuthResult(success=False, error="Username, password, and db session required")
 
+        ldap_attrs = self._bind_and_search(username, password)
+        if ldap_attrs is None:
+            return AuthResult(success=False, error="Invalid credentials")
+        if not ldap_attrs:
+            return AuthResult(success=False, error="User not found in LDAP")
+
+        ldap_uid = ldap_attrs.get("uid", [b""])[0].decode()
+        ldap_mail = ldap_attrs.get("mail", [b""])[0].decode() or f"{username}@ldap"
+        ldap_cn = ldap_attrs.get("cn", [b""])[0].decode() or username
+        member_of_raw = ldap_attrs.get("memberOf", [])
+        ldap_groups = [g.decode() for g in member_of_raw]
+
+        mapped_role = self._resolve_role(ldap_groups)
+
+        user = await self._upsert_user(db, ldap_uid, ldap_mail, ldap_cn, mapped_role)
+        if isinstance(user, AuthResult):
+            return user
+
+        if not user.is_active:
+            return AuthResult(success=False, error="Account is disabled")
+
+        return AuthResult(
+            success=True,
+            user_info=UserInfo(
+                external_id=ldap_uid,
+                email=user.email,
+                display_name=user.display_name,
+                provider="ldap",
+                roles=[user.role],
+            ),
+        )
+
+    @staticmethod
+    def _bind_and_search(username: str, password: str) -> dict[str, list[bytes]] | None:
         try:
             import ldap
             from ldap.filter import escape_filter_chars
@@ -49,22 +83,16 @@ class LDAPAuthProvider(IAuthProvider):
                 ["uid", "mail", "cn", "memberOf"],
             )
             conn.unbind_s()
-
         except Exception as exc:
             logger.exception("auth.ldap.bind_failed", error=str(exc))
-            return AuthResult(success=False, error="Invalid credentials")
+            return None
 
         if not results:
-            return AuthResult(success=False, error="User not found in LDAP")
+            return {}
+        return results[0][1]
 
-        _, ldap_attrs = results[0]
-        ldap_uid = ldap_attrs.get("uid", [b""])[0].decode()
-        ldap_mail = ldap_attrs.get("mail", [b""])[0].decode() or f"{username}@ldap"
-        ldap_cn = ldap_attrs.get("cn", [b""])[0].decode() or username
-
-        member_of_raw = ldap_attrs.get("memberOf", [])
-        ldap_groups = [g.decode() for g in member_of_raw]
-
+    @staticmethod
+    def _resolve_role(ldap_groups: list[str]) -> str:
         role_mapping = json.loads(settings.ldap_role_mapping) if settings.ldap_role_mapping else {}
         mapped_roles: list[str] = []
         for group_dn in ldap_groups:
@@ -74,9 +102,16 @@ class LDAPAuthProvider(IAuthProvider):
 
         if not mapped_roles:
             mapped_roles = ["user"]
+        return LDAPAuthProvider.map_roles(mapped_roles)
 
-        mapped_role = self.map_roles(mapped_roles)
-
+    @staticmethod
+    async def _upsert_user(
+        db: AsyncSession,
+        ldap_uid: str,
+        ldap_mail: str,
+        ldap_cn: str,
+        mapped_role: str,
+    ) -> User | AuthResult:
         result = await db.execute(
             select(User).where(User.auth_provider == "ldap", User.external_id == ldap_uid)
         )
@@ -102,20 +137,24 @@ class LDAPAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.ldap.user_created", user_id=str(user.id))
-        elif user.role != mapped_role:
-            user.role = mapped_role
-            await db.flush()
+            return user
 
-        if not user.is_active:
-            return AuthResult(success=False, error="Account is disabled")
+        if user.role != mapped_role:
+            # SEV-741 defense-in-depth: only mutate an existing user's
+            # role on subsequent federated logins if the operator has
+            # explicitly opted in via ``auth_overwrite_role_on_login``.
+            # Defaulting to no-op prevents a misconfigured or compromised
+            # upstream IdP from downgrading or escalating a role that
+            # was previously granted locally.
+            if settings.auth_overwrite_role_on_login:
+                user.role = mapped_role
+                await db.flush()
+            else:
+                logger.info(
+                    "auth.ldap.role_overwrite_skipped",
+                    user_id=str(user.id),
+                    current_role=user.role,
+                    idp_role=mapped_role,
+                )
 
-        return AuthResult(
-            success=True,
-            user_info=UserInfo(
-                external_id=ldap_uid,
-                email=user.email,
-                display_name=user.display_name,
-                provider="ldap",
-                roles=[user.role],
-            ),
-        )
+        return user

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -43,7 +43,8 @@ retention) so regressions can be diffed.
 - **Use the helpers in `lib/auth.js`** for login / Authorization
   headers. Don't re-implement the login flow per script.
 - **No destructive writes.** The baseline writes via the async-
-  backtest path (returns 202; worker may or may not run it). Don't
+  backtest path (POST `/api/v1/backtest/run`, returns immediately
+  with a `backtest_id`; the worker may or may not run it). Don't
   add scripts that mutate prod-shaped data without a separate
   destructive-OK env flag.
 - **No MFA-enabled users.** The load-test user must be a flat

--- a/tests/load/api-baseline.js
+++ b/tests/load/api-baseline.js
@@ -8,8 +8,8 @@
 //   NEXUS_LOAD_PASS         load-test user password
 //
 // Optional env:
-//   NEXUS_BASELINE_RPS      target requests-per-second (default 20)
-//   NEXUS_LOAD_STRATEGY_ID  strategy id used in backtest submissions (default: 'noop')
+//   NEXUS_BASELINE_RPS        target requests-per-second (default 20)
+//   NEXUS_LOAD_STRATEGY_NAME  strategy name used in backtest submissions (default: 'noop')
 //
 // Run:
 //   k6 run tests/load/api-baseline.js
@@ -18,14 +18,15 @@
 //
 // What's tested:
 //   - GET  /api/v1/portfolio              — read-heavy listing
-//   - GET  /api/v1/reference/exchanges    — cached reference read
-//   - POST /api/v1/backtest               — async-write path (returns 202)
+//   - GET  /api/v1/reference/suggest      — cached reference read
+//   - POST /api/v1/backtest/run           — async-write path (returns 200)
 //
 // Why these three:
 //   They exercise three distinct backend code paths (DB read, cache read,
 //   queue write) without doing anything destructive. The backtest endpoint
-//   accepts a no-op payload and returns a row id; the worker may or may not
-//   pick it up — that's covered by the task-pipeline SLO, not this test.
+//   accepts a no-op payload and returns a backtest id; the worker may or
+//   may not pick it up — that's covered by the task-pipeline SLO, not this
+//   test.
 
 import http from 'k6/http';
 import { check, sleep } from 'k6';
@@ -46,9 +47,9 @@ export const options = {
   },
   thresholds: {
     http_req_failed: ['rate<0.005'],
-    'http_req_duration{name:portfolio_list}':       ['p(95)<800',  'p(99)<1500'],
-    'http_req_duration{name:reference_exchanges}':  ['p(95)<400',  'p(99)<800'],
-    'http_req_duration{name:backtest_submit}':      ['p(95)<1500', 'p(99)<2500'],
+    'http_req_duration{name:portfolio_list}':     ['p(95)<800',  'p(99)<1500'],
+    'http_req_duration{name:reference_suggest}':  ['p(95)<400',  'p(99)<800'],
+    'http_req_duration{name:backtest_submit}':    ['p(95)<1500', 'p(99)<2500'],
   },
   summaryTrendStats: ['avg', 'min', 'med', 'p(95)', 'p(99)', 'max'],
 };
@@ -62,14 +63,15 @@ export function setup() {
   return { baseUrl, token };
 }
 
+// Minimal accepted payload — operator may need to swap this for whatever
+// the current Pydantic model requires. Kept intentionally small so it does
+// not generate meaningful load on the worker. Field names match the
+// BacktestRequest Pydantic model in engine/api/routes/backtest.py.
 const BACKTEST_BODY = JSON.stringify({
-  // Minimal accepted payload — operator may need to swap this for whatever
-  // the current Pydantic model requires. Kept intentionally small so it does
-  // not generate meaningful load on the worker.
-  strategy_id: __ENV.NEXUS_LOAD_STRATEGY_ID || 'noop',
-  start: '2024-01-01T00:00:00Z',
-  end:   '2024-01-02T00:00:00Z',
+  strategy_name: __ENV.NEXUS_LOAD_STRATEGY_NAME || 'noop',
   symbol: 'AAPL',
+  start_date: '2024-01-01',
+  end_date:   '2024-01-02',
 });
 
 export default function (data) {
@@ -82,18 +84,20 @@ export default function (data) {
     });
     check(res, { '2xx': (r) => r.status >= 200 && r.status < 300 });
   } else if (r < 0.85) {
-    const res = http.get(`${data.baseUrl}/api/v1/reference/exchanges`, {
+    const res = http.get(`${data.baseUrl}/api/v1/reference/suggest?q=AAPL`, {
       headers: authHeaders(data.token),
-      tags: { name: 'reference_exchanges' },
+      tags: { name: 'reference_suggest' },
     });
     check(res, { '2xx': (r) => r.status >= 200 && r.status < 300 });
   } else {
-    const res = http.post(`${data.baseUrl}/api/v1/backtest`, BACKTEST_BODY, {
+    const res = http.post(`${data.baseUrl}/api/v1/backtest/run`, BACKTEST_BODY, {
       headers: authHeaders(data.token),
       tags: { name: 'backtest_submit' },
     });
-    // 202 Accepted is the expected success status for the async path.
-    check(res, { 'submit accepted': (r) => r.status === 202 || r.status === 201 || r.status === 200 });
+    // The async path accepts and immediately returns a backtest id with
+    // 200; the work happens in a BackgroundTask. We accept 200/201/202 so
+    // the test stays green if the framework later moves to 202 Accepted.
+    check(res, { 'submit accepted': (r) => r.status === 200 || r.status === 201 || r.status === 202 });
   }
 
   sleep(0.1);

--- a/tests/load/api-smoke.js
+++ b/tests/load/api-smoke.js
@@ -41,8 +41,10 @@ export function setup() {
 }
 
 export default function (data) {
-  // 1. Health check — should be sub-200ms.
-  const health = http.get(`${data.baseUrl}/api/v1/health`, {
+  // 1. Health check — mounted at the top level (no /api/v1 prefix), so it
+  //    exercises the framework + middleware stack without touching auth, DB
+  //    or any business logic. Should be sub-200ms.
+  const health = http.get(`${data.baseUrl}/health`, {
     tags: { name: 'health' },
   });
   check(health, { 'health 200': (r) => r.status === 200 });
@@ -60,10 +62,10 @@ export default function (data) {
     },
   });
 
-  // 3. Reference data — instruments / exchanges (cheap GET).
-  const ref = http.get(`${data.baseUrl}/api/v1/reference/exchanges`, {
+  // 3. Reference data — instrument search (cache-backed read).
+  const ref = http.get(`${data.baseUrl}/api/v1/reference/suggest?q=AAPL`, {
     headers: authHeaders(data.token),
-    tags: { name: 'reference_exchanges' },
+    tags: { name: 'reference_suggest' },
   });
   check(ref, { 'reference 200': (r) => r.status === 200 });
 

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -205,23 +205,23 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_unknown_roles_ignored(self):
         p = self._make_provider()
-        assert p.map_roles(["superuser", "god"]) == "user"
+        assert p.map_roles(["superuser", "god"]) == "viewer"
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
         # SEV-741: map_roles no longer silently promotes domain roles.
         # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
         # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
-        # external role is unrecognized do we fall back to ``user``.
+        # external role is unrecognized do we fall back to ``viewer``.
         assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
         assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 
-    def test_map_roles_empty_list_returns_user(self):
+    def test_map_roles_empty_list_returns_viewer(self):
         p = self._make_provider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
 
 
 class TestAuthExports:

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -21,6 +21,10 @@ This module pins the new behavior:
 2. ``auth_overwrite_role_on_login`` defaults to ``False``.
 3. A warning is emitted for **any** unrecognized external role (not
    only when the entire set is unrecognized).
+4. Fallback role is ``viewer`` (least privilege) when no recognized
+   role is present, instead of ``user`` (which grants trading).
+5. Unrecognized roles are sanitized (control chars stripped, length
+   capped) before logging — see :func:`sanitize_role`.
 """
 
 from __future__ import annotations
@@ -131,12 +135,12 @@ class TestNoImplicitPromotion:
             == "admin"
         )
 
-    def test_empty_input_returns_user(self):
-        assert _ConcreteProvider().map_roles([]) == "user"
+    def test_empty_input_returns_viewer(self):
+        assert _ConcreteProvider().map_roles([]) == "viewer"
 
-    def test_all_unrecognized_falls_back_to_user(self):
+    def test_all_unrecognized_falls_back_to_viewer(self):
         assert (
-            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "viewer"
         )
 
     def test_partial_unrecognized_still_uses_recognized(self):
@@ -153,9 +157,9 @@ class TestNoImplicitPromotion:
 
     def test_whitespace_only_role_is_unrecognized(self):
         """A whitespace-only string is normalized to the empty string,
-        which is not a known role.  Should fall through to user without
+        which is not a known role.  Should fall through to viewer without
         crashing."""
-        assert _ConcreteProvider().map_roles(["   "]) == "user"
+        assert _ConcreteProvider().map_roles(["   "]) == "viewer"
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +200,7 @@ class TestUnrecognizedRoleWarning:
     def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
         calls = self._patch(monkeypatch)
         p = _ConcreteProvider()
-        assert p.map_roles(["totally_bogus"]) == "user"
+        assert p.map_roles(["totally_bogus"]) == "viewer"
         assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
 
     def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
@@ -220,7 +224,7 @@ class TestUnrecognizedRoleWarning:
     def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
         calls = self._patch(monkeypatch)
         p = _ConcreteProvider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
         assert calls == []
 
     def test_warning_includes_provider_name(self, monkeypatch):
@@ -441,3 +445,258 @@ class TestMappedRoleFlowsToRequireRole:
                 f"minimum={minimum_required}; expected {expected_status}, "
                 f"got {resp.status_code}"
             )
+
+
+# ---------------------------------------------------------------------------
+# 7. Least-privilege fallback: empty / all-unrecognized -> ``viewer``
+# ---------------------------------------------------------------------------
+
+
+class TestLeastPrivilegeFallback:
+    """SEV-741 follow-up: when no recognized role is present, the
+    internal role must fall back to ``viewer`` (the lowest privileged
+    role) rather than ``user`` (which grants trading capabilities).
+
+    Rationale: an unrecognized / missing upstream role claim should
+    not silently confer trading capabilities. Operators can grant
+    additional privileges explicitly via the standard admin tools.
+    """
+
+    def test_empty_list_falls_back_to_viewer(self):
+        assert _ConcreteProvider().map_roles([]) == "viewer"
+
+    def test_all_unrecognized_falls_back_to_viewer(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "viewer"
+        )
+
+    def test_whitespace_only_falls_back_to_viewer(self):
+        assert _ConcreteProvider().map_roles(["   "]) == "viewer"
+
+    def test_fallback_viewer_does_not_allow_user_actions(self):
+        """The mapped ``viewer`` role must not satisfy a ``require_role('user')``
+        gate — this is the whole point of the least-privilege fallback."""
+        mapped = _ConcreteProvider().map_roles(["bogus_role"])
+        assert mapped == "viewer"
+        # Mirror ROLE_HIERARCHY from engine/api/auth/dependency.py
+        role_hierarchy = {
+            "viewer": 0,
+            "user": 1,
+            "retail_trader": 2,
+            "quant_dev": 3,
+            "developer": 4,
+            "portfolio_manager": 5,
+            "admin": 6,
+        }
+        assert role_hierarchy[mapped] < role_hierarchy["user"]
+
+    def test_recognized_viewer_is_returned_verbatim(self):
+        """``viewer`` is a recognized role, so a list of just ``viewer``
+        must return ``viewer`` (not be silently promoted)."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_viewer_alone_is_not_promoted_to_user(self):
+        """Sanity: when ``viewer`` is the only recognized role and
+        other entries are unrecognized, we still return ``viewer``."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "made_up_role"]) == "viewer"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. Sanitization of unrecognized roles in log warnings
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleSanitization:
+    """Log-injection defense: the ``unrecognized=`` payload emitted by
+    :meth:`IAuthProvider.map_roles` must be sanitized via
+    :func:`sanitize_role` so that a malicious upstream IdP cannot
+    embed control characters (CR/LF, terminal escape sequences) or
+    unbounded-length strings into log records."""
+
+    def test_sanitize_role_strips_newlines(self):
+        from engine.api.auth.base import sanitize_role
+
+        assert sanitize_role("ev\nil") == "evil"
+        assert sanitize_role("ev\ril") == "evil"
+        assert sanitize_role("ev\r\nil") == "evil"
+
+    def test_sanitize_role_strips_tabs(self):
+        from engine.api.auth.base import sanitize_role
+
+        assert sanitize_role("ev\til") == "evil"
+
+    def test_sanitize_role_strips_null_bytes(self):
+        from engine.api.auth.base import sanitize_role
+
+        # Null bytes are a classic log-injection / C-string-truncation
+        # attack vector.
+        assert sanitize_role("ev\x00il") == "evil"
+
+    def test_sanitize_role_strips_bel_and_escape(self):
+        from engine.api.auth.base import sanitize_role
+
+        # BEL and ESC are terminal-control characters; they must not
+        # reach log streams verbatim.
+        assert sanitize_role("ev\x07il") == "evil"
+        assert sanitize_role("ev\x1bil") == "evil"
+
+    def test_sanitize_role_strips_c1_control_range(self):
+        from engine.api.auth.base import sanitize_role
+
+        # 0x80-0x9F is the C1 control range; strip those too.
+        assert sanitize_role("ev\x80il") == "evil"
+        assert sanitize_role("ev\x9fil") == "evil"
+
+    def test_sanitize_role_strips_multiple_control_chars(self):
+        from engine.api.auth.base import sanitize_role
+
+        assert sanitize_role("\x00e\x01v\x02i\x03l\x04") == "evil"
+
+    def test_sanitize_role_caps_length(self):
+        from engine.api.auth.base import _SANITIZED_ROLE_MAX_LENGTH, sanitize_role
+
+        huge = "A" * (_SANITIZED_ROLE_MAX_LENGTH * 4)
+        result = sanitize_role(huge)
+        assert len(result) == _SANITIZED_ROLE_MAX_LENGTH
+        assert result == "A" * _SANITIZED_ROLE_MAX_LENGTH
+
+    def test_sanitize_role_caps_length_after_stripping_controls(self):
+        from engine.api.auth.base import _SANITIZED_ROLE_MAX_LENGTH, sanitize_role
+
+        # The cap is applied AFTER stripping controls, so an attacker
+        # cannot pad with control chars to "push" the meaningful
+        # content past the truncation point.
+        huge = "A" * (_SANITIZED_ROLE_MAX_LENGTH * 2) + "\n" + "B" * 100
+        result = sanitize_role(huge)
+        assert len(result) == _SANITIZED_ROLE_MAX_LENGTH
+        assert "\n" not in result
+        # The first chunk of A's wins (control chars are stripped first,
+        # then the resulting string is truncated).
+        assert result.startswith("A" * _SANITIZED_ROLE_MAX_LENGTH)
+
+    def test_sanitize_role_preserves_safe_strings(self):
+        from engine.api.auth.base import sanitize_role
+
+        # A normal ASCII role name passes through unchanged.
+        assert sanitize_role("stale_group_name") == "stale_group_name"
+        assert sanitize_role("CN=Admins,DC=example,DC=com") == "CN=Admins,DC=example,DC=com"
+
+    def test_sanitize_role_preserves_unicode(self):
+        from engine.api.auth.base import sanitize_role
+
+        # Non-ASCII printable characters are preserved; only control
+        # characters are stripped.
+        assert sanitize_role("rolé") == "rolé"
+        assert sanitize_role("管理者") == "管理者"
+
+    def test_sanitize_role_handles_non_string_input(self):
+        from engine.api.auth.base import sanitize_role
+
+        # Defensive: callers should pass strings, but bad input must
+        # not crash the auth path.
+        assert sanitize_role(123) == "123"
+        assert sanitize_role(None) == "None"
+
+    def test_sanitize_role_empty_string_returns_empty(self):
+        from engine.api.auth.base import sanitize_role
+
+        assert sanitize_role("") == ""
+
+    def test_sanitize_role_only_control_chars_returns_empty(self):
+        from engine.api.auth.base import sanitize_role
+
+        # All-control input sanitizes to the empty string (not None,
+        # not a crash).
+        assert sanitize_role("\x00\x01\x02\x03") == ""
+
+    def test_map_roles_uses_sanitized_form_in_log(self, monkeypatch):
+        """End-to-end: ``map_roles`` must run unrecognized roles
+        through ``sanitize_role`` before emitting them in the warning
+        payload."""
+        from engine.api.auth import base
+
+        captured: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                captured.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                captured.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                captured.append({"event": _event, "level": "error", **kwargs})
+
+        monkeypatch.setattr(base, "logger", _Stub())
+
+        p = _ConcreteProvider()
+        p.map_roles(["ev\nil", "be\tnign", "nor\x00mal"])
+
+        assert len(captured) == 1
+        unrecognized = captured[0]["unrecognized"]
+        assert unrecognized == ["evil", "benign", "normal"], (
+            "Expected control characters to be stripped before logging; "
+            f"got {unrecognized!r}"
+        )
+
+    def test_map_roles_caps_overlong_unrecognized_role_in_log(self, monkeypatch):
+        """A multi-kB role name must be truncated in the log payload."""
+        from engine.api.auth import base
+
+        captured: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                captured.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                captured.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                captured.append({"event": _event, "level": "error", **kwargs})
+
+        monkeypatch.setattr(base, "logger", _Stub())
+
+        huge = "X" * (base._SANITIZED_ROLE_MAX_LENGTH * 4)
+        p = _ConcreteProvider()
+        p.map_roles([huge])
+
+        assert len(captured) == 1
+        unrecognized = captured[0]["unrecognized"]
+        assert len(unrecognized) == 1
+        assert len(unrecognized[0]) == base._SANITIZED_ROLE_MAX_LENGTH
+
+    def test_sanitize_role_is_public_api(self):
+        """``sanitize_role`` must be importable from the public auth
+        base module — operators / integrators rely on it for custom
+        logging pipelines."""
+        from engine.api.auth import base
+
+        assert hasattr(base, "sanitize_role")
+        assert callable(base.sanitize_role)
+
+
+# ---------------------------------------------------------------------------
+# 9. ``auth_overwrite_role_on_login`` integration with LDAP provider
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginWiring:
+    """SEV-741 follow-up: the LDAP federated-login role-mutation path
+    must honor ``auth_overwrite_role_on_login``. When False (the
+    default), the IdP cannot mutate a previously granted local role on
+    subsequent logins. When True, it can — operators opt in."""
+
+    def test_setting_default_is_false(self):
+        from engine.config import Settings
+
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_can_be_enabled(self):
+        from engine.config import Settings
+
+        s = Settings(_env_file=None, auth_overwrite_role_on_login=True)
+        assert s.auth_overwrite_role_on_login is True

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -404,6 +404,11 @@ class TestLDAPAuthenticateExistingUser:
     ):
         from engine.db.models import User
 
+        # SEV-741: existing-user role mutation on federated login must
+        # be opt-in via ``auth_overwrite_role_on_login``. Default-
+        # behavior (no overwrite) is exercised in a separate test.
+        mock_settings.auth_overwrite_role_on_login = True
+
         attrs = _make_ldap_attrs(
             member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
         )
@@ -434,6 +439,49 @@ class TestLDAPAuthenticateExistingUser:
         assert result.success is True
         assert existing_user.role == "admin"
         mock_db.flush.assert_called()
+
+    async def test_existing_user_role_not_overwritten_when_setting_disabled(
+        self, ldap_provider, mock_settings
+    ):
+        """SEV-741 follow-up: ``auth_overwrite_role_on_login=False`` (the
+        default) must prevent the LDAP IdP from mutating a previously
+        granted local role on each federated login."""
+        from engine.db.models import User
+
+        # Default is False; make it explicit for readability.
+        assert mock_settings.auth_overwrite_role_on_login is False
+
+        attrs = _make_ldap_attrs(
+            member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
+        )
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=kept,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="kept@example.com",
+            display_name="Kept",
+            is_active=True,
+            role="user",
+            auth_provider="ldap",
+            external_id="kept",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="kept", password="correctpass", db=mock_db
+            )
+
+        assert result.success is True
+        # Role should NOT have been mutated — defense-in-depth.
+        assert existing_user.role == "user"
+        mock_db.flush.assert_not_called()
 
 
 class TestLDAPAuthenticateEmailConflict:
@@ -559,8 +607,8 @@ class TestLDAPInheritedMethods:
     def test_map_roles_developer(self, ldap_provider):
         assert ldap_provider.map_roles(["developer"]) == "developer"
 
-    def test_map_roles_unknown_defaults_user(self, ldap_provider):
-        assert ldap_provider.map_roles(["unknown_role"]) == "user"
+    def test_map_roles_unknown_defaults_viewer(self, ldap_provider):
+        assert ldap_provider.map_roles(["unknown_role"]) == "viewer"
 
     def test_map_roles_empty_list(self, ldap_provider):
-        assert ldap_provider.map_roles([]) == "user"
+        assert ldap_provider.map_roles([]) == "viewer"

--- a/tests/test_load_tests.py
+++ b/tests/test_load_tests.py
@@ -1,0 +1,265 @@
+"""Static validation for the k6 load-test suite.
+
+The scripts in ``tests/load/`` are JavaScript executed by k6, so they're
+outside the normal pytest surface. This module gives us a single place to
+catch the most common breakage modes before they hit the weekly CI cron:
+
+* The k6 workflow YAML parses.
+* Every JS file is syntactically valid (``node -c``).
+* Every endpoint the scripts hit actually exists in the FastAPI router.
+* The threshold table in the operator runbook matches the real thresholds
+  in ``api-baseline.js``.
+
+Together these guarantee that a green CI run on the load-test workflow
+means a green run on staging.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+LOAD_DIR = ROOT / "tests" / "load"
+WORKFLOW = ROOT / ".github" / "workflows" / "load-test.yml"
+RUNBOOK = ROOT / "docs" / "operations" / "load-testing.md"
+
+JS_FILES = [
+    LOAD_DIR / "lib" / "auth.js",
+    LOAD_DIR / "api-smoke.js",
+    LOAD_DIR / "api-baseline.js",
+]
+
+
+@pytest.fixture(scope="module")
+def app_routes() -> set[str]:
+    """Collect the (path, method) surface mounted on the FastAPI app.
+
+    Done once per module — ``create_app`` is cheap but not free, and
+    every test in this file just needs the same set of paths.
+    """
+    from engine.app import create_app
+
+    app = create_app()
+    paths: set[str] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        if path:
+            paths.add(path)
+    return paths
+
+
+@pytest.fixture(scope="module")
+def app_route_methods() -> dict[str, set[str]]:
+    """Map ``path -> {methods}`` (HEAD excluded) for method-aware checks."""
+    from engine.app import create_app
+
+    app = create_app()
+    out: dict[str, set[str]] = {}
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if path and methods:
+            out.setdefault(path, set()).update(
+                m for m in methods if m != "HEAD"
+            )
+    return out
+
+
+class TestFiles:
+    def test_all_js_files_exist(self) -> None:
+        for path in JS_FILES:
+            assert path.is_file(), f"missing k6 script: {path}"
+
+    def test_readme_exists(self) -> None:
+        assert (LOAD_DIR / "README.md").is_file()
+
+    def test_workflow_exists(self) -> None:
+        assert WORKFLOW.is_file()
+
+    def test_runbook_exists(self) -> None:
+        assert RUNBOOK.is_file()
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is not installed — skipping JS syntax checks",
+)
+class TestJsSyntax:
+    @pytest.mark.parametrize("path", JS_FILES, ids=lambda p: p.name)
+    def test_node_syntax_check(self, path: Path) -> None:
+        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["node", "-c", str(path)],  # noqa: S607 — node resolved via PATH intentionally
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"node -c {path.name} failed:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+class TestWorkflow:
+    def test_yaml_parses(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        assert "jobs" in data, "workflow has no jobs"
+        assert "run" in data["jobs"], "workflow is missing the 'run' job"
+
+    def test_triggers(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        assert "workflow_dispatch" in triggers
+        assert "schedule" in triggers
+
+    def test_manual_inputs(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        wd = triggers["workflow_dispatch"]
+        assert "scenario" in wd["inputs"]
+        assert "base_url" in wd["inputs"]
+        options = wd["inputs"]["scenario"]["options"]
+        assert "smoke" in options
+        assert "baseline" in options
+
+    def test_weekly_cron(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        cron_expr = triggers["schedule"][0]["cron"]
+        # Monday 03:00 UTC — k6 docs/operations/load-testing.md commits
+        # to this exact window, so pin it.
+        assert cron_expr == "0 3 * * 1", (
+            f"weekly baseline cron changed: {cron_expr!r}"
+        )
+
+    def test_summary_artifact(self) -> None:
+        text = WORKFLOW.read_text()
+        assert "load-test-summary.json" in text, (
+            "workflow must upload load-test-summary.json for regression diffs"
+        )
+        assert "retention-days: 30" in text, (
+            "workflow must retain the summary artifact for 30 days"
+        )
+
+
+class TestScriptRoutes:
+    """The k6 scripts must hit endpoints that actually exist."""
+
+    @pytest.fixture(scope="class")
+    def smoke_text(self) -> str:
+        return (LOAD_DIR / "api-smoke.js").read_text()
+
+    @pytest.fixture(scope="class")
+    def baseline_text(self) -> str:
+        return (LOAD_DIR / "api-baseline.js").read_text()
+
+    def test_health_route_is_root_not_api_v1(self, smoke_text: str) -> None:
+        # The health router is mounted without the /api/v1 prefix; if a
+        # future refactor moves it under /api/v1/health, update both the
+        # script and this assertion together.
+        assert "${data.baseUrl}/health" in smoke_text
+        assert "/api/v1/health" not in smoke_text
+
+    def test_auth_login_route_exists(
+        self, app_route_methods: dict[str, set[str]]
+    ) -> None:
+        assert "POST" in app_route_methods.get("/api/v1/auth/login", set())
+
+    def test_portfolio_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        smoke_text: str,
+        baseline_text: str,
+    ) -> None:
+        assert "/api/v1/portfolio" in app_route_methods or (
+            "/api/v1/portfolio/" in app_route_methods
+        ), "portfolio route missing — k6 scripts will 404"
+        assert "/api/v1/portfolio" in smoke_text
+        assert "/api/v1/portfolio" in baseline_text
+
+    def test_reference_suggest_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        smoke_text: str,
+        baseline_text: str,
+    ) -> None:
+        # The reference router only exposes /suggest, not /exchanges.
+        assert "GET" in app_route_methods.get(
+            "/api/v1/reference/suggest", set()
+        ), "GET /api/v1/reference/suggest must exist for the k6 scripts"
+        assert "/api/v1/reference/suggest" in smoke_text
+        assert "/api/v1/reference/suggest" in baseline_text
+        # Guard against drift back to the old, non-existent endpoint.
+        assert "/api/v1/reference/exchanges" not in smoke_text
+        assert "/api/v1/reference/exchanges" not in baseline_text
+
+    def test_backtest_run_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        baseline_text: str,
+    ) -> None:
+        assert "POST" in app_route_methods.get(
+            "/api/v1/backtest/run", set()
+        ), "POST /api/v1/backtest/run must exist for the baseline script"
+        assert "/api/v1/backtest/run" in baseline_text
+        # The bare /api/v1/backtest path is a 404 — guard against regressions.
+        assert "'${data.baseUrl}/api/v1/backtest'," not in baseline_text
+        assert "'${data.baseUrl}/api/v1/backtest'" not in baseline_text
+
+    def test_backtest_payload_matches_pydantic_model(
+        self, baseline_text: str
+    ) -> None:
+        # engine.api.routes.backtest.BacktestRequest requires these exact
+        # field names. A rename in the Pydantic model is the #1 way this
+        # script silently breaks — pin the names here.
+        assert "strategy_name" in baseline_text
+        assert "start_date" in baseline_text
+        assert "end_date" in baseline_text
+        # The old field names would silently 422.
+        assert "strategy_id" not in baseline_text
+        assert not re.search(r"\bstart\s*:", baseline_text)
+        assert not re.search(r"\bend\s*:", baseline_text)
+
+
+class TestThresholds:
+    """The runbook's threshold table must match the baseline script."""
+
+    @pytest.fixture(scope="class")
+    def baseline_text(self) -> str:
+        return (LOAD_DIR / "api-baseline.js").read_text()
+
+    @pytest.fixture(scope="class")
+    def runbook_text(self) -> str:
+        return RUNBOOK.read_text()
+
+    @pytest.mark.parametrize(
+        ("tag", "p95"),
+        [
+            ("portfolio_list", "800"),
+            ("reference_suggest", "400"),
+            ("backtest_submit", "1500"),
+        ],
+    )
+    def test_p95_threshold_listed(
+        self, baseline_text: str, runbook_text: str, tag: str, p95: str
+    ) -> None:
+        # Must be enforced by the script…
+        assert (
+            f"http_req_duration{{name:{tag}}}" in baseline_text
+        ), f"baseline script is missing threshold for tag {tag!r}"
+        assert f"p(95)<{p95}" in baseline_text
+        # …and documented in the runbook.
+        assert tag in runbook_text, (
+            f"runbook must list threshold for tag {tag!r}"
+        )
+        assert f"p(95) < {p95}" in runbook_text or f"p(95)<{p95}" in runbook_text
+
+    def test_failed_rate_threshold(self, baseline_text: str, runbook_text: str) -> None:
+        assert "http_req_failed" in baseline_text
+        assert "rate<0.005" in baseline_text
+        assert "0.5%" in runbook_text

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -650,10 +650,10 @@ class TestOIDCRoleMapping:
         assert oidc_provider.map_roles(["user"]) == "user"
 
     def test_map_roles_unknown_role(self, oidc_provider):
-        assert oidc_provider.map_roles(["unknown_role"]) == "user"
+        assert oidc_provider.map_roles(["unknown_role"]) == "viewer"
 
     def test_map_roles_empty_list(self, oidc_provider):
-        assert oidc_provider.map_roles([]) == "user"
+        assert oidc_provider.map_roles([]) == "viewer"
 
     def test_map_roles_case_insensitive(self, oidc_provider):
         assert oidc_provider.map_roles(["ADMIN"]) == "admin"

--- a/tests/test_recent_code_comprehensive.py
+++ b/tests/test_recent_code_comprehensive.py
@@ -480,7 +480,7 @@ class TestOIDCAuthenticateEdgeCases:
 
         assert result.success is True
         assert len(created) == 1
-        assert created[0].role == "user"
+        assert created[0].role == "viewer"
 
     async def test_custom_role_claim(self, monkeypatch, rsa_keys):
         _settings(monkeypatch, oidc_role_claim="groups")
@@ -561,11 +561,11 @@ class TestIAuthProviderBase:
 
     def test_map_roles_empty_list(self):
         p = _ConcreteProvider()
-        assert p.map_roles([]) == "user"
+        assert p.map_roles([]) == "viewer"
 
     def test_map_roles_unknown_roles(self):
         p = _ConcreteProvider()
-        assert p.map_roles(["superadmin", "guest"]) == "user"
+        assert p.map_roles(["superadmin", "guest"]) == "viewer"
 
     def test_map_roles_case_insensitive(self):
         p = _ConcreteProvider()


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix remaining HIGH severity review findings from SEV-741 auth review: (1) wire up dead config auth_overwrite_role_on_login in the federated login path or remove it, (2) change default role fallback from 'user' to 'viewer' for least-privilege default, (3) sanitize raw role strings before logging to prevent log injection

Closes #813
