### PR TITLE
fix(instruments): override model_copy to preserve field normalization

### DIFF
--- a/engine/core/instruments.py
+++ b/engine/core/instruments.py
@@ -18,6 +18,7 @@ evolves independently from the instrument taxonomy (what the engine
 
 from __future__ import annotations
 
+from collections.abc import Mapping  # noqa: TC003
 from datetime import date  # noqa: TC003 - needed at runtime by pydantic
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
@@ -173,6 +174,34 @@ class Instrument(BaseModel):
                 pass
         return self
 
+    def model_copy(  # type: ignore[override]
+        self,
+        *,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> Instrument:
+        """Return a copy, re-running every validator on the new field set.
+
+        Pydantic's default ``model_copy`` short-circuits validation: it
+        splats the ``update`` values straight into ``__dict__``. Because
+        ``validate_assignment`` only governs attribute *assignment*
+        (``inst.symbol = ...``), a ``model_copy(update={"symbol": " x "})``
+        would happily yield an instrument whose symbol violates the
+        whitespace invariant — silently bypassing every check above.
+
+        We intercept the ``update`` dict, merge it on top of
+        ``model_dump()``, and rebuild through ``model_validate`` so the
+        symbol/whitespace validator and every asset-class invariant run
+        again on the merged field set. With no ``update`` we fall
+        through to the cheap parent copy so callers that only want a
+        distinct instance keep the original O(1) behaviour (and ``deep``
+        still applies there).
+        """
+        if not update:
+            return super().model_copy(update=update, deep=deep)
+        merged: dict[str, Any] = {**self.model_dump(), **update}
+        return type(self).model_validate(merged)
+
     # ── Derived properties ───────────────────────────────────────────
 
     @property
@@ -229,9 +258,7 @@ class Instrument(BaseModel):
         )
 
     @classmethod
-    def etf(
-        cls, symbol: str, *, exchange: str | None = None, currency: str = "USD"
-    ) -> Instrument:
+    def etf(cls, symbol: str, *, exchange: str | None = None, currency: str = "USD") -> Instrument:
         return cls(
             symbol=symbol,
             asset_class=InstrumentAssetClass.ETF,
@@ -240,9 +267,7 @@ class Instrument(BaseModel):
         )
 
     @classmethod
-    def crypto(
-        cls, base: str, quote: str, *, exchange: str | None = None
-    ) -> Instrument:
+    def crypto(cls, base: str, quote: str, *, exchange: str | None = None) -> Instrument:
         return cls(
             symbol=f"{base}/{quote}",
             asset_class=InstrumentAssetClass.CRYPTO,
@@ -253,9 +278,7 @@ class Instrument(BaseModel):
         )
 
     @classmethod
-    def crypto_perp(
-        cls, base: str, quote: str, *, exchange: str | None = None
-    ) -> Instrument:
+    def crypto_perp(cls, base: str, quote: str, *, exchange: str | None = None) -> Instrument:
         return cls(
             symbol=f"{base}/{quote}:PERP",
             asset_class=InstrumentAssetClass.CRYPTO_PERP,

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 
+import pydantic
 import pytest
 
 from engine.core.instruments import (
@@ -105,12 +106,8 @@ class TestUidUniqueness:
         assert a.uid != b.uid
 
     def test_two_options_with_different_strikes_distinct(self):
-        a = Instrument.option(
-            "AAPL", 200.0, date(2026, 6, 19), OptionType.CALL
-        )
-        b = Instrument.option(
-            "AAPL", 210.0, date(2026, 6, 19), OptionType.CALL
-        )
+        a = Instrument.option("AAPL", 200.0, date(2026, 6, 19), OptionType.CALL)
+        b = Instrument.option("AAPL", 210.0, date(2026, 6, 19), OptionType.CALL)
         assert a.uid != b.uid
 
     def test_spot_vs_perp_vs_future_uids_distinct(self):
@@ -183,9 +180,7 @@ class TestSerializationRoundtrip:
 class TestStrikeBoundary:
     def test_zero_strike_rejected(self):
         with pytest.raises((ValueError, TypeError)):
-            Instrument.option(
-                "AAPL", 0.0, date(2026, 6, 19), OptionType.CALL
-            )
+            Instrument.option("AAPL", 0.0, date(2026, 6, 19), OptionType.CALL)
 
 
 class TestInstrumentValidation:
@@ -198,20 +193,39 @@ class TestInstrumentValidation:
 
     def test_negative_strike_rejected(self):
         with pytest.raises((ValueError, TypeError)):
-            Instrument.option(
-                "AAPL", -1.0, date(2026, 6, 19), OptionType.CALL
-            )
+            Instrument.option("AAPL", -1.0, date(2026, 6, 19), OptionType.CALL)
 
 
 class TestSerialization:
     def test_round_trip_through_dict(self):
-        inst = Instrument.option(
-            "AAPL", 200.0, date(2026, 6, 19), OptionType.CALL
-        )
+        inst = Instrument.option("AAPL", 200.0, date(2026, 6, 19), OptionType.CALL)
         as_dict = inst.model_dump(mode="json")
         rebuilt = Instrument.model_validate(as_dict)
         assert rebuilt.uid == inst.uid
         assert rebuilt.option_type == OptionType.CALL
+
+
+class TestModelCopyRevalidates:
+    def test_model_copy_reruns_all_validators(self):
+        # Pydantic's default ``model_copy`` bypasses validation: it pokes
+        # the ``update`` values straight into __dict__, so a whitespace-
+        # laden symbol would sneak through. The override merges the
+        # update with ``model_dump()`` and rebuilds via
+        # ``model_validate``, re-running every validator — so the bad
+        # update is rejected exactly as ``Instrument.equity(" x ")`` is.
+        inst = Instrument.equity("AAPL")
+        with pytest.raises((ValueError, pydantic.ValidationError)):
+            inst.model_copy(update={"symbol": " x "})
+
+        # A valid update still round-trips and the original is untouched.
+        copy = inst.model_copy(update={"symbol": "MSFT"})
+        assert copy.symbol == "MSFT"
+        assert copy.uid == "MSFT"
+        assert inst.symbol == "AAPL"
+
+        # No-arg copy keeps the fast parent path (distinct instance).
+        assert inst.model_copy() is not inst
+        assert inst.model_copy().symbol == "AAPL"
 
 
 class TestFromString:


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Override model_copy in Instrument base class to prevent normalization bypass — ensure model_copy(update=...) re-runs field validators by routing through model_validate

Closes #1015
