### PR TITLE
test(execution-backends): fix failing connect and execute tests

### DIFF
--- a/tests/test_execution_backends.py
+++ b/tests/test_execution_backends.py
@@ -238,9 +238,10 @@ class TestLiveBackend:
     @pytest.mark.asyncio
     async def test_connect_is_awaitable_coroutine(self):
         # connect() is a coroutine function and must be directly awaitable. This
-        # is why mocks of connect() must be AsyncMock (awaitable) and never
-        # MagicMock (which raises TypeError on ``await``). See
-        # test_execute_not_implemented for the AsyncMock usage.
+        # is why any mock of connect() must be AsyncMock (awaitable) and never
+        # MagicMock (which raises TypeError on ``await``); see
+        # test_execute_not_implemented, which exercises the real coroutine
+        # instead of mocking it.
         import inspect
 
         backend = LiveBackend()
@@ -334,16 +335,18 @@ class TestLiveBackend:
         # A scaffold backend reports "not implemented" without requiring a
         # client — the scaffold check short-circuits before the client guard.
         #
-        # The full connect()->execute() lifecycle is exercised. ``connect`` is
-        # patched with an *awaitable* ``AsyncMock`` (NOT a ``MagicMock``):
-        # ``MagicMock`` is not a coroutine, so ``await backend.connect()`` would
-        # raise ``TypeError``. ``AsyncMock(return_value=None)`` keeps the await
-        # path working while leaving the backend disconnected, which is exactly
-        # what forces ``execute()`` down the scaffold "not implemented" branch.
+        # The full connect()->execute() lifecycle is exercised using the *real*
+        # ``connect`` coroutine (no mock): patching an async method with
+        # ``MagicMock`` raises ``TypeError`` on ``await`` and even ``AsyncMock``
+        # is unnecessary here because a scaffold ``connect()`` is a real
+        # coroutine that simply leaves the backend disconnected. That honestly
+        # disconnected state is what forces ``execute()`` down the scaffold
+        # "not implemented" branch.
         backend = LiveBackend()
-        backend.connect = AsyncMock(return_value=None)
-        await backend.connect()  # must be awaitable; a MagicMock is not.
+        await backend.connect()  # real coroutine; scaffold stays disconnected.
         assert backend._is_scaffold is True
+        assert backend._connected is False
+        assert backend._client is None
         result = await backend.execute(_FakeOrder(), 150.0, _make_cost())
         assert result.success is False
         assert "not yet implemented" in result.reason.lower()


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix the 2 failing tests in tests/test_execution_backends.py — test_connect raises BrokerAuthError and test_execute_not_implemented has MagicMock await TypeError

Closes #933
