### PR TITLE
security(auth): enforce role allowlist and close NULL-role bypass

### DIFF
--- a/docs/operations/load-testing.md
+++ b/docs/operations/load-testing.md
@@ -74,11 +74,12 @@ The baseline thresholds are deliberately a bit tighter than the SLOs
 in [`slos.md`](slos.md): we want this test to fail before the SLO
 budget is consumed, not after.
 
-| Threshold (baseline)                              | Related SLO                  |
-|---------------------------------------------------|------------------------------|
-| `http_req_failed < 0.5%`                          | API availability (99.5%)     |
-| `http_req_duration{portfolio_list} p(95) < 800ms` | API latency (99% < 1.0s)     |
-| `http_req_duration{backtest_submit} p(95) < 1.5s` | Backtest submit (99%)        |
+| Threshold (baseline)                                | Related SLO                  |
+|-----------------------------------------------------|------------------------------|
+| `http_req_failed < 0.5%`                            | API availability (99.5%)     |
+| `http_req_duration{portfolio_list} p(95) < 800ms`   | API latency (99% < 1.0s)     |
+| `http_req_duration{reference_suggest} p(95) < 400ms`| Cache read latency (99%)     |
+| `http_req_duration{backtest_submit} p(95) < 1500ms` | Backtest submit (99%)        |
 
 If you tighten or relax a threshold in the scripts, update this table
 in the same PR.
@@ -103,7 +104,8 @@ in the same PR.
   intentionally hit the flat `/login` path; an MFA-enabled user will
   get an `mfa_required: true` response. Disable MFA on the test user.
 - **Backtest endpoint returns 422** — the Pydantic model changed.
-  Update `BACKTEST_BODY` in `tests/load/api-baseline.js` to match.
+  Update `BACKTEST_BODY` in `tests/load/api-baseline.js` to match
+  the current `BacktestRequest` in `engine/api/routes/backtest.py`.
 - **`Frontend Lint` fails on the JS** — lint scope intentionally
   doesn't include `tests/load/`. If you see this, check the lint
   config wasn't accidentally widened.

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger()
+
 
 @dataclass
 class UserInfo:
@@ -22,12 +26,6 @@ class AuthResult:
     error: str | None = None
 
 
-_ROLE_PROMOTIONS: dict[str, str] = {
-    "viewer": "user",
-    "quant_dev": "developer",
-}
-
-
 class IAuthProvider(ABC):
     @property
     @abstractmethod
@@ -43,6 +41,17 @@ class IAuthProvider(ABC):
         return AuthResult(success=False, error=f"User creation not supported by {self.name}")
 
     def map_roles(self, external_roles: list[str]) -> str:
+        """Map an external IdP role list to a single internal role.
+
+        Security note: this function performs **no implicit promotion** of
+        unrecognized roles. Upstream Identity-Provider (IdP) roles are
+        reflected faithfully: only roles that are explicitly listed in
+        ``role_priority`` are eligible to become the user's role; anything
+        else is dropped and a warning is emitted so operators can detect
+        misconfigurations. Previously ``viewer`` was silently promoted to
+        ``user`` and ``quant_dev`` to ``developer``, which constituted a
+        silent privilege escalation (SEV-741).
+        """
         role_priority: dict[str, int] = {
             "viewer": 0,
             "user": 1,
@@ -52,9 +61,26 @@ class IAuthProvider(ABC):
             "portfolio_manager": 5,
             "admin": 6,
         }
-        best = "user"
+        recognized: list[str] = []
+        unrecognized: list[str] = []
+        best: str | None = None
         for role in external_roles:
             normalized = role.lower().strip()
-            if normalized in role_priority and role_priority[normalized] > role_priority[best]:
-                best = normalized
-        return _ROLE_PROMOTIONS.get(best, best)
+            if normalized in role_priority:
+                recognized.append(normalized)
+                if best is None or role_priority[normalized] > role_priority[best]:
+                    best = normalized
+            else:
+                unrecognized.append(role)
+        # Broaden the warning: fire on ANY unrecognized external role, not
+        # only when the entire set is unrecognized. This surfaces partial
+        # misconfigurations (e.g. one stale group name alongside valid ones).
+        if unrecognized:
+            logger.warning(
+                "auth.map_roles.unrecognized_roles",
+                provider=self.name,
+                unrecognized=unrecognized,
+                recognized=recognized,
+                mapped=best if best is not None else "user",
+            )
+        return best if best is not None else "user"

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -9,6 +9,34 @@ import structlog
 logger = structlog.get_logger()
 
 
+def _should_overwrite_role(
+    current_role: str | None,
+    mapped_role: str,
+    config: Any,
+) -> bool:
+    """Return True if an existing user's role should be replaced with the
+    IdP-mapped role on this federated login.
+
+    Centralizes the ``auth_overwrite_role_on_login`` policy so every
+    provider makes the same decision (SEV-741). A misconfigured or
+    compromised upstream Identity Provider must not be able to silently
+    downgrade or escalate a previously-granted local role on each
+    federated login — operators opt in explicitly via the setting.
+
+    - ``current_role is None`` (new user, no prior local role): always
+      True. There is nothing to preserve.
+    - ``current_role == mapped_role``: False (no-op write would be
+      wasted work and would emit a misleading audit event).
+    - Otherwise: True iff ``config.auth_overwrite_role_on_login`` is
+      truthy.
+    """
+    if current_role is None:
+        return True
+    if current_role == mapped_role:
+        return False
+    return bool(getattr(config, "auth_overwrite_role_on_login", False))
+
+
 @dataclass
 class UserInfo:
     external_id: str | None = None

--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -9,10 +11,87 @@ import structlog
 logger = structlog.get_logger()
 
 
+# ---------------------------------------------------------------------------
+# SEV-741 follow-up: hard role allow-list + sanitization helper
+# ---------------------------------------------------------------------------
+#
+# ``ALLOWED_ROLES`` is the single source of truth for the set of internal
+# role names a federated login is permitted to assert. It mirrors the
+# keys of ``IAuthProvider.map_roles``'s ``role_priority`` table; keeping
+# both in sync is enforced by the ``test_allowed_roles_matches_priority``
+# test in ``tests/test_auth_role_promotion_security_fix.py``.
+ALLOWED_ROLES: frozenset[str] = frozenset(
+    {
+        "viewer",
+        "user",
+        "retail_trader",
+        "quant_dev",
+        "developer",
+        "portfolio_manager",
+        "admin",
+    }
+)
+
+# Hard upper bound on role-string length. The longest legitimate role
+# is ``"portfolio_manager"`` (17 chars); 32 leaves headroom while still
+# rejecting any oversized payload before the regex/NFKC work below.
+_MAX_ROLE_LEN = 32
+
+# Control characters (C0 + DEL + C1). Any role containing one of these
+# is rejected outright — we do *not* silently strip, because a payload
+# that needed stripping was almost certainly crafted.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _sanitize_role(raw: Any) -> str:
+    """Return a canonical role name for an IdP-asserted string, or
+    ``"user"`` if the input fails any safety check.
+
+    Pipeline (short-circuit, cheapest checks first):
+
+    1. **Type guard** — non-string input collapses immediately.
+    2. **Oversize guard** — anything longer than ``_MAX_ROLE_LEN`` is
+       rejected *before* the control-char regex or NFKC runs, so a
+       multi-megabyte payload cannot DoS the normalization step.
+    3. **Control-character guard** — any C0/DEL/C1 byte causes
+       rejection (we do not silently strip — see SEV-741).
+    4. **NFKC stability guard** — if ``unicodedata.normalize("NFKC",
+       raw) != raw`` the input contained compatibility characters
+       (fullwidth Latin, ligatures, superscripts, …). These are a
+       well-known homoglyph attack vector; the normalized form is
+       *not* accepted.
+    5. **Allow-list match** — case-folded, whitespace-trimmed form
+       must be a member of ``ALLOWED_ROLES``.
+
+    The fallback to ``"user"`` (rather than ``None`` or an exception)
+    keeps the calling code simple: a misconfigured or hostile IdP
+    cannot break authentication, only downgrade the assertion.
+    """
+    if not isinstance(raw, str):
+        return "user"
+    # 2. Reject oversized input immediately, before regex processing.
+    if len(raw) > _MAX_ROLE_LEN:
+        return "user"
+    # 3. Reject any control characters — do not silently strip.
+    if _CONTROL_CHARS_RE.search(raw):
+        return "user"
+    # 4. Reject if NFKC would change the string (fullwidth / ligatures
+    #    / compatibility characters are a homoglyph attack vector).
+    if unicodedata.normalize("NFKC", raw) != raw:
+        return "user"
+    # 5. Validate against the allow-list (case-insensitive).
+    lowered = raw.lower().strip()
+    if lowered in ALLOWED_ROLES:
+        return lowered
+    return "user"
+
+
 def _should_overwrite_role(
     current_role: str | None,
     mapped_role: str,
     config: Any,
+    *,
+    is_new_user: bool = True,
 ) -> bool:
     """Return True if an existing user's role should be replaced with the
     IdP-mapped role on this federated login.
@@ -23,15 +102,25 @@ def _should_overwrite_role(
     downgrade or escalate a previously-granted local role on each
     federated login — operators opt in explicitly via the setting.
 
-    - ``current_role is None`` (new user, no prior local role): always
-      True. There is nothing to preserve.
+    - ``current_role is None`` *and* the caller signals a brand-new
+      user (``is_new_user=True``, the default): always True — there
+      is nothing to preserve.
+    - ``current_role is None`` *and* the caller signals an existing
+      user (``is_new_user=False``): treated as a data anomaly (a row
+      in ``users`` whose ``role`` column is NULL). The IdP-mapped
+      role is **not** allowed to silently fill the gap — operators
+      must opt in via ``auth_overwrite_role_on_login=True``.
     - ``current_role == mapped_role``: False (no-op write would be
       wasted work and would emit a misleading audit event).
     - Otherwise: True iff ``config.auth_overwrite_role_on_login`` is
       truthy.
     """
     if current_role is None:
-        return True
+        if is_new_user:
+            return True
+        # Existing user with a NULL role is an anomaly — do not let
+        # federated login silently repair it without operator opt-in.
+        return bool(getattr(config, "auth_overwrite_role_on_login", False))
     if current_role == mapped_role:
         return False
     return bool(getattr(config, "auth_overwrite_role_on_login", False))
@@ -79,6 +168,12 @@ class IAuthProvider(ABC):
         misconfigurations. Previously ``viewer`` was silently promoted to
         ``user`` and ``quant_dev`` to ``developer``, which constituted a
         silent privilege escalation (SEV-741).
+
+        SEV-741 follow-up: every external role string is routed through
+        ``_sanitize_role`` *before* the priority comparison, so that
+        oversized payloads, control-character injection, and Unicode
+        homoglyph attacks (fullwidth Latin, ligatures, …) all collapse
+        safely to ``"user"`` rather than reaching the allow-list.
         """
         role_priority: dict[str, int] = {
             "viewer": 0,
@@ -93,11 +188,21 @@ class IAuthProvider(ABC):
         unrecognized: list[str] = []
         best: str | None = None
         for role in external_roles:
-            normalized = role.lower().strip()
-            if normalized in role_priority:
-                recognized.append(normalized)
-                if best is None or role_priority[normalized] > role_priority[best]:
-                    best = normalized
+            sanitized = _sanitize_role(role)
+            # ``_sanitize_role`` collapses any invalid input to
+            # ``"user"`` — but ``"user"`` is itself a legitimate role,
+            # so to distinguish "fell back" from "really user" we
+            # require the sanitized canonical name to match a plain
+            # lowercased+stripped form of the raw input. Any input
+            # that needed NFKC / control-char / size handling fails
+            # this equality and is recorded as unrecognized.
+            normalized_input = (
+                role.lower().strip() if isinstance(role, str) else ""
+            )
+            if sanitized in role_priority and sanitized == normalized_input:
+                recognized.append(sanitized)
+                if best is None or role_priority[sanitized] > role_priority[best]:
+                    best = sanitized
             else:
                 unrecognized.append(role)
         # Broaden the warning: fire on ANY unrecognized external role, not

--- a/engine/api/auth/github_oauth.py
+++ b/engine/api/auth/github_oauth.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo
+from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
 from engine.config import settings
 from engine.db.models import User
 
@@ -67,6 +67,13 @@ class GitHubAuthProvider(IAuthProvider):
         if not github_id:
             return AuthResult(success=False, error="Incomplete GitHub profile")
 
+        # GitHub's OAuth scope (``user:email``) does not surface
+        # privilege claims; every GitHub user begins life as the
+        # default "user" role. The mapped_role is computed
+        # unconditionally so the ``_should_overwrite_role`` policy
+        # below has a consistent input.
+        mapped_role = "user"
+
         result = await db.execute(
             select(User).where(User.auth_provider == "github", User.external_id == github_id)
         )
@@ -84,7 +91,7 @@ class GitHubAuthProvider(IAuthProvider):
                 email=email,
                 hashed_password=None,
                 display_name=name,
-                role="user",
+                role=mapped_role,
                 auth_provider="github",
                 external_id=github_id,
             )
@@ -92,6 +99,18 @@ class GitHubAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.github.user_created", user_id=str(user.id))
+        elif _should_overwrite_role(user.role, mapped_role, settings):
+            # SEV-741: only overwrite an existing local role when the
+            # operator has explicitly opted in via
+            # ``auth_overwrite_role_on_login``.
+            logger.info(
+                "auth.github.role_overwritten",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
+            user.role = mapped_role
+            await db.flush()
 
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")

--- a/engine/api/auth/github_oauth.py
+++ b/engine/api/auth/github_oauth.py
@@ -99,7 +99,9 @@ class GitHubAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.github.user_created", user_id=str(user.id))
-        elif _should_overwrite_role(user.role, mapped_role, settings):
+        elif _should_overwrite_role(
+            user.role, mapped_role, settings, is_new_user=False
+        ):
             # SEV-741: only overwrite an existing local role when the
             # operator has explicitly opted in via
             # ``auth_overwrite_role_on_login``.

--- a/engine/api/auth/google.py
+++ b/engine/api/auth/google.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo
+from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
 from engine.config import settings
 from engine.db.models import User
 
@@ -61,6 +61,13 @@ class GoogleAuthProvider(IAuthProvider):
         if not google_id or not email:
             return AuthResult(success=False, error="Incomplete Google profile")
 
+        # Google does not surface role claims in its userinfo endpoint;
+        # every Google user begins life as the default "user" role. The
+        # mapped_role is computed unconditionally so the
+        # ``_should_overwrite_role`` policy below has a consistent
+        # input.
+        mapped_role = "user"
+
         result = await db.execute(
             select(User).where(User.auth_provider == "google", User.external_id == google_id)
         )
@@ -78,7 +85,7 @@ class GoogleAuthProvider(IAuthProvider):
                 email=email,
                 hashed_password=None,
                 display_name=name,
-                role="user",
+                role=mapped_role,
                 auth_provider="google",
                 external_id=google_id,
             )
@@ -86,6 +93,18 @@ class GoogleAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.google.user_created", user_id=str(user.id))
+        elif _should_overwrite_role(user.role, mapped_role, settings):
+            # SEV-741: only overwrite an existing local role when the
+            # operator has explicitly opted in via
+            # ``auth_overwrite_role_on_login``.
+            logger.info(
+                "auth.google.role_overwritten",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
+            user.role = mapped_role
+            await db.flush()
 
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")

--- a/engine/api/auth/google.py
+++ b/engine/api/auth/google.py
@@ -93,7 +93,9 @@ class GoogleAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.google.user_created", user_id=str(user.id))
-        elif _should_overwrite_role(user.role, mapped_role, settings):
+        elif _should_overwrite_role(
+            user.role, mapped_role, settings, is_new_user=False
+        ):
             # SEV-741: only overwrite an existing local role when the
             # operator has explicitly opted in via
             # ``auth_overwrite_role_on_login``.

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -102,7 +102,9 @@ class LDAPAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.ldap.user_created", user_id=str(user.id))
-        elif _should_overwrite_role(user.role, mapped_role, settings):
+        elif _should_overwrite_role(
+            user.role, mapped_role, settings, is_new_user=False
+        ):
             # SEV-741: only overwrite an existing local role when the
             # operator has explicitly opted in via
             # ``auth_overwrite_role_on_login``.

--- a/engine/api/auth/ldap.py
+++ b/engine/api/auth/ldap.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo
+from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
 from engine.config import settings
 from engine.db.models import User
 
@@ -102,7 +102,16 @@ class LDAPAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.ldap.user_created", user_id=str(user.id))
-        elif user.role != mapped_role:
+        elif _should_overwrite_role(user.role, mapped_role, settings):
+            # SEV-741: only overwrite an existing local role when the
+            # operator has explicitly opted in via
+            # ``auth_overwrite_role_on_login``.
+            logger.info(
+                "auth.ldap.role_overwritten",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
             user.role = mapped_role
             await db.flush()
 

--- a/engine/api/auth/oidc.py
+++ b/engine/api/auth/oidc.py
@@ -7,7 +7,7 @@ import jwt
 import structlog
 from sqlalchemy import select
 
-from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo
+from engine.api.auth.base import AuthResult, IAuthProvider, UserInfo, _should_overwrite_role
 from engine.config import settings
 from engine.db.models import User
 
@@ -117,6 +117,10 @@ class OIDCAuthProvider(IAuthProvider):
         if not oidc_id or not email:
             return AuthResult(success=False, error="Incomplete OIDC profile")
 
+        mapped_role = "user"
+        if isinstance(raw_roles, list):
+            mapped_role = self.map_roles(raw_roles)
+
         result = await db.execute(
             select(User).where(User.auth_provider == "oidc", User.external_id == oidc_id)
         )
@@ -129,10 +133,6 @@ class OIDCAuthProvider(IAuthProvider):
                 return AuthResult(
                     success=False, error="Email already registered with a different provider"
                 )
-
-            mapped_role = "user"
-            if isinstance(raw_roles, list):
-                mapped_role = self.map_roles(raw_roles)
 
             user = User(
                 email=email,
@@ -147,6 +147,18 @@ class OIDCAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.oidc.user_created", user_id=str(user.id))
+        elif _should_overwrite_role(user.role, mapped_role, settings):
+            # SEV-741: only overwrite an existing local role when the
+            # operator has explicitly opted in via
+            # ``auth_overwrite_role_on_login``.
+            logger.info(
+                "auth.oidc.role_overwritten",
+                user_id=str(user.id),
+                previous_role=user.role,
+                new_role=mapped_role,
+            )
+            user.role = mapped_role
+            await db.flush()
 
         if not user.is_active:
             return AuthResult(success=False, error="Account is disabled")

--- a/engine/api/auth/oidc.py
+++ b/engine/api/auth/oidc.py
@@ -147,7 +147,9 @@ class OIDCAuthProvider(IAuthProvider):
             await db.flush()
             await db.refresh(user)
             logger.info("auth.oidc.user_created", user_id=str(user.id))
-        elif _should_overwrite_role(user.role, mapped_role, settings):
+        elif _should_overwrite_role(
+            user.role, mapped_role, settings, is_new_user=False
+        ):
             # SEV-741: only overwrite an existing local role when the
             # operator has explicitly opted in via
             # ``auth_overwrite_role_on_login``.

--- a/engine/api/routes/client_errors.py
+++ b/engine/api/routes/client_errors.py
@@ -14,9 +14,16 @@ tight per-route rate limit configured in ``engine/app.py``.
 Sanitization (defence-in-depth even though structlog's default JSON
 renderer would already escape these):
 
-- CRLF and ANSI escape sequences are stripped from every inbound
-  string before logging — guards against log-line forging in plain-
-  text renderers and terminal-escape injection when humans tail logs.
+- ASCII control characters (CR, LF, NUL, ESC, DEL, etc.) **and** the
+  Unicode C1 control-character range (U+0080-U+009F) are stripped from
+  every inbound string before logging. The C1 range covers terminal-
+  control sequences that some terminals interpret even when the ESC
+  byte is not present (e.g. ``\u009b`` is a legacy CSI lead byte on
+  8-bit-clean terminals). Both are collapsed to a single space so
+  human-readable text remains legible.
+- ANSI CSI / OSC escape sequences (which depend on the ESC byte
+  remaining intact to match) are dropped first; the broader control-
+  character sweep runs second.
 - Caller-supplied ``error_id`` must parse as a UUID; arbitrary opaque
   strings are rejected so an attacker cannot collide with a real
   server-generated correlation id.
@@ -42,17 +49,24 @@ logger = structlog.get_logger()
 
 _MAX_TEXT = 64 * 1024  # 64 KiB cap per text field — guard against log-bombing.
 
-# Strips ASCII control chars (CR, LF, NUL, etc.) and CSI / OSC ANSI
-# escape sequences. Pre-compiled at import time.
+# Strips ASCII control chars (CR, LF, NUL, DEL, etc.), Unicode C1
+# control chars (U+0080-U+009F), and CSI / OSC ANSI escape sequences.
+# Pre-compiled at import time. The C1 range matters because some
+# 8-bit-clean terminals interpret U+0080-U+009F as terminal-control
+# bytes (e.g. U+009B acts as CSI) - dropping them is defence-in-depth
+# against terminal-escape injection when humans tail raw logs.
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07")
-_CTRL_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")  # keep \t, drop LF/CR/etc.
+# Keep \t (useful in stack traces), drop the rest of C0 (U+0000-U+001F
+# minus \t) and DEL (U+007F) plus the C1 range (U+0080-U+009F).
+_CTRL_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f-\x9f]")
 
 
 def _scrub(value: str | None) -> str | None:
     if value is None:
         return None
     # Drop ANSI sequences first (need the ESC byte intact to match),
-    # then collapse remaining control characters into spaces.
+    # then collapse remaining ASCII + Unicode C1 control characters
+    # into spaces.
     return _CTRL_RE.sub(" ", _ANSI_RE.sub("", value))
 
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     jwt_refresh_token_expire_days: int = 7
     auth_providers: str = "local"
     auth_local_allow_registration: bool = True
+    # When True, the engine will overwrite an existing user's role on each
+    # federated login with whatever the IdP asserts. Defaults to False for
+    # defense-in-depth: a misconfigured or compromised upstream provider
+    # cannot downgrade or escalate a previously-granted local role without
+    # explicit operator opt-in. (SEV-741)
+    auth_overwrite_role_on_login: bool = False
 
     # MFA — Fernet key (url-safe base64, 32 bytes decoded) used to
     # encrypt TOTP secrets at rest. Empty disables MFA enrollment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ ignore = ["S101", "TRY003", "PLR0913"]
 "strategies/examples/**/*.py" = ["PLR2004", "E501", "F401"]
 "scripts/*.py" = ["S110", "E501", "SIM115"]
 "tests/*" = ["PLR2004", "S105", "S106", "PT019", "PLC0415", "ARG001", "ARG002", "ARG005", "PT011", "PT018", "E501", "SLF001", "TC002", "TC003", "B008", "N806", "DTZ001"]
+"tests/test_auth_role_promotion_security_fix.py" = ["RUF001", "RUF002", "RUF003"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["engine", "nexus_sdk"]

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -43,7 +43,8 @@ retention) so regressions can be diffed.
 - **Use the helpers in `lib/auth.js`** for login / Authorization
   headers. Don't re-implement the login flow per script.
 - **No destructive writes.** The baseline writes via the async-
-  backtest path (returns 202; worker may or may not run it). Don't
+  backtest path (POST `/api/v1/backtest/run`, returns immediately
+  with a `backtest_id`; the worker may or may not run it). Don't
   add scripts that mutate prod-shaped data without a separate
   destructive-OK env flag.
 - **No MFA-enabled users.** The load-test user must be a flat

--- a/tests/load/api-baseline.js
+++ b/tests/load/api-baseline.js
@@ -8,8 +8,8 @@
 //   NEXUS_LOAD_PASS         load-test user password
 //
 // Optional env:
-//   NEXUS_BASELINE_RPS      target requests-per-second (default 20)
-//   NEXUS_LOAD_STRATEGY_ID  strategy id used in backtest submissions (default: 'noop')
+//   NEXUS_BASELINE_RPS        target requests-per-second (default 20)
+//   NEXUS_LOAD_STRATEGY_NAME  strategy name used in backtest submissions (default: 'noop')
 //
 // Run:
 //   k6 run tests/load/api-baseline.js
@@ -18,14 +18,15 @@
 //
 // What's tested:
 //   - GET  /api/v1/portfolio              — read-heavy listing
-//   - GET  /api/v1/reference/exchanges    — cached reference read
-//   - POST /api/v1/backtest               — async-write path (returns 202)
+//   - GET  /api/v1/reference/suggest      — cached reference read
+//   - POST /api/v1/backtest/run           — async-write path (returns 200)
 //
 // Why these three:
 //   They exercise three distinct backend code paths (DB read, cache read,
 //   queue write) without doing anything destructive. The backtest endpoint
-//   accepts a no-op payload and returns a row id; the worker may or may not
-//   pick it up — that's covered by the task-pipeline SLO, not this test.
+//   accepts a no-op payload and returns a backtest id; the worker may or
+//   may not pick it up — that's covered by the task-pipeline SLO, not this
+//   test.
 
 import http from 'k6/http';
 import { check, sleep } from 'k6';
@@ -46,9 +47,9 @@ export const options = {
   },
   thresholds: {
     http_req_failed: ['rate<0.005'],
-    'http_req_duration{name:portfolio_list}':       ['p(95)<800',  'p(99)<1500'],
-    'http_req_duration{name:reference_exchanges}':  ['p(95)<400',  'p(99)<800'],
-    'http_req_duration{name:backtest_submit}':      ['p(95)<1500', 'p(99)<2500'],
+    'http_req_duration{name:portfolio_list}':     ['p(95)<800',  'p(99)<1500'],
+    'http_req_duration{name:reference_suggest}':  ['p(95)<400',  'p(99)<800'],
+    'http_req_duration{name:backtest_submit}':    ['p(95)<1500', 'p(99)<2500'],
   },
   summaryTrendStats: ['avg', 'min', 'med', 'p(95)', 'p(99)', 'max'],
 };
@@ -62,14 +63,15 @@ export function setup() {
   return { baseUrl, token };
 }
 
+// Minimal accepted payload — operator may need to swap this for whatever
+// the current Pydantic model requires. Kept intentionally small so it does
+// not generate meaningful load on the worker. Field names match the
+// BacktestRequest Pydantic model in engine/api/routes/backtest.py.
 const BACKTEST_BODY = JSON.stringify({
-  // Minimal accepted payload — operator may need to swap this for whatever
-  // the current Pydantic model requires. Kept intentionally small so it does
-  // not generate meaningful load on the worker.
-  strategy_id: __ENV.NEXUS_LOAD_STRATEGY_ID || 'noop',
-  start: '2024-01-01T00:00:00Z',
-  end:   '2024-01-02T00:00:00Z',
+  strategy_name: __ENV.NEXUS_LOAD_STRATEGY_NAME || 'noop',
   symbol: 'AAPL',
+  start_date: '2024-01-01',
+  end_date:   '2024-01-02',
 });
 
 export default function (data) {
@@ -82,18 +84,20 @@ export default function (data) {
     });
     check(res, { '2xx': (r) => r.status >= 200 && r.status < 300 });
   } else if (r < 0.85) {
-    const res = http.get(`${data.baseUrl}/api/v1/reference/exchanges`, {
+    const res = http.get(`${data.baseUrl}/api/v1/reference/suggest?q=AAPL`, {
       headers: authHeaders(data.token),
-      tags: { name: 'reference_exchanges' },
+      tags: { name: 'reference_suggest' },
     });
     check(res, { '2xx': (r) => r.status >= 200 && r.status < 300 });
   } else {
-    const res = http.post(`${data.baseUrl}/api/v1/backtest`, BACKTEST_BODY, {
+    const res = http.post(`${data.baseUrl}/api/v1/backtest/run`, BACKTEST_BODY, {
       headers: authHeaders(data.token),
       tags: { name: 'backtest_submit' },
     });
-    // 202 Accepted is the expected success status for the async path.
-    check(res, { 'submit accepted': (r) => r.status === 202 || r.status === 201 || r.status === 200 });
+    // The async path accepts and immediately returns a backtest id with
+    // 200; the work happens in a BackgroundTask. We accept 200/201/202 so
+    // the test stays green if the framework later moves to 202 Accepted.
+    check(res, { 'submit accepted': (r) => r.status === 200 || r.status === 201 || r.status === 202 });
   }
 
   sleep(0.1);

--- a/tests/load/api-smoke.js
+++ b/tests/load/api-smoke.js
@@ -41,8 +41,10 @@ export function setup() {
 }
 
 export default function (data) {
-  // 1. Health check — should be sub-200ms.
-  const health = http.get(`${data.baseUrl}/api/v1/health`, {
+  // 1. Health check — mounted at the top level (no /api/v1 prefix), so it
+  //    exercises the framework + middleware stack without touching auth, DB
+  //    or any business logic. Should be sub-200ms.
+  const health = http.get(`${data.baseUrl}/health`, {
     tags: { name: 'health' },
   });
   check(health, { 'health 200': (r) => r.status === 200 });
@@ -60,10 +62,10 @@ export default function (data) {
     },
   });
 
-  // 3. Reference data — instruments / exchanges (cheap GET).
-  const ref = http.get(`${data.baseUrl}/api/v1/reference/exchanges`, {
+  // 3. Reference data — instrument search (cache-backed read).
+  const ref = http.get(`${data.baseUrl}/api/v1/reference/suggest?q=AAPL`, {
     headers: authHeaders(data.token),
-    tags: { name: 'reference_exchanges' },
+    tags: { name: 'reference_suggest' },
   });
   check(ref, { 'reference 200': (r) => r.status === 200 });
 

--- a/tests/test_auth_rbac_roles.py
+++ b/tests/test_auth_rbac_roles.py
@@ -209,9 +209,13 @@ class TestBaseProviderMapRoles:
 
     def test_map_roles_new_domain_roles(self):
         p = self._make_provider()
-        assert p.map_roles(["retail_trader", "quant_dev"]) == "developer"
+        # SEV-741: map_roles no longer silently promotes domain roles.
+        # ``quant_dev`` must remain ``quant_dev`` (not ``developer``) and
+        # ``viewer`` must remain ``viewer`` (not ``user``). Only when an
+        # external role is unrecognized do we fall back to ``user``.
+        assert p.map_roles(["retail_trader", "quant_dev"]) == "quant_dev"
         assert p.map_roles(["portfolio_manager", "quant_dev"]) == "portfolio_manager"
-        assert p.map_roles(["viewer"]) == "user"
+        assert p.map_roles(["viewer"]) == "viewer"
         assert p.map_roles(["retail_trader"]) == "retail_trader"
         assert p.map_roles(["portfolio_manager"]) == "portfolio_manager"
 

--- a/tests/test_auth_recent_integration.py
+++ b/tests/test_auth_recent_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for recent auth changes.
 
-Validates that map_roles promotions and require_role checks work end-to-end.
+Validates that map_roles reflects upstream IdP roles faithfully and that
+require_role checks work end-to-end after SEV-741.
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ class _ConcreteProvider(IAuthProvider):
 
 
 class TestRequireRoleEnforcement:
-    async def test_quant_dev_accesses_developer_resource(self):
+    async def test_quant_dev_accesses_developer_resource_denied(self):
+        """SEV-741: ``quant_dev`` is no longer silently promoted to
+        ``developer``. A user whose upstream IdP only asserts ``quant_dev``
+        must NOT be granted access to ``require_role("developer")``
+        resources — that would be a silent privilege escalation."""
         app = FastAPI()
 
         @app.get("/dev-only")
@@ -33,7 +38,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["quant_dev"])
-        assert mapped == "developer"
+        assert mapped == "quant_dev"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -52,9 +57,12 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/dev-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403
 
-    async def test_viewer_promoted_to_user(self):
+    async def test_viewer_remains_viewer(self):
+        """SEV-741: ``viewer`` is no longer silently promoted to ``user``.
+        A user whose upstream IdP only asserts ``viewer`` must NOT be
+        granted access to ``require_role("user")`` resources."""
         app = FastAPI()
 
         @app.get("/user-only")
@@ -63,7 +71,7 @@ class TestRequireRoleEnforcement:
 
         provider = _ConcreteProvider()
         mapped = provider.map_roles(["viewer"])
-        assert mapped == "user"
+        assert mapped == "viewer"
 
         fake_user = User(
             id=FAKE_USER_ID,
@@ -82,4 +90,4 @@ class TestRequireRoleEnforcement:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             resp = await ac.get("/user-only")
-            assert resp.status_code == 200
+            assert resp.status_code == 403

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -441,3 +441,121 @@ class TestMappedRoleFlowsToRequireRole:
                 f"minimum={minimum_required}; expected {expected_status}, "
                 f"got {resp.status_code}"
             )
+
+
+# ---------------------------------------------------------------------------
+# 7. _should_overwrite_role helper (SEV-741 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class _SettingsStub:
+    """Minimal stand-in for ``engine.config.Settings`` so the helper
+    can be exercised without touching pydantic-settings machinery."""
+
+    def __init__(self, *, overwrite: bool) -> None:
+        self.auth_overwrite_role_on_login = overwrite
+
+
+class TestShouldOverwriteRoleHelper:
+    """``_should_overwrite_role`` centralizes the opt-in policy that
+    guards every federated provider from silently mutating
+    ``user.role`` on each login. Pinned here in isolation so the
+    policy can be reviewed independently of the providers that
+    consume it."""
+
+    def _call(self, current_role, mapped_role, *, overwrite: bool):
+        from engine.api.auth.base import _should_overwrite_role
+
+        return _should_overwrite_role(
+            current_role, mapped_role, _SettingsStub(overwrite=overwrite)
+        )
+
+    def test_new_user_always_returns_true_when_opted_in(self):
+        """First-time user creation: no prior role to preserve."""
+        assert self._call(None, "user", overwrite=True) is True
+
+    def test_new_user_always_returns_true_when_opted_out(self):
+        """Even when overwrite is disabled, brand-new users must still
+        receive an initial role — ``None`` short-circuits the policy."""
+        assert self._call(None, "admin", overwrite=False) is True
+
+    def test_same_role_returns_false_when_opted_in(self):
+        """No-op write would just create audit noise; helper returns
+        False so providers skip the flush."""
+        assert self._call("admin", "admin", overwrite=True) is False
+
+    def test_same_role_returns_false_when_opted_out(self):
+        assert self._call("user", "user", overwrite=False) is False
+
+    def test_different_role_returns_false_when_opted_out(self):
+        """SEV-741: default policy is to PRESERVE the previously-granted
+        local role — operators must opt in to IdP-driven sync."""
+        assert self._call("user", "admin", overwrite=False) is False
+
+    def test_different_role_returns_true_when_opted_in(self):
+        """When the operator has opted in, the helper allows the
+        overwrite so providers can sync the IdP-asserted role."""
+        assert self._call("user", "admin", overwrite=True) is True
+
+    def test_demotion_blocked_when_opted_out(self):
+        """IdP must not be able to *downgrade* a privileged user
+        without operator opt-in either (the SEV-741 setting guards
+        both escalation and demotion)."""
+        assert self._call("admin", "user", overwrite=False) is False
+
+    def test_demotion_allowed_when_opted_in(self):
+        assert self._call("admin", "user", overwrite=True) is True
+
+    def test_missing_setting_attribute_defaults_to_false(self):
+        """Defence-in-depth: a config object that doesn't expose the
+        setting at all must fall back to the safe default (no
+        overwrite)."""
+        from engine.api.auth.base import _should_overwrite_role
+
+        class _BareConfig:
+            pass
+
+        assert _should_overwrite_role("user", "admin", _BareConfig()) is False
+
+    def test_non_bool_truthy_setting_allows_overwrite(self):
+        """Pydantic coerces ``"true"``/``1``; the helper just calls
+        ``bool()`` so any truthy value enables the policy."""
+        from engine.api.auth.base import _should_overwrite_role
+
+        class _TruthyConfig:
+            auth_overwrite_role_on_login = 1  # truthy, not bool
+
+        assert _should_overwrite_role("user", "admin", _TruthyConfig()) is True
+
+
+# ---------------------------------------------------------------------------
+# 8. Cross-provider: every federated provider goes through the helper
+# ---------------------------------------------------------------------------
+
+
+class TestEveryProviderGoesThroughHelper:
+    """Static-analysis style guard: each federated provider module must
+    import the helper. Catches accidental revert / re-implementation
+    that bypasses the centralized SEV-741 policy."""
+
+    @pytest.mark.parametrize(
+        ("module_path", "class_name"),
+        [
+            ("engine.api.auth.ldap", "LDAPAuthProvider"),
+            ("engine.api.auth.oidc", "OIDCAuthProvider"),
+            ("engine.api.auth.google", "GoogleAuthProvider"),
+            ("engine.api.auth.github_oauth", "GitHubAuthProvider"),
+        ],
+    )
+    def test_provider_imports_should_overwrite_role(self, module_path, class_name):
+        import importlib
+        import inspect
+
+        mod = importlib.import_module(module_path)
+        # Import is reflected in the module's source text.
+        assert "_should_overwrite_role" in inspect.getsource(mod), (
+            f"{module_path} must import _should_overwrite_role from "
+            "engine.api.auth.base (SEV-741)."
+        )
+        # The provider class still exists.
+        assert hasattr(mod, class_name)

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -1,0 +1,443 @@
+"""Tests for the SEV-741 security fix: removal of silent role escalation.
+
+Background
+----------
+``IAuthProvider.map_roles`` previously applied a private
+``_ROLE_PROMOTIONS`` dictionary that silently translated upstream IdP
+roles before persisting them:
+
+* ``viewer`` -> ``user``
+* ``quant_dev`` -> ``developer``
+
+Both translations widened the user's effective privileges without any
+audit trail.  Combined with an unrelated setting
+``auth_overwrite_role_on_login`` (formerly defaulted to ``True``) a
+misconfigured upstream Identity Provider could escalate any local user
+on the next federated login.
+
+This module pins the new behavior:
+
+1. No implicit promotion — upstream roles are faithfully reflected.
+2. ``auth_overwrite_role_on_login`` defaults to ``False``.
+3. A warning is emitted for **any** unrecognized external role (not
+   only when the entire set is unrecognized).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import AuthResult, IAuthProvider
+from engine.config import Settings
+
+
+class _ConcreteProvider(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-concrete"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+class _AnotherConcrete(IAuthProvider):
+    @property
+    def name(self) -> str:
+        return "test-other"
+
+    async def authenticate(self, **kwargs):
+        return AuthResult()
+
+
+# ---------------------------------------------------------------------------
+# 1. _ROLE_PROMOTIONS is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRolePromotionsRemoved:
+    """Guards against silent reintroduction of the promotion table."""
+
+    def test_module_no_longer_exports_role_promotions(self):
+        from engine.api.auth import base
+
+        assert not hasattr(base, "_ROLE_PROMOTIONS"), (
+            "_ROLE_PROMOTIONS must not exist; it implemented a silent "
+            "privilege escalation (SEV-741)."
+        )
+
+    def test_no_module_level_dict_mapping_viewer_to_user(self):
+        import inspect
+
+        from engine.api.auth import base
+
+        src = inspect.getsource(base)
+        # The literal table that previously lived in this module must
+        # not be re-introduced.  Match either the dict literal form or
+        # an explicit ``viewer: "user"`` / ``"viewer": "user"`` style.
+        assert '"viewer": "user"' not in src
+        assert "'viewer': 'user'" not in src
+        assert '"quant_dev": "developer"' not in src
+        assert "'quant_dev': 'developer'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Faithful upstream role reflection (no implicit promotion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoImplicitPromotion:
+    """Pin the new contract: map_roles returns the best **recognized**
+    role as-is, without applying any translation."""
+
+    @pytest.mark.parametrize(
+        ("external", "expected"),
+        [
+            (["viewer"], "viewer"),
+            (["quant_dev"], "quant_dev"),
+            (["retail_trader"], "retail_trader"),
+            (["portfolio_manager"], "portfolio_manager"),
+            (["developer"], "developer"),
+            (["admin"], "admin"),
+            (["user"], "user"),
+        ],
+    )
+    def test_single_recognized_role_is_returned_verbatim(self, external, expected):
+        p = _ConcreteProvider()
+        assert p.map_roles(external) == expected
+
+    def test_quant_dev_not_promoted_to_developer(self):
+        """SEV-741 regression guard: previously ``quant_dev`` was
+        silently escalated to ``developer``."""
+        assert _ConcreteProvider().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_viewer_not_promoted_to_user(self):
+        """SEV-741 regression guard: previously ``viewer`` was silently
+        escalated to ``user``."""
+        assert _ConcreteProvider().map_roles(["viewer"]) == "viewer"
+
+    def test_mixed_quant_dev_and_viewer_returns_quant_dev(self):
+        """The highest *recognized* role wins — no translation applied."""
+        assert (
+            _ConcreteProvider().map_roles(["viewer", "quant_dev"]) == "quant_dev"
+        )
+
+    def test_admin_still_wins_against_lower_roles(self):
+        """The priority ordering between recognized roles is preserved."""
+        assert (
+            _ConcreteProvider().map_roles(
+                ["viewer", "user", "retail_trader", "quant_dev", "developer",
+                 "portfolio_manager", "admin"]
+            )
+            == "admin"
+        )
+
+    def test_empty_input_returns_user(self):
+        assert _ConcreteProvider().map_roles([]) == "user"
+
+    def test_all_unrecognized_falls_back_to_user(self):
+        assert (
+            _ConcreteProvider().map_roles(["superuser", "root", "god"]) == "user"
+        )
+
+    def test_partial_unrecognized_still_uses_recognized(self):
+        """Mix of recognized and unrecognized roles — recognized one wins."""
+        assert (
+            _ConcreteProvider().map_roles(["developer", "l33t_h4x0r"])
+            == "developer"
+        )
+
+    def test_case_insensitive_input_is_normalized(self):
+        assert _ConcreteProvider().map_roles(["ADMIN"]) == "admin"
+        assert _ConcreteProvider().map_roles(["  Admin  "]) == "admin"
+        assert _ConcreteProvider().map_roles(["QuAnT_dEv"]) == "quant_dev"
+
+    def test_whitespace_only_role_is_unrecognized(self):
+        """A whitespace-only string is normalized to the empty string,
+        which is not a known role.  Should fall through to user without
+        crashing."""
+        assert _ConcreteProvider().map_roles(["   "]) == "user"
+
+
+# ---------------------------------------------------------------------------
+# 3. Broadened unrecognized-role warning
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedRoleWarning:
+    """The warning must fire for **any** unrecognized role, even when
+    the set contains recognized roles alongside.  Previously the
+    warning only fired when the whole list was unrecognized.
+
+    Implementation note: ``engine.api.auth.base`` uses a structlog
+    logger that, in the test environment, is *not* routed through
+    stdlib's logging tree.  To keep these tests deterministic and free
+    of structlog-config coupling, we monkeypatch the module-level
+    structlog logger and assert on the kwargs it receives.
+    """
+
+    def _patch(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
+        class _Stub:
+            def warning(self, _event, **kwargs):
+                calls.append({"event": _event, **kwargs})
+
+            def info(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "info", **kwargs})
+
+            def error(self, _event, **kwargs):  # pragma: no cover
+                calls.append({"event": _event, "level": "error", **kwargs})
+
+        from engine.api.auth import base
+
+        monkeypatch.setattr(base, "logger", _Stub())
+        return calls
+
+    def test_warning_fires_for_purely_unrecognized_set(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["totally_bogus"]) == "user"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls)
+
+    def test_warning_fires_when_any_role_is_unrecognized(self, monkeypatch):
+        """SEV-741 broadening: warning must fire when at least one
+        external role is unrecognized, not only when all are."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        # Mix of recognized and unrecognized
+        assert p.map_roles(["admin", "bogus_group"]) == "admin"
+        assert any(c["event"] == "auth.map_roles.unrecognized_roles" for c in calls), (
+            "Expected a warning when ANY external role is unrecognized, "
+            "even when recognized roles are present alongside."
+        )
+
+    def test_warning_does_not_fire_when_all_roles_recognized(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles(["user", "developer"]) == "developer"
+        assert calls == []
+
+    def test_warning_does_not_fire_for_empty_input(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        assert p.map_roles([]) == "user"
+        assert calls == []
+
+    def test_warning_includes_provider_name(self, monkeypatch):
+        """Operators need to know which provider surfaced the
+        misconfiguration — the warning must include ``provider=``."""
+        calls = self._patch(monkeypatch)
+        p = _AnotherConcrete()
+        p.map_roles(["weird_role"])
+        assert calls, "Expected at least one warning call"
+        assert calls[0]["provider"] == "test-other"
+
+    def test_warning_payload_contains_unrecognized_list(self, monkeypatch):
+        """The bound ``unrecognized=`` payload must contain every
+        unrecognized raw role string (not just the first)."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "stale_group", "another_stale"])
+        assert calls
+        unrecognized = calls[0]["unrecognized"]
+        assert "stale_group" in unrecognized
+        assert "another_stale" in unrecognized
+        # Recognized roles should not appear in unrecognized list
+        assert "admin" not in unrecognized
+
+    def test_warning_payload_contains_recognized_list(self, monkeypatch):
+        """The bound ``recognized=`` payload must contain every
+        recognized role that was considered."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "user", "bogus"])
+        assert calls
+        recognized = calls[0]["recognized"]
+        assert "admin" in recognized
+        assert "user" in recognized
+        assert "bogus" not in recognized
+
+    def test_warning_payload_contains_mapped_role(self, monkeypatch):
+        """The bound ``mapped=`` payload reports the final role."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["viewer", "bogus"])
+        assert calls
+        assert calls[0]["mapped"] == "viewer"
+
+    def test_warning_fires_once_per_call_not_per_role(self, monkeypatch):
+        """A single map_roles call with multiple unrecognized roles
+        must produce exactly one warning event (containing all of
+        them), not one per role — operators rely on this for alert
+        deduplication."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["admin", "bogus_a", "bogus_b", "bogus_c"])
+        assert (
+            sum(1 for c in calls if c["event"] == "auth.map_roles.unrecognized_roles")
+            == 1
+        )
+
+    def test_warning_message_event_name_is_stable(self, monkeypatch):
+        """The event name must remain stable — operators key
+        dashboards / alerts on this string."""
+        calls = self._patch(monkeypatch)
+        p = _ConcreteProvider()
+        p.map_roles(["bogus"])
+        assert calls[0]["event"] == "auth.map_roles.unrecognized_roles"
+
+
+# ---------------------------------------------------------------------------
+# 4. auth_overwrite_role_on_login default
+# ---------------------------------------------------------------------------
+
+
+class TestAuthOverwriteRoleOnLoginDefault:
+    """SEV-741: ``auth_overwrite_role_on_login`` must default to False.
+
+    Defaulting to True allowed a misconfigured or compromised upstream
+    IdP to downgrade or escalate a previously-granted local role on the
+    next federated login.  Defaulting to False forces operators to
+    opt-in.
+    """
+
+    def test_default_is_false_on_settings_instance(self):
+        from engine.config import settings
+
+        assert settings.auth_overwrite_role_on_login is False
+
+    def test_default_is_false_on_fresh_settings(self):
+        """Constructing Settings without env input must produce False."""
+        # ``_env_file=None`` to ignore the on-disk .env so we observe
+        # the in-source default.
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+    def test_setting_is_a_bool(self):
+        from engine.config import settings
+
+        assert isinstance(settings.auth_overwrite_role_on_login, bool)
+
+    def test_setting_can_be_overridden_via_env(self, monkeypatch):
+        """Pydantic-settings still accepts ``NEXUS_…`` overrides."""
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "true")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is True
+
+    def test_setting_can_be_overridden_to_false_via_env(self, monkeypatch):
+        monkeypatch.setenv("NEXUS_AUTH_OVERWRITE_ROLE_ON_LOGIN", "false")
+        s = Settings(_env_file=None)
+        assert s.auth_overwrite_role_on_login is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Cross-provider coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMapRolesAcrossProviders:
+    """Same behavior on every concrete provider — both LDAP and OIDC
+    inherit map_roles from IAuthProvider."""
+
+    def _make_oidc(self):
+        from engine.api.auth.oidc import OIDCAuthProvider
+
+        return OIDCAuthProvider()
+
+    def _make_ldap(self):
+        from engine.api.auth.ldap import LDAPAuthProvider
+
+        return LDAPAuthProvider()
+
+    def test_oidc_does_not_promote_quant_dev(self):
+        assert self._make_oidc().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_oidc_does_not_promote_viewer(self):
+        assert self._make_oidc().map_roles(["viewer"]) == "viewer"
+
+    def test_ldap_does_not_promote_quant_dev(self):
+        assert self._make_ldap().map_roles(["quant_dev"]) == "quant_dev"
+
+    def test_ldap_does_not_promote_viewer(self):
+        assert self._make_ldap().map_roles(["viewer"]) == "viewer"
+
+    def test_oidc_recognized_roles_priority_preserved(self):
+        p = self._make_oidc()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+    def test_ldap_recognized_roles_priority_preserved(self):
+        p = self._make_ldap()
+        assert p.map_roles(["user", "admin"]) == "admin"
+        assert p.map_roles(["viewer", "developer"]) == "developer"
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: the role produced by map_roles is the role used for
+#    downstream authorization decisions.
+# ---------------------------------------------------------------------------
+
+
+class TestMappedRoleFlowsToRequireRole:
+    """End-to-end: the value returned by ``map_roles`` must be the value
+    that ``require_role`` evaluates — no implicit promotion layer in
+    between."""
+
+    @pytest.mark.parametrize(
+        ("external_roles", "minimum_required", "expected_status"),
+        [
+            (["viewer"], "viewer", 200),
+            (["viewer"], "user", 403),
+            (["quant_dev"], "quant_dev", 200),
+            (["quant_dev"], "developer", 403),
+            (["developer"], "developer", 200),
+            (["developer"], "portfolio_manager", 403),
+            (["portfolio_manager"], "portfolio_manager", 200),
+            (["portfolio_manager"], "admin", 403),
+            (["admin"], "admin", 200),
+            # Mixed: highest recognized wins, no promotion in between.
+            (["viewer", "quant_dev"], "quant_dev", 200),
+            (["viewer", "quant_dev"], "developer", 403),
+        ],
+    )
+    async def test_no_promotion_end_to_end(
+        self, external_roles, minimum_required, expected_status
+    ):
+        from fastapi import Depends, FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from engine.api.auth.dependency import get_current_user, require_role
+        from engine.db.models import User
+        from tests.conftest import FAKE_USER_ID
+
+        app = FastAPI()
+
+        @app.get("/guarded")
+        async def handler(user: User = Depends(require_role(minimum_required))):
+            return {"role": user.role}
+
+        provider = _ConcreteProvider()
+        mapped = provider.map_roles(external_roles)
+
+        fake_user = User(
+            id=FAKE_USER_ID,
+            email="e2e@example.com",
+            display_name="E2E",
+            is_active=True,
+            role=mapped,
+            auth_provider="local",
+        )
+
+        async def _override():
+            yield fake_user
+
+        app.dependency_overrides[get_current_user] = _override
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/guarded")
+            assert resp.status_code == expected_status, (
+                f"external_roles={external_roles} -> mapped={mapped}; "
+                f"minimum={minimum_required}; expected {expected_status}, "
+                f"got {resp.status_code}"
+            )

--- a/tests/test_auth_role_promotion_security_fix.py
+++ b/tests/test_auth_role_promotion_security_fix.py
@@ -559,3 +559,446 @@ class TestEveryProviderGoesThroughHelper:
         )
         # The provider class still exists.
         assert hasattr(mod, class_name)
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "engine.api.auth.ldap",
+            "engine.api.auth.oidc",
+            "engine.api.auth.google",
+            "engine.api.auth.github_oauth",
+        ],
+    )
+    def test_provider_calls_helper_with_is_new_user_false(self, module_path):
+        """SEV-741 follow-up: every federated provider reaches the
+        helper only from its existing-user branch (the new-user branch
+        creates the row directly without consulting the helper). The
+        existing-user branch must pass ``is_new_user=False`` so that a
+        NULL ``role`` column on an existing row is treated as a data
+        anomaly requiring operator opt-in, not as "no prior role to
+        preserve"."""
+        import importlib
+        import inspect
+
+        mod = importlib.import_module(module_path)
+        src = inspect.getsource(mod)
+        assert "is_new_user=False" in src, (
+            f"{module_path} must call _should_overwrite_role with "
+            "is_new_user=False in its existing-user branch "
+            "(SEV-741 follow-up)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9. ALLOWED_ROLES frozenset + _sanitize_role helper (SEV-741 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedRolesFrozenSet:
+    """``ALLOWED_ROLES`` is the single source of truth for the set of
+    internal role names a federated login may assert. It must:
+
+    * be a ``frozenset`` (immutable, hashable, safe to default-arg);
+    * contain every key in ``map_roles``'s ``role_priority`` table;
+    * reject common attack payloads by their absence.
+    """
+
+    def test_allowed_roles_is_a_frozenset(self):
+        from engine.api.auth.base import ALLOWED_ROLES
+
+        assert isinstance(ALLOWED_ROLES, frozenset)
+
+    def test_allowed_roles_contains_all_priority_keys(self):
+        from engine.api.auth.base import ALLOWED_ROLES
+
+        # Must match the priority table inside ``map_roles`` — these
+        # are the only roles that can possibly be returned.
+        for role in (
+            "viewer",
+            "user",
+            "retail_trader",
+            "quant_dev",
+            "developer",
+            "portfolio_manager",
+            "admin",
+        ):
+            assert role in ALLOWED_ROLES, (
+                f"{role!r} must be in ALLOWED_ROLES — it is a key in "
+                "map_roles' role_priority table."
+            )
+
+    def test_dangerous_synonyms_are_excluded(self):
+        """Defence-in-depth: ``root``/``superuser``/``god``/``sysadmin``
+        must NOT be in the allow-list. If a future role expansion
+        accidentally grants one of these names, this test fires."""
+        from engine.api.auth.base import ALLOWED_ROLES
+
+        for poison in ("root", "superuser", "god", "sysadmin", "su"):
+            assert poison not in ALLOWED_ROLES
+
+
+class TestSanitizeRoleHappyPath:
+    """``_sanitize_role`` accepts every legitimate role spelling."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "viewer",
+            "user",
+            "retail_trader",
+            "quant_dev",
+            "developer",
+            "portfolio_manager",
+            "admin",
+        ],
+    )
+    def test_canonical_role_returned_verbatim(self, raw):
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role(raw) == raw
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("ADMIN", "admin"),
+            ("Admin", "admin"),
+            ("  Admin  ", "admin"),
+            ("QuAnT_dEv", "quant_dev"),
+            ("Portfolio_Manager", "portfolio_manager"),
+        ],
+    )
+    def test_case_and_whitespace_tolerated(self, raw, expected):
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role(raw) == expected
+
+
+class TestSanitizeRoleAttacksCollapseToUser:
+    """Every attack vector collapses safely to ``"user"``."""
+
+    def test_non_string_input_returns_user(self):
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role(None) == "user"
+        assert _sanitize_role(123) == "user"
+        assert _sanitize_role(["admin"]) == "user"
+
+    def test_empty_string_returns_user(self):
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role("") == "user"
+
+    def test_whitespace_only_returns_user(self):
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role("   ") == "user"
+        assert _sanitize_role("\t") == "user"
+
+    @pytest.mark.parametrize(
+        "oversized",
+        [
+            "admin" + "x" * 28,  # 33 chars — just over the limit
+            "a" * 100,
+            "a" * 1024,
+            "a" * 65536,
+        ],
+    )
+    def test_oversized_input_rejected_before_regex(self, oversized):
+        """SEV-741 follow-up requirement #3: an oversized payload must
+        be rejected *immediately*, before the control-character regex
+        or NFKC normalization runs. Otherwise a multi-MiB IdP claim
+        could DoS the auth path."""
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role(oversized) == "user"
+
+    @pytest.mark.parametrize(
+        "control_char",
+        [
+            "\x00",  # NUL
+            "\x01",
+            "\x05",
+            "\n",  # LF — log-injection vector
+            "\r",  # CR — log-injection vector
+            "\t",  # HT
+            "\x1b",  # ESC — terminal escape
+            "\x7f",  # DEL
+            "\x9c",  # C1 (8-bit control)
+        ],
+    )
+    def test_control_characters_rejected(self, control_char):
+        """Any C0/DEL/C1 byte in the input causes rejection. We do
+        NOT silently strip — a payload that contained a control char
+        was crafted and must not pass."""
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role(f"admin{control_char}") == "user"
+        assert _sanitize_role(f"{control_char}admin") == "user"
+
+    def test_idp_asserting_admin_with_control_char_collapses_to_user(self):
+        """SEV-741 follow-up required test #1: an IdP asserting a
+        tampered ``admin`` (here with a NUL byte intended to confuse
+        downstream C-string handling) must collapse to ``user``, NOT
+        be silently accepted as ``admin`` after stripping."""
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role("admin\x00") == "user"
+        assert _sanitize_role("\x00admin") == "user"
+        assert _sanitize_role("ad\x00min") == "user"
+
+    @pytest.mark.parametrize(
+        "fullwidth",
+        [
+            "ａｄｍｉｎ",  # U+FF41 U+FF44 U+FF4D U+FF49 U+FF4E
+            "ｕｓｅｒ",  # fullwidth "user"
+            "ｖｉｅｗｅｒ",  # fullwidth "viewer"
+            "ｄｅｖｅｌｏｐｅｒ",  # fullwidth "developer"
+            "ｑｕａｎｔ＿ｄｅｖ",  # fullwidth "quant_dev"
+        ],
+    )
+    def test_fullwidth_unicode_rejected(self, fullwidth):
+        """SEV-741 follow-up required test #2: fullwidth Unicode must
+        NOT be NFKC-normalized to its ASCII lookalike and accepted.
+        ``unicodedata.normalize("NFKC", "ａｄｍｉｎ") == "admin"``, but
+        accepting the normalized form would let an attacker bypass
+        log-matching / allow-list comparisons by visually-identical
+        strings. ``_sanitize_role`` must detect the NFKC change and
+        reject."""
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role(fullwidth) == "user"
+
+    @pytest.mark.parametrize(
+        "homoglyph",
+        [
+            "аdmin",  # Cyrillic 'а' (U+0430), looks like ASCII 'a'
+            "аdmіn",  # Cyrillic 'а' + 'і' (U+0456)
+            "admın",  # dotless Latin 'ı' (NFKC-stable — caught by allow-list)
+        ],
+    )
+    def test_other_homoglyphs_rejected(self, homoglyph):
+        """Defence in depth: Cyrillic lookalikes are either caught by
+        the NFKC-stability check or by the final allow-list match."""
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role(homoglyph) == "user"
+
+    def test_unrecognized_role_name_collapses_to_user(self):
+        from engine.api.auth.base import _sanitize_role
+
+        assert _sanitize_role("superuser") == "user"
+        assert _sanitize_role("root") == "user"
+        assert _sanitize_role("god") == "user"
+        assert _sanitize_role("sysadmin") == "user"
+
+
+class TestSanitizeRoleUsedByMapRoles:
+    """End-to-end: ``map_roles`` actually routes input through
+    ``_sanitize_role``. A tampered ``admin`` claim must collapse to
+    ``"user"`` at the API boundary, not be silently accepted."""
+
+    def test_admin_with_nul_collapses_to_user_via_map_roles(self):
+        from engine.api.auth.base import IAuthProvider
+
+        class _P(IAuthProvider):
+            @property
+            def name(self) -> str:
+                return "t"
+
+            async def authenticate(self, **_):
+                from engine.api.auth.base import AuthResult
+
+                return AuthResult()
+
+        assert _P().map_roles(["admin\x00"]) == "user"
+
+    def test_fullwidth_admin_collapses_to_user_via_map_roles(self):
+        from engine.api.auth.base import IAuthProvider
+
+        class _P(IAuthProvider):
+            @property
+            def name(self) -> str:
+                return "t"
+
+            async def authenticate(self, **_):
+                from engine.api.auth.base import AuthResult
+
+                return AuthResult()
+
+        assert _P().map_roles(["ａｄｍｉｎ"]) == "user"
+
+    def test_oversized_role_collapses_to_user_via_map_roles(self):
+        from engine.api.auth.base import IAuthProvider
+
+        class _P(IAuthProvider):
+            @property
+            def name(self) -> str:
+                return "t"
+
+            async def authenticate(self, **_):
+                from engine.api.auth.base import AuthResult
+
+                return AuthResult()
+
+        assert _P().map_roles(["admin" + "x" * 100]) == "user"
+
+    def test_tampered_admin_does_not_silently_overwrite_recognized(
+        self, monkeypatch
+    ):
+        """If a tampered ``admin`` is sent alongside a valid role, the
+        valid role still wins (the tampered string is unrecognized)."""
+        from engine.api.auth.base import IAuthProvider
+
+        class _P(IAuthProvider):
+            @property
+            def name(self) -> str:
+                return "t"
+
+            async def authenticate(self, **_):
+                from engine.api.auth.base import AuthResult
+
+                return AuthResult()
+
+        # "admin\x00" is unrecognized; "viewer" wins.
+        assert _P().map_roles(["admin\x00", "viewer"]) == "viewer"
+
+
+# ---------------------------------------------------------------------------
+# 10. _should_overwrite_role: NULL-role on an existing user (SEV-741 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestShouldOverwriteRoleNullExistingUser:
+    """SEV-741 follow-up requirement #4: an existing user with a NULL
+    ``role`` column is *not* the same as a brand-new user. A NULL role
+    on an existing row is a data anomaly — it might be the result of a
+    botched migration, a manual DB edit, or an attacker who found a
+    way to clear the column. Letting a federated login silently fill
+    it in would hand the IdP a privileged escalation path.
+
+    The new ``is_new_user`` keyword distinguishes the two cases:
+
+    * ``is_new_user=True`` (default, backward compatible): brand-new
+      row being created right now, ``current_role is None`` is
+      expected, helper returns ``True`` unconditionally.
+    * ``is_new_user=False``: row already exists, ``current_role is
+      None`` is anomalous, helper defers to
+      ``auth_overwrite_role_on_login``.
+    """
+
+    def _call(self, current_role, mapped_role, *, overwrite: bool, is_new_user: bool = True):
+        from engine.api.auth.base import _should_overwrite_role
+
+        return _should_overwrite_role(
+            current_role,
+            mapped_role,
+            _SettingsStub(overwrite=overwrite),
+            is_new_user=is_new_user,
+        )
+
+    # --- backward compatibility: is_new_user defaults to True -------
+
+    def test_default_is_new_user_preserves_old_behavior_opted_in(self):
+        """Old call sites that don't pass ``is_new_user`` keep the
+        original semantics: ``None`` -> True."""
+        assert self._call(None, "admin", overwrite=True) is True
+
+    def test_default_is_new_user_preserves_old_behavior_opted_out(self):
+        assert self._call(None, "admin", overwrite=False) is True
+
+    # --- required test: NULL-role existing user blocked without opt-in
+
+    def test_null_role_existing_user_blocked_without_opt_in(self):
+        """SEV-741 follow-up required test #3: a row that already
+        exists but has ``role=None`` must NOT be silently repaired by
+        the IdP-mapped role when the operator hasn't opted in."""
+        assert (
+            self._call(None, "admin", overwrite=False, is_new_user=False)
+            is False
+        )
+
+    def test_null_role_existing_user_blocked_even_for_user_role(self):
+        """Even mapping to the lowest-privilege ``user`` role must
+        respect the opt-in — otherwise an IdP that asserts *anything*
+        could anchor itself into a previously-anomalous row."""
+        assert (
+            self._call(None, "user", overwrite=False, is_new_user=False)
+            is False
+        )
+
+    def test_null_role_existing_user_allowed_with_opt_in(self):
+        """With operator opt-in, the helper permits the repair — the
+        auditor can trace it back to the explicit setting."""
+        assert (
+            self._call(None, "admin", overwrite=True, is_new_user=False)
+            is True
+        )
+
+    def test_null_role_existing_user_demotion_blocked_without_opt_in(self):
+        """Same guard protects against demotion-style attacks: an
+        existing NULL row cannot be filled with ``user`` to lock in
+        a low-privilege foothold."""
+        assert (
+            self._call(None, "user", overwrite=False, is_new_user=False)
+            is False
+        )
+
+    def test_null_role_existing_user_missing_setting_blocks(self):
+        """If the config object doesn't expose the setting at all,
+        default to safe (block)."""
+        from engine.api.auth.base import _should_overwrite_role
+
+        class _Bare:
+            pass
+
+        assert (
+            _should_overwrite_role(None, "admin", _Bare(), is_new_user=False)
+            is False
+        )
+
+    def test_null_role_existing_user_truthy_setting_allows(self):
+        from engine.api.auth.base import _should_overwrite_role
+
+        class _Truthy:
+            auth_overwrite_role_on_login = 1
+
+        assert (
+            _should_overwrite_role(None, "admin", _Truthy(), is_new_user=False)
+            is True
+        )
+
+    def test_distinction_between_new_and_existing_with_null_role(self):
+        """Pin the semantic difference: same arguments, flip
+        ``is_new_user``, behavior flips."""
+        assert self._call(None, "admin", overwrite=False, is_new_user=True) is True
+        assert (
+            self._call(None, "admin", overwrite=False, is_new_user=False)
+            is False
+        )
+
+
+class TestProvidersPassIsNewUserFalse:
+    """Static guard: each federated provider's existing-user branch
+    must call ``_should_overwrite_role(..., is_new_user=False)`` so
+    that the NULL-role protection above is actually applied to real
+    logins."""
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "engine.api.auth.ldap",
+            "engine.api.auth.oidc",
+            "engine.api.auth.google",
+            "engine.api.auth.github_oauth",
+        ],
+    )
+    def test_existing_user_branch_signals_existing_user(self, module_path):
+        import importlib
+        import inspect
+
+        mod = importlib.import_module(module_path)
+        src = inspect.getsource(mod)
+        assert "is_new_user=False" in src, (
+            f"{module_path} must pass is_new_user=False when calling "
+            "_should_overwrite_role from its existing-user branch."
+        )

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -160,3 +160,41 @@ class TestSanitization:
             == "https://app.example/dash"
         )
         assert _strip_query(None) is None
