### PR TITLE
fix(engine): harden orchestrator against mutation and timeouts

### DIFF
--- a/engine/core/strategy_orchestrator.py
+++ b/engine/core/strategy_orchestrator.py
@@ -1,0 +1,341 @@
+"""Strategy orchestrator.
+
+Run many strategies against identical inputs and merge their emitted
+signals into a single decision set.
+
+The orchestrator owns three responsibilities that the lower-level
+``SignalAggregator`` (gh#21) deliberately does not:
+
+1. Registry - strategies are registered with a per-strategy ``weight``
+   that the ``weighted`` aggregation mode consults.
+2. Evaluation - every registered strategy is invoked with the *same*
+   ``market_data`` and ``cost_model`` so cross-strategy comparisons are
+   apples-to-apples. A single failing strategy is isolated: its error is
+   recorded and the remaining strategies still contribute to the vote.
+3. Aggregation dispatch - the collected per-strategy ``SignalBatch``
+   objects are handed to ``SignalAggregator``, which already implements
+   the per-symbol majority/weighted resolution logic with HOLD-as-abstain
+   semantics. Reusing it keeps a single source of truth for tie handling.
+
+Aggregation modes
+-----------------
+
+majority / majority_vote
+    Each strategy that takes a position (BUY or SELL) casts one equal
+    vote. A side wins only if it takes strictly more than half of the
+    BUY-vs-SELL votes; a tie (e.g. 1 BUY vs 1 SELL) emits HOLD. HOLD
+    signals abstain and do not count toward the denominator.
+
+weighted
+    Each strategy's vote is multiplied by its registered weight
+    (default 1.0). The side with the strictly higher total weight wins;
+    a tie emits HOLD. This lets a high-conviction strategy override a
+    numerical majority.
+
+Both modes return HOLD for a symbol when no strategy expresses an
+opinion beyond HOLD, so downstream consumers always get a record that
+the symbol was considered.
+
+Relationship to SignalAggregator
+    The orchestrator builds one ``SignalBatch`` per strategy from its
+    raw signals, then delegates. It never reimplements voting math.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from engine.core.signal import Side, Signal, SignalBatch
+from engine.core.signal_aggregator import (
+    AggregationMethod,
+    SignalAggregator,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from typing import Protocol
+
+    class StrategyLike(Protocol):
+        """Structural contract for anything the orchestrator can run.
+
+        ``id`` may be a string attribute or a no-arg callable/property.
+        ``evaluate`` may be sync OR async; the orchestrator awaits
+        awaitable results transparently.
+        """
+
+        @property
+        def id(self) -> str: ...
+
+        def evaluate(
+            self, market_data: Any, cost_model: Any
+        ) -> list[Signal] | Awaitable[list[Signal]]: ...
+
+
+logger = structlog.get_logger()
+
+
+class StrategyOrchestratorError(ValueError):
+    """Bad orchestrator configuration: unknown aggregation mode,
+    invalid weight, or a strategy missing its ``id`` / ``evaluate``."""
+
+
+class AggregationMode(StrEnum):
+    """Orchestrator-level aggregation selectors.
+
+    ``MAJORITY`` and ``MAJORITY_VOTE`` are intentional aliases - the
+    former reads naturally as the default, the latter matches the mode
+    name used in design docs.
+    """
+
+    MAJORITY = "majority"
+    MAJORITY_VOTE = "majority_vote"
+    WEIGHTED = "weighted"
+
+
+# Map orchestrator-level mode -> underlying SignalAggregator method.
+# Both majority aliases collapse to the same one-vote-per-strategy
+# majority; they exist purely for ergonomic call sites.
+_MODE_TO_METHOD: dict[AggregationMode, AggregationMethod] = {
+    AggregationMode.MAJORITY: AggregationMethod.MAJORITY,
+    AggregationMode.MAJORITY_VOTE: AggregationMethod.MAJORITY,
+    AggregationMode.WEIGHTED: AggregationMethod.WEIGHTED,
+}
+
+
+@dataclass(frozen=True)
+class OrchestrationResult:
+    """Outcome of one ``evaluate_all`` cycle.
+
+    The result is intentionally richer than a bare ``list[Signal]``:
+    ``batches`` gives full per-strategy provenance for audit/traceability,
+    and ``errors`` reports any strategy that raised so a misbehaving
+    plugin can never silently disappear from the record.
+    """
+
+    signals: list[Signal] = field(default_factory=list)
+    batches: list[SignalBatch] = field(default_factory=list)
+    aggregation: str = ""
+    strategy_count: int = 0
+    weights: dict[str, float] = field(default_factory=dict)
+    errors: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def trade_signals(self) -> list[Signal]:
+        """Aggregated signals that express a non-HOLD intent."""
+        return [s for s in self.signals if s.side != Side.HOLD]
+
+    @property
+    def is_noop(self) -> bool:
+        """True when no aggregated signal was produced at all (e.g. an
+        empty registry, or every strategy returned no signals)."""
+        return len(self.signals) == 0
+
+
+def _strategy_id(strategy: StrategyLike) -> str:
+    """Resolve a strategy's identifier, accepting either a string
+    attribute or a no-arg callable/property."""
+    sid = getattr(strategy, "id", None)
+    if callable(sid):
+        sid = sid()
+    if not isinstance(sid, str) or not sid:
+        raise StrategyOrchestratorError(
+            f"strategy must expose a non-empty string `id`, got {sid!r}"
+        )
+    return sid
+
+
+def _validate_weight(weight: float, strategy_id: str) -> float:
+    try:
+        value = float(weight)
+    except (TypeError, ValueError) as exc:
+        raise StrategyOrchestratorError(
+            f"weight for strategy {strategy_id!r} must be a number, "
+            f"got {weight!r}"
+        ) from exc
+    if not math.isfinite(value):
+        raise StrategyOrchestratorError(
+            f"weight for strategy {strategy_id!r} must be finite, got {weight!r}"
+        )
+    if value < 0:
+        raise StrategyOrchestratorError(
+            f"weight for strategy {strategy_id!r} must be non-negative, "
+            f"got {value!r}"
+        )
+    return value
+
+
+def _resolve_mode(aggregation: object) -> AggregationMode:
+    try:
+        return AggregationMode(aggregation)
+    except ValueError as exc:
+        valid = ", ".join(sorted(m.value for m in AggregationMode))
+        raise StrategyOrchestratorError(
+            f"unknown aggregation mode {aggregation!r}; "
+            f"expected one of {valid}"
+        ) from exc
+
+
+class StrategyOrchestrator:
+    """Owns a weighted set of strategies and merges their signals.
+
+    Construct once, :meth:`register` the strategies you want to run, then
+    call :meth:`evaluate_all` each evaluation cycle with the shared
+    market data and cost model.
+    """
+
+    def __init__(self) -> None:
+        # Insertion-ordered so evaluate_all iterates deterministically.
+        self._strategies: dict[str, StrategyLike] = {}
+        self._weights: dict[str, float] = {}
+
+    # -- registry introspection ----------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._strategies)
+
+    def __contains__(self, strategy_id: object) -> bool:
+        return strategy_id in self._strategies
+
+    @property
+    def strategy_ids(self) -> list[str]:
+        """Registered strategy ids in registration order."""
+        return list(self._strategies)
+
+    @property
+    def weights(self) -> dict[str, float]:
+        """Snapshot of the per-strategy weights."""
+        return dict(self._weights)
+
+    def get_weight(self, strategy_id: str) -> float | None:
+        """Weight for ``strategy_id``, or ``None`` if unregistered."""
+        return self._weights.get(strategy_id)
+
+    # -- registration --------------------------------------------------
+
+    def register(self, strategy: StrategyLike, weight: float = 1.0) -> None:
+        """Register ``strategy`` with the given ``weight`` (default 1.0).
+
+        Re-registering an id updates both the strategy instance and its
+        weight (a warning is logged so the overwrite is never silent).
+        ``weight`` must be a finite, non-negative number.
+        """
+        sid = _strategy_id(strategy)
+        if not callable(getattr(strategy, "evaluate", None)):
+            raise StrategyOrchestratorError(
+                f"strategy {sid!r} must expose a callable `evaluate` method"
+            )
+        value = _validate_weight(weight, sid)
+        if sid in self._strategies:
+            logger.warning(
+                "orchestrator.reregister",
+                strategy_id=sid,
+                old_weight=self._weights.get(sid),
+                new_weight=value,
+            )
+        self._strategies[sid] = strategy
+        self._weights[sid] = value
+        logger.info(
+            "orchestrator.registered", strategy_id=sid, weight=value
+        )
+
+    def unregister(self, strategy_id: str) -> bool:
+        """Remove ``strategy_id``. Returns True if it was present."""
+        existed = self._strategies.pop(strategy_id, None) is not None
+        self._weights.pop(strategy_id, None)
+        if existed:
+            logger.info("orchestrator.unregistered", strategy_id=strategy_id)
+        return existed
+
+    # -- evaluation ----------------------------------------------------
+
+    async def evaluate_all(
+        self,
+        market_data: Any,
+        cost_model: Any,
+        aggregation: str = AggregationMode.MAJORITY.value,
+    ) -> OrchestrationResult:
+        """Evaluate every registered strategy against the same
+        ``market_data`` and ``cost_model`` and aggregate the results.
+
+        Parameters
+        ----------
+        market_data, cost_model:
+            Forwarded verbatim to each strategy's ``evaluate``.
+        aggregation:
+            One of ``majority`` (default), ``majority_vote`` (alias), or
+            ``weighted``.
+
+        Returns
+        -------
+        OrchestrationResult
+            ``signals`` holds the aggregated decisions; ``batches`` the
+            raw per-strategy signals; ``errors`` maps any failed
+            strategy id to its error message.
+
+        Raises
+        ------
+        StrategyOrchestratorError
+            If ``aggregation`` is not a known mode.
+        SignalAggregatorError
+            If ``weighted`` is used with all-zero weights (a genuine
+            misconfiguration surfaced from the aggregator).
+        """
+        mode = _resolve_mode(aggregation)
+
+        # Empty registry -> no-op. Short-circuit before building an
+        # aggregator so callers get a clean, empty result.
+        if not self._strategies:
+            return OrchestrationResult(
+                signals=[],
+                batches=[],
+                aggregation=mode.value,
+                strategy_count=0,
+                weights={},
+                errors={},
+            )
+
+        batches: list[SignalBatch] = []
+        errors: dict[str, str] = {}
+        for sid, strategy in self._strategies.items():
+            try:
+                raw = strategy.evaluate(market_data, cost_model)
+                # Support both sync (returns list) and async (returns
+                # coroutine) strategies transparently.
+                if inspect.isawaitable(raw):
+                    raw = await raw
+            except Exception as exc:
+                logger.exception(
+                    "orchestrator.strategy_failed", strategy_id=sid
+                )
+                errors[sid] = f"{type(exc).__name__}: {exc}"
+                continue
+            signals = list(raw) if raw else []
+            batches.append(SignalBatch(strategy_id=sid, signals=signals))
+
+        aggregator = SignalAggregator(
+            _MODE_TO_METHOD[mode], self._weights
+        )
+        aggregated = aggregator.aggregate(batches)
+        return OrchestrationResult(
+            signals=aggregated,
+            batches=batches,
+            aggregation=mode.value,
+            strategy_count=len(self._strategies),
+            weights=dict(self._weights),
+            errors=errors,
+        )
+
+
+__all__ = [
+    "AggregationMode",
+    "OrchestrationResult",
+    "StrategyLike",
+    "StrategyOrchestrator",
+    "StrategyOrchestratorError",
+]

--- a/engine/core/strategy_orchestrator.py
+++ b/engine/core/strategy_orchestrator.py
@@ -43,6 +43,8 @@ Relationship to SignalAggregator
 
 from __future__ import annotations
 
+import asyncio
+import copy
 import inspect
 import math
 from dataclasses import dataclass, field
@@ -189,10 +191,25 @@ class StrategyOrchestrator:
     market data and cost model.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, eval_timeout: float = 30.0) -> None:
         # Insertion-ordered so evaluate_all iterates deterministically.
         self._strategies: dict[str, StrategyLike] = {}
         self._weights: dict[str, float] = {}
+        # Per-strategy ``evaluate()`` wall-clock cap. A strategy that
+        # exceeds it is recorded as an error result rather than stalling
+        # the whole cycle. 30s matches the platform's overall strategy
+        # SLA; tighten via the constructor for latency-sensitive paths.
+        try:
+            value = float(eval_timeout)
+        except (TypeError, ValueError) as exc:
+            raise StrategyOrchestratorError(
+                f"eval_timeout must be a number, got {eval_timeout!r}"
+            ) from exc
+        if not math.isfinite(value) or value <= 0:
+            raise StrategyOrchestratorError(
+                f"eval_timeout must be a finite, positive number, got {eval_timeout!r}"
+            )
+        self._eval_timeout = value
 
     # -- registry introspection ----------------------------------------
 
@@ -266,7 +283,9 @@ class StrategyOrchestrator:
         Parameters
         ----------
         market_data, cost_model:
-            Forwarded verbatim to each strategy's ``evaluate``.
+            Forwarded to each strategy's ``evaluate`` as an independent
+            deep copy, so one strategy mutating them cannot leak to its
+            siblings or the caller's originals.
         aggregation:
             One of ``majority`` (default), ``majority_vote`` (alias), or
             ``weighted``.
@@ -276,7 +295,10 @@ class StrategyOrchestrator:
         OrchestrationResult
             ``signals`` holds the aggregated decisions; ``batches`` the
             raw per-strategy signals; ``errors`` maps any failed
-            strategy id to its error message.
+            strategy id (raised *or* timed out) to its error message.
+            A strategy that exceeds the configured ``eval_timeout`` is
+            reported as a ``TimeoutError`` entry rather than stalling
+            the cycle.
 
         Raises
         ------
@@ -302,13 +324,44 @@ class StrategyOrchestrator:
 
         batches: list[SignalBatch] = []
         errors: dict[str, str] = {}
-        for sid, strategy in self._strategies.items():
+        # Snapshot the registry before iterating. A strategy that
+        # registers / unregisters a sibling mid-cycle (e.g. from inside
+        # its own evaluate) must not mutate the dict we are walking,
+        # which would otherwise raise "dictionary changed size during
+        # iteration". Strategies added during this cycle are
+        # intentionally excluded from it - they will run on the next.
+        for sid, strategy in list(self._strategies.items()):
+            # Hand each strategy its own deep copy so a misbehaving
+            # plugin that mutates market_data / cost_model cannot poison
+            # its siblings or the caller's originals. The copies are
+            # recreated per strategy so cross-strategy comparisons stay
+            # apples-to-apples.
+            md = copy.deepcopy(market_data)
+            cm = copy.deepcopy(cost_model)
             try:
-                raw = strategy.evaluate(market_data, cost_model)
+                raw = strategy.evaluate(md, cm)
                 # Support both sync (returns list) and async (returns
-                # coroutine) strategies transparently.
+                # coroutine) strategies transparently. Only the async
+                # path is bounded by the per-strategy timeout - a sync
+                # call has already completed by the time we get here.
                 if inspect.isawaitable(raw):
-                    raw = await raw
+                    raw = await asyncio.wait_for(
+                        raw, timeout=self._eval_timeout
+                    )
+            except TimeoutError as exc:
+                # Catch TimeoutError before the generic handler below:
+                # it is a subclass of OSError/Exception and must be
+                # reported distinctly as a timeout, not a crash.
+                logger.warning(
+                    "orchestrator.strategy_timeout",
+                    strategy_id=sid,
+                    timeout=self._eval_timeout,
+                )
+                errors[sid] = (
+                    f"{type(exc).__name__}: evaluate exceeded "
+                    f"{self._eval_timeout}s timeout"
+                )
+                continue
             except Exception as exc:
                 logger.exception(
                     "orchestrator.strategy_failed", strategy_id=sid

--- a/tests/test_strategy_orchestrator.py
+++ b/tests/test_strategy_orchestrator.py
@@ -1,0 +1,466 @@
+"""Tests for engine.core.strategy_orchestrator.
+
+Covers: empty-registry no-op, single-strategy pass-through (sync and
+async), 3-strategy conflicting signals resolved by majority, weighted
+override of a numerical majority, registration validation, failure
+isolation, and aggregation-mode aliasing.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from engine.core.signal import Side, Signal
+from engine.core.signal_aggregator import AGGREGATED_STRATEGY_ID
+from engine.core.strategy_orchestrator import (
+    AggregationMode,
+    OrchestrationResult,
+    StrategyOrchestrator,
+    StrategyOrchestratorError,
+)
+
+# --------------------------------------------------------------------- #
+# Test doubles
+# --------------------------------------------------------------------- #
+
+
+def _sig(symbol: str, side: Side, strategy_id: str, **kw) -> Signal:
+    return Signal(symbol=symbol, side=side, strategy_id=strategy_id, **kw)
+
+
+class _RecordingStrategy:
+    """Strategy that returns a fixed signal list and records the exact
+    market_data / cost_model objects it received (so tests can assert
+    every strategy saw the *same* inputs)."""
+
+    def __init__(self, sid: str, signals: list[Signal]) -> None:
+        self._id = sid
+        self._signals = signals
+        self.received: list[tuple[object, object]] = []
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    async def evaluate(self, market_data, cost_model) -> list[Signal]:
+        # Record object identity, not value, to prove same-input sharing.
+        self.received.append((market_data, cost_model))
+        return [s.model_copy() for s in self._signals]
+
+
+class _SyncStrategy:
+    """Sync (non-async) strategy variant to prove evaluate_all handles
+    plain callables too."""
+
+    def __init__(self, sid: str, signals: list[Signal]) -> None:
+        self._id = sid
+        self._signals = signals
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    def evaluate(self, market_data, cost_model) -> list[Signal]:
+        return [s.model_copy() for s in self._signals]
+
+
+class _CallableIdStrategy:
+    """Strategy whose ``id`` is a method rather than a property."""
+
+    def __init__(self, sid: str, signals: list[Signal]) -> None:
+        self._id = sid
+        self._signals = signals
+
+    def id(self) -> str:  # type: ignore[override]
+        return self._id
+
+    async def evaluate(self, market_data, cost_model) -> list[Signal]:
+        return [s.model_copy() for s in self._signals]
+
+
+class _RaisingStrategy:
+    def __init__(self, sid: str, exc: Exception) -> None:
+        self._id = sid
+        self._exc = exc
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    async def evaluate(self, market_data, cost_model) -> list[Signal]:
+        raise self._exc
+
+
+class _NoIdStrategy:
+    async def evaluate(self, market_data, cost_model) -> list[Signal]:
+        return []
+
+
+class _NoEvaluateStrategy:
+    id = "has-id-but-no-evaluate"
+
+
+# Sentinel objects passed as market_data / cost_model so tests can verify
+# every strategy received the *same* object by identity.
+_MARKET = object()
+_COSTS = object()
+
+
+# --------------------------------------------------------------------- #
+# Registration & introspection
+# --------------------------------------------------------------------- #
+
+
+class TestRegistration:
+    def test_register_default_weight_is_one(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("s1", []))
+        assert "s1" in orch
+        assert len(orch) == 1
+        assert orch.get_weight("s1") == 1.0
+        assert orch.strategy_ids == ["s1"]
+
+    def test_register_custom_weight(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("s1", []), weight=3.5)
+        assert orch.get_weight("s1") == 3.5
+        assert orch.weights == {"s1": 3.5}
+
+    def test_weights_property_returns_snapshot(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("s1", []), weight=2.0)
+        snap = orch.weights
+        snap["s1"] = 999.0  # mutating the snapshot must not leak
+        assert orch.get_weight("s1") == 2.0
+
+    def test_reregister_updates_weight_and_strategy(self):
+        orch = StrategyOrchestrator()
+        first = _RecordingStrategy("s1", [])
+        second = _RecordingStrategy("s1", [])
+        orch.register(first, weight=1.0)
+        orch.register(second, weight=5.0)
+        assert len(orch) == 1
+        assert orch.get_weight("s1") == 5.0
+
+    def test_register_callable_id(self):
+        orch = StrategyOrchestrator()
+        orch.register(_CallableIdStrategy("s9", []))
+        assert "s9" in orch
+
+    def test_unregister(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("s1", []))
+        orch.register(_RecordingStrategy("s2", []))
+        assert orch.unregister("s1") is True
+        assert "s1" not in orch
+        assert len(orch) == 1
+        # Idempotent: removing again is a no-op returning False.
+        assert orch.unregister("s1") is False
+        assert orch.get_weight("s1") is None
+
+    def test_get_weight_unregistered_is_none(self):
+        orch = StrategyOrchestrator()
+        assert orch.get_weight("nope") is None
+
+    @pytest.mark.parametrize("bad", [-0.01, -1.0, float("nan"), float("inf"), float("-inf")])
+    async def test_register_rejects_invalid_weight(self, bad):
+        orch = StrategyOrchestrator()
+        with pytest.raises(StrategyOrchestratorError):
+            orch.register(_RecordingStrategy("s1", []), weight=bad)
+
+    def test_register_rejects_non_numeric_weight(self):
+        orch = StrategyOrchestrator()
+        with pytest.raises(StrategyOrchestratorError):
+            orch.register(_RecordingStrategy("s1", []), weight="heavy")  # type: ignore[arg-type]
+
+    def test_register_rejects_strategy_without_id(self):
+        orch = StrategyOrchestrator()
+        with pytest.raises(StrategyOrchestratorError):
+            orch.register(_NoIdStrategy())  # type: ignore[arg-type]
+
+    def test_register_rejects_strategy_without_evaluate(self):
+        orch = StrategyOrchestrator()
+        with pytest.raises(StrategyOrchestratorError):
+            orch.register(_NoEvaluateStrategy)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------- #
+# evaluate_all — core behaviour
+# --------------------------------------------------------------------- #
+
+
+class TestEvaluateAll:
+    async def test_empty_registry_is_noop(self):
+        orch = StrategyOrchestrator()
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+        assert isinstance(result, OrchestrationResult)
+        assert result.is_noop
+        assert result.signals == []
+        assert result.batches == []
+        assert result.strategy_count == 0
+        assert result.errors == {}
+        assert result.aggregation == "majority"
+
+    async def test_single_strategy_passthrough_async(self):
+        sigs = [
+            _sig("AAPL", Side.BUY, "s1"),
+            _sig("MSFT", Side.SELL, "s1"),
+        ]
+        s1 = _RecordingStrategy("s1", sigs)
+        orch = StrategyOrchestrator()
+        orch.register(s1)
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        assert not result.is_noop
+        assert {sig.symbol: sig.side for sig in result.signals} == {
+            "AAPL": Side.BUY,
+            "MSFT": Side.SELL,
+        }
+        # The lone strategy received the exact shared objects.
+        assert s1.received == [(_MARKET, _COSTS)]
+        # Aggregated signals are tagged as aggregated for the audit trail.
+        assert all(sig.strategy_id == AGGREGATED_STRATEGY_ID for sig in result.signals)
+
+    async def test_single_strategy_passthrough_sync(self):
+        # A sync (non-async) evaluate must be handled identically.
+        sigs = [_sig("AAPL", Side.HOLD, "s1")]
+        orch = StrategyOrchestrator()
+        orch.register(_SyncStrategy("s1", sigs))
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        assert len(result.signals) == 1
+        assert result.signals[0].symbol == "AAPL"
+
+    async def test_all_strategies_receive_same_inputs(self):
+        # The whole point of the orchestrator: identical market_data and
+        # cost_model reach every strategy by object identity.
+        a = _RecordingStrategy("a", [_sig("AAPL", Side.BUY, "a")])
+        b = _RecordingStrategy("b", [_sig("AAPL", Side.BUY, "b")])
+        c = _RecordingStrategy("c", [_sig("AAPL", Side.BUY, "c")])
+        orch = StrategyOrchestrator()
+        for s in (a, b, c):
+            orch.register(s)
+
+        await orch.evaluate_all(_MARKET, _COSTS)
+
+        assert a.received == [(_MARKET, _COSTS)]
+        assert b.received == [(_MARKET, _COSTS)]
+        assert c.received == [(_MARKET, _COSTS)]
+
+    async def test_majority_resolves_conflict_buy_wins(self):
+        # 2 BUY vs 1 SELL -> BUY takes 2/3 > 50%.
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]))
+        orch.register(_RecordingStrategy("b2", [_sig("AAPL", Side.BUY, "b2")]))
+        orch.register(_RecordingStrategy("s1", [_sig("AAPL", Side.SELL, "s1")]))
+
+        result = await orch.evaluate_all(_MARKET, _COSTS, aggregation="majority")
+
+        assert len(result.signals) == 1
+        assert result.signals[0].symbol == "AAPL"
+        assert result.signals[0].side == Side.BUY
+
+    async def test_majority_sell_wins(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("s1", [_sig("TSLA", Side.SELL, "s1")]))
+        orch.register(_RecordingStrategy("s2", [_sig("TSLA", Side.SELL, "s2")]))
+        orch.register(_RecordingStrategy("b1", [_sig("TSLA", Side.BUY, "b1")]))
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        assert result.signals[0].side == Side.SELL
+
+    async def test_majority_tie_emits_hold(self):
+        # 1 BUY vs 1 SELL -> neither > 50% -> HOLD.
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]))
+        orch.register(_RecordingStrategy("s1", [_sig("AAPL", Side.SELL, "s1")]))
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        assert len(result.signals) == 1
+        assert result.signals[0].side == Side.HOLD
+
+    async def test_hold_abstains_from_majority_denominator(self):
+        # 1 BUY, 1 SELL, 1 HOLD: HOLD abstains -> 1 vs 1 tie -> HOLD.
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]))
+        orch.register(_RecordingStrategy("s1", [_sig("AAPL", Side.SELL, "s1")]))
+        orch.register(_RecordingStrategy("h1", [_sig("AAPL", Side.HOLD, "h1")]))
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        assert result.signals[0].side == Side.HOLD
+
+    async def test_per_symbol_independent_resolution(self):
+        # Different symbols resolve independently in one pass.
+        orch = StrategyOrchestrator()
+        orch.register(
+            _RecordingStrategy(
+                "a", [_sig("AAPL", Side.BUY, "a"), _sig("MSFT", Side.SELL, "a")]
+            )
+        )
+        orch.register(
+            _RecordingStrategy(
+                "b", [_sig("AAPL", Side.BUY, "b"), _sig("MSFT", Side.BUY, "b")]
+            )
+        )
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        by_symbol = {sig.symbol: sig.side for sig in result.signals}
+        assert by_symbol == {"AAPL": Side.BUY, "MSFT": Side.HOLD}
+
+
+class TestWeightedOverride:
+    async def test_weighted_overrides_numerical_majority(self):
+        # Numerical majority is BUY (2 vs 1), but the lone SELL strategy
+        # carries enough weight to win under `weighted`.
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]), weight=1.0)
+        orch.register(_RecordingStrategy("b2", [_sig("AAPL", Side.BUY, "b2")]), weight=1.0)
+        orch.register(_RecordingStrategy("s1", [_sig("AAPL", Side.SELL, "s1")]), weight=5.0)
+
+        majority = await orch.evaluate_all(_MARKET, _COSTS, aggregation="majority")
+        weighted = await orch.evaluate_all(_MARKET, _COSTS, aggregation="weighted")
+
+        # Majority mode ignores weights -> BUY wins on a 2-vs-1 count.
+        assert majority.signals[0].side == Side.BUY
+        # Weighted mode -> SELL total weight 5.0 beats BUY total 2.0.
+        assert weighted.signals[0].side == Side.SELL
+        assert weighted.aggregation == "weighted"
+        assert weighted.weights["s1"] == 5.0
+
+    async def test_weighted_tie_emits_hold(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]), weight=2.0)
+        orch.register(_RecordingStrategy("s1", [_sig("AAPL", Side.SELL, "s1")]), weight=2.0)
+
+        result = await orch.evaluate_all(_MARKET, _COSTS, aggregation="weighted")
+
+        assert result.signals[0].side == Side.HOLD
+
+    async def test_weighted_default_weight_for_unset_is_one(self):
+        # Unregistered-weight strategies still vote with weight 1.0 in
+        # weighted mode, so two equal BUYs beat one SELL.
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]))
+        orch.register(_RecordingStrategy("b2", [_sig("AAPL", Side.BUY, "b2")]))
+        orch.register(
+            _RecordingStrategy("s1", [_sig("AAPL", Side.SELL, "s1")]), weight=1.5
+        )
+
+        result = await orch.evaluate_all(_MARKET, _COSTS, aggregation="weighted")
+
+        # BUY 1.0 + 1.0 = 2.0 vs SELL 1.5 -> BUY.
+        assert result.signals[0].side == Side.BUY
+
+
+class TestAggregationModeHandling:
+    async def test_majority_and_majority_vote_are_aliases(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]))
+        orch.register(_RecordingStrategy("b2", [_sig("AAPL", Side.BUY, "b2")]))
+        orch.register(_RecordingStrategy("s1", [_sig("AAPL", Side.SELL, "s1")]))
+
+        a = await orch.evaluate_all(_MARKET, _COSTS, aggregation="majority")
+        b = await orch.evaluate_all(_MARKET, _COSTS, aggregation="majority_vote")
+
+        assert [s.side for s in a.signals] == [s.side for s in b.signals]
+        assert b.aggregation == "majority_vote"
+
+    async def test_default_aggregation_is_majority(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]))
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+        assert result.aggregation == AggregationMode.MAJORITY.value
+
+    async def test_enum_accepted_as_mode(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", [_sig("AAPL", Side.BUY, "b1")]))
+        result = await orch.evaluate_all(_MARKET, _COSTS, aggregation=AggregationMode.WEIGHTED)
+        assert result.aggregation == "weighted"
+
+    async def test_unknown_aggregation_mode_raises(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("b1", []))
+        with pytest.raises(StrategyOrchestratorError):
+            await orch.evaluate_all(_MARKET, _COSTS, aggregation="plurality")
+
+
+# --------------------------------------------------------------------- #
+# Robustness
+# --------------------------------------------------------------------- #
+
+
+class TestFailureIsolation:
+    async def test_one_strategy_raising_does_not_kill_orchestration(self):
+        orch = StrategyOrchestrator()
+        good = _RecordingStrategy("good", [_sig("AAPL", Side.BUY, "good")])
+        bad = _RaisingStrategy("bad", RuntimeError("boom"))
+        orch.register(good)
+        orch.register(bad)
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        # The healthy strategy still contributed and the symbol resolves.
+        assert any(s.symbol == "AAPL" for s in result.signals)
+        # The failure is recorded, not swallowed.
+        assert "bad" in result.errors
+        assert "RuntimeError" in result.errors["bad"]
+        # Only the good strategy produced a batch.
+        assert [b.strategy_id for b in result.batches] == ["good"]
+        assert result.strategy_count == 2  # both were registered
+
+    async def test_strategy_returning_none_treated_as_empty(self):
+        class _NoneStrategy:
+            id = "none"
+
+            async def evaluate(self, market_data, cost_model):
+                return None
+
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("a", [_sig("AAPL", Side.BUY, "a")]))
+        orch.register(_NoneStrategy())  # type: ignore[arg-type]
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        assert [b.strategy_id for b in result.batches] == ["a", "none"]
+        assert result.batches[1].signals == []
+        assert result.signals[0].side == Side.BUY
+
+
+class TestResultShape:
+    async def test_result_records_batches_and_metadata(self):
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("a", [_sig("AAPL", Side.BUY, "a")]), weight=2.0)
+        orch.register(_RecordingStrategy("b", [_sig("AAPL", Side.BUY, "b")]), weight=3.0)
+
+        result = await orch.evaluate_all(_MARKET, _COSTS, aggregation="weighted")
+
+        assert result.strategy_count == 2
+        assert {b.strategy_id for b in result.batches} == {"a", "b"}
+        assert math.isclose(result.weights["a"], 2.0)
+        assert math.isclose(result.weights["b"], 3.0)
+        # trade_signals excludes any HOLD outcome.
+        assert all(s.side != Side.HOLD for s in result.trade_signals)
+        assert len(result.trade_signals) == 1
+
+    async def test_all_hold_still_emits_hold_signal(self):
+        # When every strategy abstains, the aggregator emits a single
+        # HOLD so downstream code has a record the symbol was considered.
+        orch = StrategyOrchestrator()
+        orch.register(_RecordingStrategy("a", [_sig("AAPL", Side.HOLD, "a")]))
+        orch.register(_RecordingStrategy("b", [_sig("AAPL", Side.HOLD, "b")]))
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        assert len(result.signals) == 1
+        assert result.signals[0].side == Side.HOLD
+        # HOLD-only is not a no-op (no-op == empty result).
+        assert not result.is_noop
+        assert result.trade_signals == []

