### PR TITLE
fix(instruments): resolve field collisions and fix section 1256 logic

### DIFF
--- a/engine/core/instruments.py
+++ b/engine/core/instruments.py
@@ -80,6 +80,30 @@ _DERIVATIVE_CLASSES = frozenset(
     }
 )
 
+# Asset classes that are US Section 1256 contracts by default (60/40 tax
+# treatment). Used by the auto-detecting ``is_section_1256`` validator when
+# the caller does not state an explicit value.
+_SECTION_1256_CLASSES = frozenset({InstrumentAssetClass.FUTURE})
+
+# Well-known exchange-traded futures contract sizes (units per contract).
+# Used by :meth:`Instrument.future` to default ``multiplier`` from the
+# symbol, mirroring how ``multiplier`` already encodes "size per contract"
+# for options (e.g. 100 shares). There is deliberately NO separate
+# ``contract_multiplier`` field — ``multiplier`` is the single canonical
+# representation of "units per contract" for every asset class.
+_FUTURE_CONTRACT_SIZES: dict[str, int] = {
+    "ES": 50,  # CME E-mini S&P 500 — $50 x index
+    "NQ": 20,  # CME E-mini Nasdaq-100 — $20 x index
+    "YM": 5,  # CBOT E-mini Dow — $5 x index
+    "RTY": 50,  # CME E-mini Russell 2000 — $50 x index
+    "CL": 1000,  # NYMEX WTI crude — 1 000 barrels
+    "GC": 100,  # COMEX gold — 100 troy oz
+    "SI": 5000,  # COMEX silver — 5 000 troy oz
+    "ZC": 5000,  # CBOT corn — 5 000 bushels
+    "ZS": 5000,  # CBOT soybeans — 5 000 bushels
+    "ZN": 1000,  # CBOT 10-Year Treasury — $1 000 face
+}
+
 
 class Instrument(BaseModel):
     """Canonical, typed representation of any tradable instrument."""
@@ -111,7 +135,16 @@ class Instrument(BaseModel):
     strike: float | None = Field(default=None, gt=0.0)
     expiration: date | None = Field(default=None)
     option_type: OptionType | None = Field(default=None)
-    multiplier: int = Field(default=1, ge=1)
+    multiplier: int = Field(default=1, ge=1, description="Units per contract")
+
+    # Tax classification (US Section 1256 — 60/40 treatment). A ``None``
+    # input means "auto-detect"; the ``_auto_section_1256`` model validator
+    # resolves it to a concrete bool at construction time based on the asset
+    # class. Callers may override by passing an explicit ``True``/``False``.
+    is_section_1256: bool | None = Field(
+        default=None,
+        description="US 60/40 tax-treatment flag; auto-detected when omitted",
+    )
 
     @field_validator("symbol")
     @classmethod
@@ -120,6 +153,28 @@ class Instrument(BaseModel):
             msg = "symbol must be non-empty and contain no leading/trailing whitespace"
             raise ValueError(msg)
         return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_expiry_date_alias(cls, data: Any) -> Any:
+        """Keep ``expiration`` canonical.
+
+        ``expiry_date`` is intentionally NOT a model field (no duplicate
+        date fields). If a caller nonetheless supplies both ``expiry_date``
+        and ``expiration`` with *differing* values we fail loudly rather
+        than silently dropping one. Equal values are tolerated (and the
+        alias is discarded) so that legacy callers stay compatible.
+        """
+        if isinstance(data, dict):
+            expiry = data.get("expiry_date")
+            expiration = data.get("expiration")
+            if expiry is not None and expiration is not None and expiry != expiration:
+                msg = (
+                    "Both 'expiry_date' and 'expiration' were provided with "
+                    "differing values; set only 'expiration' (the canonical field)."
+                )
+                raise ValueError(msg)
+        return data
 
     @model_validator(mode="after")
     def _enforce_class_invariants(self) -> Instrument:
@@ -148,6 +203,25 @@ class Instrument(BaseModel):
                     raise ValueError(msg)
             case _:
                 pass
