### PR TITLE
security(sentry): fix HIGH severity security review findings

### DIFF
--- a/engine/observability/sentry.py
+++ b/engine/observability/sentry.py
@@ -1,8 +1,37 @@
 from __future__ import annotations
 
+import logging
+from typing import Any
+
 import sentry_sdk
 
 from engine.config import settings
+from engine.observability.redact import _scrub_dict, _scrub_value
+
+logger = logging.getLogger(__name__)
+
+
+def _before_send(
+    event: dict[str, Any], _hint: dict[str, Any]
+) -> dict[str, Any]:
+    """Sentry ``before_send`` hook.
+
+    Reuses the structlog redaction logic (``engine.observability.redact``) to
+    strip secrets / PII from the event's ``contexts`` and ``breadcrumbs``
+    before it leaves the process.  Mirrors the guarantee the log redaction
+    processor already provides for log records.
+    """
+    contexts = event.get("contexts")
+    if isinstance(contexts, dict):
+        event["contexts"] = _scrub_dict(contexts)
+
+    breadcrumbs = event.get("breadcrumbs")
+    if isinstance(breadcrumbs, dict):
+        event["breadcrumbs"] = _scrub_dict(breadcrumbs)
+    elif isinstance(breadcrumbs, list):
+        event["breadcrumbs"] = _scrub_value(breadcrumbs)
+
+    return event
 
 
 def setup_sentry() -> None:
@@ -16,7 +45,11 @@ def setup_sentry() -> None:
 
     sentry_sdk.init(
         dsn=settings.sentry_dsn,
+        release=settings.app_version,
+        environment=settings.app_env,
         traces_sample_rate=settings.sentry_traces_sample_rate,
+        send_default_pii=False,
+        before_send=_before_send,
     )
 
 
@@ -29,10 +62,18 @@ def close_sentry() -> None:
     if not sentry_sdk.is_initialized():
         return
 
-    sentry_sdk.flush(timeout=2)
+    flushed = sentry_sdk.flush(timeout=2)
+    if not flushed:
+        logger.warning(
+            "sentry.flush_timeout",
+            extra={
+                "detail": "Sentry failed to flush events within the "
+                "2 s timeout; some events may be lost"
+            },
+        )
 
     client = sentry_sdk.get_client()
     client.close()
 
 
-__all__ = ["close_sentry", "setup_sentry"]
+__all__ = ["_before_send", "close_sentry", "setup_sentry"]

--- a/tests/observability/test_sentry.py
+++ b/tests/observability/test_sentry.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
-from engine.observability.sentry import close_sentry, setup_sentry
+import pytest
+
+from engine.observability.redact import REDACTED
+from engine.observability.sentry import _before_send, close_sentry, setup_sentry
 
 
 class TestSetupSentry:
@@ -27,12 +31,46 @@ class TestSetupSentry:
         ):
             mock_settings.sentry_dsn = "https://example@sentry.io/1"
             mock_settings.sentry_traces_sample_rate = 0.5
+            mock_settings.app_version = "1.2.3"
+            mock_settings.app_env = "production"
             setup_sentry()
 
         mock_init.assert_called_once_with(
             dsn="https://example@sentry.io/1",
+            release="1.2.3",
+            environment="production",
             traces_sample_rate=0.5,
+            send_default_pii=False,
+            before_send=_before_send,
         )
+
+    def test_send_default_pii_disabled(self):
+        """``send_default_pii`` must be False so Sentry never scrapes PII."""
+        with (
+            patch("engine.observability.sentry.settings") as mock_settings,
+            patch("sentry_sdk.init") as mock_init,
+        ):
+            mock_settings.sentry_dsn = "https://example@sentry.io/1"
+            mock_settings.sentry_traces_sample_rate = 0.0
+            mock_settings.app_version = "1.0.0"
+            mock_settings.app_env = "test"
+            setup_sentry()
+
+        assert mock_init.call_args.kwargs["send_default_pii"] is False
+
+    def test_release_and_environment_passed(self):
+        with (
+            patch("engine.observability.sentry.settings") as mock_settings,
+            patch("sentry_sdk.init") as mock_init,
+        ):
+            mock_settings.sentry_dsn = "https://example@sentry.io/1"
+            mock_settings.sentry_traces_sample_rate = 0.0
+            mock_settings.app_version = "9.9.9"
+            mock_settings.app_env = "staging"
+            setup_sentry()
+
+        assert mock_init.call_args.kwargs["release"] == "9.9.9"
+        assert mock_init.call_args.kwargs["environment"] == "staging"
 
 
 class TestCloseSentry:
