### PR TITLE
security(ws): fix IP spoofing and channel permissions

### DIFF
--- a/engine/api/ws/auth.py
+++ b/engine/api/ws/auth.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import ipaddress
 import os
 import time
 from dataclasses import dataclass
@@ -191,10 +192,22 @@ def _get_remote_ip(ws: WebSocket) -> str:
     if _TRUSTED_PROXIES and ws.client and ws.client.host in _TRUSTED_PROXIES:
         forwarded = ws.headers.get("x-forwarded-for")
         if forwarded:
-            return forwarded.split(",")[0].strip()
+            ip_str = forwarded.split(",")[-1].strip()
+            try:
+                ipaddress.ip_address(ip_str)
+            except ValueError:
+                pass
+            else:
+                return ip_str
         real_ip = ws.headers.get("x-real-ip")
         if real_ip:
-            return real_ip.strip()
+            ip_str = real_ip.strip()
+            try:
+                ipaddress.ip_address(ip_str)
+            except ValueError:
+                pass
+            else:
+                return ip_str
     if ws.client:
         return ws.client.host
     return "unknown"

--- a/engine/api/ws/permissions.py
+++ b/engine/api/ws/permissions.py
@@ -21,7 +21,7 @@ CHANNEL_PERMISSIONS: dict[str, PermissionCheck] = {
     "orders": PermissionCheck(
         required_scope="read:orders",
         all_scope="read:orders:all",
-        owner_field="symbol",
+        owner_field="account_id",
     ),
     "strategies": PermissionCheck(
         required_scope="read:strategies",

--- a/tests/test_ws_lint_fixes.py
+++ b/tests/test_ws_lint_fixes.py
@@ -346,11 +346,20 @@ class TestCheckChannelAccess:
         ok, err = check_channel_access(
             "orders",
             ["read:orders"],
-            {"symbol": "AAPL"},
-            user_id="u_other",
+            {"account_id": "acct_other"},
+            user_id="acct_mine",
         )
         assert ok is False
         assert err == "403"
+
+    def test_orders_owner_match(self):
+        ok, _err = check_channel_access(
+            "orders",
+            ["read:orders"],
+            {"account_id": "acct_mine"},
+            user_id="acct_mine",
+        )
+        assert ok is True
 
     def test_strategies_owner_match(self):
         ok, _err = check_channel_access(
@@ -517,7 +526,7 @@ class TestGetRemoteIp:
     def test_trusted_proxy_forwarded(self):
         ws = _FakeWebSocket(
             client_host="10.0.0.1",
-            headers={"x-forwarded-for": "9.8.7.6, 10.0.0.1"},
+            headers={"x-forwarded-for": "10.0.0.1, 9.8.7.6"},
         )
         assert _get_remote_ip(ws) == "9.8.7.6"
 
@@ -547,6 +556,30 @@ class TestGetRemoteIp:
             headers={"x-forwarded-for": "9.8.7.6"},
         )
         assert _get_remote_ip(ws) == "10.0.0.2"
+
+    @patch("engine.api.ws.auth._TRUSTED_PROXIES", frozenset({"10.0.0.1"}))
+    def test_trusted_proxy_forwarded_invalid_ip_falls_back(self):
+        ws = _FakeWebSocket(
+            client_host="10.0.0.1",
+            headers={"x-forwarded-for": "10.0.0.1, not-an-ip"},
+        )
+        assert _get_remote_ip(ws) == "10.0.0.1"
+
+    @patch("engine.api.ws.auth._TRUSTED_PROXIES", frozenset({"10.0.0.1"}))
+    def test_trusted_proxy_real_ip_invalid_falls_back(self):
+        ws = _FakeWebSocket(
+            client_host="10.0.0.1",
+            headers={"x-real-ip": "!!!invalid"},
+        )
+        assert _get_remote_ip(ws) == "10.0.0.1"
+
+    @patch("engine.api.ws.auth._TRUSTED_PROXIES", frozenset({"10.0.0.1"}))
+    def test_trusted_proxy_forwarded_multiple_hops(self):
+        ws = _FakeWebSocket(
+            client_host="10.0.0.1",
+            headers={"x-forwarded-for": "1.2.3.4, 5.6.7.8, 9.8.7.6"},
+        )
+        assert _get_remote_ip(ws) == "9.8.7.6"
 
     @patch("engine.api.ws.auth._TRUSTED_PROXIES", frozenset())
     def test_empty_trusted_proxies(self):


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix 3 critical security issues from last review: (1) X-Forwarded-For IP spoofing in engine/api/ws/auth.py - take rightmost IP instead of leftmost, (2) validate extracted IP with ipaddress.ip_address() before returning, (3) change orders channel owner_field from 'symbol' to 'account_id' in engine/api/ws/permissions.py

Closes #883
