### PR TITLE
fix(websocket): snapshot connections under lock and add channel authorization

### DIFF
--- a/engine/api/websocket/manager.py
+++ b/engine/api/websocket/manager.py
@@ -38,6 +38,7 @@ from fastapi import WebSocketDisconnect
 
 if TYPE_CHECKING:
     import uuid
+    from collections.abc import Callable
 
     from fastapi import WebSocket
 
@@ -82,17 +83,39 @@ class ConnectionManager:
     registry tidy.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        channel_name_validator: Callable[[str, str], bool] | None = None,
+    ) -> None:
         self.connections: dict[str, WebSocket] = {}
         self.channel_subscriptions: dict[str, set[str]] = {}
+        # connection_id -> authenticated owner id (``None`` = anonymous).
+        # Backs the prefix-based ACL enforced in :meth:`subscribe` so a
+        # caller can only join its own ``user:{id}`` channels.
+        self._connection_owners: dict[str, str | None] = {}
+        # Optional extra gate ``(connection_id, channel) -> bool``. Runs
+        # *in addition to* (never instead of) the built-in owned-channel
+        # ACL, so a buggy validator can never widen access.
+        self._channel_name_validator = channel_name_validator
         self._lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self, connection_id: str, ws: WebSocket) -> None:
+    async def connect(
+        self,
+        connection_id: str,
+        ws: WebSocket,
+        *,
+        user_id: str | None = None,
+    ) -> None:
         """Register an open WebSocket under ``connection_id``.
+
+        ``user_id`` (optional) records the authenticated identity that
+        owns this connection; :meth:`subscribe` uses it for the
+        prefix-based ACL on ``user:{id}`` channels.
 
         Reconnecting with an id that already exists replaces the socket
         (the new socket inherits no prior channel membership — call
@@ -102,6 +125,7 @@ class ConnectionManager:
         """
         async with self._lock:
             self.connections[connection_id] = ws
+            self._connection_owners[connection_id] = user_id
             # Defensive: drop any orphan memberships left over from a
             # prior connection that reused this id without disconnecting.
             for members in self.channel_subscriptions.values():
@@ -110,6 +134,7 @@ class ConnectionManager:
         logger.info(
             "ws.connected",
             connection_id=connection_id,
+            user_id=user_id,
             total_connections=len(self.connections),
         )
 
@@ -120,6 +145,7 @@ class ConnectionManager:
         """
         async with self._lock:
             removed = self.connections.pop(connection_id, None)
+            self._connection_owners.pop(connection_id, None)
             for members in self.channel_subscriptions.values():
                 members.discard(connection_id)
             self._prune_empty_channels_locked()
@@ -139,14 +165,72 @@ class ConnectionManager:
 
         Returns ``True`` if the connection exists and was subscribed
         (or was already a member), ``False`` if the connection is not
-        registered — subscribing an unknown id is a no-op so we never
-        accumulate orphan memberships that broadcasts would chase.
+        registered or the channel is denied — subscribing an unknown id
+        is a no-op so we never accumulate orphan memberships that
+        broadcasts would chase.
+
+        Channel authorization runs two gates, both of which must pass:
+
+        1. **Prefix-based owned-channel ACL** — a channel of the form
+           ``user:{id}`` or ``user:{id}:...`` is private to the
+           connection authenticated as ``{id}`` (recorded via
+           :meth:`connect`). Anonymous connections (no ``user_id``) are
+           denied; a mismatched identity is denied. All other channels
+           pass this gate.
+        2. **Optional ``channel_name_validator``** — if one was supplied
+           to the constructor it must also return ``True`` for the
+           ``(connection_id, channel)`` pair.
         """
         async with self._lock:
             if connection_id not in self.connections:
                 return False
+            if not self._channel_allowed_locked(connection_id, channel):
+                logger.warning(
+                    "ws.subscribe_denied",
+                    connection_id=connection_id,
+                    channel=channel,
+                )
+                return False
             self.channel_subscriptions.setdefault(channel, set()).add(connection_id)
             return True