@@ -51,7 +89,7 @@ class TestCloseSentry:
         mock_client = MagicMock()
         with (
             patch("sentry_sdk.is_initialized", return_value=True),
-            patch("sentry_sdk.flush") as mock_flush,
+            patch("sentry_sdk.flush", return_value=True) as mock_flush,
             patch("sentry_sdk.get_client", return_value=mock_client),
         ):
             close_sentry()
@@ -63,9 +101,180 @@ class TestCloseSentry:
         mock_client = MagicMock()
         with (
             patch("sentry_sdk.is_initialized", return_value=True),
-            patch("sentry_sdk.flush") as mock_flush,
+            patch("sentry_sdk.flush", return_value=True) as mock_flush,
             patch("sentry_sdk.get_client", return_value=mock_client),
         ):
             close_sentry()
 
         assert mock_flush.call_args.kwargs["timeout"] == 2
+
+    def test_close_still_called_when_flush_times_out(self):
+        """Even when flush reports a timeout the client must still be closed."""
+        mock_client = MagicMock()
+        with (
+            patch("sentry_sdk.is_initialized", return_value=True),
+            patch("sentry_sdk.flush", return_value=False),
+            patch("sentry_sdk.get_client", return_value=mock_client),
+        ):
+            close_sentry()
+
+        mock_client.close.assert_called_once()
+
+    def test_flush_timeout_logs_warning(self, caplog):
+        mock_client = MagicMock()
+        with (
+            patch("sentry_sdk.is_initialized", return_value=True),
+            patch("sentry_sdk.flush", return_value=False),
+            patch("sentry_sdk.get_client", return_value=mock_client),
+            caplog.at_level(logging.WARNING, logger="engine.observability.sentry"),
+        ):
+            close_sentry()
+
+        assert any(
+            "sentry.flush_timeout" in rec.message
+            or rec.message == "sentry.flush_timeout"
+            for rec in caplog.records
+        )
+
+    def test_flush_success_does_not_log_warning(self, caplog):
+        mock_client = MagicMock()
+        with (
+            patch("sentry_sdk.is_initialized", return_value=True),
+            patch("sentry_sdk.flush", return_value=True),
+            patch("sentry_sdk.get_client", return_value=mock_client),
+            caplog.at_level(logging.WARNING, logger="engine.observability.sentry"),
+        ):
+            close_sentry()
+
+        assert not any(
+            "flush_timeout" in rec.message for rec in caplog.records
+        )
+
+
+class TestBeforeSend:
+    """``_before_send`` must strip PII from contexts and breadcrumbs."""
+
+    def test_returns_event_unchanged_when_no_pii(self):
+        event = {
+            "event_id": "abc",
+            "message": "all good",
+            "contexts": {"app": {"version": "1.0.0"}},
+        }
+        result = _before_send(dict(event), {})
+        assert result["event_id"] == "abc"
+        assert result["contexts"]["app"]["version"] == "1.0.0"
+
+    def test_accepts_hint_argument(self):
+        """Sentry passes a hint dict as the second positional argument."""
+        event = {"contexts": {}}
+        result = _before_send(event, {"exc_info": ValueError("x")})
+        assert result is event
+
+    def test_scrubs_banned_keys_in_contexts(self):
+        event = {
+            "contexts": {
+                "app": {"version": "1.0.0"},
+                "user": {"token": "leak-me", "password": "secret"},
+            }
+        }
+        result = _before_send(event, {})
+        assert result["contexts"]["user"]["token"] == REDACTED
+        assert result["contexts"]["user"]["password"] == REDACTED
+        assert result["contexts"]["app"]["version"] == "1.0.0"
+
+    def test_scrubs_pii_patterns_in_context_values(self):
+        event = {
+            "contexts": {
+                "request": {"header": "Bearer eyJhbGciOiJIUzI1.supersecret.sig"},
+            }
+        }
+        result = _before_send(event, {})
+        assert "supersecret" not in str(result["contexts"]["request"]["header"])
+
+    def test_scrubs_credit_card_in_context(self):
+        event = {"contexts": {"billing": {"note": "card 4242 4242 4242 4242"}}}
+        result = _before_send(event, {})
+        assert "4242 4242 4242 4242" not in str(result["contexts"]["billing"]["note"])
+
+    def test_scrubs_breadcrumb_data_dicts(self):
+        event = {
+            "breadcrumbs": {
+                "values": [
+                    {
+                        "type": "http",
+                        "message": "request",
+                        "data": {"authorization": "Bearer abc", "ok": "keep"},
+                    },
+                ]
+            }
+        }
+        result = _before_send(event, {})
+        crumb = result["breadcrumbs"]["values"][0]
+        assert crumb["data"]["authorization"] == REDACTED
+        assert crumb["data"]["ok"] == "keep"
+
+    def test_scrubs_pii_in_breadcrumb_messages(self):
+        event = {
+            "breadcrumbs": {
+                "values": [
+                    {"message": "auth header Bearer eyJhbGciOiJIUzI1.secret.sig"},
+                ]
+            }
+        }
+        result = _before_send(event, {})
+        assert "secret" not in str(result["breadcrumbs"]["values"][0]["message"])
+
+    def test_scrubs_breadcrumbs_when_list_form(self):
+        event = {
+            "breadcrumbs": [
+                {"message": "ok", "data": {"token": "leak"}},
+            ]
+        }
+        result = _before_send(event, {})
+        assert result["breadcrumbs"][0]["data"]["token"] == REDACTED
+
+    def test_handles_missing_contexts_and_breadcrumbs(self):
+        event = {"event_id": "x", "message": "no contexts"}
+        result = _before_send(dict(event), {})
+        assert result == event
+
+    def test_handles_none_contexts(self):
+        event = {"contexts": None, "breadcrumbs": None}
+        result = _before_send(event, {})
+        assert result["contexts"] is None
+        assert result["breadcrumbs"] is None
+
+    def test_scrubbed_breadcrumbs_use_new_dict_not_input(self):
+        """``_scrub_dict`` returns fresh structures; the original nested
+        secret survives untouched rather than being replaced in place."""
+        event = {
+            "breadcrumbs": {
+                "values": [{"data": {"token": "leak"}}],
+            }
+        }
+        original_data = event["breadcrumbs"]["values"][0]["data"]
+        result = _before_send(event, {})
+        assert result["breadcrumbs"]["values"][0]["data"]["token"] == REDACTED
+        assert result["breadcrumbs"]["values"][0]["data"] is not original_data
+        assert original_data["token"] == "leak"
+
+
+class TestBeforeSendIntegrationWithScrubDict:
+    """``_before_send`` must reuse ``_scrub_dict`` from the redact module."""
+
+    def test_contexts_match_scrub_dict_output(self):
+        from engine.observability.redact import _scrub_dict
+
+        contexts = {"user": {"password": "p", "name": "alice"}}
+        event = {"contexts": dict(contexts)}
+        result = _before_send(event, {})
+        assert result["contexts"] == _scrub_dict(contexts)
+
+    @pytest.mark.parametrize(
+        "key",
+        ["password", "token", "api_key", "authorization", "secret", "ssn"],
+    )
+    def test_each_banned_key_redacted_in_contexts(self, key: str):
+        event = {"contexts": {"block": {key: "leak"}}}
+        result = _before_send(event, {})
+        assert result["contexts"]["block"][key] == REDACTED


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix HIGH severity security review findings in engine/observability/sentry.py: add send_default_pii=False, attach before_send hook reusing _scrub_dict, set release/environment from settings, and handle flush() return value properly

Closes #946
