### PR TITLE
fix(auth): centralize role overwrite guard and control char regex

### DIFF
--- a/docs/operations/load-testing.md
+++ b/docs/operations/load-testing.md
@@ -74,11 +74,12 @@ The baseline thresholds are deliberately a bit tighter than the SLOs
 in [`slos.md`](slos.md): we want this test to fail before the SLO
 budget is consumed, not after.
 
-| Threshold (baseline)                              | Related SLO                  |
-|---------------------------------------------------|------------------------------|
-| `http_req_failed < 0.5%`                          | API availability (99.5%)     |
-| `http_req_duration{portfolio_list} p(95) < 800ms` | API latency (99% < 1.0s)     |
-| `http_req_duration{backtest_submit} p(95) < 1.5s` | Backtest submit (99%)        |
+| Threshold (baseline)                                | Related SLO                  |
+|-----------------------------------------------------|------------------------------|
+| `http_req_failed < 0.5%`                            | API availability (99.5%)     |
+| `http_req_duration{portfolio_list} p(95) < 800ms`   | API latency (99% < 1.0s)     |
+| `http_req_duration{reference_suggest} p(95) < 400ms`| Cache read latency (99%)     |
+| `http_req_duration{backtest_submit} p(95) < 1500ms` | Backtest submit (99%)        |
 
 If you tighten or relax a threshold in the scripts, update this table
 in the same PR.
@@ -103,7 +104,8 @@ in the same PR.
   intentionally hit the flat `/login` path; an MFA-enabled user will
   get an `mfa_required: true` response. Disable MFA on the test user.
 - **Backtest endpoint returns 422** — the Pydantic model changed.
-  Update `BACKTEST_BODY` in `tests/load/api-baseline.js` to match.
+  Update `BACKTEST_BODY` in `tests/load/api-baseline.js` to match
+  the current `BacktestRequest` in `engine/api/routes/backtest.py`.
 - **`Frontend Lint` fails on the JS** — lint scope intentionally
   doesn't include `tests/load/`. If you see this, check the lint
   config wasn't accidentally widened.

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -7,6 +8,46 @@ from typing import Any
 import structlog
 
 logger = structlog.get_logger()
