### PR TITLE
fix(observability): Address HIGH severity redaction findings

### DIFF
--- a/engine/observability/redact.py
+++ b/engine/observability/redact.py
@@ -17,38 +17,59 @@ REDACTED = "***REDACTED***"
 
 _BANNED_KEYS_LOWER = frozenset(
     {
-        # explicit secrets
+        # explicit secrets / passwords
         "password",
         "passwd",
         "pw",
-        "pass",
+        "pwd",
+        "passphrase",
+        "passcode",
+        # tokens
         "token",
         "auth_token",
         "access_token",
         "refresh_token",
         "session_token",
         "id_token",
+        "jwt",
+        "csrf_token",
+        "otp",
+        "mfa_code",
+        "verification_code",
+        # secrets / keys
         "secret",
         "client_secret",
+        "webhook_secret",
+        "signing_secret",
         "private_key",
         "ssh_key",
+        "signing_key",
+        "encryption_key",
+        "mfa_encryption_key",
         "api_key",
         "apikey",
         "x_api_key",
         "x_auth_token",
+        "credentials",
         # auth payloads
         "authorization",
         "auth",
         "bearer",
         "cookie",
         "set_cookie",
-        # PII / cards
+        "session_id",
+        # PII / cards / banking
         "credit_card",
         "creditcard",
         "card_number",
         "cardnumber",
         "cvv",
         "ssn",
+        "iban",
+        "swift_code",
+        "routing_number",
+        "bank_account",
+        "account_number",
     }
 )
 
@@ -63,28 +84,95 @@ def _is_banned(key: object) -> bool:
         return False
 
 
+# ---------------------------------------------------------------------------
+# Value-level patterns
+# ---------------------------------------------------------------------------
+
 _VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     # Bearer / authorization tokens
     re.compile(r"(?i)\bBearer\s+[\w\-._~+/=]+"),
-    # JWT-shaped: 3 dot-separated base64url segments, each ≥16 chars to
-    # avoid matching dotted module paths or version strings
+    # JWT-shaped tokens that start with ``eyJ`` (the base64url encoding of
+    # ``{"`` — every JSON-object JWT header *and* payload begins with it).
+    # Catches shorter tokens that the generic 16-char pattern misses.
+    re.compile(r"\beyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\b"),
+    # Generic 3-segment base64url blobs (each >=16 chars) — catches opaque
+    # tokens / dotted secrets that don't start with eyJ.
     re.compile(r"\b[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}\b"),
-    # 13-19 digit blocks with optional separators (PAN-shaped). Anchored
-    # to non-word boundaries so it survives most word-boundary edge cases.
-    re.compile(r"\b(?:\d[ \-]?){13,19}\b"),
-    # Prefixed secrets (Slack, Stripe, GitHub, AWS access keys)
-    re.compile(r"\b(?:sk|xoxb|xoxp|ghp|ghs|AKIA)[A-Za-z0-9_\-]{16,}\b"),
+    # Prefixed secrets (Stripe sk-/pk-, Slack, GitHub, AWS access keys)
+    re.compile(r"\b(?:sk|xoxb|xoxp|ghp|ghs|pk|AKIA)[A-Za-z0-9_\-]{16,}\b"),
     # PEM blocks (multi-line). Use [\s\S] so it crosses newlines without
     # needing re.DOTALL on the engine.
     re.compile(r"-----BEGIN [A-Z0-9 ]+-----[\s\S]+?-----END [A-Z0-9 ]+-----"),
 )
