### PR TITLE
feat(instruments): add FUTURES type with multiplier, expiry, 1256 flag

### DIFF
--- a/engine/core/instruments.py
+++ b/engine/core/instruments.py
@@ -113,6 +113,25 @@ class Instrument(BaseModel):
     option_type: OptionType | None = Field(default=None)
     multiplier: int = Field(default=1, ge=1)
 
+    # Futures (regulated futures contracts / Section 1256)
+    contract_multiplier: int = Field(
+        default=1,
+        ge=1,
+        description="Units per contract — e.g. ES=$50/point, CL=1000 bbl",
+    )
+    expiry_date: date | None = Field(
+        default=None,
+        description="Futures contract expiry / final settlement date",
+    )
+    is_section_1256: bool = Field(
+        default=False,
+        description=(
+            "US \u00a71256 60/40 mark-to-market treatment. Regulated futures "
+            "contracts default to True; set False for a \u00a71256(d) opt-out "
+            "or non-qualifying contracts."
+        ),
+    )
+
     @field_validator("symbol")
     @classmethod
     def _symbol_no_whitespace(cls, v: str) -> str:
@@ -146,6 +165,15 @@ class Instrument(BaseModel):
                 if not (self.base_asset and self.quote_asset):
                     msg = "Forex requires base_asset and quote_asset"
                     raise ValueError(msg)
+            case InstrumentAssetClass.FUTURE:
+                # ``contract_multiplier`` has a floor of 1 at the field
+                # level, so nothing else is structurally required for a
+                # future. Regulated futures contracts qualify for
+                # \u00a71256 60/40 treatment by default; only auto-enable
+                # it when the caller did not explicitly pass the flag,
+                # leaving room for a \u00a71256(d) opt-out.
+                if "is_section_1256" not in self.model_fields_set:
+                    object.__setattr__(self, "is_section_1256", True)
             case _:
                 pass
         return self
@@ -168,8 +196,13 @@ class Instrument(BaseModel):
             yyyymmdd = self.expiration.strftime("%Y%m%d")
             cp = "C" if self.option_type == OptionType.CALL else "P"
             return f"{self.underlying}_{yyyymmdd}_{cp}_{self.strike:.2f}"
-        if ac == InstrumentAssetClass.FUTURE and self.expiration:
-            return f"{self.symbol}_{self.expiration.strftime('%Y%m%d')}"
+        if ac == InstrumentAssetClass.FUTURE:
+            # Prefer the futures-specific ``expiry_date``, falling back to
+            # the shared ``expiration`` field so legacy constructions keep
+            # producing the same uid.
+            exp = self.expiry_date or self.expiration
+            if exp:
+                return f"{self.symbol}_{exp.strftime('%Y%m%d')}"
         if ac == InstrumentAssetClass.CRYPTO and self.base_asset and self.quote_asset:
             return f"{self.base_asset}/{self.quote_asset}"
         if ac == InstrumentAssetClass.CRYPTO_PERP and self.base_asset and self.quote_asset:
@@ -277,6 +310,33 @@ class Instrument(BaseModel):
             expiration=expiration,
             option_type=option_type,
             multiplier=multiplier,
+            currency=currency,
+        )
+
+    @classmethod
+    def future(
+        cls,
+        symbol: str,
+        *,
+        contract_multiplier: int = 1,
+        expiry_date: date | None = None,
+        is_section_1256: bool = True,
+        exchange: str | None = None,
+        currency: str = "USD",
+    ) -> Instrument:
+        """Regulated futures contract (e.g. CME ES, NYMEX CL).
+
+        Defaults to US \u00a71256 60/40 tax treatment, the canonical regime
+        for listed/index futures. Pass ``is_section_1256=False`` for a
+        \u00a71256(d) opt-out or non-qualifying contracts.
+        """
+        return cls(
+            symbol=symbol,
+            asset_class=InstrumentAssetClass.FUTURE,
+            contract_multiplier=contract_multiplier,
+            expiry_date=expiry_date,
+            is_section_1256=is_section_1256,
+            exchange=exchange,
             currency=currency,
         )
 

--- a/tests/test_instruments_coverage.py
+++ b/tests/test_instruments_coverage.py
@@ -192,3 +192,108 @@ class TestCoerce:
     def test_coerce_none(self):
         with pytest.raises(TypeError, match="cannot coerce"):
             Instrument.coerce(None)
