### PR TITLE
security(auth): eliminate fail-open auth bypass

### DIFF
--- a/engine/legal/dependencies.py
+++ b/engine/legal/dependencies.py
@@ -2,28 +2,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import Depends, HTTPException, params, status
+from fastapi import Depends, HTTPException, status
 
 from engine.api.auth.dependency import get_current_user
 from engine.deps import get_db
 from engine.legal import service as legal_service
 
 if TYPE_CHECKING:
-    from uuid import UUID
-
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from engine.db.models import User
 
-# Stand-in for the authenticated principal used by consent enforcement until
-# ``get_current_user`` is wired through every route. Routes that have not yet
-# been integrated with the auth dependency call ``require_legal_acceptance``
-# directly, so the ``principal`` parameter arrives as an *unresolved* FastAPI
-# ``Depends`` marker. In that situation we fall back to this module-level id.
-# When it is ``None`` the dependency is a deliberate no-op — this is what lets
-# the public read-only routes work pre-auth. Tests exercise the 451/200 paths
-# with ``monkeypatch.setattr(dependencies, "_placeholder_user_id", value)``.
-_placeholder_user_id: UUID | None = None
+#: HTTP 451 — Unavailable For Legal Reasons (RFC 7725). Kept as a named
+#: constant so the status code reads as intent rather than a magic number.
+_LEGAL_RE_ACCEPTANCE_REQUIRED = 451
 
 
 async def require_legal_acceptance(
@@ -36,41 +28,32 @@ async def require_legal_acceptance(
     Principal resolution:
 
     * **Through FastAPI dependency injection** the ``principal`` is resolved by
-      :func:`get_current_user`, which raises HTTP 401 itself when no credential
-      is present. We keep a defensive guard so the function is safe to invoke
-      even outside DI: an explicitly-resolved ``None`` principal surfaces a
-      deterministic 401.
-    * **Invoked directly** (bypassing DI) ``principal`` is left as the
-      unresolved ``Depends`` marker. In that case we fall back to
-      :data:`_placeholder_user_id`. When even that is unset the dependency is a
-      deliberate no-op so public/read-only routes keep working pre-auth; once
-      it is set, a pending re-acceptance surfaces as HTTP 451.
+      :func:`get_current_user`, which raises HTTP 401 itself when no valid
+      credential is present.
+    * **Invoked outside DI** (e.g. in a unit test) with an explicitly-resolved
+      ``None`` principal, this function **fails closed**: it raises HTTP 401
+      unconditionally. There is no global placeholder, fail-open escape hatch,
+      or ``Depends``-marker fallback.
 
     A pending re-acceptance raises HTTP 451 with a structured detail body
     listing the offending document slugs. When everything is in order the
     function returns ``None``.
     """
-    if isinstance(principal, params.Depends):
-        # Called outside FastAPI's DI machinery — the principal is still the
-        # unresolved ``Depends`` marker. Use the module-level placeholder.
-        user_id = _placeholder_user_id
-        if user_id is None:
-            return
-    else:
-        if principal is None:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Authentication required",
-            )
-        user_id = principal.id
+    # Fail closed: an unresolved principal is never permitted through, whether
+    # the principal arrived unresolved via DI or was explicitly passed as
+    # ``None``. Authentication is always required — there is no bypass.
+    if principal is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
 
-    pending = await legal_service.get_pending_acceptances(db, user_id)
+    pending = await legal_service.get_pending_acceptances(db, principal.id)
     if pending:
         raise HTTPException(
-            status_code=451,
+            status_code=_LEGAL_RE_ACCEPTANCE_REQUIRED,
             detail={
                 "code": "legal_re_acceptance_required",
                 "documents": [p.slug for p in pending],
             },
         )
-    return

--- a/tests/test_legal_documents_schema.py
+++ b/tests/test_legal_documents_schema.py
@@ -310,28 +310,36 @@ class TestRequireLegalAcceptanceWithoutOverride:
             yield s
         await engine.dispose()
 
-    async def test_dependency_noop_when_placeholder_unset(
-        self, session: AsyncSession, monkeypatch
+    async def test_dependency_raises_401_without_principal(
+        self, session: AsyncSession
     ) -> None:
-        """The current contract: when no user is wired up, the dependency
-        returns immediately without touching the DB. This is what allows
-        the public read-only routes to work pre-auth."""
-        from engine.legal import dependencies
+        """The dependency fails closed: when no principal is resolved it
+        raises HTTP 401 unconditionally rather than silently letting the
+        request through. There is no module-global placeholder to patch."""
+        from fastapi import HTTPException
 
-        monkeypatch.setattr(dependencies, "_placeholder_user_id", None)
-        # Must not raise — and must not require legal_documents to be populated.
-        result = await require_legal_acceptance(db=session)  # type: ignore[call-arg]
-        assert result is None
+        with pytest.raises(HTTPException) as exc:
+            await require_legal_acceptance(db=session, principal=None)
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Authentication required"
 
     async def test_dependency_raises_451_when_pending(
-        self, session: AsyncSession, monkeypatch
+        self, session: AsyncSession
     ) -> None:
-        """End-to-end: with a placeholder user and an unaccepted required
-        document, the dependency raises HTTP 451."""
-        from engine.legal import dependencies
+        """End-to-end: with an authenticated user and an unaccepted required
+        document, the dependency raises HTTP 451. The principal is passed
+        directly — no module global is involved."""
+        from fastapi import HTTPException
+
+        from engine.db.models import User
 
         user_id = uuid.uuid4()
-        monkeypatch.setattr(dependencies, "_placeholder_user_id", user_id)
+        principal = User(
+            id=user_id,
+            email="dep-pending@example.com",
+            display_name="Dep Pending",
+            is_active=True,
+        )
 
         session.add(
             LegalDocument(
@@ -347,26 +355,28 @@ class TestRequireLegalAcceptanceWithoutOverride:
         )
         await session.flush()
 
-        from fastapi import HTTPException
-
         with pytest.raises(HTTPException) as exc:
-            await require_legal_acceptance(db=session)  # type: ignore[call-arg]
+            await require_legal_acceptance(db=session, principal=principal)
         assert exc.value.status_code == 451
         assert exc.value.detail["code"] == "legal_re_acceptance_required"
         assert "must-accept-dep" in exc.value.detail["documents"]
 
     async def test_dependency_passes_when_all_accepted(
-        self, session: AsyncSession, monkeypatch
+        self, session: AsyncSession
     ) -> None:
         """Once a user accepts every required doc at the current version,
         the dependency must return ``None`` — proving the table round-trip
-        (insert acceptance + query pending) works on SQLite."""
-        from engine.legal import dependencies
+        (insert acceptance + query pending) works on SQLite. The principal
+        is passed directly, no module global involved."""
+        from engine.db.models import User
 
         user_id = uuid.uuid4()
-        monkeypatch.setattr(dependencies, "_placeholder_user_id", user_id)
-
-        from engine.db.models import User
+        principal = User(
+            id=user_id,
+            email="dep-test@example.com",
+            display_name="Dep Test",
+            is_active=True,
+        )
 
         session.add(
             User(
@@ -403,7 +413,7 @@ class TestRequireLegalAcceptanceWithoutOverride:
         )
         await session.flush()
 
-        result = await require_legal_acceptance(db=session)  # type: ignore[call-arg]
+        result = await require_legal_acceptance(db=session, principal=principal)
         assert result is None
 
 

--- a/tests/test_legal_qa.py
+++ b/tests/test_legal_qa.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from engine.db.models import User
+
 
 class TestAcceptanceRecordImmutability:
     async def _seed(self, db_session: AsyncSession):
@@ -127,33 +129,56 @@ class TestAcceptanceRecordImmutability:
 
 
 class TestConsentEnforcementIntegration:
-    @pytest.fixture
-    async def consent_client(self, db_session: AsyncSession):
+    """End-to-end consent enforcement driven through FastAPI DI.
+
+    The protected routes declare ``Depends(require_legal_acceptance)`` and the
+    authenticated principal is supplied exclusively via an
+    ``app.dependency_overrides`` entry on ``get_current_user`` — never via
+    module-global state. The real dependency runs (the autouse conftest noop
+    override is popped) against the shared test session so the full
+    401 / 200 / 451 contract is exercised.
+    """
+
+    @staticmethod
+    def _build_consent_app(db_session: AsyncSession, principal: User | None) -> FastAPI:
+        from engine.api.auth.dependency import get_current_user
+
         app = FastAPI()
 
         async def override_get_db():
             yield db_session
 
         app.dependency_overrides[get_db] = override_get_db
+        app.dependency_overrides[get_current_user] = lambda: principal
+        # The autouse conftest fixture noop's require_legal_acceptance on every
+        # new app; pop it so the real dependency (and its 401/451 paths) runs.
+        app.dependency_overrides.pop(require_legal_acceptance, None)
 
-        @app.get("/protected/backtest")
-        async def protected_backtest(db: AsyncSession = Depends(get_db)):
-            await require_legal_acceptance(db)
+        @app.get(
+            "/protected/backtest",
+            dependencies=[Depends(require_legal_acceptance)],
+        )
+        async def protected_backtest() -> dict[str, str]:
             return {"status": "ok"}
 
-        @app.get("/protected/live-trade")
-        async def protected_live_trade(db: AsyncSession = Depends(get_db)):
-            await require_legal_acceptance(db)
+        @app.get(
+            "/protected/live-trade",
+            dependencies=[Depends(require_legal_acceptance)],
+        )
+        async def protected_live_trade() -> dict[str, str]:
             return {"order_id": "123"}
 
+        return app
+
+    async def test_no_principal_returns_401(self, db_session: AsyncSession):
+        """An unresolved principal fails closed with HTTP 401 — no bypass."""
+        app = self._build_consent_app(db_session, principal=None)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            yield client
+            resp = await client.get("/protected/backtest")
+        assert resp.status_code == HTTPStatus.UNAUTHORIZED
+        assert resp.json()["detail"] == "Authentication required"
 
-    @pytest.mark.skip(
-        reason="require_legal_acceptance is a no-op until the auth dependency "
-        "is wired (tracked separately as consent-enforcement follow-up)."
-    )
     async def test_require_legal_acceptance_raises_451_when_pending(
         self, db_session: AsyncSession
     ):
@@ -168,15 +193,22 @@ class TestConsentEnforcementIntegration:
             file_path="legal/terms-of-service.md",
         )
         db_session.add(doc)
+
+        user = make_user(email=f"consent-{uuid.uuid4()}@example.com")
+        db_session.add(user)
         await db_session.flush()
 
-        with pytest.raises(HTTPException) as exc_info:
-            await require_legal_acceptance(db_session)
-        assert exc_info.value.status_code == 451
-        detail = exc_info.value.detail
+        app = self._build_consent_app(db_session, principal=user)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected/backtest")
+
+        assert resp.status_code == HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS
+        detail = resp.json()["detail"]
         assert detail["code"] == "legal_re_acceptance_required"
         assert "documents" in detail
         assert isinstance(detail["documents"], list)
+        assert doc.slug in detail["documents"]
 
     async def test_no_451_when_all_accepted(self, db_session: AsyncSession):
         doc = LegalDocument(
@@ -207,11 +239,17 @@ class TestConsentEnforcementIntegration:
         db_session.add(acceptance)
         await db_session.flush()
 
-    @pytest.mark.skip(
-        reason="require_legal_acceptance is a no-op until the auth dependency "
-        "is wired (tracked separately as consent-enforcement follow-up)."
-    )
-    async def test_451_response_contains_pending_document_slugs(self, db_session: AsyncSession):
+        app = self._build_consent_app(db_session, principal=user)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected/backtest")
+
+        assert resp.status_code == HTTPStatus.OK
+        assert resp.json() == {"status": "ok"}
+
+    async def test_451_response_contains_pending_document_slugs(
+        self, db_session: AsyncSession
+    ):
         slugs = [f"pending-{uuid.uuid4().hex[:8]}" for _ in range(3)]
         for i, slug in enumerate(slugs):
             doc = LegalDocument(
@@ -225,12 +263,18 @@ class TestConsentEnforcementIntegration:
                 file_path="legal/terms-of-service.md",
             )
             db_session.add(doc)
+
+        user = make_user(email=f"pending-{uuid.uuid4()}@example.com")
+        db_session.add(user)
         await db_session.flush()
 
-        with pytest.raises(HTTPException) as exc_info:
-            await require_legal_acceptance(db_session)
-        assert exc_info.value.status_code == 451
-        pending_slugs = exc_info.value.detail["documents"]
+        app = self._build_consent_app(db_session, principal=user)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected/backtest")
+
+        assert resp.status_code == HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS
+        pending_slugs = resp.json()["detail"]["documents"]
         for slug in slugs:
             assert slug in pending_slugs
 


### PR DESCRIPTION
## Delivery

- Action: refactor
- Target: Rewrite engine/legal/dependencies.py to eliminate the fail-open auth bypass: remove _placeholder_user_id global, remove isinstance(Depends) check, raise 401 unconditionally when principal unresolved, update tests to use FastAPI dependency_overrides

Closes #1059
