### PR TITLE
fix(auth): enforce strict role allowlist validation

### DIFF
--- a/engine/api/auth/base.py
+++ b/engine/api/auth/base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -50,6 +52,60 @@ _ROLE_PRIORITY: dict[str, int] = {
     "portfolio_manager": 5,
     "admin": 6,
 }
+
+
+# Roles that an untrusted upstream Identity Provider (IdP) may legitimately
+# assert for a single role string. This is the *strict* allowlist used by
+# :func:`_sanitize_role`; anything outside it collapses to ``"user"``.
+ALLOWED_ROLES: frozenset[str] = frozenset(
+    {"user", "viewer", "developer", "portfolio_manager", "admin"}
+)
+
+# Role names are short ASCII identifiers. Anything longer is either garbage
+# or a hostile payload; reject it *before* running any regex so a huge input
+# cannot trigger pathological backtracking (regex DoS hardening).
+_MAX_ROLE_LENGTH = 128
+
+# C0 (\x00-\x1f) and C1 (\x7f-\x9f) control characters. Stripped so they
+# cannot smuggle a role past a naive ``in`` check (e.g. ``"admin\x00"``).
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _sanitize_role(role: str | None) -> str:
+    """Validate a single role string received from an untrusted source
+    (an upstream Identity Provider) against :data:`ALLOWED_ROLES`.
+
+    The pipeline is ordered for both safety and DoS resistance:
+
+    1. **Type / length guard** -- non-strings and oversize inputs collapse to
+       ``"user"`` immediately, *before* any regex work, defeating regex-based
+       denial of service.
+    2. **NFKC normalization** -- canonicalizes Unicode so look-alike sequences
+       become detectable.
+    3. **Control-character strip** -- removes C0/C1 control codes.
+    4. **Spoofing guard** -- if normalization or stripping altered the input
+       it was a look-alike spoof (e.g. a fullwidth-Unicode ``admin`` that NFKC
+       would otherwise turn into the real ``admin``); collapse to
+       ``"user"`` rather than accept it.
+    5. **Allowlist membership** -- only the exact strings in
+       :data:`ALLOWED_ROLES` survive; everything else collapses to ``"user"``.
+
+    This guarantees a hostile or misconfigured IdP cannot inject an arbitrary
+    or look-alike role (e.g. a spoofed ``admin``) into a local user account.
+    """
+    if not isinstance(role, str) or len(role) > _MAX_ROLE_LENGTH:
+        return "user"
+    normalized = unicodedata.normalize("NFKC", role)
+    cleaned = _CONTROL_CHARS_RE.sub("", normalized)
+    # Anti-spoofing: a legitimate role name is already in canonical form.
+    # If NFKC or control-char stripping changed the value, the caller sent a
+    # look-alike (e.g. fullwidth-Unicode "admin") -- never trust it with
+    # elevated privileges.
+    if cleaned != role:
+        return "user"
+    if cleaned in ALLOWED_ROLES:
+        return cleaned
+    return "user"
 
 
 class IAuthProvider(ABC):