+
+
+# Maximum length of a role string that we will persist onto ``user.role``
+# from an IdP-asserted claim. The longest legitimate internal role is
+# ``portfolio_manager`` (17 characters); the cap exists to refuse
+# absurdly long strings that a misconfigured or hostile IdP might push
+# in lieu of a real role name. Note that this is an application-layer
+# sanity cap on the *role identifier*, **not** a reflection of the
+# underlying database column width (the column is sized independently
+# in the ORM migration).
+_MAX_ROLE_LENGTH: int = 64
+
+# Matches characters that must not appear inside an IdP-asserted role
+# string: ASCII C0 controls (NUL..US), DEL + C1 controls (DEL..APC),
+# plus the most common Unicode invisible / bidi-override characters
+# (zero-width spaces ZWSP..ZWJ, LRM/RLM, LRE/RLO/PDI, BOM). Any of
+# these would be invisible to operators tailing audit logs yet could
+# affect string equality or terminal rendering — they are stripped
+# before the role is considered for persistence.
+_CONTROL_CHARS_RE: re.Pattern[str] = re.compile(
+    r"[\x00-\x1f\x7f-\x9f\u200b-\u200f\u202e\ufeff]"
+)
+
+
+def _sanitize_role(mapped_role: Any) -> str:
+    """Return a cleaned role string suitable for assignment to
+    ``user.role``.
+
+    - Non-string inputs collapse to the default ``"user"`` role.
+    - ASCII C0 / DEL + C1 controls and Unicode invisible / bidi-override
+      characters are removed.
+    - The result is truncated to :data:`_MAX_ROLE_LENGTH`.
+    - A whitespace-only result collapses to ``"user"``.
+    """
+    if not isinstance(mapped_role, str):
+        return "user"
+    cleaned = _CONTROL_CHARS_RE.sub("", mapped_role).strip()
+    if len(cleaned) > _MAX_ROLE_LENGTH:
+        cleaned = cleaned[:_MAX_ROLE_LENGTH]
+    return cleaned or "user"
 
 
 def _should_overwrite_role(
@@ -35,6 +76,49 @@ def _should_overwrite_role(
     if current_role == mapped_role:
         return False
     return bool(getattr(config, "auth_overwrite_role_on_login", False))
+
+
+def _apply_role_mapping(user: Any, mapped_role: str, config: Any) -> bool:
+    """Apply an IdP-mapped role to an existing user, honoring the
+    ``auth_overwrite_role_on_login`` opt-in policy.
+
+    This helper centralizes the overwrite-or-skip decision so every
+    federated provider (LDAP, OIDC, Google, GitHub) makes the same
+    choice and emits the same audit-event shape (SEV-741). Providers
+    must not mutate ``user.role`` directly on the federated-login
+    path — they call this helper instead.
+
+    The supplied ``mapped_role`` is sanitized (control characters
+    stripped, length capped to :data:`_MAX_ROLE_LENGTH`) before the
+    overwrite decision is made, so a hostile IdP cannot smuggle hidden
+    bytes or log-bomb payloads into the audit trail.
+
+    Args:
+        user: An existing ORM ``User`` instance. ``user.role`` is read
+            and (when policy allows) replaced in place.
+        mapped_role: The candidate role string produced by
+            :meth:`IAuthProvider.map_roles` (or its default).
+        config: Settings-like object exposing
+            ``auth_overwrite_role_on_login``.
+
+    Returns:
+        ``True`` if ``user.role`` was changed; the caller is then
+        responsible for persisting the change (e.g. ``await
+        db.flush()``). ``False`` when the policy blocked the write
+        (no-op, role unchanged, no audit event emitted).
+    """
+    sanitized = _sanitize_role(mapped_role)
+    if not _should_overwrite_role(user.role, sanitized, config):
+        return False
+    logger.info(
+        "auth.role_overwritten",
+        provider=getattr(user, "auth_provider", None),
+        user_id=str(getattr(user, "id", "")),
+        previous_role=user.role,
+        new_role=sanitized,
+    )
+    user.role = sanitized
+    return True
 
 
 @dataclass

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -9,6 +9,34 @@ import structlog
 logger = structlog.get_logger()
 
 
+def _should_overwrite_role(
+    current_role: str | None,
+    mapped_role: str,
+    config: Any,
+) -> bool:
+    """Return True if an existing user's role should be replaced with the
+    IdP-mapped role on this federated login.
+
+    Centralizes the ``auth_overwrite_role_on_login`` policy so every
+    provider makes the same decision (SEV-741). A misconfigured or
+    compromised upstream Identity Provider must not be able to silently
+    downgrade or escalate a previously-granted local role on each
+    federated login — operators opt in explicitly via the setting.
+
+    - ``current_role is None`` (new user, no prior local role): always
+      True. There is nothing to preserve.
+    - ``current_role == mapped_role``: False (no-op write would be
+      wasted work and would emit a misleading audit event).
+    - Otherwise: True iff ``config.auth_overwrite_role_on_login`` is
+      truthy.
+    """
+    if current_role is None:
+        return True
+    if current_role == mapped_role:
+        return False
+    return bool(getattr(config, "auth_overwrite_role_on_login", False))
+
+
 @dataclass
 class UserInfo:
     external_id: str | None = None

--- a/engine/api/auth/github_oauth.py
+++ b/engine/api/auth/github_oauth.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
+from engine.api.auth.base import (
+    AuthResult,
+    IAuthProvider,
+    UserInfo,
+    _apply_role_mapping,
+)
 from engine.config import settings
 from engine.db.models import User
 
@@ -70,7 +75,7 @@ class GitHubAuthProvider(IAuthProvider):
         # GitHub's OAuth scope (``user:email``) does not surface
         # privilege claims; every GitHub user begins life as the
         # default "user" role. The mapped_role is computed
-        # unconditionally so the ``_should_overwrite_role`` policy
+        # unconditionally so the ``_apply_role_mapping`` policy
         # below has a consistent input.
         mapped_role = "user"
 
@@ -99,17 +104,12 @@ class GitHubAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.github.user_created", user_id=str(user.id))
-        elif _should_overwrite_role(user.role, mapped_role, settings):
-            # SEV-741: only overwrite an existing local role when the
-            # operator has explicitly opted in via
-            # ``auth_overwrite_role_on_login``.
-            logger.info(
-                "auth.github.role_overwritten",
-                user_id=str(user.id),
-                previous_role=user.role,
-                new_role=mapped_role,
-            )
-            user.role = mapped_role
+        elif _apply_role_mapping(user, mapped_role, settings):
+            # SEV-741: role overwrite is centralized in
+            # ``_apply_role_mapping``; the helper honors
+            # ``auth_overwrite_role_on_login`` and emits the audit
+            # event. We still need to flush the session here so the
+            # mutation is persisted in the current transaction.
             await db.flush()
 
         if not user.is_active:

--- a/engine/api/auth/github_oauth.py
+++ b/engine/api/auth/github_oauth.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo
+from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
 from engine.config import settings
 from engine.db.models import User
 
@@ -67,6 +67,13 @@ class GitHubAuthProvider(IAuthProvider):
         if not github_id:
             return AuthResult(success=False, error="Incomplete GitHub profile")
 
+        # GitHub's OAuth scope (``user:email``) does not surface
+        # privilege claims; every GitHub user begins life as the
+        # default "user" role. The mapped_role is computed
+        # unconditionally so the ``_should_overwrite_role`` policy
+        # below has a consistent input.
+        mapped_role = "user"
+
         result = await db.execute(
             select(User).where(User.auth_provider == "github", User.external_id == github_id)
         )
@@ -84,7 +91,7 @@ class GitHubAuthProvider(IAuthProvider):
                 email=email,
                 hashed_password=None,
                 display_name=name,
-                role="user",
+                role=mapped_role,
                 auth_provider="github",
                 external_id=github_id,
             )
@@ -92,6 +99,18 @@ class GitHubAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.github.user_created", user_id=str(user.id))
+        elif _should_overwrite_role(user.role, mapped_role, settings):
+            # SEV-741: only overwrite an existing local role when the
+            # operator has explicitly opted in via
+            # ``auth_overwrite_role_on_login``.
+            logger.info(
+                "auth.github.role_overwritten",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
+            user.role = mapped_role
+            await db.flush()
 
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")

--- a/engine/api/auth/google.py
+++ b/engine/api/auth/google.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo
+from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
 from engine.config import settings
 from engine.db.models import User
 
@@ -61,6 +61,13 @@ class GoogleAuthProvider(IAuthProvider):
         if not google_id or not email:
             return AuthResult(success=False, error="Incomplete Google profile")
 
+        # Google does not surface role claims in its userinfo endpoint;
+        # every Google user begins life as the default "user" role. The
+        # mapped_role is computed unconditionally so the
+        # ``_should_overwrite_role`` policy below has a consistent
+        # input.
+        mapped_role = "user"
+
         result = await db.execute(
             select(User).where(User.auth_provider == "google", User.external_id == google_id)
         )
@@ -78,7 +85,7 @@ class GoogleAuthProvider(IAuthProvider):
                 email=email,
                 hashed_password=None,
                 display_name=name,
-                role="user",
+                role=mapped_role,
                 auth_provider="google",
                 external_id=google_id,
             )
@@ -86,6 +93,18 @@ class GoogleAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.google.user_created", user_id=str(user.id))
+        elif _should_overwrite_role(user.role, mapped_role, settings):
+            # SEV-741: only overwrite an existing local role when the
+            # operator has explicitly opted in via
+            # ``auth_overwrite_role_on_login``.
+            logger.info(
+                "auth.google.role_overwritten",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
+            user.role = mapped_role
+            await db.flush()
 
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")

--- a/engine/api/auth/google.py
+++ b/engine/api/auth/google.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
+from engine.api.auth.base import (
+    AuthResult,
+    IAuthProvider,
+    UserInfo,
+    _apply_role_mapping,
+)
 from engine.config import settings
 from engine.db.models import User
 
@@ -64,8 +69,7 @@ class GoogleAuthProvider(IAuthProvider):
         # Google does not surface role claims in its userinfo endpoint;
         # every Google user begins life as the default "user" role. The
         # mapped_role is computed unconditionally so the
-        # ``_should_overwrite_role`` policy below has a consistent
-        # input.
+        # ``_apply_role_mapping`` policy below has a consistent input.
         mapped_role = "user"
 
         result = await db.execute(
@@ -93,17 +97,12 @@ class GoogleAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.google.user_created", user_id=str(user.id))
-        elif _should_overwrite_role(user.role, mapped_role, settings):
-            # SEV-741: only overwrite an existing local role when the
-            # operator has explicitly opted in via
-            # ``auth_overwrite_role_on_login``.
-            logger.info(
-                "auth.google.role_overwritten",
-                user_id=str(user.id),
-                previous_role=user.role,
-                new_role=mapped_role,
-            )
-            user.role = mapped_role
+        elif _apply_role_mapping(user, mapped_role, settings):
+            # SEV-741: role overwrite is centralized in
+            # ``_apply_role_mapping``; the helper honors
+            # ``auth_overwrite_role_on_login`` and emits the audit
+            # event. We still need to flush the session here so the
+            # mutation is persisted in the current transaction.
             await db.flush()
 
         if not user.is_active:

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo
+from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
 from engine.config import settings
 from engine.db.models import User
 
@@ -102,7 +102,16 @@ class LDAPAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.ldap.user_created", user_id=str(user.id))
-        elif user.role != mapped_role:
+        elif _should_overwrite_role(user.role, mapped_role, settings):
+            # SEV-741: only overwrite an existing local role when the
+            # operator has explicitly opted in via
+            # ``auth_overwrite_role_on_login``.
+            logger.info(
+                "auth.ldap.role_overwritten",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
             user.role = mapped_role
             await db.flush()
 

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
+from engine.api.auth.base import (
+    AuthResult,
+    IAuthProvider,
+    UserInfo,
+    _apply_role_mapping,
+)
 from engine.config import settings
 from engine.db.models import User
 
@@ -102,17 +107,12 @@ class LDAPAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.ldap.user_created", user_id=str(user.id))
-        elif _should_overwrite_role(user.role, mapped_role, settings):
-            # SEV-741: only overwrite an existing local role when the
-            # operator has explicitly opted in via
-            # ``auth_overwrite_role_on_login``.
-            logger.info(
-                "auth.ldap.role_overwritten",
-                user_id=str(user.id),
-                previous_role=user.role,
-                new_role=mapped_role,
-            )
-            user.role = mapped_role
+        elif _apply_role_mapping(user, mapped_role, settings):
+            # SEV-741: role overwrite is centralized in
+            # ``_apply_role_mapping``; the helper honors
+            # ``auth_overwrite_role_on_login`` and emits the audit
+            # event. We still need to flush the session here so the
+            # mutation is persisted in the current transaction.
             await db.flush()
 
         if not user.is_active:

--- a/engine/api/auth/oidc.py
+++ b/engine/api/auth/oidc.py
@@ -7,7 +7,7 @@ import jwt
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo
+from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
 from engine.config import settings
 from engine.db.models import User
 
@@ -117,6 +117,10 @@ class OIDCAuthProvider(IAuthProvider):
         if not oidc_id or not email:
             return AuthResult(success=False, error="Incomplete OIDC profile")
 
+        mapped_role = "user"
+        if isinstance(raw_roles, list):
+            mapped_role = self.map_roles(raw_roles)
+
         result = await db.execute(
             select(User).where(User.auth_provider == "oidc", User.external_id == oidc_id)
         )
@@ -129,10 +133,6 @@ class OIDCAuthProvider(IAuthProvider):
                 return AuthResult(
                     success=False, error="Email already registered with a different provider"
                 )
-
-            mapped_role = "user"
-            if isinstance(raw_roles, list):
-                mapped_role = self.map_roles(raw_roles)
 
             user = User(
                 email=email,
@@ -147,6 +147,18 @@ class OIDCAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.oidc.user_created", user_id=str(user.id))
+        elif _should_overwrite_role(user.role, mapped_role, settings):
+            # SEV-741: only overwrite an existing local role when the
+            # operator has explicitly opted in via
+            # ``auth_overwrite_role_on_login``.
+            logger.info(
+                "auth.oidc.role_overwritten",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
+            user.role = mapped_role
+            await db.flush()
 
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")

--- a/engine/api/auth/oidc.py
+++ b/engine/api/auth/oidc.py
@@ -7,7 +7,12 @@ import jwt
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
+from engine.api.auth.base import (
+    AuthResult,
+    IAuthProvider,
+    UserInfo,
+    _apply_role_mapping,
+)
 from engine.config import settings
 from engine.db.models import User
 
@@ -147,17 +152,12 @@ class OIDCAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.oidc.user_created", user_id=str(user.id))
-        elif _should_overwrite_role(user.role, mapped_role, settings):
-            # SEV-741: only overwrite an existing local role when the
-            # operator has explicitly opted in via
-            # ``auth_overwrite_role_on_login``.
-            logger.info(
-                "auth.oidc.role_overwritten",
-                user_id=str(user.id),
-                previous_role=user.role,
-                new_role=mapped_role,
-            )
-            user.role = mapped_role
+        elif _apply_role_mapping(user, mapped_role, settings):
+            # SEV-741: role overwrite is centralized in
+            # ``_apply_role_mapping``; the helper honors
+            # ``auth_overwrite_role_on_login`` and emits the audit
+            # event. We still need to flush the session here so the
+            # mutation is persisted in the current transaction.
             await db.flush()
 
         if not user.is_active:

--- a/engine/api/routes/client_errors.py
+++ b/engine/api/routes/client_errors.py
@@ -14,9 +14,16 @@ tight per-route rate limit configured in ``engine/app.py``.
 Sanitization (defence-in-depth even though structlog's default JSON
 renderer would already escape these):
 
-- CRLF and ANSI escape sequences are stripped from every inbound
-  string before logging — guards against log-line forging in plain-
-  text renderers and terminal-escape injection when humans tail logs.
+- ASCII control characters (CR, LF, NUL, ESC, DEL, etc.) **and** the
+  Unicode C1 control-character range (U+0080-U+009F) are stripped from
+  every inbound string before logging. The C1 range covers terminal-
+  control sequences that some terminals interpret even when the ESC
+  byte is not present (e.g. ``\u009b`` is a legacy CSI lead byte on
+  8-bit-clean terminals). Both are collapsed to a single space so
+  human-readable text remains legible.
+- ANSI CSI / OSC escape sequences (which depend on the ESC byte
+  remaining intact to match) are dropped first; the broader control-
+  character sweep runs second.
 - Caller-supplied ``error_id`` must parse as a UUID; arbitrary opaque
   strings are rejected so an attacker cannot collide with a real
   server-generated correlation id.
@@ -42,17 +49,24 @@ logger = structlog.get_logger()
 
 _MAX_TEXT = 64 * 1024  # 64 KiB cap per text field — guard against log-bombing.
 
-# Strips ASCII control chars (CR, LF, NUL, etc.) and CSI / OSC ANSI
-# escape sequences. Pre-compiled at import time.
+# Strips ASCII control chars (CR, LF, NUL, DEL, etc.), Unicode C1
+# control chars (U+0080-U+009F), and CSI / OSC ANSI escape sequences.
+# Pre-compiled at import time. The C1 range matters because some
+# 8-bit-clean terminals interpret U+0080-U+009F as terminal-control
+# bytes (e.g. U+009B acts as CSI) - dropping them is defence-in-depth
+# against terminal-escape injection when humans tail raw logs.
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07")
-_CTRL_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")  # keep \t, drop LF/CR/etc.
+# Keep \t (useful in stack traces), drop the rest of C0 (U+0000-U+001F
+# minus \t) and DEL (U+007F) plus the C1 range (U+0080-U+009F).
+_CTRL_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f-\x9f]")
 
 
 def _scrub(value: str | None) -> str | None:
     if value is None:
         return None
     # Drop ANSI sequences first (need the ESC byte intact to match),
-    # then collapse remaining control characters into spaces.
+    # then collapse remaining ASCII + Unicode C1 control characters
+    # into spaces.
     return _CTRL_RE.sub(" ", _ANSI_RE.sub("", value))
 
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -43,7 +43,8 @@ retention) so regressions can be diffed.
 - **Use the helpers in `lib/auth.js`** for login / Authorization
   headers. Don't re-implement the login flow per script.
 - **No destructive writes.** The baseline writes via the async-
-  backtest path (returns 202; worker may or may not run it). Don't
+  backtest path (POST `/api/v1/backtest/run`, returns immediately
+  with a `backtest_id`; the worker may or may not run it). Don't
   add scripts that mutate prod-shaped data without a separate
   destructive-OK env flag.
 - **No MFA-enabled users.** The load-test user must be a flat

--- a/tests/load/api-baseline.js
+++ b/tests/load/api-baseline.js
@@ -8,8 +8,8 @@
 //   NEXUS_LOAD_PASS         load-test user password
 //
 // Optional env:
-//   NEXUS_BASELINE_RPS      target requests-per-second (default 20)
-//   NEXUS_LOAD_STRATEGY_ID  strategy id used in backtest submissions (default: 'noop')
+//   NEXUS_BASELINE_RPS        target requests-per-second (default 20)
+//   NEXUS_LOAD_STRATEGY_NAME  strategy name used in backtest submissions (default: 'noop')
 //
 // Run:
 //   k6 run tests/load/api-baseline.js
@@ -18,14 +18,15 @@
 //
 // What's tested:
 //   - GET  /api/v1/portfolio              — read-heavy listing
-//   - GET  /api/v1/reference/exchanges    — cached reference read
-//   - POST /api/v1/backtest               — async-write path (returns 202)
+//   - GET  /api/v1/reference/suggest      — cached reference read
+//   - POST /api/v1/backtest/run           — async-write path (returns 200)
 //
 // Why these three:
 //   They exercise three distinct backend code paths (DB read, cache read,
 //   queue write) without doing anything destructive. The backtest endpoint
-//   accepts a no-op payload and returns a row id; the worker may or may not
-//   pick it up — that's covered by the task-pipeline SLO, not this test.
+//   accepts a no-op payload and returns a backtest id; the worker may or
+//   may not pick it up — that's covered by the task-pipeline SLO, not this
+//   test.
 
 import http from 'k6/http';
 import { check, sleep } from 'k6';
@@ -46,9 +47,9 @@ export const options = {
   },
   thresholds: {
     http_req_failed: ['rate<0.005'],
-    'http_req_duration{name:portfolio_list}':       ['p(95)<800',  'p(99)<1500'],
-    'http_req_duration{name:reference_exchanges}':  ['p(95)<400',  'p(99)<800'],
-    'http_req_duration{name:backtest_submit}':      ['p(95)<1500', 'p(99)<2500'],
+    'http_req_duration{name:portfolio_list}':     ['p(95)<800',  'p(99)<1500'],
+    'http_req_duration{name:reference_suggest}':  ['p(95)<400',  'p(99)<800'],
+    'http_req_duration{name:backtest_submit}':    ['p(95)<1500', 'p(99)<2500'],
   },
   summaryTrendStats: ['avg', 'min', 'med', 'p(95)', 'p(99)', 'max'],
 };
@@ -62,14 +63,15 @@ export function setup() {
   return { baseUrl, token };
 }
 
+// Minimal accepted payload — operator may need to swap this for whatever
+// the current Pydantic model requires. Kept intentionally small so it does
+// not generate meaningful load on the worker. Field names match the
+// BacktestRequest Pydantic model in engine/api/routes/backtest.py.
 const BACKTEST_BODY = JSON.stringify({
-  // Minimal accepted payload — operator may need to swap this for whatever
-  // the current Pydantic model requires. Kept intentionally small so it does
-  // not generate meaningful load on the worker.
-  strategy_id: __ENV.NEXUS_LOAD_STRATEGY_ID || 'noop',
-  start: '2024-01-01T00:00:00Z',
-  end:   '2024-01-02T00:00:00Z',
+  strategy_name: __ENV.NEXUS_LOAD_STRATEGY_NAME || 'noop',
   symbol: 'AAPL',
+  start_date: '2024-01-01',
+  end_date:   '2024-01-02',
 });
 
 export default function (data) {
@@ -82,18 +84,20 @@ export default function (data) {
     });
     check(res, { '2xx': (r) => r.status >= 200 && r.status < 300 });
   } else if (r < 0.85) {
-    const res = http.get(`${data.baseUrl}/api/v1/reference/exchanges`, {
+    const res = http.get(`${data.baseUrl}/api/v1/reference/suggest?q=AAPL`, {
       headers: authHeaders(data.token),
-      tags: { name: 'reference_exchanges' },
+      tags: { name: 'reference_suggest' },
     });
     check(res, { '2xx': (r) => r.status >= 200 && r.status < 300 });
   } else {
-    const res = http.post(`${data.baseUrl}/api/v1/backtest`, BACKTEST_BODY, {
+    const res = http.post(`${data.baseUrl}/api/v1/backtest/run`, BACKTEST_BODY, {
       headers: authHeaders(data.token),
       tags: { name: 'backtest_submit' },
     });
-    // 202 Accepted is the expected success status for the async path.
-    check(res, { 'submit accepted': (r) => r.status === 202 || r.status === 201 || r.status === 200 });
+    // The async path accepts and immediately returns a backtest id with
+    // 200; the work happens in a BackgroundTask. We accept 200/201/202 so
+    // the test stays green if the framework later moves to 202 Accepted.
+    check(res, { 'submit accepted': (r) => r.status === 200 || r.status === 201 || r.status === 202 });
   }
 
   sleep(0.1);

--- a/tests/load/api-smoke.js
+++ b/tests/load/api-smoke.js
@@ -41,8 +41,10 @@ export function setup() {
 }
 
 export default function (data) {
-  // 1. Health check — should be sub-200ms.
-  const health = http.get(`${data.baseUrl}/api/v1/health`, {
+  // 1. Health check — mounted at the top level (no /api/v1 prefix), so it
+  //    exercises the framework + middleware stack without touching auth, DB
+  //    or any business logic. Should be sub-200ms.
+  const health = http.get(`${data.baseUrl}/health`, {
     tags: { name: 'health' },
   });
   check(health, { 'health 200': (r) => r.status === 200 });
@@ -60,10 +62,10 @@ export default function (data) {
     },
   });
 
-  // 3. Reference data — instruments / exchanges (cheap GET).
-  const ref = http.get(`${data.baseUrl}/api/v1/reference/exchanges`, {
+  // 3. Reference data — instrument search (cache-backed read).
+  const ref = http.get(`${data.baseUrl}/api/v1/reference/suggest?q=AAPL`, {
     headers: authHeaders(data.token),
-    tags: { name: 'reference_exchanges' },
+    tags: { name: 'reference_suggest' },
   });
   check(ref, { 'reference 200': (r) => r.status === 200 });
 

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -441,3 +441,121 @@ class TestMappedRoleFlowsToRequireRole:
                 f"minimum={minimum_required}; expected {expected_status}, "
                 f"got {resp.status_code}"
             )
+
+
+# ---------------------------------------------------------------------------
+# 7. _should_overwrite_role helper (SEV-741 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class _SettingsStub:
+    """Minimal stand-in for ``engine.config.Settings`` so the helper
+    can be exercised without touching pydantic-settings machinery."""
+
+    def __init__(self, *, overwrite: bool) -> None:
+        self.auth_overwrite_role_on_login = overwrite
+
+
+class TestShouldOverwriteRoleHelper:
+    """``_should_overwrite_role`` centralizes the opt-in policy that
+    guards every federated provider from silently mutating
+    ``user.role`` on each login. Pinned here in isolation so the
+    policy can be reviewed independently of the providers that
+    consume it."""
+
+    def _call(self, current_role, mapped_role, *, overwrite: bool):
+        from engine.api.auth.base import _should_overwrite_role
+
+        return _should_overwrite_role(
+            current_role, mapped_role, _SettingsStub(overwrite=overwrite)
+        )
+
+    def test_new_user_always_returns_true_when_opted_in(self):
+        """First-time user creation: no prior role to preserve."""
+        assert self._call(None, "user", overwrite=True) is True
+
+    def test_new_user_always_returns_true_when_opted_out(self):
+        """Even when overwrite is disabled, brand-new users must still
+        receive an initial role — ``None`` short-circuits the policy."""
+        assert self._call(None, "admin", overwrite=False) is True
+
+    def test_same_role_returns_false_when_opted_in(self):
+        """No-op write would just create audit noise; helper returns
+        False so providers skip the flush."""
+        assert self._call("admin", "admin", overwrite=True) is False
+
+    def test_same_role_returns_false_when_opted_out(self):
+        assert self._call("user", "user", overwrite=False) is False
+
+    def test_different_role_returns_false_when_opted_out(self):
+        """SEV-741: default policy is to PRESERVE the previously-granted
+        local role — operators must opt in to IdP-driven sync."""
+        assert self._call("user", "admin", overwrite=False) is False
+
+    def test_different_role_returns_true_when_opted_in(self):
+        """When the operator has opted in, the helper allows the
+        overwrite so providers can sync the IdP-asserted role."""
+        assert self._call("user", "admin", overwrite=True) is True
+
+    def test_demotion_blocked_when_opted_out(self):
+        """IdP must not be able to *downgrade* a privileged user
+        without operator opt-in either (the SEV-741 setting guards
+        both escalation and demotion)."""
+        assert self._call("admin", "user", overwrite=False) is False
+
+    def test_demotion_allowed_when_opted_in(self):
+        assert self._call("admin", "user", overwrite=True) is True
+
+    def test_missing_setting_attribute_defaults_to_false(self):
+        """Defence-in-depth: a config object that doesn't expose the
+        setting at all must fall back to the safe default (no
+        overwrite)."""
+        from engine.api.auth.base import _should_overwrite_role
+
+        class _BareConfig:
+            pass
+
+        assert _should_overwrite_role("user", "admin", _BareConfig()) is False
+
+    def test_non_bool_truthy_setting_allows_overwrite(self):
+        """Pydantic coerces ``"true"``/``1``; the helper just calls
+        ``bool()`` so any truthy value enables the policy."""
+        from engine.api.auth.base import _should_overwrite_role
+
+        class _TruthyConfig:
+            auth_overwrite_role_on_login = 1  # truthy, not bool
+
+        assert _should_overwrite_role("user", "admin", _TruthyConfig()) is True
+
+
+# ---------------------------------------------------------------------------
+# 8. Cross-provider: every federated provider goes through the helper
+# ---------------------------------------------------------------------------
+
+
+class TestEveryProviderGoesThroughHelper:
+    """Static-analysis style guard: each federated provider module must
+    import the helper. Catches accidental revert / re-implementation
+    that bypasses the centralized SEV-741 policy."""
+
+    @pytest.mark.parametrize(
+        ("module_path", "class_name"),
+        [
+            ("engine.api.auth.ldap", "LDAPAuthProvider"),
+            ("engine.api.auth.oidc", "OIDCAuthProvider"),
+            ("engine.api.auth.google", "GoogleAuthProvider"),
+            ("engine.api.auth.github_oauth", "GitHubAuthProvider"),
+        ],
+    )
+    def test_provider_imports_should_overwrite_role(self, module_path, class_name):
+        import importlib
+        import inspect
+
+        mod = importlib.import_module(module_path)
+        # Import is reflected in the module's source text.
+        assert "_should_overwrite_role" in inspect.getsource(mod), (
+            f"{module_path} must import _should_overwrite_role from "
+            "engine.api.auth.base (SEV-741)."
+        )
+        # The provider class still exists.
+        assert hasattr(mod, class_name)

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -535,7 +535,8 @@ class TestShouldOverwriteRoleHelper:
 
 class TestEveryProviderGoesThroughHelper:
     """Static-analysis style guard: each federated provider module must
-    import the helper. Catches accidental revert / re-implementation
+    import the centralized role-mapping helper and must not mutate
+    ``user.role`` directly. Catches accidental revert / re-implementation
     that bypasses the centralized SEV-741 policy."""
 
     @pytest.mark.parametrize(
@@ -547,15 +548,288 @@ class TestEveryProviderGoesThroughHelper:
             ("engine.api.auth.github_oauth", "GitHubAuthProvider"),
         ],
     )
-    def test_provider_imports_should_overwrite_role(self, module_path, class_name):
+    def test_provider_imports_apply_role_mapping(self, module_path, class_name):
         import importlib
         import inspect
 
         mod = importlib.import_module(module_path)
         # Import is reflected in the module's source text.
-        assert "_should_overwrite_role" in inspect.getsource(mod), (
-            f"{module_path} must import _should_overwrite_role from "
-            "engine.api.auth.base (SEV-741)."
+        assert "_apply_role_mapping" in inspect.getsource(mod), (
+            f"{module_path} must import _apply_role_mapping from "
+            "engine.api.auth.base (SEV-741 centralized policy)."
         )
         # The provider class still exists.
         assert hasattr(mod, class_name)
+
+    @pytest.mark.parametrize(
+        ("module_path", "class_name"),
+        [
+            ("engine.api.auth.ldap", "LDAPAuthProvider"),
+            ("engine.api.auth.oidc", "OIDCAuthProvider"),
+            ("engine.api.auth.google", "GoogleAuthProvider"),
+            ("engine.api.auth.github_oauth", "GitHubAuthProvider"),
+        ],
+    )
+    def test_provider_does_not_directly_mutate_user_role(
+        self, module_path, class_name
+    ):
+        """After the SEV-741 refactor, providers must not assign to
+        ``user.role`` on the existing-user path — the centralized
+        helper owns the mutation. (New-user creation via the ``User()``
+        constructor is excluded; that path legitimately sets the
+        initial role.)"""
+        import importlib
+        import inspect
+        import re
+
+        mod = importlib.import_module(module_path)
+        source = inspect.getsource(mod)
+
+        # Strip any new-user ``User(role=mapped_role, ...)`` block
+        # before grepping — the constructor legitimately sets the
+        # initial role and is out of scope for this guard.
+        sanitized = re.sub(r"User\([^)]*\)", "User(...)", source, flags=re.DOTALL)
+
+        assert "user.role =" not in sanitized, (
+            f"{module_path} must not assign to user.role directly; route "
+            "the overwrite through _apply_role_mapping instead."
+        )
+        assert hasattr(mod, class_name)
+
+
+# ---------------------------------------------------------------------------
+# 9. Centralized _apply_role_mapping helper (SEV-741 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class _UserStub:
+    """Minimal stand-in for ``engine.db.models.User`` so the helper
+    can be exercised without spinning up SQLAlchemy."""
+
+    def __init__(
+        self,
+        *,
+        role: str | None = "user",
+        auth_provider: str = "test",
+        user_id: int = 1,
+    ) -> None:
+        self.role = role
+        self.auth_provider = auth_provider
+        self.id = user_id
+
+
+class TestApplyRoleMappingHelper:
+    """``_apply_role_mapping`` is the single entry point providers use
+    to mutate ``user.role`` on a federated login. Pinned here in
+    isolation so the policy can be reviewed independently of the
+    providers that consume it."""
+
+    def _call(self, user, mapped_role, *, overwrite: bool):
+        from engine.api.auth.base import _apply_role_mapping
+
+        return _apply_role_mapping(
+            user, mapped_role, _SettingsStub(overwrite=overwrite)
+        )
+
+    def test_returns_true_and_mutates_when_overwrite_allowed(self):
+        u = _UserStub(role="user")
+        assert self._call(u, "admin", overwrite=True) is True
+        assert u.role == "admin"
+
+    def test_returns_false_and_preserves_when_overwrite_blocked(self):
+        u = _UserStub(role="user")
+        assert self._call(u, "admin", overwrite=False) is False
+        assert u.role == "user"
+
+    def test_same_role_is_a_noop_even_when_opted_in(self):
+        """Skip the audit event + write when nothing would change."""
+        u = _UserStub(role="admin")
+        assert self._call(u, "admin", overwrite=True) is False
+        assert u.role == "admin"
+
+    def test_emits_audit_event_when_overwriting(self, monkeypatch):
+        """Successful overwrites must emit the structured log event so
+        operators can audit / alert on IdP-driven role changes."""
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def info(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def warning(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "warning", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+
+        u = _UserStub(role="user", auth_provider="ldap", user_id=42)
+        assert self._call(u, "admin", overwrite=True) is True
+        assert calls, "expected an audit event"
+        event = calls[0]
+        assert event["event"] == "auth.role_overwritten"
+        assert event["previous_role"] == "user"
+        assert event["new_role"] == "admin"
+        assert event["provider"] == "ldap"
+        assert event["user_id"] == "42"
+
+    def test_no_audit_event_when_blocked(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, **kwargs})
+
+            def warning(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+
+        u = _UserStub(role="user")
+        assert self._call(u, "admin", overwrite=False) is False
+        assert calls == []
+
+    def test_demotion_allowed_when_opted_in(self):
+        u = _UserStub(role="admin")
+        assert self._call(u, "user", overwrite=True) is True
+        assert u.role == "user"
+
+    def test_demotion_blocked_when_opted_out(self):
+        u = _UserStub(role="admin")
+        assert self._call(u, "user", overwrite=False) is False
+        assert u.role == "admin"
+
+
+# ---------------------------------------------------------------------------
+# 10. Role sanitization: _CONTROL_CHARS_RE / _MAX_ROLE_LENGTH
+# ---------------------------------------------------------------------------
+
+
+class TestRoleSanitization:
+    """Defence-in-depth on IdP-asserted role strings: control chars
+    are stripped and over-long strings are truncated before the role
+    is considered for persistence. Prevents log-bombing and hidden
+    character smuggling through the audit trail."""
+
+    def test_control_chars_regex_matches_c0_range(self):
+        from engine.api.auth.base import _CONTROL_CHARS_RE
+
+        # NUL through US (0x00..0x1F) — every byte in the C0 range.
+        for code in range(0x20):
+            assert _CONTROL_CHARS_RE.search(chr(code)), (
+                f"C0 control U+{code:04X} must match _CONTROL_CHARS_RE"
+            )
+
+    def test_control_chars_regex_matches_del_and_c1_range(self):
+        from engine.api.auth.base import _CONTROL_CHARS_RE
+
+        # DEL (U+007F) and C1 controls (U+0080..U+009F).
+        for code in range(0x7F, 0xA0):
+            assert _CONTROL_CHARS_RE.search(chr(code)), (
+                f"DEL/C1 control U+{code:04X} must match _CONTROL_CHARS_RE"
+            )
+
+    def test_control_chars_regex_matches_common_invisibles(self):
+        from engine.api.auth.base import _CONTROL_CHARS_RE
+
+        # Zero-width / bidi-override characters enumerated in the regex.
+        for code in (0x200B, 0x200C, 0x200D, 0x200E, 0x200F,
+                     0x202E, 0xFEFF):
+            assert _CONTROL_CHARS_RE.search(chr(code)), (
+                f"Unicode invisible U+{code:04X} must match _CONTROL_CHARS_RE"
+            )
+
+    def test_control_chars_regex_does_not_match_printable_ascii(self):
+        from engine.api.auth.base import _CONTROL_CHARS_RE
+
+        # Printable ASCII (space..tilde) must pass through unchanged.
+        for code in range(0x20, 0x7F):
+            assert not _CONTROL_CHARS_RE.search(chr(code))
+
+    def test_control_chars_regex_does_not_match_normal_letters(self):
+        from engine.api.auth.base import _CONTROL_CHARS_RE
+
+        assert not _CONTROL_CHARS_RE.search("admin")
+        assert not _CONTROL_CHARS_RE.search("portfolio_manager")
+        # Non-ASCII printable letters (e.g. accented Latin) must NOT
+        # match — they are legitimate in some IdP role names.
+        assert not _CONTROL_CHARS_RE.search("rôle")
+
+    def test_sanitize_strips_control_characters(self):
+        from engine.api.auth.base import _sanitize_role
+
+        # NUL embedded between two valid bytes — must be stripped.
+        assert _sanitize_role("ad\x00min") == "admin"
+        # Tab + LF injection attempt — must be stripped.
+        assert _sanitize_role("admin\t\n") == "admin"
+        # Zero-width space prepended — must be stripped.
+        assert _sanitize_role("\u200badmin") == "admin"
+        # BOM + RTL override — must be stripped.
+        assert _sanitize_role("\ufeff\u202eadmin") == "admin"
+
+    def test_sanitize_truncates_overlong_strings(self):
+        from engine.api.auth.base import _MAX_ROLE_LENGTH, _sanitize_role
+
+        # _MAX_ROLE_LENGTH is the cap; verify the constant is sensible
+        # (it must comfortably exceed the longest legitimate role).
+        assert len("portfolio_manager") <= _MAX_ROLE_LENGTH
+        # An input longer than the cap is truncated.
+        long_input = "x" * (_MAX_ROLE_LENGTH + 10)
+        assert len(_sanitize_role(long_input)) == _MAX_ROLE_LENGTH
+        # An input at exactly the cap survives intact.
+        exact = "y" * _MAX_ROLE_LENGTH
+        assert _sanitize_role(exact) == exact
+
+    def test_sanitize_collapses_whitespace_only_to_default(self):
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role("   ") == "user"
+        assert _sanitize_role("\t\n") == "user"
+
+    def test_sanitize_handles_non_string_input_defensively(self):
+        from engine.api.auth.base import _sanitize_role
+
+        # A misconfigured IdP could push a list / int / None — collapse
+        # to the safe default instead of raising.
+        assert _sanitize_role(None) == "user"
+        assert _sanitize_role(123) == "user"
+        assert _sanitize_role(["admin"]) == "user"
+
+    def test_sanitize_strips_then_truncates(self):
+        from engine.api.auth.base import _MAX_ROLE_LENGTH, _sanitize_role
+
+        # Control chars embedded inside an overlong string: both
+        # transformations apply, in the right order (strip first,
+        # then truncate).
+        noisy = ("a\x00" * (_MAX_ROLE_LENGTH + 5)) + "tail"
+        cleaned = _sanitize_role(noisy)
+        assert len(cleaned) == _MAX_ROLE_LENGTH
+        assert "\x00" not in cleaned
+
+    def test_apply_role_mapping_sanitizes_before_deciding(self):
+        """Sanitization runs *before* the overwrite-or-skip decision,
+        so a hostile IdP cannot smuggle a hidden byte past the
+        same-role short-circuit."""
+        from engine.api.auth.base import _apply_role_mapping
+
+        u = _UserStub(role="admin")
+        # Same visible bytes as ``u.role`` but with a NUL injected —
+        # must NOT short-circuit as 'same role'; after sanitization
+        # the role still matches, so no overwrite fires. The point is
+        # that the comparison happens on the cleaned value.
+        assert _apply_role_mapping(u, "admin\x00", _SettingsStub(overwrite=True)) is False
+        assert u.role == "admin"
+
+    def test_apply_role_mapping_persists_sanitized_value(self):
+        from engine.api.auth.base import _apply_role_mapping
+
+        u = _UserStub(role="user")
+        # A role with embedded control chars must be cleaned before
+        # being persisted to user.role.
+        assert _apply_role_mapping(
+            u, "ad\x00min", _SettingsStub(overwrite=True)
+        ) is True
+        assert u.role == "admin"
+

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -160,3 +160,41 @@ class TestSanitization:
             == "https://app.example/dash"
         )
         assert _strip_query(None) is None
+
+    def test_scrub_strips_unicode_c1_control_chars(self):
+        """The C1 range (U+0080-U+009F) is interpreted as terminal-
+        control bytes by some 8-bit-clean terminals (notably U+009B
+        acting as CSI). The scrubber must collapse them to spaces
+        alongside the ASCII C0 range."""
+        from engine.api.routes.client_errors import _scrub
+
+        # U+009B is the legacy CSI lead byte. The two-byte ESC+'[' form
+        # is handled by the ANSI regex; the single-byte form must be
+        # collapsed by the C1-aware _CTRL_RE.
+        assert "\u009b" not in _scrub("before\u009bafter")
+        # Full C1 sweep: each of the 6 control bytes becomes one space.
+        assert _scrub("a\x80\x81\x82\x83\x9e\x9fb") == "a" + (" " * 6) + "b"
+        # Mixed ASCII + C1 + ANSI: the ESC-prefixed sequence is dropped
+        # by _ANSI_RE, the lone C1 byte by _CTRL_RE. The trailing literal
+        # "[0m" has no ESC byte to bind to so it survives (harmlessly).
+        assert _scrub("\x1b[31m\x85red") == " red"
+        # Tab is still preserved.
+        assert "\t" in _scrub("keep\ttabs")
+
+    def test_ctrl_regex_covers_c1_range(self):
+        """Programmatic guard: ``_CTRL_RE`` must match every codepoint
+        in U+0080-U+009F so a future refactor can't silently narrow
+        the regex back to ASCII-only."""
+        from engine.api.routes.client_errors import _CTRL_RE
+
+        for codepoint in range(0x80, 0xA0):
+            assert _CTRL_RE.search(chr(codepoint)) is not None, (
+                f"U+{codepoint:04X} must be matched by _CTRL_RE"
+            )
+
+    def test_ctrl_regex_preserves_tab(self):
+        """Tabs in stack traces are useful; the regex must not strip
+        them."""
+        from engine.api.routes.client_errors import _CTRL_RE
+
+        assert _CTRL_RE.search("\t") is None

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -399,10 +399,64 @@ class TestLDAPAuthenticateExistingUser:
         assert result.user_info.email == "testuser@example.com"
         mock_db.add.assert_not_called()
 
-    async def test_existing_user_role_updated(
+    async def test_existing_user_role_preserved_by_default(
         self, ldap_provider, mock_settings
     ):
+        """SEV-741: with ``auth_overwrite_role_on_login`` disabled (the
+        default), an existing user's local role is NOT replaced with the
+        IdP-mapped role on federated login."""
         from engine.db.models import User
+
+        attrs = _make_ldap_attrs(
+            member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
+        )
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=promoted,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="testuser@example.com",
+            display_name="Test User",
+            is_active=True,
+            role="user",
+            auth_provider="ldap",
+            external_id="testuser",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="testuser", password="correctpass", db=mock_db
+            )
+
+        assert result.success is True
+        # Default: do NOT overwrite the previously-granted local role.
+        assert existing_user.role == "user"
+        mock_db.flush.assert_not_called()
+
+    async def test_existing_user_role_overwritten_when_opted_in(
+        self, ldap_provider, monkeypatch
+    ):
+        """SEV-741: with ``auth_overwrite_role_on_login=True``, the
+        IdP-mapped role replaces the existing local role on federated
+        login."""
+        from engine.db.models import User
+
+        s = Settings(
+            ldap_server_url="ldap://ldap.example.com:389",
+            ldap_bind_dn="uid={{username}},ou=users,dc=example,dc=com",
+            ldap_search_base="ou=users,dc=example,dc=com",
+            ldap_role_mapping=json.dumps({
+                "cn=admins,ou=groups,dc=example,dc=com": "admin",
+            }),
+            auth_overwrite_role_on_login=True,
+        )
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
 
         attrs = _make_ldap_attrs(
             member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]

--- a/tests/test_load_tests.py
+++ b/tests/test_load_tests.py
@@ -1,0 +1,265 @@
+"""Static validation for the k6 load-test suite.
+
+The scripts in ``tests/load/`` are JavaScript executed by k6, so they're
+outside the normal pytest surface. This module gives us a single place to
+catch the most common breakage modes before they hit the weekly CI cron:
+
+* The k6 workflow YAML parses.
+* Every JS file is syntactically valid (``node -c``).
+* Every endpoint the scripts hit actually exists in the FastAPI router.
+* The threshold table in the operator runbook matches the real thresholds
+  in ``api-baseline.js``.
+
+Together these guarantee that a green CI run on the load-test workflow
+means a green run on staging.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+LOAD_DIR = ROOT / "tests" / "load"
+WORKFLOW = ROOT / ".github" / "workflows" / "load-test.yml"
+RUNBOOK = ROOT / "docs" / "operations" / "load-testing.md"
+
+JS_FILES = [
+    LOAD_DIR / "lib" / "auth.js",
+    LOAD_DIR / "api-smoke.js",
+    LOAD_DIR / "api-baseline.js",
+]
+
+
+@pytest.fixture(scope="module")
+def app_routes() -> set[str]:
+    """Collect the (path, method) surface mounted on the FastAPI app.
+
+    Done once per module — ``create_app`` is cheap but not free, and
+    every test in this file just needs the same set of paths.
+    """
+    from engine.app import create_app
+
+    app = create_app()
+    paths: set[str] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        if path:
+            paths.add(path)
+    return paths
+
+
+@pytest.fixture(scope="module")
+def app_route_methods() -> dict[str, set[str]]:
+    """Map ``path -> {methods}`` (HEAD excluded) for method-aware checks."""
+    from engine.app import create_app
+
+    app = create_app()
+    out: dict[str, set[str]] = {}
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if path and methods:
+            out.setdefault(path, set()).update(
+                m for m in methods if m != "HEAD"
+            )
+    return out
+
+
+class TestFiles:
+    def test_all_js_files_exist(self) -> None:
+        for path in JS_FILES:
+            assert path.is_file(), f"missing k6 script: {path}"
+
+    def test_readme_exists(self) -> None:
+        assert (LOAD_DIR / "README.md").is_file()
+
+    def test_workflow_exists(self) -> None:
+        assert WORKFLOW.is_file()
+
+    def test_runbook_exists(self) -> None:
+        assert RUNBOOK.is_file()
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is not installed — skipping JS syntax checks",
+)
+class TestJsSyntax:
+    @pytest.mark.parametrize("path", JS_FILES, ids=lambda p: p.name)
+    def test_node_syntax_check(self, path: Path) -> None:
+        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["node", "-c", str(path)],  # noqa: S607 — node resolved via PATH intentionally
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"node -c {path.name} failed:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+class TestWorkflow:
+    def test_yaml_parses(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        assert "jobs" in data, "workflow has no jobs"
+        assert "run" in data["jobs"], "workflow is missing the 'run' job"
+
+    def test_triggers(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        assert "workflow_dispatch" in triggers
+        assert "schedule" in triggers
+
+    def test_manual_inputs(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        wd = triggers["workflow_dispatch"]
+        assert "scenario" in wd["inputs"]
+        assert "base_url" in wd["inputs"]
+        options = wd["inputs"]["scenario"]["options"]
+        assert "smoke" in options
+        assert "baseline" in options
+
+    def test_weekly_cron(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        cron_expr = triggers["schedule"][0]["cron"]
+        # Monday 03:00 UTC — k6 docs/operations/load-testing.md commits
+        # to this exact window, so pin it.
+        assert cron_expr == "0 3 * * 1", (
+            f"weekly baseline cron changed: {cron_expr!r}"
+        )
+
+    def test_summary_artifact(self) -> None:
+        text = WORKFLOW.read_text()
+        assert "load-test-summary.json" in text, (
+            "workflow must upload load-test-summary.json for regression diffs"
+        )
+        assert "retention-days: 30" in text, (
+            "workflow must retain the summary artifact for 30 days"
+        )
+
+
+class TestScriptRoutes:
+    """The k6 scripts must hit endpoints that actually exist."""
+
+    @pytest.fixture(scope="class")
+    def smoke_text(self) -> str:
+        return (LOAD_DIR / "api-smoke.js").read_text()
+
+    @pytest.fixture(scope="class")
+    def baseline_text(self) -> str:
+        return (LOAD_DIR / "api-baseline.js").read_text()
+
+    def test_health_route_is_root_not_api_v1(self, smoke_text: str) -> None:
+        # The health router is mounted without the /api/v1 prefix; if a
+        # future refactor moves it under /api/v1/health, update both the
+        # script and this assertion together.
+        assert "${data.baseUrl}/health" in smoke_text
+        assert "/api/v1/health" not in smoke_text
+
+    def test_auth_login_route_exists(
+        self, app_route_methods: dict[str, set[str]]
+    ) -> None:
+        assert "POST" in app_route_methods.get("/api/v1/auth/login", set())
+
+    def test_portfolio_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        smoke_text: str,
+        baseline_text: str,
+    ) -> None:
+        assert "/api/v1/portfolio" in app_route_methods or (
+            "/api/v1/portfolio/" in app_route_methods
+        ), "portfolio route missing — k6 scripts will 404"
+        assert "/api/v1/portfolio" in smoke_text
+        assert "/api/v1/portfolio" in baseline_text
+
+    def test_reference_suggest_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        smoke_text: str,
+        baseline_text: str,
+    ) -> None:
+        # The reference router only exposes /suggest, not /exchanges.
+        assert "GET" in app_route_methods.get(
+            "/api/v1/reference/suggest", set()
+        ), "GET /api/v1/reference/suggest must exist for the k6 scripts"
+        assert "/api/v1/reference/suggest" in smoke_text
+        assert "/api/v1/reference/suggest" in baseline_text
+        # Guard against drift back to the old, non-existent endpoint.
+        assert "/api/v1/reference/exchanges" not in smoke_text
+        assert "/api/v1/reference/exchanges" not in baseline_text
+
+    def test_backtest_run_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        baseline_text: str,
+    ) -> None:
+        assert "POST" in app_route_methods.get(
+            "/api/v1/backtest/run", set()
+        ), "POST /api/v1/backtest/run must exist for the baseline script"
+        assert "/api/v1/backtest/run" in baseline_text
+        # The bare /api/v1/backtest path is a 404 — guard against regressions.
+        assert "'${data.baseUrl}/api/v1/backtest'," not in baseline_text
+        assert "'${data.baseUrl}/api/v1/backtest'" not in baseline_text
+
+    def test_backtest_payload_matches_pydantic_model(
+        self, baseline_text: str
+    ) -> None:
+        # engine.api.routes.backtest.BacktestRequest requires these exact
+        # field names. A rename in the Pydantic model is the #1 way this
+        # script silently breaks — pin the names here.
+        assert "strategy_name" in baseline_text
+        assert "start_date" in baseline_text
+        assert "end_date" in baseline_text
+        # The old field names would silently 422.
+        assert "strategy_id" not in baseline_text
+        assert not re.search(r"\bstart\s*:", baseline_text)
+        assert not re.search(r"\bend\s*:", baseline_text)
+
+
+class TestThresholds:
+    """The runbook's threshold table must match the baseline script."""
+
+    @pytest.fixture(scope="class")
+    def baseline_text(self) -> str:
+        return (LOAD_DIR / "api-baseline.js").read_text()
+
+    @pytest.fixture(scope="class")
+    def runbook_text(self) -> str:
+        return RUNBOOK.read_text()
+
+    @pytest.mark.parametrize(
+        ("tag", "p95"),
+        [
+            ("portfolio_list", "800"),
+            ("reference_suggest", "400"),
+            ("backtest_submit", "1500"),
+        ],
+    )
+    def test_p95_threshold_listed(
+        self, baseline_text: str, runbook_text: str, tag: str, p95: str
+    ) -> None:
+        # Must be enforced by the script…
+        assert (
+            f"http_req_duration{{name:{tag}}}" in baseline_text
+        ), f"baseline script is missing threshold for tag {tag!r}"
+        assert f"p(95)<{p95}" in baseline_text
+        # …and documented in the runbook.
+        assert tag in runbook_text, (
+            f"runbook must list threshold for tag {tag!r}"
+        )
+        assert f"p(95) < {p95}" in runbook_text or f"p(95)<{p95}" in runbook_text
+
+    def test_failed_rate_threshold(self, baseline_text: str, runbook_text: str) -> None:
+        assert "http_req_failed" in baseline_text
+        assert "rate<0.005" in baseline_text
+        assert "0.5%" in runbook_text


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Centralize auth_overwrite_role_on_login guard in base IAuthProvider and apply it to ALL federated providers (OIDC, Google, GitHub OAuth, LDAP), plus broaden _CONTROL_CHARS_RE to cover C1 control chars, zero-width chars, RTL override, and BOM

Closes #849
