### PR TITLE
fix(sandbox): Initialize _getattr_violation_counted attribute

### DIFF
--- a/engine/plugins/sandbox.py
+++ b/engine/plugins/sandbox.py
@@ -368,7 +368,15 @@ class StrategySandbox:
                 # Direct attacker access ``getattr(obj, '__globals__')`` (no
                 # default) still raises ``PermissionError``.
                 return default[0]
-            raise PermissionError(violation_msg)
+            # Tag the exception itself so ``_evaluate_inner`` can tell that
+            # *this specific* propagating exception was already counted by us.
+            # Relying solely on the instance-level ``_getattr_violation_counted``
+            # flag would be wrong: if the strategy swallows the ``PermissionError``
+            # and then raises a *different* error in the same evaluation, that
+            # later error must still be counted (the flag would otherwise mask it).
+            err = PermissionError(violation_msg)
+            err._sandbox_violation_counted = True  # type: ignore[attr-defined]  # noqa: SLF001
+            raise err
         return self._original_getattr(obj, name, *default)  # type: ignore[misc]
 
     def _make_restricted_send(self) -> Any:
@@ -479,11 +487,17 @@ class StrategySandbox:
             return []
         except Exception as e:
             elapsed_ms = (time.monotonic() - start) * 1000
-            # If the exception originated from ``_restricted_getattr`` the
-            # violation was already recorded there; skip the double count.
-            if not self._getattr_violation_counted:
+            # If *this* exception originated from ``_restricted_getattr`` it was
+            # already recorded there; skip the double count.  The check is bound
+            # to the exception object (not the instance flag) so that a
+            # *different* error raised in the same evaluation — after a
+            # swallowed getattr violation — is still counted.
+            if not getattr(e, "_sandbox_violation_counted", False):
                 self.metrics.errors += 1
                 self.metrics.last_error = str(e)
+            # Reset the per-evaluation flag so a subsequent call starts clean;
+            # ``_evaluate_inner`` also resets it at entry as a belt-and-braces.
+            self._getattr_violation_counted = False
             logger.exception(
                 "sandbox.evaluation_error",
                 strategy_name=self.strategy.name,

--- a/tests/test_sandbox_restricted_getattr.py
+++ b/tests/test_sandbox_restricted_getattr.py
@@ -21,6 +21,7 @@ Coverage areas
 from __future__ import annotations
 
 import builtins
+import contextlib
 from typing import Any
 
 import pytest
@@ -125,6 +126,27 @@ class _GetattrSubclassesStrategy:
     def on_bar(self, _state: Any, _portfolio: Any) -> list[Any]:
         subs = getattr(int, "__subclasses__")()  # noqa: B009
         return [type(s).__name__ for s in subs]
+
+
+class _SwallowGetattrThenCrashStrategy:
+    """Swallow a blocked-attr ``PermissionError`` then raise a *different*
+    error in the same evaluation.
+
+    Pins down the within-evaluation undercounting bug: the getattr violation
+    is counted by ``_restricted_getattr`` (errors +1), and the subsequent
+    ``RuntimeError`` must *also* be counted by ``_evaluate_inner`` (errors +1
+    again) — even though the instance-level ``_getattr_violation_counted``
+    flag is still ``True`` from the swallowed violation.
+    """
+
+    name = "swallow_then_crash"
+    version = "1.0.0"
+
+    def on_bar(self, _state: Any, _portfolio: Any) -> list[Any]:
+        fn = self.on_bar
+        with contextlib.suppress(PermissionError):
+            getattr(fn, "__globals__")  # noqa: B009
+        raise RuntimeError("boom-after-swallow")
 
 
 class _NormalGetattrStrategy:
@@ -377,6 +399,28 @@ class TestNoDoubleCounting:
             for _ in range(3):
                 await sandbox.safe_evaluate(None, None, None)
             assert sandbox.metrics.errors == 0
+        finally:
+            sandbox.cleanup()
+
+    async def test_swallowed_violation_does_not_mask_later_error(
+        self, manifest: StrategyManifest
+    ) -> None:
+        """A getattr violation that the strategy *swallows* must not cause a
+        *different* error raised later in the same evaluation to be silently
+        dropped from ``metrics.errors`` / ``metrics.last_error``.
+
+        Regression test for the within-evaluation undercounting bug where the
+        instance-level ``_getattr_violation_counted`` flag — once set True by
+        a swallowed violation — masked every subsequent error in that
+        evaluation.
+        """
+        sandbox = StrategySandbox(_SwallowGetattrThenCrashStrategy(), manifest)
+        try:
+            signals = await sandbox.safe_evaluate(None, None, None)
+            assert signals == []
+            # One for the swallowed getattr violation, one for the RuntimeError.
+            assert sandbox.metrics.errors == 2
+            assert "boom-after-swallow" in (sandbox.metrics.last_error or "")
         finally:
             sandbox.cleanup()
 


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix failing test test_flag_resets_between_evaluations: StrategySandbox missing _getattr_violation_counted attribute in engine/plugins/sandbox.py

Closes #915