+
+# PAN-shaped digit runs (13-19 digits, optional separators). Each candidate
+# is validated against the Luhn checksum so that non-card digit sequences
+# (phone numbers, reference IDs, …) are preserved.
+_PAN_PATTERN = re.compile(r"\b(?:\d[ \-]?){13,19}\b")
+
+# Inline key=value / key:value secret pairs, e.g. ``password=hunter2`` or
+# ``api_key: secret``. Only the *value* is replaced; the key and separator
+# are preserved. Keys use ``[_-]?`` so that ``api_key``, ``api-key`` and
+# ``apikey`` are all matched by a single alternative.
+_KV_KEYS = (
+    r"password|passwd|pwd|passphrase|passcode|secret|client[_-]?secret|"
+    r"webhook[_-]?secret|signing[_-]?secret|api[_-]?key|apikey|token|"
+    r"auth[_-]?token|access[_-]?token|refresh[_-]?token|session[_-]?token|"
+    r"id[_-]?token|jwt|csrf[_-]?token|otp|mfa[_-]?code|"
+    r"verification[_-]?code|private[_-]?key|ssh[_-]?key|signing[_-]?key|"
+    r"encryption[_-]?key|mfa[_-]?encryption[_-]?key|x[_-]?api[_-]?key|"
+    r"x[_-]?auth[_-]?token|credentials|authorization|auth|bearer|cookie|"
+    r"set[_-]?cookie|session[_-]?id|credit[_-]?card|card[_-]?number|cvv|ssn|"
+    r"iban|swift[_-]?code|routing[_-]?number|bank[_-]?account|"
+    r"account[_-]?number"
+)
+_KV_PATTERN = re.compile(rf"(?i)\b({_KV_KEYS})(\s*[=:]\s*)(\S+)")
+
+
+_PAN_MIN_DIGITS = 13
+_PAN_MAX_DIGITS = 19
+_DIGIT_WRAP = 9
+
+
+def _luhn_valid(candidate: str) -> bool:
+    """Return True if *candidate* passes the Luhn checksum.
+
+    *candidate* is a digit run that may include space/hyphen separators.
+    """
+    digits = re.sub(r"[^0-9]", "", candidate)
+    if len(digits) < _PAN_MIN_DIGITS or len(digits) > _PAN_MAX_DIGITS:
+        return False
+    total = 0
+    for i, ch in enumerate(reversed(digits)):
+        d = int(ch)
+        if i % 2 == 1:
+            d *= 2
+            if d > _DIGIT_WRAP:
+                d -= _DIGIT_WRAP
+        total += d
+    return total % 10 == 0
+
+
+def _redact_pans(s: str) -> str:
+    """Redact Luhn-valid PAN-shaped runs; leave other digit sequences intact."""
+
+    def _maybe(m: re.Match[str]) -> str:
+        return REDACTED if _luhn_valid(m.group(0)) else m.group(0)
+
+    return _PAN_PATTERN.sub(_maybe, s)
+
+
+def _redact_kv(s: str) -> str:
+    """Redact values in inline ``key=value`` / ``key: value`` secret pairs."""
+    return _KV_PATTERN.sub(rf"\1\2{REDACTED}", s)
 
 
 def _scrub_string(s: str) -> str:
     out = s
     for pat in _VALUE_PATTERNS:
         out = pat.sub(REDACTED, out)
-    return out
+    out = _redact_pans(out)
+    return _redact_kv(out)
 
 
 def _scrub_value(value: Any) -> Any:  # noqa: PLR0911 - clear branch per type
@@ -125,9 +213,7 @@ def scrub_pii(event_dict: dict[str, Any]) -> dict[str, Any]:
     return _scrub_dict(dict(event_dict))
 
 
-def redact_processor(
-    _logger: WrappedLogger, _name: str, event_dict: EventDict
-) -> EventDict:
+def redact_processor(_logger: WrappedLogger, _name: str, event_dict: EventDict) -> EventDict:
     """structlog processor entry point. Returns a new dict; input is not mutated."""
     return _scrub_dict(dict(event_dict))
 

