### PR TITLE
fix(test): sync sqlite schema with user model

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from sqlalchemy import event as sa_event
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.pool import StaticPool
 
 from engine.api.auth.dependency import get_current_user
@@ -33,6 +34,12 @@ from engine.config import settings
 from engine.db.models import Base, User
 from engine.deps import get_db
 from engine.legal.dependencies import require_legal_acceptance
+
+# SQLite has no native JSONB. Register the compile override exactly once, at
+# import time, so *every* test module and every ad-hoc SQLite engine can run
+# ``Base.metadata.create_all`` without each re-registering it. This is the
+# single source of truth for the JSONB→TEXT override across the suite.
+compiles(JSONB, "sqlite")(lambda type_, compiler, **kw: "TEXT")
 
 
 async def _noop_legal_acceptance() -> None:
@@ -127,10 +134,6 @@ def _build_test_engine() -> tuple[AsyncEngine, bool]:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-
-    from sqlalchemy.ext.compiler import compiles
-
-    compiles(JSONB, "sqlite")(lambda type_, compiler, **kw: "TEXT")
 
     @sa_event.listens_for(engine.sync_engine, "connect")
     def _set_sqlite_pragma(dbapi_conn, _connection_record):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -41,6 +41,7 @@ async def auth_engine():
         Column("hashed_password", String(255), nullable=True),
         Column("display_name", String(100), nullable=False),
         Column("is_active", Boolean, default=True),
+        Column("processing_restricted", Boolean, default=False, nullable=False),
         Column("role", String(20), default="user"),
         Column("auth_provider", String(20), default="local"),
         Column("external_id", String(255), nullable=True),

--- a/tests/test_auth_e2e.py
+++ b/tests/test_auth_e2e.py
@@ -52,6 +52,7 @@ def _build_metadata() -> MetaData:
         Column("hashed_password", String(255), nullable=True),
         Column("display_name", String(100), nullable=False),
         Column("is_active", Boolean, default=True),
+        Column("processing_restricted", Boolean, default=False, nullable=False),
         Column("role", String(20), default="user"),
         Column("auth_provider", String(20), default="local"),
         Column("external_id", String(255), nullable=True),
@@ -88,6 +89,29 @@ def _build_metadata() -> MetaData:
         Column("created_at", DateTime, default=datetime.now),
     )
     return metadata
+
+
+class TestE2ESchemaDriftGuard:
+    """Pin the hand-built e2e schema to the ORM ``User`` model.
+
+    The e2e suite deliberately builds a lightweight SQLite schema instead of
+    running ``Base.metadata.create_all`` (which would drag in every table).
+    Any column added to :class:`engine.db.models.User` therefore has to be
+    mirrored in ``_build_metadata`` or the real ORM queries fail with
+    ``no such column``. This test makes that drift fail loudly here instead
+    of surfacing as ``OperationalError`` in dozens of unrelated auth tests.
+    """
+
+    def test_e2e_users_schema_has_every_user_model_column(self):
+        from engine.db.models import User
+
+        model_cols = {c.name for c in User.__table__.columns}
+        schema_cols = set(_build_metadata().tables["users"].columns.keys())
+        missing = model_cols - schema_cols
+        assert not missing, (
+            "The e2e users schema is missing columns that exist on the User "
+            f"model: {sorted(missing)}. Add them to _build_metadata()."
+        )
 
 
 @pytest.fixture

--- a/tests/test_legal_documents_schema.py
+++ b/tests/test_legal_documents_schema.py
@@ -28,9 +28,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from sqlalchemy import inspect, select, text
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.pool import StaticPool
 
 from engine.db.models import Base, LegalAcceptance, LegalDocument
@@ -39,9 +37,6 @@ from engine.legal.service import get_pending_acceptances
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-
-# SQLite has no JSONB; mirror the conftest override so create_all can run.
-compiles(JSONB, "sqlite")(lambda type_, compiler, **kw: "TEXT")
 
 
 def _sqlite_engine():


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix the 25 failing tests caused by 'no such column: users.processing_restricted' — the SQLite test schema is out of sync with the User model. Add the missing column to the test database setup.

Closes #962