--- a/tests/test_auth_sanitize_role.py
+++ b/tests/test_auth_sanitize_role.py
@@ -1,0 +1,131 @@
+"""Tests for ``_sanitize_role`` / ``ALLOWED_ROLES`` (role-spoofing hardening).
+
+A hostile or misconfigured upstream Identity Provider (IdP) can send an
+arbitrary role string in a federated login. ``_sanitize_role`` is the
+defence-in-depth layer that collapses anything which is not an exact,
+canonical member of :data:`ALLOWED_ROLES` to the safe default ``"user"``.
+
+The five scenarios pinned here:
+
+1. valid roles pass through verbatim,
+2. a spoofed/hybrid ``admin`` claim from a hostile IdP collapses to ``user``,
+3. garbage strings collapse to ``user``,
+4. a Unicode fullwidth look-alike of ``admin`` collapses to ``user`` (NFKC
+   would otherwise turn it into ``admin`` -- a privilege-escalation spoof),
+5. an empty string collapses to ``user``.
+
+Additional guards (DoS length cap, control-char injection) are also covered.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.api.auth.base import ALLOWED_ROLES, _sanitize_role
+
+# Fullwidth-Unicode look-alikes (intentionally non-ASCII). Spelled out as
+# explicit code points so the source stays ASCII-clean for the linter.
+_FULLWIDTH_ADMIN = "\uff41\uff44\uff4d\uff49\uff4e"  # "admin" in fullwidth
+_FULLWIDTH_USER = "\uff55\uff53\uff45\uff52"  # "user" in fullwidth
+
+
+class TestAllowedRolesConstant:
+    def test_allowed_roles_is_a_frozenset(self):
+        assert isinstance(ALLOWED_ROLES, frozenset)
+
+    def test_allowed_roles_contains_expected_members(self):
+        assert (
+            frozenset({"user", "viewer", "developer", "portfolio_manager", "admin"})
+            == ALLOWED_ROLES
+        )
+
+
+class TestSanitizeRoleValidRolesPass:
+    """Scenario 1: every canonical allowed role is returned verbatim."""
+
+    @pytest.mark.parametrize("role", sorted(ALLOWED_ROLES))
+    def test_valid_role_passes_through(self, role):
+        assert _sanitize_role(role) == role
+
+
+class TestSanitizeRoleHostileAdminCollapses:
+    """Scenario 2: an ``admin`` claim from a hostile IdP that is not the
+    exact canonical string collapses to ``user``."""
+
+    @pytest.mark.parametrize(
+        "hostile",
+        [
+            "Admin",  # wrong case
+            "ADMIN",  # all-caps
+            "administrator",  # a different word entirely
+            " admin",  # leading whitespace
+            "admin ",  # trailing whitespace
+            "admin\x00",  # embedded NUL
+            "admin\n",  # embedded newline
+            "super-admin",  # invented privilege
+            "root",  # invented privilege
+        ],
+    )
+    def test_hostile_admin_collapses_to_user(self, hostile):
+        assert _sanitize_role(hostile) == "user"
+
+
+class TestSanitizeRoleGarbageCollapses:
+    """Scenario 3: arbitrary garbage strings collapse to ``user``."""
+
+    @pytest.mark.parametrize(
+        "garbage",
+        [
+            "xyz",
+            "!@#$%",
+            "not-a-role",
+            "12345",
+            "guest",
+            "superuser",
+            "role=admin",
+        ],
+    )
+    def test_garbage_collapses_to_user(self, garbage):
+        assert _sanitize_role(garbage) == "user"
+
+
+class TestSanitizeRoleFullwidthSpoofCollapses:
+    """Scenario 4: a Unicode fullwidth look-alike must NOT become ``admin``.
+
+    NFKC normalization alone would turn the fullwidth form into ``admin`` --
+    accepting that would let a hostile IdP escalate to admin via a spoof. The
+    spoofing guard collapses it to ``user`` instead.
+    """
+
+    @pytest.mark.parametrize(
+        "spoof",
+        [_FULLWIDTH_ADMIN, _FULLWIDTH_USER],
+    )
+    def test_fullwidth_spoof_collapses_to_user(self, spoof):
+        assert _sanitize_role(spoof) == "user"
+
+    def test_fullwidth_admin_is_not_accepted_as_admin(self):
+        assert _sanitize_role(_FULLWIDTH_ADMIN) != "admin"
+
+
+class TestSanitizeRoleEmptyAndNoneCollapse:
+    """Scenario 5: empty / missing input collapses to ``user``."""
+
+    @pytest.mark.parametrize("empty", ["", "   ", "\t", None])
+    def test_empty_or_none_collapses_to_user(self, empty):
+        assert _sanitize_role(empty) == "user"
+
+
+class TestSanitizeRoleDosGuard:
+    """Oversize input is rejected before any regex runs (regex DoS)."""
+
+    def test_oversize_input_collapses_to_user(self):
+        assert _sanitize_role("a" * 200) == "user"
+
+    def test_boundary_length_is_accepted_when_valid(self):
+        # A legit role is always short, so the cap never rejects valid input.
+        assert _sanitize_role("admin") == "admin"
+
+    def test_non_string_input_collapses_to_user(self):
+        assert _sanitize_role(123) == "user"  # type: ignore[arg-type]
+        assert _sanitize_role(["admin"]) == "user"  # type: ignore[arg-type]

--- a/tests/test_role_promotion_sev741.py
+++ b/tests/test_role_promotion_sev741.py
@@ -3,7 +3,7 @@
 
 The change introduced:
 
-1.  ``_ROLE_PROMOTIONS`` mapping: ``viewer`` -> ``user`` and ``quant_dev`` ->
+1.  ``_EXTERNAL_ROLE_ALIASES`` mapping: ``viewer`` -> ``user`` and ``quant_dev`` ->
     ``developer``.
 2.  ``IAuthProvider.map_roles`` applies that mapping to the highest-priority
     role it selects from the input list.
@@ -19,7 +19,7 @@ from __future__ import annotations
 import pytest
 
 from engine.api.auth.base import (
-    _ROLE_PROMOTIONS,
+    _EXTERNAL_ROLE_ALIASES,
     AuthResult,
     IAuthProvider,
     UserInfo,
@@ -43,7 +43,7 @@ def provider() -> _ConcreteProvider:
 
 
 # ---------------------------------------------------------------------------
-# _ROLE_PROMOTIONS constant
+# _EXTERNAL_ROLE_ALIASES constant
 # ---------------------------------------------------------------------------
 
 
@@ -51,26 +51,27 @@ class TestRolePromotionsConstant:
     """Guarantees the promotion table exposed by the module is correct."""
 
     def test_viewer_promoted_to_user(self):
-        assert _ROLE_PROMOTIONS["viewer"] == "user"
+        assert _EXTERNAL_ROLE_ALIASES["viewer"] == "user"
 
     def test_quant_dev_promoted_to_developer(self):
-        assert _ROLE_PROMOTIONS["quant_dev"] == "developer"
+        assert _EXTERNAL_ROLE_ALIASES["quant_dev"] == "developer"
 
     def test_only_two_promotions_defined(self):
-        assert set(_ROLE_PROMOTIONS.keys()) == {"viewer", "quant_dev"}
+        assert set(_EXTERNAL_ROLE_ALIASES.keys()) == {"viewer", "quant_dev"}
 
     def test_promotion_targets_are_canonical_roles(self):
         # Promoted values must themselves be valid (non-promoted) role names
         # so map_roles is idempotent.
-        for target in _ROLE_PROMOTIONS.values():
-            assert target not in _ROLE_PROMOTIONS
+        for target in _EXTERNAL_ROLE_ALIASES.values():
+            assert target not in _EXTERNAL_ROLE_ALIASES
 
     def test_promotion_targets_are_priority_roles(self):
         # Targets are real priority-table keys, not arbitrary strings.
 
         # Inspect the priority dict by calling map_roles with each target
         # alone — it must select itself.
-        for target in _ROLE_PROMOTIONS.values():
+        for target in _EXTERNAL_ROLE_ALIASES.values():
+
             class _P(IAuthProvider):
                 @property
                 def name(self) -> str:
@@ -88,7 +89,7 @@ class TestRolePromotionsConstant:
 
 
 class TestMapRolesPromotion:
-    """Direct coverage of the ``_ROLE_PROMOTIONS.get(best, best)`` line."""
+    """Direct coverage of the ``_EXTERNAL_ROLE_ALIASES.get(best, best)`` line."""
 
     def test_viewer_alone_is_promoted_to_user(self, provider):
         assert provider.map_roles(["viewer"]) == "user"
@@ -124,11 +125,9 @@ class TestMapRolesPromotion:
         # needed but the result still matches the promoted target.
         assert provider.map_roles(["quant_dev", "developer"]) == "developer"
 
-    def test_viewer_plus_user_picks_user_without_needing_promotion(
-        self, provider
-    ):
+    def test_viewer_plus_user_picks_user_without_needing_promotion(self, provider):
         # user (priority 1) > viewer (priority 0) — "best" becomes "user"
-        # which is not in _ROLE_PROMOTIONS.
+        # which is not in _EXTERNAL_ROLE_ALIASES.
         assert provider.map_roles(["viewer", "user"]) == "user"
 
     def test_promotion_is_idempotent(self, provider):
@@ -143,9 +142,7 @@ class TestMapRolesPromotion:
         second_q = provider.map_roles([first_q])
         assert second_q == "developer"
 
-    def test_promotion_respects_case_insensitive_normalisation(
-        self, provider
-    ):
+    def test_promotion_respects_case_insensitive_normalisation(self, provider):
         assert provider.map_roles(["VIEWER"]) == "user"
         assert provider.map_roles(["QUANT_DEV"]) == "developer"
         assert provider.map_roles(["Quant_Dev"]) == "developer"
@@ -199,26 +196,24 @@ class TestMapRolesPromotion:
         # and is the default starting value for ``best``).
         import engine.api.auth.base as base_mod
 
-        monkeypatch.setitem(
-            base_mod._ROLE_PROMOTIONS, "quant_dev", "portfolio_manager"
-        )
+        monkeypatch.setitem(base_mod._EXTERNAL_ROLE_ALIASES, "quant_dev", "portfolio_manager")
         assert provider.map_roles(["quant_dev"]) == "portfolio_manager"
 
     def test_viewer_promotion_entry_is_dead_code(self, provider):
         # Documents current behaviour: ``viewer`` has priority 0 while the
         # default ``best = "user"`` has priority 1, so best never becomes
-        # ``"viewer"`` and the viewer entry in _ROLE_PROMOTIONS is never
+        # ``"viewer"`` and the viewer entry in _EXTERNAL_ROLE_ALIASES is never
         # consulted. map_roles(["viewer"]) returns "user" by virtue of the
         # default, not the promotion.
         import engine.api.auth.base as base_mod
 
-        assert "viewer" in base_mod._ROLE_PROMOTIONS
+        assert "viewer" in base_mod._EXTERNAL_ROLE_ALIASES
         # Even when we remove the entry, the result is the same.
-        original = base_mod._ROLE_PROMOTIONS.pop("viewer")
+        original = base_mod._EXTERNAL_ROLE_ALIASES.pop("viewer")
         try:
             assert provider.map_roles(["viewer"]) == "user"
         finally:
-            base_mod._ROLE_PROMOTIONS["viewer"] = original
+            base_mod._EXTERNAL_ROLE_ALIASES["viewer"] = original
 
 
 # ---------------------------------------------------------------------------
@@ -275,9 +270,7 @@ class TestIAuthProviderDefaults:
         assert result.success is False
         assert "concrete-test" in (result.error or "")
 
-    async def test_create_user_default_error_mentions_provider_name(
-        self, provider
-    ):
+    async def test_create_user_default_error_mentions_provider_name(self, provider):
         result = await provider.create_user(UserInfo())
         assert result.error is not None
         assert provider.name in result.error


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Add strict role allowlist validation in _sanitize_role — the CRITICAL review finding that blocks merge. Add ALLOWED_ROLES frozenset and reject/collapse any role not in the set.

Closes #859