--- a/tests/observability/test_redact.py
+++ b/tests/observability/test_redact.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import typing
+
 import pytest
 
 from engine.observability.redact import (
     _BANNED_KEYS_LOWER,
     REDACTED,
+    _scrub_string,
     _scrub_value,
     redact_processor,
     scrub_pii,
@@ -58,9 +61,7 @@ class TestNestedRedaction:
     def test_nested_dict_redacts_inner_banned_key(self):
         # When the outer key is *not* banned, recursion redacts the
         # banned inner key while preserving siblings.
-        out = _emit(
-            {"event": "x", "payload": {"token": "leak", "user": "ok"}}
-        )
+        out = _emit({"event": "x", "payload": {"token": "leak", "user": "ok"}})
         assert out["payload"]["token"] == REDACTED
         assert out["payload"]["user"] == "ok"
 
@@ -78,11 +79,7 @@ class TestPatternRedaction:
     def test_jwt_like_string_value_redacted(self):
         # Real JWT segments are 16+ chars; the regex requires that to
         # avoid matching dotted module paths.
-        jwt_like = (
-            "aaaaaaaaaaaaaaaaaaaa."
-            "bbbbbbbbbbbbbbbbbbbb."
-            "cccccccccccccccc-dddd"
-        )
+        jwt_like = "aaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccc-dddd"
         out = _emit({"event": "x", "note": f"token={jwt_like}"})
         assert jwt_like not in str(out["note"])
 
@@ -189,3 +186,272 @@ class TestScrubPiiRoundTrip:
     def test_scrub_pii_redacts_banned_key(self):
         out = scrub_pii({"event": "x", "api_key": "leak"})
         assert out["api_key"] == REDACTED
+
+
+# ---------------------------------------------------------------------------
+# Expanded banned-key set
+# ---------------------------------------------------------------------------
+
+
+class TestExpandedBannedKeys:
+    """Every newly-added sensitive field name must be redacted as a key."""
+
+    NEW_KEYS: typing.ClassVar[list[str]] = [
+        "pwd",
+        "passphrase",
+        "passcode",
+        "credentials",
+        "iban",
+        "swift_code",
+        "routing_number",
+        "otp",
+        "mfa_code",
+        "verification_code",
+        "signing_key",
+        "encryption_key",
+        "webhook_secret",
+        "signing_secret",
+        "jwt",
+        "session_id",
+        "csrf_token",
+        "bank_account",
+        "account_number",
+        "mfa_encryption_key",
+    ]
+
+    @pytest.mark.parametrize("key", NEW_KEYS)
+    def test_new_key_redacted(self, key: str):
+        assert key in _BANNED_KEYS_LOWER
+        out = _emit({"event": "x", key: "leak-me"})
+        assert out[key] == REDACTED
+
+    @pytest.mark.parametrize("key", NEW_KEYS)
+    def test_new_key_case_insensitive(self, key: str):
+        out = _emit({"event": "x", key.upper(): "leak-me"})
+        assert out[key.upper()] == REDACTED
+
+    @pytest.mark.parametrize("key", NEW_KEYS)
+    def test_new_key_hyphen_variant(self, key: str):
+        hyphen_key = key.replace("_", "-")
+        out = _emit({"event": "x", hyphen_key: "leak-me"})
+        assert out[hyphen_key] == REDACTED
+
+    def test_nested_new_key_redacted(self):
+        out = _emit({"event": "x", "payload": {"iban": "GB29NWBK", "name": "ok"}})
+        assert out["payload"]["iban"] == REDACTED
+        assert out["payload"]["name"] == "ok"
+
+
+class TestPassNotBanned:
+    """The ambiguous 'pass' key is no longer banned; precise alternatives are."""
+
+    def test_pass_key_preserved(self):
+        assert "pass" not in _BANNED_KEYS_LOWER
+        out = _emit({"event": "x", "pass": "boarding"})
+        assert out["pass"] == "boarding"
+
+    def test_precise_alternatives_present(self):
+        for k in ("pwd", "passphrase", "passcode", "passwd", "password"):
+            assert k in _BANNED_KEYS_LOWER
+
+
+# ---------------------------------------------------------------------------
+# Value-level pattern redaction
+# ---------------------------------------------------------------------------
+
+
+class TestJwtEyJPattern:
+    """JWTs starting with eyJ are redacted, including short-segment variants."""
+
+    def test_real_jwt_redacted(self):
+        jwt = (
+            "eyJhbGciOiJIUzI1NiJ9."
+            "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+            "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        )
+        out = _emit({"event": "x", "note": f"auth {jwt}"})
+        assert jwt not in str(out["note"])
+
+    def test_short_jwt_segment_redacted(self):
+        # Segments shorter than 16 chars — only the eyJ pattern catches this.
+        jwt = "eyJhbGci.eyJzdWI.Xbmd"
+        out = _emit({"event": "x", "note": jwt})
+        assert jwt not in str(out["note"])
+
+    def test_short_jwt_in_kv_pair_redacted(self):
+        jwt = "eyJhbGci.eyJzdWI.Xbmd"
+        out = _emit({"event": "x", "note": f"token={jwt}"})
+        assert jwt not in str(out["note"])
+
+    def test_non_jwt_dotted_string_preserved(self):
+        # Dotted module paths / versions must NOT be redacted.
+        s = "package.module.v1.2.3"
+        out = _emit({"event": "x", "note": s})
+        assert out["note"] == s
+
+
+class TestApiKeyPrefixPatterns:
+    """Prefixed secrets (sk-, pk-, AKIA, …) are redacted in values."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "sk_live_abc123def456ghi7",  # Stripe secret
+            "sk_test_abcdefghijklmnop",  # Stripe test secret
+            "pk_live_abc123def456ghi7",  # Stripe publishable
+            "AKIAIOSFODNN7EXAMPLEabc",  # AWS access key + extra
+            "ghp_abc123def456ghi7jkl",  # GitHub PAT
+            "xoxb_abc123def456ghi7jkl",  # Slack bot token
+        ],
+    )
+    def test_prefixed_secret_redacted(self, value: str):
+        out = _emit({"event": "x", "note": f"key={value} done"})
+        assert value not in str(out["note"])
+
+    def test_short_prefix_not_redacted(self):
+        # A prefix followed by too few chars (<16) is not a secret.
+        s = "sk-short"
+        out = _emit({"event": "x", "note": s})
+        assert out["note"] == s
+
+
+class TestBearerTokenRedaction:
+    def test_bearer_redacted(self):
+        out = _emit({"event": "x", "header": "Bearer abc123def456"})
+        assert "abc123def456" not in str(out["header"])
+
+    def test_bearer_case_insensitive(self):
+        out = _emit({"event": "x", "header": "bearer abc123def456"})
+        assert "abc123def456" not in str(out["header"])
+
+    def test_bearer_with_special_chars(self):
+        out = _emit({"event": "x", "header": "Bearer a.b_c-d~e/f+g=h"})
+        assert "a.b_c-d~e/f+g=h" not in str(out["header"])
+
+
+class TestLuhnCreditCardRedaction:
+    """Only Luhn-valid digit sequences (real card numbers) are redacted."""
+
+    @pytest.mark.parametrize(
+        "card",
+        [
+            "4242424242424242",  # Visa test
+            "4111111111111111",  # Visa test
+            "5555555555554444",  # Mastercard test
+            "378282246310005",  # Amex test (15 digits)
+            "4242 4242 4242 4242",  # spaced
+            "4242-4242-4242-4242",  # dashed
+            "4242424242424242428",  # 19 digits (Luhn-valid)
+        ],
+    )
+    def test_valid_card_redacted(self, card: str):
+        out = _emit({"event": "x", "note": f"card {card} declined"})
+        assert card not in str(out["note"])
+
+    @pytest.mark.parametrize(
+        "seq",
+        [
+            "1234567890123",  # 13 digits, not Luhn-valid
+            "9999999999999",  # 13 digits, not Luhn-valid
+            "1111111111111111",  # 16 digits, not Luhn-valid
+            "2222222222222222",  # 16 digits, not Luhn-valid
+        ],
+    )
+    def test_non_luhn_sequence_preserved(self, seq: str):
+        out = _emit({"event": "x", "note": f"id {seq} done"})
+        assert seq in str(out["note"])
+
+    def test_short_digit_sequence_preserved(self):
+        s = "order #1234567890"
+        out = _emit({"event": "x", "note": s})
+        assert out["note"] == s
+
+    def test_luhn_helper_valid(self):
+        from engine.observability.redact import _luhn_valid
+
+        assert _luhn_valid("4242424242424242") is True
+        assert _luhn_valid("4242 4242 4242 4242") is True
+        assert _luhn_valid("4242424242424242428") is True
+
+    def test_luhn_helper_invalid(self):
+        from engine.observability.redact import _luhn_valid
+
+        assert _luhn_valid("1234567890123") is False
+        assert _luhn_valid("1111111111111111") is False
+        assert _luhn_valid("2222222222222222") is False
+
+
+class TestInlineKeyValueRedaction:
+    """Inline ``key=value`` secret pairs have their values redacted."""
+
+    @pytest.mark.parametrize(
+        "pair",
+        [
+            "password=hunter2",
+            "pwd=hunter2",
+            "passphrase=mysecret",
+            "api_key=sk_live_abc123",
+            "apikey=sk_live_abc123",
+            "secret=topsecret",
+            "token=abc123def456",
+            "access_token=abc123",
+            "authorization=Bearer xyz",
+            "iban=GB29NWBK60161331926819",
+            "cvv=123",
+            "ssn=123-45-6789",
+            "otp=987654",
+            "mfa_code=987654",
+            "session_id=abc123",
+        ],
+    )
+    def test_kv_pair_value_redacted(self, pair: str):
+        out = _emit({"event": "x", "note": f"config {pair} end"})
+        result = str(out["note"])
+        # The key and separator are preserved; only the value is replaced.
+        key_part = pair.split("=", 1)[0]
+        assert key_part in result
+        assert REDACTED in result
+        assert pair not in result
+
+    def test_kv_colon_separator(self):
+        out = _emit({"event": "x", "note": "secret: topsecret"})
+        assert "topsecret" not in str(out["note"])
+        assert "secret:" in str(out["note"])
+
+    def test_kv_with_spaces(self):
+        out = _emit({"event": "x", "note": "password = hunter2"})
+        assert "hunter2" not in str(out["note"])
+
+    def test_kv_hyphenated_key(self):
+        out = _emit({"event": "x", "note": "api-key=sk_live_abc123"})
+        assert "sk_live_abc123" not in str(out["note"])
+
+    def test_non_secret_kv_preserved(self):
+        s = "host=localhost port=5432"
+        out = _emit({"event": "x", "note": s})
+        assert out["note"] == s
+
+    def test_kv_preserves_surrounding_text(self):
+        out = _emit({"event": "x", "note": "pre password=secret post"})
+        result = out["note"]
+        assert result.startswith("pre ")
+        assert result.endswith(" post")
+        assert "secret" not in result
+
+
+class TestScrubeStringEdgeCases:
+    """_scrub_string must not corrupt benign strings."""
+
+    def test_empty_string(self):
+        assert _scrub_string("") == ""
+
+    def test_plain_text_unchanged(self):
+        s = "The quick brown fox jumps over the lazy dog."
+        assert _scrub_string(s) == s
+
+    def test_url_preserved(self):
+        s = "https://example.com/path?key=value&page=1"
+        # `key=value` inside a URL query string — `key` is not a banned key
+        # name, so the whole URL is preserved.
+        out = _scrub_string(s)
+        assert "example.com" in out


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Address HIGH severity security review findings in engine/observability/redact.py: missing banned keys, no value-pattern regex redaction, and 'pass' key ambiguity

Closes #954
