### PR TITLE
feat(instruments): add CRYPTO instrument type and CoinInstrument model

### DIFF
--- a/engine/core/instruments.py
+++ b/engine/core/instruments.py
@@ -229,9 +229,7 @@ class Instrument(BaseModel):
         )
 
     @classmethod
-    def etf(
-        cls, symbol: str, *, exchange: str | None = None, currency: str = "USD"
-    ) -> Instrument:
+    def etf(cls, symbol: str, *, exchange: str | None = None, currency: str = "USD") -> Instrument:
         return cls(
             symbol=symbol,
             asset_class=InstrumentAssetClass.ETF,
@@ -240,9 +238,7 @@ class Instrument(BaseModel):
         )
 
     @classmethod
-    def crypto(
-        cls, base: str, quote: str, *, exchange: str | None = None
-    ) -> Instrument:
+    def crypto(cls, base: str, quote: str, *, exchange: str | None = None) -> Instrument:
         return cls(
             symbol=f"{base}/{quote}",
             asset_class=InstrumentAssetClass.CRYPTO,
@@ -253,9 +249,7 @@ class Instrument(BaseModel):
         )
 
     @classmethod
-    def crypto_perp(
-        cls, base: str, quote: str, *, exchange: str | None = None
-    ) -> Instrument:
+    def crypto_perp(cls, base: str, quote: str, *, exchange: str | None = None) -> Instrument:
         return cls(
             symbol=f"{base}/{quote}:PERP",
             asset_class=InstrumentAssetClass.CRYPTO_PERP,
@@ -359,7 +353,105 @@ class Instrument(BaseModel):
         raise TypeError(msg)
 
 
+class CoinInstrument(BaseModel):
+    """A single cryptocurrency coin/token as a *base asset*.
+
+    Complements :class:`Instrument`, which models tradable *pairs*
+    (e.g. ``BTC/USDT``), by describing the underlying coin itself with
+    the on-chain metadata — settlement :attr:`chain` and
+    :attr:`decimals` precision — required for custody, on-chain
+    accounting, and fee math.
+
+    ``decimals`` follows the EVM/ERC-20 convention (8 for BTC/satoshi,
+    18 for ETH/wei, 6 for USDC). ``chain`` is ``None`` when the coin is
+    chain-agnostic or its native chain is implied, otherwise it names
+    the settlement network (e.g. ``"ethereum"``, ``"bitcoin"``,
+    ``"solana"``).
+    """
+
+    model_config = {"frozen": False, "validate_assignment": True}
+
+    asset_class: InstrumentAssetClass = Field(
+        default=InstrumentAssetClass.CRYPTO,
+        description="Discriminator — always CRYPTO for a CoinInstrument.",
+    )
+    symbol: str = Field(
+        ...,
+        min_length=1,
+        description="Canonical coin ticker — e.g. 'BTC', 'ETH', 'USDC'.",
+    )
+    chain: str | None = Field(
+        default=None,
+        description=(
+            "Settlement chain — e.g. 'ethereum', 'bitcoin'. None when native or chain-agnostic."
+        ),
+    )
+    decimals: int = Field(
+        default=8,
+        ge=0,
+        description=("Smallest-unit precision: 8 (satoshi), 18 (wei), 6 (USDC)."),
+    )
+
+    @field_validator("symbol")
+    @classmethod
+    def _symbol_no_whitespace(cls, v: str) -> str:
+        if not v.strip() or v.strip() != v:
+            msg = "symbol must be non-empty and contain no leading/trailing whitespace"
+            raise ValueError(msg)
+        return v
+
+    @property
+    def smallest_unit(self) -> int:
+        """Integer factor representing one whole coin: ``10 ** decimals``.
+
+        e.g. ``10 ** 8 == 100_000_000`` satoshis per BTC.
+        """
+        return 10**self.decimals
+
+    @classmethod
+    def crypto(
+        cls,
+        symbol: str,
+        *,
+        chain: str | None = None,
+        decimals: int = 8,
+    ) -> CoinInstrument:
+        """Factory for a coin instrument with a strict string guard.
+
+        Mirrors :meth:`Instrument.future`'s input hygiene but raises
+        ``ValueError`` (not ``TypeError``) on a non-string ``symbol`` so
+        callers branching on the value-error family get a single,
+        consistent contract. Without this guard a ``None`` or ``int``
+        ``symbol`` would surface as an opaque ``AttributeError`` deep
+        inside pydantic validation.
+
+        Parameters
+        ----------
+        symbol:
+            Canonical coin ticker (e.g. ``"BTC"``).
+        chain:
+            Optional settlement chain name.
+        decimals:
+            Decimal precision; defaults to 8 (satoshi).
+
+        Examples
+        --------
+        >>> CoinInstrument.crypto("BTC", chain="bitcoin", decimals=8)
+        CoinInstrument(...)
+        """
+        if not isinstance(symbol, str):
+            # NOTE: TRY004 prefers TypeError for type guards, but this
+            # factory's input contract deliberately raises ValueError
+            # (per spec) so callers branching on the value-error family
+            # get a single, consistent contract — distinct from
+            # Instrument.future(), which raises TypeError.
+            msg = f"symbol must be a string, got {type(symbol).__name__}"
+            raise ValueError(msg)  # noqa: TRY004 - intentional value-error contract
+        return cls(symbol=symbol, chain=chain, decimals=decimals)
+
+
 __all__ = [
+    "CoinInstrument",
     "Instrument",
     "InstrumentAssetClass",
     "OptionType",

--- a/tests/test_instruments_coverage.py
+++ b/tests/test_instruments_coverage.py
@@ -8,6 +8,7 @@ import pydantic
 import pytest
 
 from engine.core.instruments import (
+    CoinInstrument,
     Instrument,
     InstrumentAssetClass,
     OptionType,
@@ -285,9 +286,103 @@ class TestExpiryDateAlias:
         assert inst.asset_class == InstrumentAssetClass.EQUITY
 
     def test_model_instance_input_round_trips(self):
-        original = Instrument.option(
-            "AAPL", 200.0, date(2026, 6, 19), OptionType.CALL
-        )
+        original = Instrument.option("AAPL", 200.0, date(2026, 6, 19), OptionType.CALL)
         rebuilt = Instrument.model_validate(original)
         assert rebuilt.uid == original.uid
         assert rebuilt.option_type == OptionType.CALL
+
+
+class TestCoinInstrumentEnum:
+    """Enum membership: CRYPTO is present on the canonical instrument enum."""
+
+    def test_crypto_is_enum_member(self):
+        assert InstrumentAssetClass.CRYPTO in InstrumentAssetClass
+
+    def test_crypto_enum_value(self):
+        assert InstrumentAssetClass.CRYPTO.value == "crypto"
+
+    def test_coin_instrument_defaults_to_crypto_asset_class(self):
+        coin = CoinInstrument.crypto("BTC")
+        assert coin.asset_class is InstrumentAssetClass.CRYPTO
+
+
+class TestCoinInstrumentFactory:
+    """crypto() factory: valid construction + isinstance(symbol, str) guard."""
+
+    @pytest.mark.parametrize(
+        ("symbol", "chain", "decimals"),
+        [
+            ("BTC", "bitcoin", 8),
+            ("ETH", "ethereum", 18),
+            ("USDC", "ethereum", 6),
+            ("SOL", "solana", 9),
+            ("DOGE", None, 8),
+        ],
+    )
+    def test_valid_construction(self, symbol, chain, decimals):
+        coin = CoinInstrument.crypto(symbol, chain=chain, decimals=decimals)
+        assert coin.symbol == symbol
+        assert coin.chain == chain
+        assert coin.decimals == decimals
+        assert coin.asset_class == InstrumentAssetClass.CRYPTO
+
+    @pytest.mark.parametrize("bad_symbol", [None, 42, 3.14, ["BTC"], ("ETH",), {"x": 1}])
+    def test_non_string_symbol_rejected(self, bad_symbol):
+        with pytest.raises(ValueError, match="symbol must be a string"):
+            CoinInstrument.crypto(bad_symbol)
+
+    def test_int_symbol_rejected_with_explicit_message(self):
+        # The task calls out int rejection explicitly — assert the
+        # reported type name is surfaced for clear diagnostics.
+        with pytest.raises(ValueError, match="int"):
+            CoinInstrument.crypto(123)
+
+    def test_factory_chain_and_decimals_override(self):
+        coin = CoinInstrument.crypto("USDC", chain="ethereum", decimals=6)
+        assert coin.chain == "ethereum"
+        assert coin.decimals == 6
+        assert coin.smallest_unit == 1_000_000
+
+
+class TestCoinInstrumentDefaults:
+    """Field defaults: chain=None, decimals=8."""
+
+    def test_defaults_when_only_symbol_supplied(self):
+        coin = CoinInstrument.crypto("BTC")
+        assert coin.chain is None
+        assert coin.decimals == 8
+
+    def test_defaults_via_direct_construction(self):
+        coin = CoinInstrument(symbol="ETH")
+        assert coin.chain is None
+        assert coin.decimals == 8
+        assert coin.asset_class == InstrumentAssetClass.CRYPTO
+
+    def test_smallest_unit_default_decimals(self):
+        # 10 ** 8 satoshis per BTC.
+        assert CoinInstrument.crypto("BTC").smallest_unit == 100_000_000
+
+
+class TestCoinInstrumentValidation:
+    """Pydantic-level invariants on the CoinInstrument model itself."""
+
+    def test_empty_symbol_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            CoinInstrument(symbol="")
+
+    def test_whitespace_symbol_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            CoinInstrument(symbol="  BTC  ")
+
+    def test_negative_decimals_rejected(self):
+        with pytest.raises((ValueError, TypeError)):
+            CoinInstrument(symbol="BTC", decimals=-1)
+
+    def test_symbol_whitespace_guard_fires_via_factory(self):
+        with pytest.raises((ValueError, TypeError)):
+            CoinInstrument.crypto("   ")
+
+    def test_assignment_validates(self):
+        coin = CoinInstrument.crypto("BTC")
+        with pytest.raises((ValueError, TypeError)):
+            coin.symbol = ""


### PR DESCRIPTION
## Delivery

- Action: implement
- Target: Add CRYPTO instrument type to engine/core/instruments.py: extend InstrumentType enum, add CoinInstrument model with crypto-specific fields (chain, decimals), add crypto() factory with type-guard validation, and write targeted tests

Closes #1011
