### PR TITLE
security(sandbox): fix DNS bypass in hostname allowlist enforcement

### DIFF
--- a/docs/LAST_AUDIT.md
+++ b/docs/LAST_AUDIT.md
@@ -1,9 +1,9 @@
 # Last engineering-docs audit
 
-- **Timestamp:** 2026-06-30T20:00:01Z
-- **Cycle:** 1470
-- **Commit:** `5a4eab5`
-- **Target:** reflect latest 1470 cycles of development
+- **Timestamp:** 2026-07-01T02:33:28Z
+- **Cycle:** 1476
+- **Commit:** `124d31b`
+- **Target:** reflect latest 1476 cycles of development
 
 This file is touched on every `do_engineering_docs` run by kaizen, so
 its mtime tells you when documentation was last reconciled with the

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -57,7 +57,15 @@ that lack the required scope get `403`.
 `strategies` routers are mounted with
 `Depends(require_legal_acceptance)`. Callers without an
 `acceptances` row for the *current version* of every
-`requires_acceptance` document get `403`. Acceptance is recorded via
+`requires_acceptance` document get **`451 Unavailable For Legal
+Reasons`** with body `{code:"legal_re_acceptance_required",
+documents:[<slug>, …]}` (not `403` — the dedicated code lets clients
+and the frontend distinguish a consent gate from an RBAC denial; see
+[`engine/legal/dependencies.py`](../engine/legal/dependencies.py)).
+An unauthenticated request hits `401` first: the dependency's
+principal guard treats both an unresolved `Depends` marker and an
+explicit `None` as "no user" so the gate can't be silently bypassed
+when it is invoked outside FastAPI DI. Acceptance is recorded via
 `POST /api/v1/legal/accept`. See [`data-model.md`](data-model.md) for
 the immutable acceptance table.
 
@@ -416,8 +424,9 @@ still per-process, but event distribution is cross-replica.
 
 ## Errors
 
-- **Auth**: `401` for missing/invalid/expired credentials, `403` for
-  insufficient role/scope or missing legal acceptance.
+- **Auth**: `401` for missing/invalid/expired credentials; `403` for
+  insufficient role/scope; **`451`** for missing legal acceptance
+  (body `{code:"legal_re_acceptance_required", documents:[…]}`).
 - **Validation**: `422` from FastAPI; `400` for hand-rolled checks
   (e.g. invalid scope in API keys, unknown tax jurisdiction).
 - **Rate limit**: `429` with `Retry-After` from

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -145,7 +145,7 @@ target and is tracked as a follow-up.
 
 | Layer | Kind | Status | Mechanism |
 |---|---|---|---|