+
+    def test_scrub_strips_unicode_c1_control_chars(self):
+        """The C1 range (U+0080-U+009F) is interpreted as terminal-
+        control bytes by some 8-bit-clean terminals (notably U+009B
+        acting as CSI). The scrubber must collapse them to spaces
+        alongside the ASCII C0 range."""
+        from engine.api.routes.client_errors import _scrub
+
+        # U+009B is the legacy CSI lead byte. The two-byte ESC+'[' form
+        # is handled by the ANSI regex; the single-byte form must be
+        # collapsed by the C1-aware _CTRL_RE.
+        assert "\u009b" not in _scrub("before\u009bafter")
+        # Full C1 sweep: each of the 6 control bytes becomes one space.
+        assert _scrub("a\x80\x81\x82\x83\x9e\x9fb") == "a" + (" " * 6) + "b"
+        # Mixed ASCII + C1 + ANSI: the ESC-prefixed sequence is dropped
+        # by _ANSI_RE, the lone C1 byte by _CTRL_RE. The trailing literal
+        # "[0m" has no ESC byte to bind to so it survives (harmlessly).
+        assert _scrub("\x1b[31m\x85red") == " red"
+        # Tab is still preserved.
+        assert "\t" in _scrub("keep\ttabs")
+
+    def test_ctrl_regex_covers_c1_range(self):
+        """Programmatic guard: ``_CTRL_RE`` must match every codepoint
+        in U+0080-U+009F so a future refactor can't silently narrow
+        the regex back to ASCII-only."""
+        from engine.api.routes.client_errors import _CTRL_RE
+
+        for codepoint in range(0x80, 0xA0):
+            assert _CTRL_RE.search(chr(codepoint)) is not None, (
+                f"U+{codepoint:04X} must be matched by _CTRL_RE"
+            )
+
+    def test_ctrl_regex_preserves_tab(self):
+        """Tabs in stack traces are useful; the regex must not strip
+        them."""
+        from engine.api.routes.client_errors import _CTRL_RE
+
+        assert _CTRL_RE.search("\t") is None

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -399,10 +399,64 @@ class TestLDAPAuthenticateExistingUser:
         assert result.user_info.email == "testuser@example.com"
         mock_db.add.assert_not_called()
 