--- a/tests/test_strategy_orchestrator.py
+++ b/tests/test_strategy_orchestrator.py
@@ -8,6 +8,7 @@ isolation, and aggregation-mode aliasing.
 
 from __future__ import annotations
 
+import asyncio
 import math
 
 import pytest
@@ -102,10 +103,13 @@ class _NoEvaluateStrategy:
     id = "has-id-but-no-evaluate"
 
 
-# Sentinel objects passed as market_data / cost_model so tests can verify
-# every strategy received the *same* object by identity.
-_MARKET = object()
-_COSTS = object()
+# Sentinel values passed as market_data / cost_model. These are
+# deep-copyable, value-comparable dicts (not bare objects) so tests can
+# assert that every strategy received an *equal* copy of the same source
+# data while the orchestrator still guarantees each gets its own
+# independent deep copy (mutation isolation).
+_MARKET = {"prices": {"AAPL": 150.0, "MSFT": 300.0}}
+_COSTS = {"fee_bps": 5.0, "spread_bps": 1.0}
 
 
 # --------------------------------------------------------------------- #
@@ -236,8 +240,10 @@ class TestEvaluateAll:
         assert result.signals[0].symbol == "AAPL"
 
     async def test_all_strategies_receive_same_inputs(self):
-        # The whole point of the orchestrator: identical market_data and
-        # cost_model reach every strategy by object identity.
+        # The whole point of the orchestrator: equal copies of the same
+        # source market_data and cost_model reach every strategy. Each
+        # strategy gets its own deep copy (see test_mutation_isolation),
+        # so we assert value equality rather than object identity.
         a = _RecordingStrategy("a", [_sig("AAPL", Side.BUY, "a")])
         b = _RecordingStrategy("b", [_sig("AAPL", Side.BUY, "b")])
         c = _RecordingStrategy("c", [_sig("AAPL", Side.BUY, "c")])
