### PR TITLE
fix(instruments): respect deep=True in model_copy when update is provided

### DIFF
--- a/engine/core/instruments.py
+++ b/engine/core/instruments.py
@@ -18,6 +18,7 @@ evolves independently from the instrument taxonomy (what the engine
 
 from __future__ import annotations
 
+import copy
 from collections.abc import Mapping  # noqa: TC003
 from datetime import date  # noqa: TC003 - needed at runtime by pydantic
 from enum import StrEnum
@@ -200,6 +201,16 @@ class Instrument(BaseModel):
         if not update:
             return super().model_copy(update=update, deep=deep)
         merged: dict[str, Any] = {**self.model_dump(), **update}
+        if deep:
+            # ``model_validate`` only re-runs the field validators; for
+            # nested mutable values it cannot reach into (custom/
+            # arbitrary types, or collections pydantic copies by default
+            # today but is free to stop copying tomorrow) it passes the
+            # *same* object reference through. ``deep=True`` promises a
+            # fully independent copy, so deep-copy the merged payload
+            # before validation — this is what makes the contract hold
+            # for every field type, not just the scalar ones above.
+            merged = copy.deepcopy(merged)
         return type(self).model_validate(merged)
 
     # ── Derived properties ───────────────────────────────────────────

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -228,6 +228,85 @@ class TestModelCopyRevalidates:
         assert inst.model_copy().symbol == "AAPL"
 
 
+class TestModelCopyDeepIsolatesNestedMutables:
+    """``model_copy(update=..., deep=True)`` must yield fully independent
+    nested mutable values.
+
+    The override's update branch rebuilds via ``model_validate``. That
+    re-runs the field validators, but for nested mutables it cannot
+    reach into (custom/arbitrary types especially) pydantic passes the
+    *same* object reference through, so the copy and the original would
+    share the mutable and a mutation in one would leak into the other.
+    ``deep=True`` promises a truly independent copy, so the merged
+    payload is deep-copied before validation.
+    """
+
+    @staticmethod
+    def _mutable_model():
+        # A nested mutable type that pydantic treats as an arbitrary
+        # type and therefore passes *by reference* during validation —
+        # this is the field shape that makes the deep-copy contract
+        # observable (pydantic deep-copies plain lists/dicts itself, so
+        # those don't surface the bug).
+        class Notes:
+            def __init__(self, items):
+                self.items = list(items)
+
+        class TaggedInstrument(Instrument):
+            # Subclasses inherit Instrument.model_config (validate_assignment,
+            # frozen=False); we only add the opt-in needed to accept the
+            # custom ``Notes`` type, which pydantic then passes *by
+            # reference* during validation — the field shape that makes
+            # the deep-copy contract observable.
+            model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+            notes: Notes | None = None
+
+        return TaggedInstrument, Notes
+
+    def test_deep_copy_update_does_not_share_nested_mutable(self):
+        TaggedInstrument, _Notes = self._mutable_model()
+        orig = TaggedInstrument(
+            symbol="AAPL",
+            asset_class=InstrumentAssetClass.EQUITY,
+            notes=_Notes(["a", "b"]),
+        )
+
+        copy = orig.model_copy(update={"symbol": "MSFT"}, deep=True)
+
+        # The nested mutable is a distinct object — not the original's.
+        assert copy.notes is not orig.notes
+
+    def test_mutating_deep_copy_does_not_leak_into_original(self):
+        TaggedInstrument, _Notes = self._mutable_model()
+        orig = TaggedInstrument(
+            symbol="AAPL",
+            asset_class=InstrumentAssetClass.EQUITY,
+            notes=_Notes(["a", "b"]),
+        )
+
+        copy = orig.model_copy(update={"symbol": "MSFT"}, deep=True)
+        copy.notes.items.append("MUT")
+
+        # Original is untouched even after mutating the copy's nested mutable.
+        assert orig.notes.items == ["a", "b"]
+        assert copy.notes.items == ["a", "b", "MUT"]
+
+    def test_deep_copy_update_still_revalidates_and_applies_update(self):
+        inst = Instrument.equity("AAPL")
+        deep_copy = inst.model_copy(update={"symbol": "MSFT"}, deep=True)
+
+        assert deep_copy.symbol == "MSFT"
+        assert deep_copy.uid == "MSFT"
+        assert inst.symbol == "AAPL"  # original untouched
+
+    def test_deep_copy_update_re_runs_validators(self):
+        # deep=True must not short-circuit revalidation: a bad update is
+        # rejected just like the deep=False / plain update path.
+        inst = Instrument.equity("AAPL")
+        with pytest.raises((ValueError, pydantic.ValidationError)):
+            inst.model_copy(update={"symbol": " x "}, deep=True)
+
+
 class TestFromString:
     def test_from_string_equity(self):
         inst = Instrument.from_string("AAPL")


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix deep=True parameter silently ignored when update is provided in Instrument.model_copy override (engine/core/instruments.py lines 195-197). When update is truthy, the code routes through model_validate(merged) which never deep-copies nested model instances, lists, or other shared mutable references — even when the caller explicitly passed deep=True. This causes silent aliasing bugs.

Closes #1017