+
+
+class TestFuturesFactory:
+    """Regulated futures contracts — data-model foundation (SEV-223+)."""
+
+    def test_future_factory_basic(self):
+        inst = Instrument.future(
+            "ES",
+            contract_multiplier=50,
+            expiry_date=date(2026, 12, 19),
+            exchange="CME",
+            currency="USD",
+        )
+        assert inst.asset_class == InstrumentAssetClass.FUTURE
+        assert inst.symbol == "ES"
+        assert inst.contract_multiplier == 50
+        assert inst.expiry_date == date(2026, 12, 19)
+        assert inst.exchange == "CME"
+        assert inst.currency == "USD"
+        # A future is a derivative.
+        assert inst.is_derivative is True
+        # uid embeds the expiry so distinct contracts never collapse.
+        assert inst.uid == "ES_20261219"
+
+    def test_future_uid_without_expiry_falls_back_to_symbol(self):
+        # No expiry or expiration → bare symbol uid (continuous/index style).
+        inst = Instrument.future("ES", contract_multiplier=50)
+        assert inst.uid == "ES"
+
+    def test_future_uid_prefers_expiry_date_over_legacy_expiration(self):
+        inst = Instrument(
+            symbol="ES",
+            asset_class=InstrumentAssetClass.FUTURE,
+            expiry_date=date(2026, 12, 19),
+            expiration=date(2025, 6, 20),
+        )
+        assert inst.uid == "ES_20261219"
+
+
+class TestFuturesFieldValidation:
+    def test_contract_multiplier_defaults_to_one(self):
+        inst = Instrument.future("ES")
+        assert inst.contract_multiplier == 1
+
+    def test_zero_contract_multiplier_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            Instrument.future("ES", contract_multiplier=0)
+
+    def test_negative_contract_multiplier_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            Instrument.future("ES", contract_multiplier=-50)
+
+    def test_expiry_date_is_optional(self):
+        inst = Instrument.future("ES", contract_multiplier=50)
+        assert inst.expiry_date is None
+
+
+class TestSection1256Flag:
+    def test_factory_defaults_section_1256_true(self):
+        inst = Instrument.future("ES", contract_multiplier=50)
+        assert inst.is_section_1256 is True
+
+    def test_direct_construction_auto_enables_section_1256(self):
+        # Constructing a FUTURE directly (no factory) still defaults to
+        # §1256 treatment so callers can't accidentally skip it.
+        inst = Instrument(
+            symbol="ES",
+            asset_class=InstrumentAssetClass.FUTURE,
+            contract_multiplier=50,
+        )
+        assert inst.is_section_1256 is True
+
+    def test_section_1256_opt_out_respected(self):
+        # §1256(d) opt-out (or non-qualifying contract) must survive both
+        # factory and direct construction paths.
+        via_factory = Instrument.future(
+            "ES", contract_multiplier=50, is_section_1256=False
+        )
+        assert via_factory.is_section_1256 is False
+
+        direct = Instrument(
+            symbol="ES",
+            asset_class=InstrumentAssetClass.FUTURE,
+            contract_multiplier=50,
+            is_section_1256=False,
+        )
+        assert direct.is_section_1256 is False
+
+    def test_non_future_instruments_default_section_1256_false(self):
+        assert Instrument.equity("AAPL").is_section_1256 is False
+        assert Instrument.crypto("BTC", "USDT").is_section_1256 is False
+
+    def test_future_round_trips_section_1256_flag(self):
+        inst = Instrument.future(
+            "CL",
+            contract_multiplier=1000,
+            expiry_date=date(2026, 3, 20),
+            is_section_1256=True,
+        )
+        rebuilt = Instrument.model_validate(inst.model_dump(mode="json"))
+        assert rebuilt.asset_class == InstrumentAssetClass.FUTURE
+        assert rebuilt.contract_multiplier == 1000
+        assert rebuilt.expiry_date == date(2026, 3, 20)
+        assert rebuilt.is_section_1256 is True
+        assert rebuilt.uid == inst.uid


### PR DESCRIPTION
## Delivery

- Action: implement
- Target: Add FUTURES instrument type support: extend the Instrument model/enum with FUTURES type, add contract multiplier and expiry fields, and wire basic Section 1256 tax treatment flag

Closes #997