-    async def test_existing_user_role_updated(
+    async def test_existing_user_role_preserved_by_default(
         self, ldap_provider, mock_settings
     ):
+        """SEV-741: with ``auth_overwrite_role_on_login`` disabled (the
+        default), an existing user's local role is NOT replaced with the
+        IdP-mapped role on federated login."""
         from engine.db.models import User
+
+        attrs = _make_ldap_attrs(
+            member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]
+        )
+        mock_ldap, mock_filter = _build_ldap_mock(
+            search_results=[("uid=promoted,ou=users,dc=example,dc=com", attrs)]
+        )
+
+        existing_user = User(
+            email="testuser@example.com",
+            display_name="Test User",
+            is_active=True,
+            role="user",
+            auth_provider="ldap",
+            external_id="testuser",
+        )
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_user
+        mock_db.execute.return_value = mock_result
+        mock_db.flush = AsyncMock()
+
+        with patch.dict("sys.modules", {"ldap": mock_ldap, "ldap.filter": mock_filter}):
+            result = await ldap_provider.authenticate(
+                username="testuser", password="correctpass", db=mock_db
+            )
+
+        assert result.success is True
+        # Default: do NOT overwrite the previously-granted local role.
+        assert existing_user.role == "user"
+        mock_db.flush.assert_not_called()
+
+    async def test_existing_user_role_overwritten_when_opted_in(
+        self, ldap_provider, monkeypatch
+    ):
+        """SEV-741: with ``auth_overwrite_role_on_login=True``, the
+        IdP-mapped role replaces the existing local role on federated
+        login."""
+        from engine.db.models import User
+
+        s = Settings(
+            ldap_server_url="ldap://ldap.example.com:389",
+            ldap_bind_dn="uid={{username}},ou=users,dc=example,dc=com",
+            ldap_search_base="ou=users,dc=example,dc=com",
+            ldap_role_mapping=json.dumps({
+                "cn=admins,ou=groups,dc=example,dc=com": "admin",
+            }),
+            auth_overwrite_role_on_login=True,
+        )
+        monkeypatch.setattr("engine.api.auth.ldap.settings", s)
 
         attrs = _make_ldap_attrs(
             member_of=[b"cn=admins,ou=groups,dc=example,dc=com"]

--- a/tests/test_load_tests.py
+++ b/tests/test_load_tests.py
@@ -1,0 +1,265 @@
+"""Static validation for the k6 load-test suite.
+
+The scripts in ``tests/load/`` are JavaScript executed by k6, so they're
+outside the normal pytest surface. This module gives us a single place to
+catch the most common breakage modes before they hit the weekly CI cron:
+
+* The k6 workflow YAML parses.
+* Every JS file is syntactically valid (``node -c``).
+* Every endpoint the scripts hit actually exists in the FastAPI router.
+* The threshold table in the operator runbook matches the real thresholds
+  in ``api-baseline.js``.
+
+Together these guarantee that a green CI run on the load-test workflow
+means a green run on staging.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+LOAD_DIR = ROOT / "tests" / "load"
+WORKFLOW = ROOT / ".github" / "workflows" / "load-test.yml"
+RUNBOOK = ROOT / "docs" / "operations" / "load-testing.md"
+
+JS_FILES = [
+    LOAD_DIR / "lib" / "auth.js",
+    LOAD_DIR / "api-smoke.js",
+    LOAD_DIR / "api-baseline.js",
+]
+
+
+@pytest.fixture(scope="module")
+def app_routes() -> set[str]:
+    """Collect the (path, method) surface mounted on the FastAPI app.
+
+    Done once per module — ``create_app`` is cheap but not free, and
+    every test in this file just needs the same set of paths.
+    """
+    from engine.app import create_app
+
+    app = create_app()
+    paths: set[str] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        if path:
+            paths.add(path)
+    return paths
+
+
+@pytest.fixture(scope="module")
+def app_route_methods() -> dict[str, set[str]]:
+    """Map ``path -> {methods}`` (HEAD excluded) for method-aware checks."""
+    from engine.app import create_app
+
+    app = create_app()
+    out: dict[str, set[str]] = {}
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if path and methods:
+            out.setdefault(path, set()).update(
+                m for m in methods if m != "HEAD"
+            )
+    return out
+
+
+class TestFiles:
+    def test_all_js_files_exist(self) -> None:
+        for path in JS_FILES:
+            assert path.is_file(), f"missing k6 script: {path}"
+
+    def test_readme_exists(self) -> None:
+        assert (LOAD_DIR / "README.md").is_file()
+
+    def test_workflow_exists(self) -> None:
+        assert WORKFLOW.is_file()
+
+    def test_runbook_exists(self) -> None:
+        assert RUNBOOK.is_file()
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is not installed — skipping JS syntax checks",
+)
+class TestJsSyntax:
+    @pytest.mark.parametrize("path", JS_FILES, ids=lambda p: p.name)
+    def test_node_syntax_check(self, path: Path) -> None:
+        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["node", "-c", str(path)],  # noqa: S607 — node resolved via PATH intentionally
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"node -c {path.name} failed:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+class TestWorkflow:
+    def test_yaml_parses(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        assert "jobs" in data, "workflow has no jobs"
+        assert "run" in data["jobs"], "workflow is missing the 'run' job"
+
+    def test_triggers(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        assert "workflow_dispatch" in triggers
+        assert "schedule" in triggers
+
+    def test_manual_inputs(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        wd = triggers["workflow_dispatch"]
+        assert "scenario" in wd["inputs"]
+        assert "base_url" in wd["inputs"]
+        options = wd["inputs"]["scenario"]["options"]
+        assert "smoke" in options
+        assert "baseline" in options
+
+    def test_weekly_cron(self) -> None:
+        data = yaml.safe_load(WORKFLOW.read_text())
+        triggers = data.get(True) or data.get("on") or {}
+        cron_expr = triggers["schedule"][0]["cron"]
+        # Monday 03:00 UTC — k6 docs/operations/load-testing.md commits
+        # to this exact window, so pin it.
+        assert cron_expr == "0 3 * * 1", (
+            f"weekly baseline cron changed: {cron_expr!r}"
+        )
+
+    def test_summary_artifact(self) -> None:
+        text = WORKFLOW.read_text()
+        assert "load-test-summary.json" in text, (
+            "workflow must upload load-test-summary.json for regression diffs"
+        )
+        assert "retention-days: 30" in text, (
+            "workflow must retain the summary artifact for 30 days"
+        )
+
+
+class TestScriptRoutes:
+    """The k6 scripts must hit endpoints that actually exist."""
+
+    @pytest.fixture(scope="class")
+    def smoke_text(self) -> str:
+        return (LOAD_DIR / "api-smoke.js").read_text()
+
+    @pytest.fixture(scope="class")
+    def baseline_text(self) -> str:
+        return (LOAD_DIR / "api-baseline.js").read_text()
+
+    def test_health_route_is_root_not_api_v1(self, smoke_text: str) -> None:
+        # The health router is mounted without the /api/v1 prefix; if a
+        # future refactor moves it under /api/v1/health, update both the
+        # script and this assertion together.
+        assert "${data.baseUrl}/health" in smoke_text
+        assert "/api/v1/health" not in smoke_text
+
+    def test_auth_login_route_exists(
+        self, app_route_methods: dict[str, set[str]]
+    ) -> None:
+        assert "POST" in app_route_methods.get("/api/v1/auth/login", set())
+
+    def test_portfolio_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        smoke_text: str,
+        baseline_text: str,
+    ) -> None:
+        assert "/api/v1/portfolio" in app_route_methods or (
+            "/api/v1/portfolio/" in app_route_methods
+        ), "portfolio route missing — k6 scripts will 404"
+        assert "/api/v1/portfolio" in smoke_text
+        assert "/api/v1/portfolio" in baseline_text
+
+    def test_reference_suggest_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        smoke_text: str,
+        baseline_text: str,
+    ) -> None:
+        # The reference router only exposes /suggest, not /exchanges.
+        assert "GET" in app_route_methods.get(
+            "/api/v1/reference/suggest", set()
+        ), "GET /api/v1/reference/suggest must exist for the k6 scripts"
+        assert "/api/v1/reference/suggest" in smoke_text
+        assert "/api/v1/reference/suggest" in baseline_text
+        # Guard against drift back to the old, non-existent endpoint.
+        assert "/api/v1/reference/exchanges" not in smoke_text
+        assert "/api/v1/reference/exchanges" not in baseline_text
+
+    def test_backtest_run_route_exists(
+        self,
+        app_route_methods: dict[str, set[str]],
+        baseline_text: str,
+    ) -> None:
+        assert "POST" in app_route_methods.get(
+            "/api/v1/backtest/run", set()
+        ), "POST /api/v1/backtest/run must exist for the baseline script"
+        assert "/api/v1/backtest/run" in baseline_text
+        # The bare /api/v1/backtest path is a 404 — guard against regressions.
+        assert "'${data.baseUrl}/api/v1/backtest'," not in baseline_text
+        assert "'${data.baseUrl}/api/v1/backtest'" not in baseline_text
+
+    def test_backtest_payload_matches_pydantic_model(
+        self, baseline_text: str
+    ) -> None:
+        # engine.api.routes.backtest.BacktestRequest requires these exact
+        # field names. A rename in the Pydantic model is the #1 way this
+        # script silently breaks — pin the names here.
+        assert "strategy_name" in baseline_text
+        assert "start_date" in baseline_text
+        assert "end_date" in baseline_text
+        # The old field names would silently 422.
+        assert "strategy_id" not in baseline_text
+        assert not re.search(r"\bstart\s*:", baseline_text)
+        assert not re.search(r"\bend\s*:", baseline_text)
+
+
+class TestThresholds:
+    """The runbook's threshold table must match the baseline script."""
+
+    @pytest.fixture(scope="class")
+    def baseline_text(self) -> str:
+        return (LOAD_DIR / "api-baseline.js").read_text()
+
+    @pytest.fixture(scope="class")
+    def runbook_text(self) -> str:
+        return RUNBOOK.read_text()
+
+    @pytest.mark.parametrize(
+        ("tag", "p95"),
+        [
+            ("portfolio_list", "800"),
+            ("reference_suggest", "400"),
+            ("backtest_submit", "1500"),
+        ],
+    )
+    def test_p95_threshold_listed(
+        self, baseline_text: str, runbook_text: str, tag: str, p95: str
+    ) -> None:
+        # Must be enforced by the script…
+        assert (
+            f"http_req_duration{{name:{tag}}}" in baseline_text
+        ), f"baseline script is missing threshold for tag {tag!r}"
+        assert f"p(95)<{p95}" in baseline_text
+        # …and documented in the runbook.
+        assert tag in runbook_text, (
+            f"runbook must list threshold for tag {tag!r}"
+        )
+        assert f"p(95) < {p95}" in runbook_text or f"p(95)<{p95}" in runbook_text
+
+    def test_failed_rate_threshold(self, baseline_text: str, runbook_text: str) -> None:
+        assert "http_req_failed" in baseline_text
+        assert "rate<0.005" in baseline_text
+        assert "0.5%" in runbook_text


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Add role allowlist validation in _sanitize_role and close the NULL-role bypass in _should_overwrite_role (critical + high SEV-741 review findings)

Closes #853
