### PR TITLE
security(observability): scrub all PII vectors in Sentry events

### DIFF
--- a/engine/observability/sentry.py
+++ b/engine/observability/sentry.py
@@ -1,8 +1,104 @@
 from __future__ import annotations
 
+import re
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
 import sentry_sdk
 
 from engine.config import settings
+
+if TYPE_CHECKING:
+    from sentry_sdk._types import Event, Hint
+
+REDACTED = "***REDACTED***"
+
+# Keys whose *presence* — matched as a case-insensitive substring — marks
+# the associated value as sensitive and therefore redacted in full. The
+# substring approach is deliberate so that compound keys such as
+# ``user_email``, ``refresh_token`` or ``x-api-key`` are caught without an
+# ever-growing allow/deny list.
+_SENSITIVE_KEY_RE = re.compile(
+    r"(authorization|password|passwd|token|secret|api[_-]?key|apikey|cookie|email)",
+    re.IGNORECASE,
+)
+
+# Value-level patterns scrubbed out of free-form strings even when the
+# surrounding key looks innocuous — e.g. an error message that happened to
+# embed a bearer token or a PEM block.
+_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # ``Authorization: Bearer <token>``
+    re.compile(r"(?i)\bBearer\s+[\w\-._~+/=]+"),
+    # JWT-shaped strings: three dot-separated base64url segments, each
+    # >= 16 chars so dotted module paths / version strings are untouched.
+    re.compile(r"\b[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}\b"),
+    # Prefixed provider secrets (Stripe, Slack, GitHub, AWS, …).
+    re.compile(r"\b(?:sk|xoxb|xoxp|ghp|ghs|AKIA)[A-Za-z0-9_\-]{16,}\b"),
+    # PEM blocks — ``[\s\S]`` lets the match span newlines.
+    re.compile(r"-----BEGIN [A-Z0-9 ]+-----[\s\S]+?-----END [A-Z0-9 ]+-----"),
+)
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    """True when ``key`` contains any sensitive substring."""
+    try:
+        return bool(_SENSITIVE_KEY_RE.search(str(key)))
+    except Exception:  # pragma: no cover - defensive for odd key types
+        return False
+
+
+def _scrub_string(value: str) -> str:
+    out = value
+    for pattern in _VALUE_PATTERNS:
+        out = pattern.sub(REDACTED, out)
+    return out
+
+
+def _scrub_value(value: Any) -> Any:  # noqa: PLR0911 - one clear branch per type
+    """Recursively scrub sensitive data from any JSON-shaped value."""
+    if isinstance(value, str):
+        return _scrub_string(value)
+    if isinstance(value, bytes):
+        return _scrub_string(value.decode("utf-8", errors="replace"))
+    if isinstance(value, Mapping):
+        return {k: _scrub_entry(k, v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_scrub_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub_value(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        # Sets are unhashable-after-scrub; fall back to a sorted list so the
+        # result stays deterministic and JSON-serialisable.
+        return sorted({_scrub_value(item) for item in value}, key=repr)
+    return value
+
+
+def _scrub_entry(key: Any, value: Any) -> Any:
+    if _is_sensitive_key(key):
+        return REDACTED
+    return _scrub_value(value)
+
+
+def scrub_event(event: Any) -> Any:
+    """Walk the entire Sentry event/transaction dict and redact secrets.
+
+    The function is intentionally generic: it recurses through every
+    nested mapping, list, tuple and set it encounters, so sensitive data
+    is masked regardless of *where* in the event payload it surfaces
+    (request headers, breadcrumbs, extra, contexts, tags, …).
+    """
+    scrubbed = _scrub_value(event)
+    return scrubbed if isinstance(scrubbed, dict) else event
+
+
+def _before_send(event: Event, _hint: Hint) -> Event | None:
+    """``before_send`` hook — scrub every error/issue event."""
+    return scrub_event(event)
+
+
+def _before_send_transaction(event: Event, _hint: Hint) -> Event | None:
+    """``before_send_transaction`` hook — scrub performance/transaction events."""
+    return scrub_event(event)
 
 
 def setup_sentry() -> None:
@@ -17,6 +113,11 @@ def setup_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.sentry_dsn,
         traces_sample_rate=settings.sentry_traces_sample_rate,
+        before_send=_before_send,
+        before_send_transaction=_before_send_transaction,
+        # Never ship local/stack frame variables — they frequently carry
+        # credentials captured into locals at the point of failure.
+        include_local_variables=False,
     )
 
 
@@ -35,4 +136,4 @@ def close_sentry() -> None:
     client.close()
 
 
-__all__ = ["close_sentry", "setup_sentry"]
+__all__ = ["close_sentry", "scrub_event", "setup_sentry"]

--- a/tests/observability/test_sentry.py
+++ b/tests/observability/test_sentry.py
@@ -1,10 +1,17 @@
-"""Tests for engine.observability.sentry — setup and teardown of the Sentry SDK."""
+"""Tests for engine.observability.sentry — setup, teardown and PII scrubbing."""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from engine.observability.sentry import close_sentry, setup_sentry
+import pytest
+
+from engine.observability.sentry import (
+    REDACTED,
+    close_sentry,
+    scrub_event,
+    setup_sentry,
+)
 
 
 class TestSetupSentry:
@@ -29,10 +36,15 @@ class TestSetupSentry:
             mock_settings.sentry_traces_sample_rate = 0.5
             setup_sentry()
 
-        mock_init.assert_called_once_with(
-            dsn="https://example@sentry.io/1",
-            traces_sample_rate=0.5,
-        )
+        mock_init.assert_called_once()
+        kwargs = mock_init.call_args.kwargs
+        assert kwargs["dsn"] == "https://example@sentry.io/1"
+        assert kwargs["traces_sample_rate"] == 0.5
+        # Local frame variables must never be shipped to Sentry.
+        assert kwargs["include_local_variables"] is False
+        # Both error and transaction events are scrubbed.
+        assert callable(kwargs["before_send"])
+        assert callable(kwargs["before_send_transaction"])
 
 
 class TestCloseSentry:
@@ -69,3 +81,181 @@ class TestCloseSentry:
             close_sentry()
 
         assert mock_flush.call_args.kwargs["timeout"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Sensitive-key scrubbing
+# ---------------------------------------------------------------------------
+
+SENTITIVE_KEYS = pytest.mark.parametrize(
+    "key",
+    [
+        "authorization",
+        "Authorization",
+        "password",
+        "PASSWORD",
+        "token",
+        "access_token",
+        "refresh-token",
+        "id_token",
+        "secret",
+        "client_secret",
+        "api_key",
+        "apikey",
+        "x-api-key",
+        "X-Api-Key",
+        "cookie",
+        "set-cookie",
+        "email",
+        "user_email",
+        "Email-Address",
+    ],
+    ids=lambda v: v.replace(" ", "_"),
+)
+
+
+class TestScrubEventKeys:
+    """Sensitive keys are redacted wherever they appear in the event."""
+
+    @SENTITIVE_KEYS
+    def test_top_level_key_is_redacted(self, key):
+        assert scrub_event({key: "super-secret-value"}) == {key: REDACTED}
+
+    @SENTITIVE_KEYS
+    def test_input_event_is_not_mutated(self, key):
+        event = {key: "super-secret-value"}
+        scrub_event(event)
+        assert event == {key: "super-secret-value"}
+
+    def test_innocuous_keys_are_preserved(self):
+        event = {"message": "hello", "level": "error", "count": 3}
+        assert scrub_event(event) == event
+
+    def test_nested_dict_keys_are_redacted(self):
+        event = {
+            "request": {
+                "headers": {
+                    "Authorization": "Bearer abc.def.ghi1234567890",
+                    "X-Api-Key": "sk_1234567890abcdef",
+                    "Content-Type": "application/json",
+                },
+                "data": {"password": "hunter2", "username": "alice"},
+            }
+        }
+        result = scrub_event(event)
+        assert result["request"]["headers"]["Authorization"] == REDACTED
+        assert result["request"]["headers"]["X-Api-Key"] == REDACTED
+        assert result["request"]["headers"]["Content-Type"] == "application/json"
+        assert result["request"]["data"]["password"] == REDACTED
+        assert result["request"]["data"]["username"] == "alice"
+
+    def test_lists_inside_event_are_walked(self):
+        event = {
+            "breadcrumbs": [
+                {"data": {"token": "t0", "ok": "fine"}},
+                {"data": {"cookie": "c1"}},
+            ]
+        }
+        result = scrub_event(event)
+        assert result["breadcrumbs"][0]["data"]["token"] == REDACTED
+        assert result["breadcrumbs"][0]["data"]["ok"] == "fine"
+        assert result["breadcrumbs"][1]["data"]["cookie"] == REDACTED
+
+    def test_tuples_inside_event_are_walked(self):
+        event = {"frames": ({"secret": "s"}, {"ok": True})}
+        result = scrub_event(event)
+        assert result["frames"][0]["secret"] == REDACTED
+        assert result["frames"][1]["ok"] is True
+
+    def test_deeply_nested_structure(self):
+        event = {"contexts": {"trace": {"extra": {"meta": {"auth": {"token": "deep"}}}}}}
+        assert (
+            scrub_event(event)["contexts"]["trace"]["extra"]["meta"]["auth"]["token"] == REDACTED
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sensitive value patterns (free-form string scrubbing)
+# ---------------------------------------------------------------------------
+
+
+class TestScrubEventValues:
+    """Secret-shaped *values* are masked even under innocuous keys."""
+
+    def test_bearer_token_in_message(self):
+        event = {"message": "fail: Authorization: Bearer eyJhbGci.eyJzdWIiS16chars.e30"}
+        result = scrub_event(event)
+        assert "Bearer eyJhbGci" not in result["message"]
+        assert REDACTED in result["message"]
+
+    def test_jwt_shaped_value(self):
+        jwt = "aaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbb.cccccccccccccccc"
+        event = {"extra": {"detail": f"token was {jwt}"}}
+        result = scrub_event(event)
+        assert jwt not in result["extra"]["detail"]
+        assert REDACTED in result["extra"]["detail"]
+
+    def test_prefixed_provider_secret(self):
+        event = {"tags": {"note": "key=sk_live_1234567890abcdef"}}
+        result = scrub_event(event)
+        assert "sk_live_1234567890abcdef" not in result["tags"]["note"]
+        assert REDACTED in result["tags"]["note"]
+
+    def test_pem_block_is_redacted(self):
+        pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANB\n-----END PRIVATE KEY-----"
+        event = {"extra": {"dump": pem}}
+        result = scrub_event(event)
+        assert "BEGIN PRIVATE KEY" not in result["extra"]["dump"]
+        assert REDACTED in result["extra"]["dump"]
+
+    def test_bytes_value_is_decoded_and_scrubbed(self):
+        event = {
+            "extra": {
+                "blob": b"Authorization: Bearer aaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbb.cccccccccccccccc"
+            }
+        }
+        result = scrub_event(event)
+        assert result["extra"]["blob"] == f"Authorization: {REDACTED}"
+
+    def test_non_dict_event_returned_unchanged(self):
+        assert scrub_event(None) is None
+        assert scrub_event("plain") == "plain"
+
+
+# ---------------------------------------------------------------------------
+# before_send / before_send_transaction wiring
+# ---------------------------------------------------------------------------
+
+
+class TestBeforeSendHooks:
+    """The init hooks scrub events of every category."""
+
+    def test_before_send_scrubs_request_headers(self):
+        from engine.observability.sentry import _before_send
+
+        event = {
+            "request": {"headers": {"Authorization": "Bearer xyz"}},
+            "extra": {"api_key": "abc"},
+        }
+        result = _before_send(event, {})
+        assert result["request"]["headers"]["Authorization"] == REDACTED
+        assert result["extra"]["api_key"] == REDACTED
+
+    def test_before_send_transaction_scrubs_user_email(self):
+        from engine.observability.sentry import _before_send_transaction
+
+        event = {
+            "transaction": "GET /api",
+            "user": {"email": "alice@example.com", "id": "u1"},
+        }
+        result = _before_send_transaction(event, {})
+        assert result["user"]["email"] == REDACTED
+        assert result["user"]["id"] == "u1"
+        assert result["transaction"] == "GET /api"
+
+    def test_hooks_do_not_mutate_original(self):
+        from engine.observability.sentry import _before_send
+
+        event = {"extra": {"password": "p"}}
+        _before_send(event, {})
+        assert event["extra"]["password"] == "p"


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix HIGH severity security review findings in engine/observability/sentry.py: (1) _before_send must recursively scrub all PII vectors (request, extra, user, tags, exception stacktrace vars, headers, cookies, query_string), not just contexts/breadcrumbs; (2) add with_locals=False to sentry_sdk.init to prevent local variable capture; (3) register before_send_transaction hook with same scrubbing for transaction events

Closes #952
