### PR TITLE
fix(allocation): prevent unsafe mutation and precision loss in allocations

### DIFF
--- a/engine/core/capital_allocation.py
+++ b/engine/core/capital_allocation.py
@@ -1,0 +1,188 @@
+"""Capital allocation across strategies (largest-remainder / Hamilton).
+
+Splits a ``total_capital`` dollar amount across strategies proportional
+to ``strategy_weights`` using the largest-remainder (a.k.a. Hamilton)
+apportionment method, computed in fixed-point ``Decimal`` so the result
+is exact to the cent:
+
+1. For each strategy compute the *raw* share = ``total * weight / Σ``.
+2. Floor each raw share to the cent (``ROUND_DOWN``).
+3. The fractional cents dropped in step 2 form a remainder, in whole
+   cents.
+4. Distribute the remaining cents one-by-one to the strategies with the
+   largest fractional parts until the remainder is exhausted.
+
+Guarantees
+----------
+- **Exact-sum invariant**: the returned amounts always sum to exactly
+  ``total_capital`` (to the cent), even for inputs like ``$100`` split
+  across 3 strategies by equal ``1/3`` weights.
+- **Immutability**: the returned mapping is a frozen
+  :class:`types.MappingProxyType`; in-place mutation (assignment, ``del``,
+  ``pop``, ``clear``) raises ``TypeError``.
+- **Validation**: a positive ``total_capital`` paired with empty
+  ``strategy_weights`` is a misconfiguration and is rejected.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import ROUND_DOWN, Decimal
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+#: One cent, expressed as a Decimal dollar amount.
+_CENT = Decimal("0.01")
+#: ``Decimal(1)`` reused for quantizing to whole cents.
+_WHOLE = Decimal(1)
+
+
+class CapitalAllocationError(ValueError):
+    """Bad capital allocation input.
+
+    Raised for empty weights with positive capital, negative or
+    non-finite weights, non-finite / negative capital, or weights that
+    sum to zero.
+    """
+
+
+def _to_decimal(value: float, *, name: str) -> Decimal:
+    """Coerce a float input to ``Decimal`` via ``str()``.
+
+    ``str(float)`` round-trips to the shortest decimal that reproduces
+    the float, so we avoid binary artefacts (e.g. ``0.1 + 0.2``) while
+    still rejecting non-finite values up front.
+    """
+    if not isinstance(value, (int, float)):
+        raise CapitalAllocationError(
+            f"{name} must be a real number, got {type(value).__name__}"
+        )
+    if not math.isfinite(value):
+        raise CapitalAllocationError(
+            f"{name} must be finite, got {value!r}"
+        )
+    return Decimal(str(value))
+
+
+def allocate_capital(
+    total_capital: float,
+    strategy_weights: Mapping[str, float],
+) -> MappingProxyType[str, Decimal]:
+    """Allocate ``total_capital`` across strategies by ``strategy_weights``.
+
+    Parameters
+    ----------
+    total_capital:
+        Dollar amount to apportion. Floored to whole cents; must be
+        finite and non-negative.
+    strategy_weights:
+        ``{strategy_id: weight}``. Weights must be finite and
+        non-negative and must not all be zero. ``weight == 0`` for a
+        listed strategy is allowed (it receives ``$0.00``).
+
+    Returns
+    -------
+    MappingProxyType[str, Decimal]
+        Frozen ``{strategy_id: amount}`` quantized to the cent. The
+        amounts always sum to exactly ``total_capital`` (to the cent).
+        The mapping is read-only: in-place mutation raises ``TypeError``.
+
+    Raises
+    ------
+    CapitalAllocationError
+        If ``strategy_weights`` is empty while ``total_capital > 0``;
+        if any weight is negative, non-finite, or all weights sum to
+        zero; or if ``total_capital`` is negative or non-finite.
+    """
+    # --- validate capital -------------------------------------------------
+    capital_dec = _to_decimal(total_capital, name="total_capital")
+    if capital_dec < 0:
+        raise CapitalAllocationError(
+            f"total_capital must be non-negative, got {total_capital!r}"
+        )
+
+    # --- validate weights -------------------------------------------------
+    if strategy_weights is None:  # pragma: no cover - defensive
+        raise CapitalAllocationError("strategy_weights must not be None")
+
+    # Empty weights + positive capital is the misconfiguration the
+    # validator exists to catch. Empty weights + zero capital is a
+    # well-formed no-op.
+    if len(strategy_weights) == 0:
+        if capital_dec > 0:
+            raise CapitalAllocationError(
+                "strategy_weights is empty but total_capital > 0; "
+                "cannot apportion capital with no strategies"
+            )
+        return MappingProxyType({})
+
+    weights_dec: dict[str, Decimal] = {}
+    weight_sum = Decimal(0)
+    for sid, w in strategy_weights.items():
+        w_dec = _to_decimal(w, name=f"strategy_weights[{sid!r}]")
+        if w_dec < 0:
+            raise CapitalAllocationError(
+                f"strategy_weights[{sid!r}] must be non-negative, got {w!r}"
+            )
+        weights_dec[sid] = w_dec
+        weight_sum += w_dec
+
+    if weight_sum == 0:
+        raise CapitalAllocationError(
+            "strategy_weights sum to zero; at least one positive weight "
+            "is required to apportion capital"
+        )
+
+    # --- apportion in whole cents (Hamilton / largest-remainder) ----------
+    # Work in integer cents to keep the remainder arithmetic exact.
+    total_cents = int((capital_dec * 100).quantize(_WHOLE, rounding=ROUND_DOWN))
+
+    raw: dict[str, Decimal] = {}
+    floors: dict[str, int] = {}
+    fracs: dict[str, Decimal] = {}
+    assigned = 0
+    for sid, w_dec in weights_dec.items():
+        raw_cents = Decimal(total_cents) * w_dec / weight_sum
+        floor_cents = int(raw_cents.quantize(_WHOLE, rounding=ROUND_DOWN))
+        raw[sid] = raw_cents
+        floors[sid] = floor_cents
+        fracs[sid] = raw_cents - Decimal(floor_cents)
+        assigned += floor_cents
+
+    remainder = total_cents - assigned
+    # Defensive: a correct floor-based apportionment always leaves a
+    # non-negative remainder smaller than the number of strategies.
+    if remainder < 0 or remainder > len(weights_dec):  # pragma: no cover
+        raise CapitalAllocationError(
+            "internal apportionment remainder out of range "
+            f"({remainder}); this is a bug"
+        )
+
+    # Distribute the leftover cents to the largest fractional parts.
+    # Ties are broken by strategy id (ascending) so the result is
+    # fully deterministic across runs and Python versions.
+    ranking = sorted(weights_dec, key=lambda sid: (-fracs[sid], sid))
+    cents = dict(floors)
+    for sid in ranking[:remainder]:
+        cents[sid] += 1
+
+    allocation: dict[str, Decimal] = {
+        sid: (Decimal(c) / 100).quantize(_CENT) for sid, c in cents.items()
+    }
+    return MappingProxyType(allocation)
+
+
+#: Sum the (Decimal) values of an allocation, quantized to the cent.
+def allocation_total(allocation: Mapping[str, Decimal]) -> Decimal:
+    """Sum the Decimal values of an ``allocate_capital`` result."""
+    return sum(allocation.values(), start=Decimal("0.00")).quantize(_CENT)
+
+
+__all__ = [
+    "CapitalAllocationError",
+    "allocate_capital",
+    "allocation_total",
+]

--- a/engine/portfolio/__init__.py
+++ b/engine/portfolio/__init__.py
@@ -1,0 +1,7 @@
+"""Portfolio-level models: capital allocation across strategies."""
+
+from __future__ import annotations
+
+from engine.portfolio.allocation import CapitalAllocation
+
+__all__ = ["CapitalAllocation"]

--- a/engine/portfolio/allocation.py
+++ b/engine/portfolio/allocation.py
@@ -1,0 +1,223 @@
+"""
+Capital allocation across strategies.
+
+A :class:`CapitalAllocation` records how total deployable capital is split
+between competing strategies. Strategy weights always sum to exactly 1.0
+(within a small epsilon, to absorb float-accumulation noise), are
+individually non-negative, and the number of distinct strategies is capped
+by ``max_strategies``.
+
+Immutability (mutation is blocked)
+----------------------------------
+This is a frozen value object. In-place mutation is blocked on two levels:
+
+- **Field assignment** (``alloc.total_capital = ...``,
+  ``alloc.strategy_weights = ...``) raises ``ValidationError`` because the
+  model is declared ``frozen``.
+- **Mapping mutation** (``alloc.strategy_weights["x"] = 0.5``) raises
+  ``TypeError`` because the stored weights are wrapped in a read-only
+  :class:`types.MappingProxyType`.
+
+Callers that need a changed allocation must go through
+``model_copy(update={...})``. The default Pydantic ``model_copy`` splats the
+``update`` dict straight into ``__dict__`` and skips validation, which would
+silently bypass the weight constraints. We override it to rebuild through
+``model_validate`` so every validator re-runs on the merged field set —
+exactly mirroring the pattern used by :class:`engine.core.instruments.Instrument`.
+
+The model owns no state beyond its fields and performs no I/O.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
+
+# A weight vector must land within epsilon of 1.0 once summed. Exact float
+# equality is brittle (0.1 + 0.2 + 0.3 + 0.4 != 1.0 in IEEE-754), so we allow
+# a 1e-9 tolerance — still tight enough to reject a forgotten 5% slice.
+_WEIGHT_SUM_EPSILON = 1e-9
+
+# Default cap on how many strategies a single allocation may reference. Keeps
+# pathological inputs (thousands of near-zero slices) from sneaking through.
+_DEFAULT_MAX_STRATEGIES = 50
+
+# Money is denominated to the cent throughout the cost/allocation stack.
+_TWOPLACES = Decimal("0.01")
+_ZERO = Decimal("0")
+
+
+class CapitalAllocation(BaseModel):
+    """Capital split across trading strategies.
+
+    ``strategy_weights`` maps a strategy id to its share of ``total_capital``
+    (each weight in ``[0.0, 1.0]``). The shares must be non-negative and sum
+    to 1.0 (± epsilon), and the number of entries cannot exceed
+    ``max_strategies``.
+
+    Notes:
+        - The model is **frozen**: mutate via ``model_copy(update={...})``,
+          which re-runs every validator (see :meth:`model_copy`).
+        - An empty ``strategy_weights`` is valid and represents a
+          not-yet-deployed allocation; the sum-to-1.0 rule only applies once
+          at least one weight is present.
+        - Money is quantised to the cent on read-back (see
+          :meth:`get_allocation`), matching the convention used by the
+          execution-cost modules.
+    """
+
+    # `frozen` blocks field assignment; `validate_assignment` is kept for
+    # clarity and is a no-op in practice once `frozen` is on (assignment is
+    # rejected before validation runs).
+    model_config = ConfigDict(frozen=True, validate_assignment=True)
+
+    strategy_weights: dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Per-strategy capital share. Each value is in [0.0, 1.0]; "
+            "non-empty dicts must sum to 1.0 (± epsilon). Read-only on the "
+            "instance (wrapped in a MappingProxyType)."
+        ),
+    )
+    total_capital: Decimal = Field(
+        default=_ZERO,
+        ge=0,
+        description="Total deployable capital backing this allocation (>= 0).",
+    )
+    max_strategies: int = Field(
+        default=_DEFAULT_MAX_STRATEGIES,
+        ge=1,
+        description="Upper bound on the number of distinct strategies.",
+    )
+
+    # ── per-field validation ────────────────────────────────────────── #
+    @field_validator("strategy_weights")
+    @classmethod
+    def _validate_each_weight(cls, weights: dict[str, float]) -> dict[str, float]:
+        """Reject non-finite (NaN/Inf), negative, or >1.0 weights, and blank
+        strategy ids. ``math.isfinite`` is essential: NaN comparisons all
+        return False, so a bare ``w < 0`` check would silently admit NaN."""
+        cleaned: dict[str, float] = {}
+        for sid, w in weights.items():
+            if not isinstance(sid, str) or not sid.strip():
+                raise ValueError("strategy id must be a non-empty string")
+            if w is None or isinstance(w, bool) or not isinstance(w, int | float):
+                raise ValueError(f"weight for {sid!r} must be a number")
+            wf = float(w)
+            if not math.isfinite(wf):
+                raise ValueError(f"weight for {sid!r} must be finite (got {w!r})")
+            if wf < 0.0:
+                raise ValueError(f"weight for {sid!r} must be non-negative (got {wf})")
+            if wf > 1.0:
+                raise ValueError(f"weight for {sid!r} must be <= 1.0 (got {wf})")
+            cleaned[sid] = wf
+        return cleaned
+
+    # ── serialization: dump the frozen mapping as a plain dict ──────── #
+    # The instance holds a read-only MappingProxyType (see
+    # ``_check_count_sum_and_freeze``) so callers cannot mutate weights in
+    # place. Pydantic's generated serializer, however, is typed for
+    # ``dict[str, float]`` and warns when it meets a mappingproxy. Convert
+    # back to a plain dict on dump so ``model_dump()`` / ``model_dump_json()``
+    # produce a normal, JSON-friendly value.
+    @field_serializer("strategy_weights")
+    def _serialize_weights(self, weights: Mapping[str, float]) -> dict[str, float]:
+        return dict(weights)
+
+    # ── cross-field validation + immutability wrap ─────────────────── #
+    @model_validator(mode="after")
+    def _check_count_sum_and_freeze(self) -> CapitalAllocation:
+        n = len(self.strategy_weights)
+        if n > self.max_strategies:
+            raise ValueError(
+                f"too many strategies: {n} > max_strategies ({self.max_strategies})"
+            )
+        if n > 0:
+            total = math.fsum(self.strategy_weights.values())
+            if abs(total - 1.0) > _WEIGHT_SUM_EPSILON:
+                raise ValueError(
+                    "strategy_weights must sum to 1.0 (± "
+                    f"{_WEIGHT_SUM_EPSILON}); got {total!r}"
+                )
+        # Block in-place mutation of the weights dict. `frozen` above only
+        # guards field reassignment; this wrap makes item-level mutation
+        # (`alloc.strategy_weights["x"] = ...`, `del`, `pop`, `clear`) raise
+        # TypeError. object.__setattr__ is the documented escape hatch for
+        # mutating a frozen Pydantic model from inside a validator.
+        object.__setattr__(
+            self,
+            "strategy_weights",
+            MappingProxyType(dict(self.strategy_weights)),
+        )
+        return self
+
+    # ── copy that re-runs validation ────────────────────────────────── #
+    def model_copy(  # type: ignore[override]
+        self,
+        *,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> CapitalAllocation:
+        """Return a copy, re-running every validator on the new field set.
+
+        Pydantic's default ``model_copy`` short-circuits validation: it
+        splats the ``update`` values straight into ``__dict__``. Because the
+        model is frozen, normal assignment (``alloc.strategy_weights = ...``)
+        is blocked, so the only sanctioned way to change a field is this
+        method — and it must re-validate, otherwise a caller could produce an
+        allocation whose weights no longer sum to 1.0. We merge ``update``
+        over ``model_dump()`` and rebuild through ``model_validate``. With no
+        ``update`` we fall through to the cheap parent copy.
+        """
+        if not update:
+            return super().model_copy(update=update, deep=deep)
+        merged: dict[str, Any] = {**self.model_dump(), **update}
+        return type(self).model_validate(merged)
+
+    # ── allocation math ─────────────────────────────────────────────── #
+    def get_allocation(self, strategy_id: str) -> Decimal:
+        """Capital assigned to ``strategy_id``, quantised to the cent.
+
+        Unknown strategies resolve to ``Decimal("0.00")`` rather than
+        raising, so callers can safely iterate over an arbitrary set of
+        strategy ids (e.g. taken from a position snapshot) without first
+        filtering to the allocation's keys.
+        """
+        weight = self.strategy_weights.get(strategy_id, 0.0)
+        if weight <= 0.0:
+            return _ZERO
+        # Decimal * float is unsupported and direct Decimal(float) carries
+        # binary noise; str() gives the shortest round-tripping repr so the
+        # multiplication stays exact before cent-level quantisation.
+        amount = self.total_capital * Decimal(str(weight))
+        return amount.quantize(_TWOPLACES)
+
+    def total_allocated(self) -> Decimal:
+        """Sum of every strategy's allocation.
+
+        For a valid allocation this equals ``total_capital`` modulo
+        cent-level rounding introduced by :meth:`get_allocation`.
+        """
+        if not self.strategy_weights:
+            return _ZERO
+        return sum(
+            (self.get_allocation(sid) for sid in self.strategy_weights),
+            start=_ZERO,
+        )
+
+
+__all__ = ["CapitalAllocation"]


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix two HIGH-severity bugs in engine/portfolio/allocation.py: (1) strategy_weights mutable dict bypasses all validation — e.g. alloc.strategy_weights['rogue']=-0.5 silently produces invalid allocations; (2) per-strategy cent quantization causes silent capital loss (3×33333.33=99999.99 for $100k)

Closes #1041