-| 1. Import restrictions | best-effort in-process | **shipped** | `RestrictedImporter` blocks `subprocess`, `os.system`, `socket`, etc. unless the manifest declares them. |
+| 1. Import restrictions | best-effort in-process | **shipped** | Default-deny **allowlist** (`FROZEN_ALLOWED_MODULES` in [`allowlist.py`](../../engine/plugins/allowlist.py)): a strategy may import a module only if its root name is in the frozen set. Enforced by [`RestrictedImporter`](../../engine/plugins/restricted_importer.py) at both `sys.meta_path` and `builtins.__import__`. The old denylist (`DENYLIST_MODULES`) is retained as defence-in-depth and as the test-suite's escape-vector oracle, but enforcement is purely allowlist-based. Adding a module requires a security review (see [ADR-0007](../adr/0007-strategy-sandbox-allowlist-imports.md)). |
 | 2. Network whitelist | best-effort in-process | **shipped** | `SandboxedHttpClient` proxies every outbound call through an allowlist declared in the manifest (`requires_network: true` + URL prefixes). |
 | 3. Resource limits | best-effort in-process | **shipped** | `resource.setrlimit` for memory / file descriptors on Linux. |
 | 4. Filesystem isolation | best-effort in-process | **shipped** | Each evaluation runs in a fresh `tempfile.TemporaryDirectory`; the strategy only sees its own declared artifacts (read-only). |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -289,7 +289,8 @@ scheduled_for <= now()`).
 
 ## Adding a new table
 
-1. Pick the next migration number (`013_…` today).
+1. Pick the next migration number (`014_…` today — `013` is the latest
+   revision; run `alembic history` to confirm before adding one).
 2. Add the model in `engine/db/models.py` in the same PR.
 3. Write the migration with both `upgrade()` and `downgrade()`.
 4. Add a test in `tests/` that round-trips a representative row and

--- a/engine/plugins/restricted_importer.py
+++ b/engine/plugins/restricted_importer.py
@@ -25,6 +25,7 @@ regardless of whether it appears in ``BLOCKED_MODULES``.
 from __future__ import annotations
 
 import builtins
+import socket
 import sys
 from importlib.abc import MetaPathFinder
 from typing import TYPE_CHECKING, Any
@@ -146,12 +147,19 @@ class RestrictedImporter(MetaPathFinder):
         blocked: set[str] | None = None,
         *,
         allowed: frozenset[str] | None = None,
+        allowed_hosts: list[str] | None = None,
     ) -> None:
         # The authoritative allowlist.  ``blocked`` is retained for explicit
         # denylist defence-in-depth and backward compatibility with callers
         # that pass a custom blocked set.
         self.allowed: frozenset[str] = allowed if allowed is not None else ALLOWED_MODULES
         self.blocked: set[str] = blocked if blocked is not None else set()
+        # Hostname allowlist for the DNS-resolution guard installed by
+        # ``install()``.  Sourced from the strategy manifest's
+        # ``network.allowed_endpoints``.  Mirrors the endpoint-matching logic
+        # used by ``SandboxedHttpClient`` and the httpx ``send`` hook: a host
+        # is permitted if it exactly matches an entry or is a subdomain of one.
+        self.allowed_hosts: list[str] = list(allowed_hosts) if allowed_hosts else []
         self._installed = False
         # Stable identity for the hook.  ``self._restricted_import`` creates a
         # *new* bound-method object on every attribute access (a Python
@@ -172,6 +180,15 @@ class RestrictedImporter(MetaPathFinder):
         # delegation target keeps the import system usable rather than turning
         # every import into an error.
         self._original_import: Callable[..., Any] | None = None
+        # DNS-resolution guard.  ``install()`` wraps ``socket.getaddrinfo`` so
+        # that hostnames are checked against ``allowed_hosts`` *before* any
+        # resolution occurs (defence-in-depth beneath the httpx ``send`` hook:
+        # ``socket`` itself is blocked by the allowlist, but allowlisted
+        # networking libraries resolve hostnames through this function).  As
+        # with ``_import_hook``, the bound method is captured once so
+        # ``install()``/``uninstall()`` can compare identity via ``is``.
+        self._getaddrinfo_hook: Callable[..., Any] = self._restricted_getaddrinfo
+        self._original_getaddrinfo: Callable[..., Any] | None = None
 
     # ── Core decision logic ────────────────────────────────────────────
 
@@ -236,10 +253,69 @@ class RestrictedImporter(MetaPathFinder):
             )
         return original(name, globals_, locals_, fromlist, level)
 
+    # ── socket.getaddrinfo override (hostname allowlist guard) ─────────
+
+    def _is_host_allowed(self, host: Any) -> bool:
+        """Return ``True`` iff *host* is permitted by the hostname allowlist.
+
+        Uses the same endpoint-matching logic as
+        :class:`~engine.plugins.sandboxed_http.SandboxedHttpClient` and the
+        httpx ``send`` hook: a host is allowed if it exactly matches an entry
+        in :attr:`allowed_hosts` or is a subdomain of one
+        (``api.foo.com`` for a ``foo.com`` entry).  With an empty allowlist
+        (no network declared) every host is rejected — matching the
+        ``SandboxedHttpClient`` semantics where an empty whitelist blocks all
+        network access.
+        """
+        if not self.allowed_hosts:
+            return False
+        if host is None:
+            return False
+        name = str(host)
+        if not name:
+            return False
+        return any(name == ep or name.endswith(f".{ep}") for ep in self.allowed_hosts)
+
+    def _restricted_getaddrinfo(self, host: Any, *args: Any, **kwargs: Any) -> Any:
+        """Hostname-allowlist guard wrapped around ``socket.getaddrinfo``.
+
+        Extracts the *host* argument and checks it against
+        :meth:`_is_host_allowed` **before** any DNS resolution occurs.
+        Non-allowlisted hosts raise ``ConnectionError``; allowlisted hosts are
+        delegated to the original ``getaddrinfo`` captured at ``install()``
+        time.
+        """
+        if not self._is_host_allowed(host):
+            raise ConnectionError(
+                f"DNS resolution for {host!r} is not allowed in strategy sandbox "
+                "(host not in network allowlist)"
+            )
+        original = self._original_getaddrinfo
+        if original is None:
+            # Unreachable in normal operation: the hook is only installed by
+            # ``install()``, which captures ``_original_getaddrinfo`` first.
+            # Guard defensively rather than calling ``None``.
+            raise ConnectionError(
+                "RestrictedImporter has no original getaddrinfo to delegate to "
+                "(install() was never called)"
+            )
+        return original(host, *args, **kwargs)
+
     # ── Lifecycle ──────────────────────────────────────────────────────
 
     def install(self) -> None:
         if not self._installed:
+            # Wrap ``socket.getaddrinfo`` so hostnames are checked against the
+            # network allowlist *before* any DNS resolution occurs.  ``socket``
+            # is itself blocked by the import allowlist, but allowlisted
+            # networking libraries (httpx) resolve hostnames through this
+            # function, so we gate it here as defence-in-depth.  ``socket`` is
+            # imported at module top level — i.e. before this hook is ever
+            # installed — so the allowlist (which denies ``socket``) does not
+            # reject the import.
+            self._original_getaddrinfo = socket.getaddrinfo
+            socket.getaddrinfo = self._getaddrinfo_hook
+
             # Capture the real importer BEFORE replacing it.  If we replaced
             # first, ``_original_import`` would end up pointing at our own hook
             # and every delegated import would recurse infinitely.
@@ -264,6 +340,14 @@ class RestrictedImporter(MetaPathFinder):
                 builtins.__import__ = self._original_import  # type: ignore[assignment]
             if self in sys.meta_path:
                 sys.meta_path.remove(self)
+            # Restore ``socket.getaddrinfo`` using the same ownership guard.
+            # ``socket`` is imported at module top level, so this needs no
+            # local import; the allowlist only denies ``socket`` to sandboxed
+            # code anyway, and the host has already imported it.
+            if self._original_getaddrinfo is not None:
+                if socket.getaddrinfo is self._getaddrinfo_hook:
+                    socket.getaddrinfo = self._original_getaddrinfo
+                self._original_getaddrinfo = None
             self._installed = False
 
     # ── sys.modules hardening ──────────────────────────────────────────

--- a/engine/plugins/sandbox.py
+++ b/engine/plugins/sandbox.py
@@ -198,7 +198,9 @@ class StrategySandbox:
         self.metrics = SandboxMetrics()
         self._max_eval_seconds = manifest.resources.max_cpu_seconds
 
-        self._importer = RestrictedImporter()
+        self._importer = RestrictedImporter(
+            allowed_hosts=self.manifest.network.allowed_endpoints,
+        )
         self._http_client: SandboxedHttpClient | None = None
         self._work_dir: str | None = None
         self._original_open: Any = None

--- a/tests/test_sandbox_security.py
+++ b/tests/test_sandbox_security.py
@@ -371,6 +371,80 @@ class TestRestrictedImporter:
         importer.uninstall()
 
 
+class TestGetaddrinfoGuard:
+    """DNS-resolution guard: ``install()`` wraps ``socket.getaddrinfo`` so a
+    non-allowlisted hostname is rejected with ``ConnectionError`` *before* any
+    resolution occurs, and ``uninstall()`` restores the original.
+
+    This is defence-in-depth beneath the httpx ``send`` hook: ``socket`` is
+    blocked by the import allowlist, but allowlisted networking libraries
+    resolve hostnames through ``socket.getaddrinfo``, so the guard closes that
+    path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_socket_and_import(self) -> Any:
+        """Snapshot/restore ``sys.meta_path``, ``builtins.__import__`` and
+        ``socket.getaddrinfo`` so a failing assertion cannot leak the guard
+        onto the process-global socket function for the rest of the session."""
+        import socket
+
+        meta_snapshot = list(sys.meta_path)
+        import_snapshot = builtins.__import__
+        gai_snapshot = socket.getaddrinfo
+        try:
+            yield
+        finally:
+            builtins.__import__ = import_snapshot
+            sys.meta_path[:] = meta_snapshot
+            socket.getaddrinfo = gai_snapshot
+
+    def test_non_allowlisted_host_blocked_at_resolution(self) -> None:
+        import socket
+
+        original_gai = socket.getaddrinfo
+        importer = RestrictedImporter(allowed_hosts=["api.anthropic.com"])
+        importer.install()
+
+        # The guard is in place.
+        assert socket.getaddrinfo is importer._getaddrinfo_hook
+        # A non-allowlisted host is rejected *before* any DNS lookup happens.
+        with pytest.raises(ConnectionError, match=r"evil\.example\.com"):
+            socket.getaddrinfo("evil.example.com", 80)
+
+        importer.uninstall()
+        # Original ``getaddrinfo`` restored after teardown.
+        assert socket.getaddrinfo is original_gai
+        assert importer._original_getaddrinfo is None
+
+    def test_allowlisted_host_delegates_to_original(self) -> None:
+        import socket
+
+        real_original = socket.getaddrinfo
+        delegated: list[Any] = []
+
+        def fake_getaddrinfo(host: Any, *args: Any, **kwargs: Any) -> Any:
+            delegated.append(host)
+            return [("resolved", host)]
+
+        importer = RestrictedImporter(allowed_hosts=["api.anthropic.com"])
+        importer.install()
+        # ``install()`` captured the real ``getaddrinfo``; swap in a stub so
+        # the test makes no real DNS/network call.  An allowlisted host must
+        # reach the original (here, the stub).
+        real_captured = importer._original_getaddrinfo
+        importer._original_getaddrinfo = fake_getaddrinfo
+
+        result = socket.getaddrinfo("api.anthropic.com", 443)
+        assert delegated == ["api.anthropic.com"]
+        assert result == [("resolved", "api.anthropic.com")]
+
+        # Restore the real original so ``uninstall()`` reinstates it cleanly.
+        importer._original_getaddrinfo = real_captured
+        importer.uninstall()
+        assert socket.getaddrinfo is real_original
+
+
 class TestPurgeNonAllowlisted:
     """Cover ``RestrictedImporter.purge_non_allowlisted`` (lines 201-208).
 


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix the critical DNS resolution bypass in engine/plugins/network_guard.py by wrapping socket.getaddrinfo to enforce hostname allowlist BEFORE resolution

Closes #1071
