### PR TITLE
feat(portfolio): add CapitalAllocation model for strategy capital weights

### DIFF
--- a/engine/portfolio/__init__.py
+++ b/engine/portfolio/__init__.py
@@ -1,0 +1,7 @@
+"""Portfolio-level models: capital allocation across strategies."""
+
+from __future__ import annotations
+
+from engine.portfolio.allocation import CapitalAllocation
+
+__all__ = ["CapitalAllocation"]

--- a/engine/portfolio/allocation.py
+++ b/engine/portfolio/allocation.py
@@ -1,0 +1,145 @@
+"""
+Capital allocation across strategies.
+
+A :class:`CapitalAllocation` records how total deployable capital is split
+between competing strategies. Strategy weights always sum to exactly 1.0
+(within a small epsilon, to absorb float-accumulation noise), are
+individually non-negative, and the number of distinct strategies is capped
+by ``max_strategies``.
+
+This model is a pure value object: it owns no state beyond its fields and
+performs no I/O. The engine consults it when sizing positions per strategy.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# A weight vector must land within epsilon of 1.0 once summed. Exact float
+# equality is brittle (0.1 + 0.2 + 0.3 + 0.4 != 1.0 in IEEE-754), so we allow
+# a 1e-9 tolerance — still tight enough to reject a forgotten 5% slice.
+_WEIGHT_SUM_EPSILON = 1e-9
+
+# Default cap on how many strategies a single allocation may reference. Keeps
+# pathological inputs (thousands of near-zero slices) from sneaking through.
+_DEFAULT_MAX_STRATEGIES = 50
+
+# Money is denominated to the cent throughout the cost/allocation stack.
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0")
+
+
+class CapitalAllocation(BaseModel):
+    """Capital split across trading strategies.
+
+    ``strategy_weights`` maps a strategy id to its share of ``total_capital``
+    (each weight in ``[0.0, 1.0]``). The shares must be non-negative and sum
+    to 1.0 (± epsilon), and the number of entries cannot exceed
+    ``max_strategies``.
+
+    Notes:
+        - An empty ``strategy_weights`` is valid and represents a
+          not-yet-deployed allocation; the sum-to-1.0 rule only applies once
+          at least one weight is present.
+        - Money is quantised to the cent on read-back (see
+          :meth:`get_allocation`), matching the convention used by the
+          execution-cost modules.
+    """
+
+    model_config = {"validate_assignment": True}
+
+    strategy_weights: dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Per-strategy capital share. Each value is in [0.0, 1.0]; "
+            "non-empty dicts must sum to 1.0 (± epsilon)."
+        ),
+    )
+    total_capital: Decimal = Field(
+        default=_ZERO,
+        ge=0,
+        description="Total deployable capital backing this allocation (>= 0).",
+    )
+    max_strategies: int = Field(
+        default=_DEFAULT_MAX_STRATEGIES,
+        ge=1,
+        description="Upper bound on the number of distinct strategies.",
+    )
+
+    # ── per-field validation ────────────────────────────────────────── #
+    @field_validator("strategy_weights")
+    @classmethod
+    def _validate_each_weight(cls, weights: dict[str, float]) -> dict[str, float]:
+        """Reject non-finite (NaN/Inf), negative, or >1.0 weights, and blank
+        strategy ids. ``math.isfinite`` is essential: NaN comparisons all
+        return False, so a bare ``w < 0`` check would silently admit NaN."""
+        cleaned: dict[str, float] = {}
+        for sid, w in weights.items():
+            if not isinstance(sid, str) or not sid.strip():
+                raise ValueError("strategy id must be a non-empty string")
+            if w is None or isinstance(w, bool) or not isinstance(w, int | float):
+                raise ValueError(f"weight for {sid!r} must be a number")
+            wf = float(w)
+            if not math.isfinite(wf):
+                raise ValueError(f"weight for {sid!r} must be finite (got {w!r})")
+            if wf < 0.0:
+                raise ValueError(f"weight for {sid!r} must be non-negative (got {wf})")
+            if wf > 1.0:
+                raise ValueError(f"weight for {sid!r} must be <= 1.0 (got {wf})")
+            cleaned[sid] = wf
+        return cleaned
+
+    # ── cross-field validation ──────────────────────────────────────── #
+    @model_validator(mode="after")
+    def _check_count_and_sum(self) -> CapitalAllocation:
+        n = len(self.strategy_weights)
+        if n > self.max_strategies:
+            raise ValueError(
+                f"too many strategies: {n} > max_strategies ({self.max_strategies})"
+            )
+        if n == 0:
+            return self
+        total = math.fsum(self.strategy_weights.values())
+        if abs(total - 1.0) > _WEIGHT_SUM_EPSILON:
+            raise ValueError(
+                "strategy_weights must sum to 1.0 (± "
+                f"{_WEIGHT_SUM_EPSILON}); got {total!r}"
+            )
+        return self
+
+    # ── allocation math ─────────────────────────────────────────────── #
+    def get_allocation(self, strategy_id: str) -> Decimal:
+        """Capital assigned to ``strategy_id``, quantised to the cent.
+
+        Unknown strategies resolve to ``Decimal("0.00")`` rather than
+        raising, so callers can safely iterate over an arbitrary set of
+        strategy ids (e.g. taken from a position snapshot) without first
+        filtering to the allocation's keys.
+        """
+        weight = self.strategy_weights.get(strategy_id, 0.0)
+        if weight <= 0.0:
+            return _ZERO
+        # Decimal * float is unsupported and direct Decimal(float) carries
+        # binary noise; str() gives the shortest round-tripping repr so the
+        # multiplication stays exact before cent-level quantisation.
+        amount = self.total_capital * Decimal(str(weight))
+        return amount.quantize(_TWOPLACES)
+
+    def total_allocated(self) -> Decimal:
+        """Sum of every strategy's allocation.
+
+        For a valid allocation this equals ``total_capital`` modulo
+        cent-level rounding introduced by :meth:`get_allocation`.
+        """
+        if not self.strategy_weights:
+            return _ZERO
+        return sum(
+            (self.get_allocation(sid) for sid in self.strategy_weights),
+            start=_ZERO,
+        )
+
+
+__all__ = ["CapitalAllocation"]

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -1,0 +1,223 @@
+"""Tests for engine.portfolio.allocation.CapitalAllocation.
+
+Covers: valid multi-strategy allocation, weight-sum / sign / max-strategies
+constraints, NaN/Inf rejection (comparison-bypass guard), get_allocation
+correctness (known + unknown strategy, cent quantisation), total_allocated,
+and edge cases (zero capital, single strategy, empty allocation,
+validate_assignment).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from engine.portfolio.allocation import CapitalAllocation
+
+# --------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------- #
+
+
+def _allocation(
+    weights: dict[str, float],
+    capital: Decimal | str = "100000.00",
+    max_strategies: int = 50,
+) -> CapitalAllocation:
+    return CapitalAllocation(
+        strategy_weights=dict(weights),
+        total_capital=Decimal(str(capital)) if not isinstance(capital, Decimal) else capital,
+        max_strategies=max_strategies,
+    )
+
+
+# --------------------------------------------------------------------- #
+# Valid construction
+# --------------------------------------------------------------------- #
+
+
+def test_valid_equal_split_three_strategies() -> None:
+    alloc = _allocation({"alpha": 1 / 3, "beta": 1 / 3, "gamma": 1 / 3})
+    assert set(alloc.strategy_weights) == {"alpha", "beta", "gamma"}
+    assert alloc.total_capital == Decimal("100000.00")
+
+
+def test_valid_round_weight_split() -> None:
+    alloc = _allocation({"alpha": 0.5, "beta": 0.5})
+    assert alloc.strategy_weights == {"alpha": 0.5, "beta": 0.5}
+
+
+def test_single_strategy_weight_one_is_valid() -> None:
+    alloc = _allocation({"alpha": 1.0})
+    assert alloc.strategy_weights == {"alpha": 1.0}
+
+
+def test_empty_weights_is_valid_default_state() -> None:
+    alloc = CapitalAllocation(total_capital=Decimal("1000.00"))
+    assert alloc.strategy_weights == {}
+    assert alloc.get_allocation("alpha") == Decimal("0.00")
+    assert alloc.total_allocated() == Decimal("0")
+
+
+def test_default_max_strategies_is_fifty() -> None:
+    # 50 equal slices of 0.02; float drift absorbed by the epsilon guard.
+    weights = {f"s{i}": 0.02 for i in range(50)}
+    alloc = CapitalAllocation(
+        strategy_weights=weights, total_capital=Decimal("1.00")
+    )
+    assert len(alloc.strategy_weights) == 50
+
+
+# --------------------------------------------------------------------- #
+# Invalid weights
+# --------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [
+        {"alpha": -0.1, "beta": 1.1},  # negative + compensating >1
+        {"alpha": -0.5, "beta": 1.5},
+    ],
+    ids=["negative-and-over-one", "deeper-negative"],
+)
+def test_negative_weight_rejected(weights: dict[str, float]) -> None:
+    with pytest.raises(ValidationError, match=r"non-negative|<= 1.0"):
+        _allocation(weights)
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [
+        {"alpha": 0.5, "beta": 0.6},  # sum 1.1
+        {"alpha": 0.3, "beta": 0.3},  # sum 0.6
+        {"alpha": 0.9},  # single strategy, not 1.0
+    ],
+    ids=["sum-too-high", "sum-too-low", "single-not-one"],
+)
+def test_sum_not_one(weights: dict[str, float]) -> None:
+    with pytest.raises(ValidationError, match=r"sum to 1.0"):
+        _allocation(weights)
+
+
+def test_weight_above_one_rejected() -> None:
+    with pytest.raises(ValidationError, match=r"<= 1.0"):
+        _allocation({"alpha": 1.2, "beta": -0.2})
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_weight_rejected(bad: float) -> None:
+    # NaN/Inf bypass plain comparison guards (nan < 0 is False); the field
+    # validator processes alpha first and must reject it on the finite check
+    # before the model-level sum validator ever runs.
+    with pytest.raises(ValidationError, match="finite"):
+        _allocation({"alpha": bad, "beta": 1.0})
+
+
+def test_blank_strategy_id_rejected() -> None:
+    with pytest.raises(ValidationError, match="non-empty string"):
+        _allocation({"": 1.0})
+
+
+def test_negative_total_capital_rejected() -> None:
+    with pytest.raises(ValidationError):
+        CapitalAllocation(
+            strategy_weights={"alpha": 1.0}, total_capital=Decimal("-1.00")
+        )
+
+
+# --------------------------------------------------------------------- #
+# max_strategies constraint
+# --------------------------------------------------------------------- #
+
+
+def test_exceeding_max_strategies_rejected() -> None:
+    weights = {"a": 0.5, "b": 0.3, "c": 0.2}  # 3 strategies, sum 1.0
+    with pytest.raises(ValidationError, match=r"too many strategies: 3 > .* 2"):
+        _allocation(weights, max_strategies=2)
+
+
+def test_exactly_at_max_strategies_ok() -> None:
+    weights = {"a": 0.5, "b": 0.5}  # exactly max_strategies=2
+    alloc = _allocation(weights, max_strategies=2)
+    assert len(alloc.strategy_weights) == 2
+
+
+# --------------------------------------------------------------------- #
+# get_allocation
+# --------------------------------------------------------------------- #
+
+
+def test_get_allocation_known_strategy() -> None:
+    alloc = _allocation({"alpha": 0.25, "beta": 0.75}, capital="10000.00")
+    assert alloc.get_allocation("alpha") == Decimal("2500.00")
+    assert alloc.get_allocation("beta") == Decimal("7500.00")
+
+
+def test_get_allocation_unknown_strategy_is_zero() -> None:
+    alloc = _allocation({"alpha": 1.0}, capital="5000.00")
+    assert alloc.get_allocation("nope") == Decimal("0.00")
+
+
+def test_get_allocation_quantises_to_cents() -> None:
+    # 1000.00 * 0.3333 = 333.30 after cent quantisation.
+    alloc = _allocation({"alpha": 0.3333, "beta": 0.6667}, capital="1000.00")
+    assert alloc.get_allocation("alpha") == Decimal("333.30")
+    # 1000 * 0.6667 = 666.70
+    assert alloc.get_allocation("beta") == Decimal("666.70")
+
+
+def test_get_allocation_zero_weight_is_zero() -> None:
+    alloc = _allocation({"alpha": 1.0, "beta": 0.0}, capital="1000.00")
+    assert alloc.get_allocation("beta") == Decimal("0.00")
+
+
+# --------------------------------------------------------------------- #
+# total_allocated
+# --------------------------------------------------------------------- #
+
+
+def test_total_allocated_equals_capital_for_equal_split() -> None:
+    alloc = _allocation({"alpha": 0.5, "beta": 0.5}, capital="1000.00")
+    assert alloc.total_allocated() == Decimal("1000.00")
+
+
+def test_total_allocated_with_carrying_rounding() -> None:
+    # 1/3 slices: each allocation rounds to cents; total should still land
+    # within a cent of total_capital.
+    alloc = _allocation(
+        {"a": 1 / 3, "b": 1 / 3, "c": 1 / 3}, capital="9999.99"
+    )
+    diff = abs(alloc.total_allocated() - Decimal("9999.99"))
+    assert diff <= Decimal("0.03")
+
+
+# --------------------------------------------------------------------- #
+# Edge cases
+# --------------------------------------------------------------------- #
+
+
+def test_zero_capital_single_strategy() -> None:
+    alloc = _allocation({"alpha": 1.0}, capital="0")
+    assert alloc.get_allocation("alpha") == Decimal("0.00")
+    assert alloc.total_allocated() == Decimal("0")
+
+
+def test_total_capital_accepts_int_and_str_coercion() -> None:
+    alloc = CapitalAllocation(strategy_weights={"alpha": 1.0}, total_capital=1000)
+    assert alloc.total_capital == Decimal(1000)
+    assert alloc.get_allocation("alpha") == Decimal("1000.00")
+
+
+def test_validate_assignment_rejects_bad_update() -> None:
+    alloc = _allocation({"alpha": 1.0})
+    with pytest.raises(ValidationError, match=r"sum to 1.0"):
+        alloc.strategy_weights = {"alpha": 0.5, "beta": 0.4}
+
+
+def test_weights_sums_to_one_with_float_noise_tolerated() -> None:
+    # Classic 0.1+0.2+0.3+0.4 float drift must pass the epsilon guard.
+    alloc = _allocation({"a": 0.1, "b": 0.2, "c": 0.3, "d": 0.4})
+    assert len(alloc.strategy_weights) == 4


### PR DESCRIPTION
## Delivery

- Action: implement
- Target: Create engine/portfolio/allocation.py with CapitalAllocation model that tracks per-strategy capital weights, validates weight constraints (sum=1.0, no negatives), and provides allocation amounts given total capital; include focused unit tests in tests/test_allocation.py

Closes #1037