+
+    def _channel_allowed_locked(
+        self, connection_id: str, channel: str
+    ) -> bool:
+        """Owned-channel ACL + optional custom validator (caller holds lock).
+
+        Returns ``True`` only when *both* gates pass:
+
+        - The built-in prefix rule: ``user:{id}`` / ``user:{id}:*``
+          channels require the connection's recorded ``user_id`` to
+          equal ``{id}``. Bare ``user`` / ``user:`` (no id) and any
+          user-scoped channel for an anonymous or mismatched caller are
+          denied. Non-``user`` channels pass.
+        - The optional ``channel_name_validator`` (if set) must return
+          ``True``. A validator that raises is treated as a denial so a
+          buggy callback can never open access.
+        """
+        if channel == "user" or channel.startswith("user:"):
+            parts = channel.split(":", 2)
+            target_id = parts[1] if len(parts) > 1 else ""
+            owner = self._connection_owners.get(connection_id)
+            if not target_id or owner is None or owner != target_id:
+                return False
+        if self._channel_name_validator is not None:
+            try:
+                allowed = self._channel_name_validator(connection_id, channel)
+            except Exception as exc:
+                logger.warning(
+                    "ws.channel_validator_error",
+                    connection_id=connection_id,
+                    channel=channel,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc)[:200],
+                )
+                return False
+            if not allowed:
+                return False
+        return True
 
     async def unsubscribe(self, connection_id: str, channel: str) -> bool:
         """Remove ``connection_id`` from ``channel``.
@@ -178,7 +262,14 @@ class ConnectionManager:
             members = self.channel_subscriptions.get(channel)
             if not members:
                 return 0
-            recipients = list(members)
+            # Snapshot the actual WebSocket handles under the lock so a
+            # reconnect mid-broadcast can't redirect the send to a
+            # replacement socket — the original handle stays the target.
+            recipients = [
+                (cid, ws)
+                for cid in members
+                if (ws := self.connections.get(cid)) is not None
+            ]
 
         sent = await self._fanout(recipients, message)
         logger.debug(
@@ -197,7 +288,8 @@ class ConnectionManager:
         successful deliveries.
         """
         async with self._lock:
-            recipients = list(self.connections)
+            # Snapshot the (id, ws) pairs under the lock — see broadcast().
+            recipients = list(self.connections.items())
 
         sent = await self._fanout(recipients, message)
         logger.debug(
@@ -214,49 +306,62 @@ class ConnectionManager:
         or the send failed (a failed send triggers cleanup just like a
         broadcast failure).
         """
-        sent = await self._fanout([connection_id], message)
+        async with self._lock:
+            ws = self.connections.get(connection_id)
+            if ws is None:
+                return False
+            recipients = [(connection_id, ws)]
+        sent = await self._fanout(recipients, message)
         return sent == 1
 
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
 
-    async def _fanout(self, recipients: list[str], message: Any) -> int:
+    async def _fanout(
+        self, recipients: list[tuple[str, WebSocket]], message: Any
+    ) -> int:
         """Concurrently deliver ``message`` to ``recipients`` and clean up failures.
 
-        ``recipients`` is a snapshot taken under the lock; the actual
-        sends (and the cleanup of any that fail) happen without holding
-        the lock so a single unresponsive client can't block the rest.
+        ``recipients`` is a snapshot of ``(connection_id, WebSocket)``
+        pairs taken under the lock. Because the *actual handle* is
+        captured, the send always targets the original socket even if a
+        reconnect swaps the entry in :attr:`connections` while the
+        fan-out is in flight. The sends (and the cleanup of any that
+        fail) run without holding the lock so a single unresponsive
+        client can't block the rest.
         """
         if not recipients:
             return 0
         results = await asyncio.gather(
-            *(self._safe_send(cid, message) for cid in recipients),
+            *(self._safe_send(cid, ws, message) for cid, ws in recipients),
             return_exceptions=True,
         )
 
-        failed: list[str] = []
+        failed: list[tuple[str, WebSocket]] = []
         delivered = 0
-        for cid, result in zip(recipients, results, strict=True):
+        for (cid, ws), result in zip(recipients, results, strict=True):
             if result is True:
                 delivered += 1
             else:
-                failed.append(cid)
+                failed.append((cid, ws))
 
         if failed:
             await self._cleanup_failed(failed)
         return delivered
 
-    async def _safe_send(self, connection_id: str, message: Any) -> bool:
+    async def _safe_send(
+        self, connection_id: str, ws: WebSocket, message: Any
+    ) -> bool:
         """Deliver one message; return ``True`` on success, ``False`` on failure.
 
+        Sends to the *snapshotted* ``ws`` handle (not a fresh lookup) so
+        a reconnect that swaps the entry in :attr:`connections` mid-
+        broadcast can't redirect the message to a replacement socket.
         ``WebSocketDisconnect`` and any other send error are swallowed
         and reported as a failure so the caller can clean the dead
         connection up.
         """
-        ws = self.connections.get(connection_id)
-        if ws is None:
-            return False
         try:
             await ws.send_json(message)
         except WebSocketDisconnect:
@@ -272,14 +377,29 @@ class ConnectionManager:
                 error_message=str(exc)[:200],
             )
             return False
+        return True
 
-    async def _cleanup_failed(self, connection_ids: list[str]) -> None:
-        """Detach every id whose send failed and prune their memberships."""
-        if not connection_ids:
+    async def _cleanup_failed(
+        self, failed: list[tuple[str, WebSocket]]
+    ) -> None:
+        """Detach every (id, handle) whose send failed and prune memberships.
+
+        Identity-checks each handle before evicting: if a reconnect has
+        already replaced the failed socket with a fresh healthy one, we
+        leave the new handle in place rather than tearing down the wrong
+        connection. Owner records are pruned alongside the connection.
+        """
+        if not failed:
             return
         async with self._lock:
-            for cid in connection_ids:
+            for cid, ws in failed:
+                current = self.connections.get(cid)
+                if current is not ws:
+                    # A reconnect swapped the handle — leave the new,
+                    # presumably healthy, socket alone.
+                    continue
                 self.connections.pop(cid, None)
+                self._connection_owners.pop(cid, None)
                 for members in self.channel_subscriptions.values():
                     members.discard(cid)
             self._prune_empty_channels_locked()

--- a/tests/test_websocket_channel_manager.py
+++ b/tests/test_websocket_channel_manager.py
@@ -1,0 +1,346 @@
+"""Tests for the channel-based :class:`ConnectionManager` (SEV-298).
+
+Covers the two hardening fixes tracked in this cycle:
+
+1. ``_fanout`` snapshots the *actual* WebSocket handles under the asyncio
+   lock so a reconnect mid-broadcast can't redirect a send to a
+   replacement socket, and cleanup never evicts a freshly-reconnected
+   healthy handle.
+2. ``subscribe`` enforces a prefix-based owned-channel ACL (plus an
+   optional ``channel_name_validator`` callback) so a caller can only
+   join its own ``user:{id}`` channels.
+
+It also pins the long-latent regression where ``_safe_send`` failed to
+``return True`` on success — every successful delivery used to be
+counted as a failure and the connection torn down.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from engine.api.websocket.manager import ConnectionManager
+
+
+class _FakeWS:
+    """Minimal WebSocket stand-in. Captures every send_json call.
+
+    ``fail`` raises a generic ``RuntimeError``; ``disconnect`` raises
+    ``WebSocketDisconnect`` to exercise the manager's dead-connection
+    path. ``on_send`` is an optional hook invoked *before* the send so a
+    test can simulate a reconnect happening mid-broadcast.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail: bool = False,
+        disconnect: bool = False,
+        on_send=None,
+    ) -> None:
+        self.sent: list[dict] = []
+        self.fail = fail
+        self.disconnect = disconnect
+        self.on_send = on_send
+        self.id = uuid.uuid4()
+
+    async def send_json(self, payload: dict) -> None:
+        if self.on_send is not None:
+            self.on_send(self)
+        if self.disconnect:
+            raise WebSocketDisconnect
+        if self.fail:
+            raise RuntimeError("simulated send failure")
+        self.sent.append(payload)
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeWS) and other.id == self.id
+
+
+@pytest.fixture
+def manager() -> ConnectionManager:
+    return ConnectionManager()
+
+
+# ---------------------------------------------------------------------------
+# _fanout — snapshot the actual handle under the lock
+# ---------------------------------------------------------------------------
+
+
+class TestFanoutSnapshotsHandle:
+    async def test_send_targets_original_handle_after_reconnect(self, manager):
+        """A reconnect during fan-out must NOT redirect the in-flight send."""
+        original = _FakeWS()
+        replacement = _FakeWS()
+
+        await manager.connect("conn-1", original, user_id="u1")
+        await manager.subscribe("conn-1", "portfolio")
+
+        # When the original handle is asked to send, a brand-new socket
+        # reconnects under the same id — swapping the registry entry.
+        def reconnect_mid_send(_ws):
+            awaitable = manager.connect("conn-1", replacement, user_id="u1")
+            # Schedule the reconnect synchronously by driving it to
+            # completion inside the running loop.
+            import asyncio
+
+            asyncio.get_running_loop().create_task(awaitable)
+
+        original.on_send = reconnect_mid_send
+
+        delivered = await manager.broadcast("portfolio", {"v": 1})
+        # Let the scheduled reconnect land.
+        import asyncio
+
+        await asyncio.sleep(0)
+
+        assert delivered == 1
+        # The ORIGINAL handle received the message...
+        assert original.sent == [{"v": 1}]
+        # ...the replacement did NOT, even though it now owns the id.
+        assert replacement.sent == []
+
+    async def test_reconnected_healthy_handle_not_evicted(self, manager):
+        """A failed send whose handle was already replaced must not pull
+        the fresh, healthy replacement down with it."""
+        stale = _FakeWS(disconnect=True)  # send raises WebSocketDisconnect
+        fresh = _FakeWS()
+
+        await manager.connect("conn-1", stale, user_id="u1")
+        await manager.subscribe("conn-1", "portfolio")
+
+        # The stale socket's send triggers a reconnect before failing.
+        def reconnect_then_fail(_ws):
+            import asyncio
+
+            asyncio.get_running_loop().create_task(
+                manager.connect("conn-1", fresh, user_id="u1")
+            )
+
+        stale.on_send = reconnect_then_fail
+
+        delivered = await manager.broadcast("portfolio", {"v": 2})
+        import asyncio
+
+        await asyncio.sleep(0)
+
+        # The stale send failed, so nothing was delivered this round.
+        assert delivered == 0
+        # But the fresh handle is still registered — cleanup must not
+        # evict it just because the stale handle (same id) failed.
+        assert manager.is_connected("conn-1")
+        assert manager.connections["conn-1"] is fresh
+
+    async def test_successful_send_not_counted_as_failure(self, manager):
+        """Regression: _safe_send must return True so healthy sockets
+        are neither under-counted nor evicted after a successful send."""
+        ws = _FakeWS()
+        await manager.connect("conn-1", ws, user_id="u1")
+        await manager.subscribe("conn-1", "portfolio")
+
+        delivered = await manager.broadcast("portfolio", {"v": 3})
+
+        assert delivered == 1
+        assert ws.sent == [{"v": 3}]
+        # The connection must survive a successful delivery.
+        assert manager.is_connected("conn-1")
+        assert manager.is_subscribed("conn-1", "portfolio")
+
+    async def test_failed_send_evicts_only_that_connection(self, manager):
+        good = _FakeWS()
+        bad = _FakeWS(disconnect=True)
+        await manager.connect("good", good)
+        await manager.connect("bad", bad)
+        await manager.subscribe("good", "alerts")
+        await manager.subscribe("bad", "alerts")
+
+        delivered = await manager.broadcast("alerts", {"v": 4})
+
+        assert delivered == 1
+        assert good.sent == [{"v": 4}]
+        assert manager.is_connected("good")
+        assert not manager.is_connected("bad")
+        # Bad connection pruned from the channel membership too.
+        assert manager.get_subscribers("alerts") == frozenset({"good"})
+
+
+# ---------------------------------------------------------------------------
+# broadcast / broadcast_all / send
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcast:
+    async def test_only_subscribed_recipients(self, manager):
+        a, b = _FakeWS(), _FakeWS()
+        await manager.connect("a", a)
+        await manager.connect("b", b)
+        await manager.subscribe("a", "portfolio")
+        await manager.subscribe("b", "alerts")
+
+        delivered = await manager.broadcast("portfolio", {"v": 1})
+
+        assert delivered == 1
+        assert a.sent == [{"v": 1}]
+        assert b.sent == []
+
+    async def test_no_subscribers_returns_zero(self, manager):
+        assert await manager.broadcast("ghost", {"v": 1}) == 0
+
+    async def test_broadcast_all_reaches_every_connection(self, manager):
+        a, b = _FakeWS(), _FakeWS()
+        await manager.connect("a", a)
+        await manager.connect("b", b)
+
+        delivered = await manager.broadcast_all({"v": 9})
+
+        assert delivered == 2
+        assert a.sent == [{"v": 9}]
+        assert b.sent == [{"v": 9}]
+
+    async def test_send_single_connection(self, manager):
+        ws = _FakeWS()
+        await manager.connect("x", ws)
+
+        assert await manager.send("x", {"v": 5}) is True
+        assert ws.sent == [{"v": 5}]
+
+    async def test_send_unknown_connection(self, manager):
+        assert await manager.send("ghost", {"v": 5}) is False
+
+
+# ---------------------------------------------------------------------------
+# subscribe — prefix-based owned-channel ACL + optional validator
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeAcl:
+    async def test_owner_match_allows_owned_channel(self, manager):
+        ws = _FakeWS()
+        await manager.connect("c1", ws, user_id="42")
+
+        assert await manager.subscribe("c1", "user:42") is True
+        assert manager.is_subscribed("c1", "user:42")
+
+        # Owned sub-channels under the same id are allowed too.
+        assert await manager.subscribe("c1", "user:42:portfolio") is True
+        assert manager.is_subscribed("c1", "user:42:portfolio")
+
+    async def test_owner_mismatch_denies_owned_channel(self, manager):
+        ws = _FakeWS()
+        await manager.connect("c1", ws, user_id="42")
+
+        assert await manager.subscribe("c1", "user:99") is False
+        assert not manager.is_subscribed("c1", "user:99")
+
+    async def test_anonymous_denied_owned_channel(self, manager):
+        ws = _FakeWS()
+        await manager.connect("c1", ws)  # no user_id
+
+        assert await manager.subscribe("c1", "user:42") is False
+        assert not manager.is_subscribed("c1", "user:42")
+
+    async def test_bare_user_and_empty_id_denied(self, manager):
+        ws = _FakeWS()
+        await manager.connect("c1", ws, user_id="42")
+
+        assert await manager.subscribe("c1", "user") is False
+        assert await manager.subscribe("c1", "user:") is False
+        assert not manager.is_subscribed("c1", "user")
+        assert not manager.is_subscribed("c1", "user:")
+
+    async def test_non_user_channels_allowed_regardless_of_owner(self, manager):
+        anon = _FakeWS()
+        owned = _FakeWS()
+        await manager.connect("anon", anon)  # anonymous
+        await manager.connect("owned", owned, user_id="1")
+
+        assert await manager.subscribe("anon", "portfolio") is True
+        assert await manager.subscribe("owned", "alerts") is True
+        # 'users' (plural) is NOT an owned channel — must be allowed.
+        assert await manager.subscribe("anon", "users:global") is True
+
+    async def test_subscribe_unknown_connection_is_noop(self, manager):
+        assert await manager.subscribe("ghost", "portfolio") is False
+
+
+class TestChannelNameValidator:
+    async def test_validator_can_deny_extra_channels(self):
+        mgr = ConnectionManager(
+            channel_name_validator=lambda cid, ch: ch.startswith("allow:")
+        )
+        ws = _FakeWS()
+        await mgr.connect("c1", ws)
+
+        assert await mgr.subscribe("c1", "allow:topic") is True
+        assert await mgr.subscribe("c1", "deny:topic") is False
+        assert mgr.is_subscribed("c1", "allow:topic")
+        assert not mgr.is_subscribed("c1", "deny:topic")
+
+    async def test_validator_cannot_widen_owned_channel_acl(self):
+        # Validator always returns True, yet the built-in owned-channel
+        # ACL must still reject a user:{id} channel for the wrong caller.
+        mgr = ConnectionManager(channel_name_validator=lambda cid, ch: True)
+        ws = _FakeWS()
+        await mgr.connect("c1", ws, user_id="1")
+
+        assert await mgr.subscribe("c1", "user:99") is False
+        assert not mgr.is_subscribed("c1", "user:99")
+        # The owner's own channel is still allowed.
+        assert await mgr.subscribe("c1", "user:1") is True
+
+    async def test_validator_raising_is_treated_as_denial(self):
+        def boom(_cid, _ch):
+            raise RuntimeError("validator exploded")
+
+        mgr = ConnectionManager(channel_name_validator=boom)
+        ws = _FakeWS()
+        await mgr.connect("c1", ws)
+
+        assert await mgr.subscribe("c1", "portfolio") is False
+        assert not mgr.is_subscribed("c1", "portfolio")
+
+
+# ---------------------------------------------------------------------------
+# connect / disconnect — owner bookkeeping & reconnect semantics
+# ---------------------------------------------------------------------------
+
+
+class TestConnectDisconnect:
+    async def test_connect_records_owner(self, manager):
+        ws = _FakeWS()
+        await manager.connect("c1", ws, user_id="u1")
+
+        assert manager._connection_owners["c1"] == "u1"
+
+    async def test_disconnect_clears_owner(self, manager):
+        ws = _FakeWS()
+        await manager.connect("c1", ws, user_id="u1")
+        await manager.disconnect("c1")
+
+        assert "c1" not in manager._connection_owners
+        assert not manager.is_connected("c1")
+
+    async def test_disconnect_unknown_is_noop(self, manager):
+        await manager.disconnect("ghost")  # must not raise
+        assert manager.connection_count == 0
+
+    async def test_reconnect_clears_old_subscriptions(self, manager):
+        old = _FakeWS()
+        new = _FakeWS()
+        await manager.connect("c1", old, user_id="u1")
+        await manager.subscribe("c1", "portfolio")
+
+        # Reconnect under the same id with a fresh socket.
+        await manager.connect("c1", new, user_id="u1")
+
+        # The new socket inherits no prior channel membership.
+        assert not manager.is_subscribed("c1", "portfolio")
+        assert await manager.broadcast("portfolio", {"v": 1}) == 0
+        assert old.sent == []
+        assert new.sent == []


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix the race condition in ConnectionManager._fanout (snapshot WebSocket objects under lock instead of IDs) and add basic channel-name authorization to subscribe()

Closes #1029