@@ -464,3 +470,157 @@ class TestResultShape:
         # HOLD-only is not a no-op (no-op == empty result).
         assert not result.is_noop
         assert result.trade_signals == []
+
+
+# --------------------------------------------------------------------- #
+# Robustness fixes: registry mutation during evaluation, per-strategy
+# timeouts, and mutation isolation between strategies.
+# --------------------------------------------------------------------- #
+
+
+class TestRegistryMutationDuringEvaluate:
+    async def test_register_during_evaluate_does_not_crash(self):
+        # Without a snapshot, a strategy that registers a sibling while
+        # the orchestrator is iterating raises "dictionary changed size
+        # during iteration". The snapshot keeps the cycle stable; the
+        # late sibling is picked up on the *next* cycle.
+        orch = StrategyOrchestrator()
+
+        class _RegisteringStrategy:
+            id = "early"
+
+            async def evaluate(self, market_data, cost_model):
+                # Mutate the registry mid-cycle.
+                orch.register(
+                    _RecordingStrategy(
+                        "late", [_sig("AAPL", Side.SELL, "late")]
+                    )
+                )
+                return [_sig("AAPL", Side.BUY, "early")]
+
+        orch.register(_RegisteringStrategy())
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        # The cycle completed instead of raising.
+        assert [b.strategy_id for b in result.batches] == ["early"]
+        # The registration took effect for the registry...
+        assert "late" in orch
+        # ...but the latecomer did not run this cycle.
+        assert "late" not in {b.strategy_id for b in result.batches}
+
+    async def test_unregister_during_evaluate_does_not_crash(self):
+        # Symmetric: unregistering a sibling mid-cycle must not raise.
+        orch = StrategyOrchestrator()
+
+        class _UnregisteringStrategy:
+            id = "keeper"
+
+            async def evaluate(self, market_data, cost_model):
+                orch.unregister("victim")
+                return [_sig("AAPL", Side.BUY, "keeper")]
+
+        orch.register(_UnregisteringStrategy())
+        orch.register(_RecordingStrategy("victim", [_sig("AAPL", Side.SELL, "victim")]))
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        # Both ran (snapshot captured both before the mutation).
+        assert {b.strategy_id for b in result.batches} == {"keeper", "victim"}
+        assert "victim" not in orch  # removal took effect afterwards
+
+
+class TestStrategyTimeout:
+    async def test_slow_async_strategy_times_out_and_is_recorded(self):
+        # A strategy whose evaluate() exceeds the configured timeout is
+        # cancelled and recorded as a TimeoutError error result; the
+        # remaining strategies still contribute.
+        orch = StrategyOrchestrator(eval_timeout=0.05)
+        good = _RecordingStrategy("good", [_sig("AAPL", Side.BUY, "good")])
+
+        class _SlowStrategy:
+            id = "slow"
+
+            async def evaluate(self, market_data, cost_model):
+                # Far beyond the 0.05s cap; wait_for cancels us.
+                await asyncio.sleep(5.0)
+                return [_sig("AAPL", Side.BUY, "slow")]  # never reached
+
+        orch.register(good)
+        orch.register(_SlowStrategy())
+
+        result = await orch.evaluate_all(_MARKET, _COSTS)
+
+        # Timeout surfaced as a distinct error entry.
+        assert "slow" in result.errors
+        assert "TimeoutError" in result.errors["slow"]
+        assert "0.05" in result.errors["slow"]
+        # The healthy strategy still produced a batch and a decision.
+        assert [b.strategy_id for b in result.batches] == ["good"]
+        assert result.signals[0].side == Side.BUY
+        assert result.strategy_count == 2  # both registered
+
+    async def test_default_timeout_is_thirty_seconds(self):
+        orch = StrategyOrchestrator()
+        assert math.isclose(orch._eval_timeout, 30.0)
+
+    @pytest.mark.parametrize("bad", [0, -1, float("nan"), float("inf"), float("-inf")])
+    def test_constructor_rejects_invalid_timeout(self, bad):
+        with pytest.raises(StrategyOrchestratorError):
+            StrategyOrchestrator(eval_timeout=bad)
+
+    def test_constructor_rejects_non_numeric_timeout(self):
+        with pytest.raises(StrategyOrchestratorError):
+            StrategyOrchestrator(eval_timeout="soon")  # type: ignore[arg-type]
+
+
+class TestMutationIsolation:
+    async def test_each_strategy_receives_its_own_deep_copy(self):
+        # A strategy that mutates the market_data / cost_model handed to
+        # it must not poison its siblings or the caller's originals.
+        market = {"prices": {"AAPL": 150.0}}
+        costs = {"fee_bps": 5.0}
+
+        class _MutatingStrategy:
+            id = "mutator"
+
+            async def evaluate(self, market_data, cost_model):
+                # Mutate the copy we received in place.
+                market_data["prices"]["AAPL"] = 999.0
+                cost_model["fee_bps"] = 999.0
+                return [_sig("AAPL", Side.BUY, "mutator")]
+
+        observer = _RecordingStrategy(
+            "observer", [_sig("AAPL", Side.BUY, "observer")]
+        )
+
+        orch = StrategyOrchestrator()
+        orch.register(_MutatingStrategy())
+        orch.register(observer)
+
+        await orch.evaluate_all(market, costs)
+
+        # The caller's originals are untouched.
+        assert market == {"prices": {"AAPL": 150.0}}
+        assert costs == {"fee_bps": 5.0}
+        # The sibling observed the original, unmutated data.
+        observed_md, observed_cm = observer.received[0]
+        assert observed_md == {"prices": {"AAPL": 150.0}}
+        assert observed_cm == {"fee_bps": 5.0}
+
+    async def test_strategies_receive_distinct_copies(self):
+        # Even when no mutation happens, the objects handed to two
+        # strategies are distinct (proving the copy is per-strategy, not
+        # a single shared deepcopy).
+        a = _RecordingStrategy("a", [_sig("AAPL", Side.BUY, "a")])
+        b = _RecordingStrategy("b", [_sig("AAPL", Side.BUY, "b")])
+        orch = StrategyOrchestrator()
+        orch.register(a)
+        orch.register(b)
+
+        await orch.evaluate_all(_MARKET, _COSTS)
+
+        a_md = a.received[0][0]
+        b_md = b.received[0][0]
+        assert a_md == b_md  # equal by value ...
+        assert a_md is not b_md  # ... but independent objects


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix the 3 high-severity review findings in engine/core/strategy_orchestrator.py: (1) snapshot dict before iteration to prevent concurrent mutation, (2) add asyncio.wait_for timeout on strategy.evaluate() calls, (3) deep-copy market_data and cost_model per strategy to prevent cross-strategy mutation

Closes #985