+        return self
+
+    @model_validator(mode="after")
+    def _auto_section_1256(self) -> Instrument:
+        """Auto-set ``is_section_1256`` when the caller omitted it.
+
+        Detection is driven by ``model_fields_set`` so that an explicit
+        caller value (including the ``future()`` factory passing through an
+        override) is always honoured, while an omitted value is resolved
+        from the asset class. ``object.__setattr__`` is used because the
+        model has ``validate_assignment=True`` and a plain assignment would
+        re-run every model validator.
+        """
+        if "is_section_1256" not in self.model_fields_set:
+            object.__setattr__(
+                self,
+                "is_section_1256",
+                self.asset_class in _SECTION_1256_CLASSES,
+            )
         return self
 
     # ── Derived properties ───────────────────────────────────────────
@@ -215,6 +289,41 @@ class Instrument(BaseModel):
             exchange=exchange,
             currency=currency,
         )
+
+    @classmethod
+    def future(
+        cls,
+        symbol: str,
+        *,
+        expiration: date | None = None,
+        exchange: str | None = None,
+        currency: str = "USD",
+        multiplier: int | None = None,
+        is_section_1256: bool | None = None,
+    ) -> Instrument:
+        """Exchange-traded future.
+
+        ``multiplier`` defaults to the contract size for well-known symbols
+        (e.g. 50 for ES). Pass ``is_section_1256=None`` (the default) to let
+        the model auto-detect the 60/40 flag — when omitted from the
+        constructor kwargs the validator resolves it from the asset class.
+        """
+        size = (
+            multiplier
+            if multiplier is not None
+            else _FUTURE_CONTRACT_SIZES.get(symbol.upper(), 1)
+        )
+        kwargs: dict[str, Any] = {
+            "symbol": symbol,
+            "asset_class": InstrumentAssetClass.FUTURE,
+            "expiration": expiration,
+            "exchange": exchange,
+            "currency": currency,
+            "multiplier": size,
+        }
+        if is_section_1256 is not None:
+            kwargs["is_section_1256"] = is_section_1256
+        return cls(**kwargs)
 
     @classmethod
     def crypto(

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -227,3 +227,153 @@ class TestFromString:
     def test_from_string_forex_short_pair_does_not_crash(self):
         inst = Instrument.from_string("EUR/USD")
         assert inst.symbol == "EUR/USD"
+
+
+class TestFutureFactory:
+    """The future() factory sets multiplier to the contract size and
+    classifies as a derivative — there is no separate contract_multiplier."""
+
+    def test_es_contract_size_defaults_multiplier_to_50(self):
+        inst = Instrument.future("ES", expiration=date(2026, 12, 19))
+        assert inst.asset_class == InstrumentAssetClass.FUTURE
+        assert inst.multiplier == 50  # $50 x index, the ES contract size
+        assert inst.expiration == date(2026, 12, 19)
+        assert inst.is_derivative is True
+        assert inst.uid == "ES_20261219"
+
+    def test_known_contract_sizes(self):
+        assert Instrument.future("NQ").multiplier == 20
+        assert Instrument.future("CL").multiplier == 1000
+        assert Instrument.future("GC").multiplier == 100
+
+    def test_unknown_symbol_defaults_multiplier_to_one(self):
+        inst = Instrument.future("WIDGET")
+        assert inst.multiplier == 1
+
+    def test_explicit_multiplier_overrides_contract_size(self):
+        inst = Instrument.future("ES", multiplier=500)
+        assert inst.multiplier == 500
+
+    def test_no_contract_multiplier_field_exists(self):
+        # The refactor removed contract_multiplier in favour of multiplier.
+        assert "contract_multiplier" not in Instrument.model_fields
+        inst = Instrument.future("ES")
+        assert not hasattr(inst, "contract_multiplier")
+
+    def test_case_insensitive_symbol_lookup(self):
+        assert Instrument.future("es").multiplier == 50
+
+
+class TestSection1256AutoDetection:
+    """is_section_1256 defaults to None and is auto-set from model_fields_set."""
+
+    def test_future_auto_detected_via_factory(self):
+        # Factory omits the kwarg -> validator auto-detects True for futures.
+        inst = Instrument.future("ES")
+        assert inst.is_section_1256 is True
+
+    def test_future_auto_detected_via_direct_construction(self):
+        inst = Instrument(
+            symbol="NQ",
+            asset_class=InstrumentAssetClass.FUTURE,
+        )
+        assert inst.is_section_1256 is True
+
+    def test_non_future_auto_detected_false(self):
+        assert Instrument.equity("AAPL").is_section_1256 is False
+        assert Instrument.etf("SPY").is_section_1256 is False
+        assert Instrument.crypto("BTC", "USDT").is_section_1256 is False
+        assert Instrument.option(
+            "AAPL", 200.0, date(2026, 6, 19), OptionType.CALL
+        ).is_section_1256 is False
+
+    def test_factory_explicit_override_respected(self):
+        inst = Instrument.future("ES", is_section_1256=False)
+        assert inst.is_section_1256 is False
+
+    def test_direct_explicit_override_respected(self):
+        inst = Instrument(
+            symbol="ES",
+            asset_class=InstrumentAssetClass.FUTURE,
+            is_section_1256=False,
+        )
+        assert inst.is_section_1256 is False
+
+    def test_default_field_value_is_none_before_construction(self):
+        # The field's declared default is None (auto-detect sentinel).
+        assert Instrument.model_fields["is_section_1256"].default is None
+
+
+class TestNoDuplicateFields:
+    """Guards against re-introducing the removed duplicate fields."""
+
+    def test_no_expiry_date_field(self):
+        assert "expiry_date" not in Instrument.model_fields
+
+    def test_no_contract_multiplier_field(self):
+        assert "contract_multiplier" not in Instrument.model_fields
+
+    def test_single_canonical_date_and_size_fields(self):
+        # expiration and multiplier are the only canonical fields for these.
+        assert "expiration" in Instrument.model_fields
+        assert "multiplier" in Instrument.model_fields
+
+
+class TestExpiryDateAlias:
+    """expiration is canonical; a conflicting expiry_date must raise."""
+
+    def test_conflicting_dates_raise(self):
+        with pytest.raises(ValueError, match="expiry_date"):
+            Instrument(
+                symbol="ES",
+                asset_class=InstrumentAssetClass.FUTURE,
+                expiration=date(2026, 12, 19),
+                expiry_date=date(2026, 6, 19),
+            )
+
+    def test_conflicting_dates_raise_via_validate(self):
+        with pytest.raises(ValueError, match="expiration"):
+            Instrument.model_validate(
+                {
+                    "symbol": "ES",
+                    "asset_class": "future",
+                    "expiration": "2026-12-19",
+                    "expiry_date": "2026-06-19",
+                }
+            )
+
+    def test_equal_dates_tolerated_and_expiration_kept(self):
+        # Legacy callers passing the same value on both keys stay compatible.
+        inst = Instrument.model_validate(
+            {
+                "symbol": "ES",
+                "asset_class": "future",
+                "expiration": "2026-12-19",
+                "expiry_date": "2026-12-19",
+            }
+        )
+        assert inst.expiration == date(2026, 12, 19)
+        # expiry_date is not a field, so it never lands on the instance.
+        assert not hasattr(inst, "expiry_date")
+
+    def test_expiry_date_alone_is_ignored_not_stored(self):
+        # expiration stays canonical: passing only the alias is a no-op.
+        inst = Instrument.model_validate(
+            {
+                "symbol": "ES",
+                "asset_class": "future",
+                "expiry_date": "2026-12-19",
+            }
+        )
+        assert inst.expiration is None
+        assert not hasattr(inst, "expiry_date")
+
+
+class TestFutureSerialization:
+    def test_future_round_trips_through_dict(self):
+        inst = Instrument.future("ES", expiration=date(2026, 12, 19))
+        rebuilt = Instrument.model_validate(inst.model_dump(mode="json"))
+        assert rebuilt.asset_class == InstrumentAssetClass.FUTURE
+        assert rebuilt.multiplier == 50
+        assert rebuilt.is_section_1256 is True
+        assert rebuilt.uid == inst.uid


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix the 3 high-severity bugs in engine/core/instruments.py: (1) resolve multiplier vs contract_multiplier field collision by consolidating to one field, (2) resolve expiry_date vs expiration duplication with a model_validator that rejects conflicting values, (3) fix is_section_1256 dead-code by making the factory default None and letting the validator decide

Closes #1001
