### PR TITLE
security(sandbox): Harden _extract_hostnames URL parsing

### DIFF
--- a/engine/plugins/manifest.py
+++ b/engine/plugins/manifest.py
@@ -8,8 +8,109 @@ network whitelist, config schema, and marketplace listing.
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+def normalize_endpoint(entry: str) -> str:
+    """Canonicalise a single ``allowed_endpoints`` entry to a bare hostname.
+
+    Accepts any of the convenient forms a manifest author might write and
+    reduces them all to the same canonical, lowercase hostname:
+
+      * bare hostname — ``api.example.com``
+      * schemeless URL — ``//api.example.com`` or ``api.example.com/v1``
+      * full URL — ``https://api.example.com``
+
+    The hostname is returned lowercased for case-normalisation consistency
+    (DNS hostnames are case-insensitive, and the sandbox's allowlist matchers
+    compare against this canonical form).
+
+    Entries that carry a port, path, query, fragment or userinfo are rejected
+    with a clear ``ValueError`` at manifest-load time.  The sandbox's
+    host-allowlist matches on *hostnames only*; a port/path component would
+    therefore silently never match (request hosts carry no port/path) and must
+    be surfaced as an explicit configuration error rather than a silent
+    network-access failure.
+    """
+    if not isinstance(entry, str):
+        raise TypeError("allowed_endpoints entry must be a string")
+    raw = entry.strip()
+    if not raw:
+        raise ValueError("allowed_endpoints entry must not be empty")
+    # Prepend ``//`` to schemeless entries so ``urlparse`` treats the leading
+    # segment as the netloc/hostname.  Without this a bare URL such as
+    # ``api.example.com/v1`` is parsed with ``api.example.com`` as the
+    # *scheme* and the hostname comes back as ``None``.
+    candidate = raw
+    if "://" not in candidate and not candidate.startswith("//"):
+        candidate = "//" + candidate
+    parsed = urlparse(candidate)
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(
+            f"allowed_endpoints entry {entry!r} has no parseable hostname"
+        )
+    # Reject anything beyond a bare hostname so the host-only matcher never
+    # silently fails to match.  Each check produces a targeted, actionable
+    # error message.
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(
+            f"allowed_endpoints entry {entry!r} must not include userinfo; "
+            "specify the hostname only"
+        )
+    if parsed.port is not None:
+        raise ValueError(
+            f"allowed_endpoints entry {entry!r} must not include a port "
+            f"({parsed.port}); specify the hostname only"
+        )
+    if parsed.path and parsed.path != "/":
+        raise ValueError(
+            f"allowed_endpoints entry {entry!r} must not include a path "
+            f"({parsed.path!r}); specify the hostname only"
+        )
+    if parsed.query:
+        raise ValueError(
+            f"allowed_endpoints entry {entry!r} must not include a query "
+            f"string ({parsed.query!r}); specify the hostname only"
+        )
+    if parsed.fragment:
+        raise ValueError(
+            f"allowed_endpoints entry {entry!r} must not include a fragment "
+            f"({parsed.fragment!r}); specify the hostname only"
+        )
+    return hostname.lower()
+
+
+def host_matches_allowlist(
+    host: Any,
+    allowed_endpoints: list[str] | tuple[str, ...] | None,
+) -> bool:
+    """Return ``True`` iff *host* is permitted by the endpoint allowlist.
+
+    A host matches when it exactly equals an allowlist entry or is a subdomain
+    of one (e.g. ``api.foo.com`` for a ``foo.com`` entry).  Comparison is
+    case-insensitive: both sides are lowercased so a mixed-case request host
+    matches a canonical (lowercase) entry even if the entry was supplied
+    directly (bypassing the manifest validator).
+
+    With an empty allowlist (no network declared) every host is rejected —
+    matching the ``SandboxedHttpClient`` semantics where an empty whitelist
+    blocks all network access.
+    """
+    if not allowed_endpoints:
+        return False
+    if host is None:
+        return False
+    name = str(host).lower()
+    if not name:
+        return False
+    return any(
+        name == ep.lower() or name.endswith(f".{ep.lower()}")
+        for ep in allowed_endpoints
+    )
+
 
 
 class ResourceLimits(BaseModel):
@@ -20,6 +121,19 @@ class ResourceLimits(BaseModel):
 
 class NetworkConfig(BaseModel):
     allowed_endpoints: list[str] = Field(default_factory=list)
+
+    @field_validator("allowed_endpoints", mode="after")
+    @classmethod
+    def _normalize_allowed_endpoints(cls, value: list[str]) -> list[str]:
+        """Normalise every endpoint to a bare, lowercase hostname at load time.
+
+        This is the single chokepoint where manifest-declared endpoints are
+        canonicalised *before* they reach the sandbox's host-allowlist.  Doing
+        it here (rather than ad hoc at each enforcement site) guarantees that
+        every matcher — ``RestrictedImporter``, ``SandboxedHttpClient`` and the
+        httpx ``send`` hook — compares against identical, well-formed values.
+        """
+        return [normalize_endpoint(ep) for ep in value]
 
 
 class StrategyManifest(BaseModel):

--- a/engine/plugins/restricted_importer.py
+++ b/engine/plugins/restricted_importer.py
@@ -31,6 +31,7 @@ from importlib.abc import MetaPathFinder
 from typing import TYPE_CHECKING, Any
 
 from engine.plugins.allowlist import DENYLIST_MODULES, FROZEN_ALLOWED_MODULES
+from engine.plugins.manifest import host_matches_allowlist
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -258,23 +259,17 @@ class RestrictedImporter(MetaPathFinder):
     def _is_host_allowed(self, host: Any) -> bool:
         """Return ``True`` iff *host* is permitted by the hostname allowlist.
 
-        Uses the same endpoint-matching logic as
-        :class:`~engine.plugins.sandboxed_http.SandboxedHttpClient` and the
-        httpx ``send`` hook: a host is allowed if it exactly matches an entry
-        in :attr:`allowed_hosts` or is a subdomain of one
-        (``api.foo.com`` for a ``foo.com`` entry).  With an empty allowlist
-        (no network declared) every host is rejected — matching the
-        ``SandboxedHttpClient`` semantics where an empty whitelist blocks all
-        network access.
+        Delegates to :func:`engine.plugins.manifest.host_matches_allowlist`
+        so the endpoint-matching logic is identical across every enforcement
+        site (``RestrictedImporter``, ``SandboxedHttpClient`` and the httpx
+        ``send`` hook).  A host is allowed if it exactly matches an entry in
+        :attr:`allowed_hosts` or is a subdomain of one
+        (``api.foo.com`` for a ``foo.com`` entry), compared case-insensitively.
+        With an empty allowlist (no network declared) every host is rejected
+        — matching the ``SandboxedHttpClient`` semantics where an empty
+        whitelist blocks all network access.
         """
-        if not self.allowed_hosts:
-            return False
-        if host is None:
-            return False
-        name = str(host)
-        if not name:
-            return False
-        return any(name == ep or name.endswith(f".{ep}") for ep in self.allowed_hosts)
+        return host_matches_allowlist(host, self.allowed_hosts)
 
     def _restricted_getaddrinfo(self, host: Any, *args: Any, **kwargs: Any) -> Any:
         """Hostname-allowlist guard wrapped around ``socket.getaddrinfo``.

--- a/engine/plugins/sandbox.py
+++ b/engine/plugins/sandbox.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from engine.core.signal import Signal
+from engine.plugins.manifest import host_matches_allowlist
 from engine.plugins.restricted_importer import RestrictedImporter
 from engine.plugins.sandboxed_http import SandboxedHttpClient
 
@@ -393,7 +394,7 @@ class StrategySandbox:
             if not _in_sandbox_execution.get(False):
                 return await original_send(client, request, stream=stream, **kwargs)
             host = request.url.host
-            if not any(host == ep or host.endswith(f".{ep}") for ep in allowed):
+            if not host_matches_allowlist(host, allowed):
                 raise PermissionError(f"Network access to {host} is not allowed")
             return await original_send(client, request, stream=stream, **kwargs)
 

--- a/engine/plugins/sandboxed_http.py
+++ b/engine/plugins/sandboxed_http.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import httpx
 
+from engine.plugins.manifest import host_matches_allowlist
+
 
 class SandboxedHttpClient(httpx.AsyncClient):
     """HTTP client that only allows requests to whitelisted hosts."""
@@ -25,6 +27,6 @@ class SandboxedHttpClient(httpx.AsyncClient):
         **kwargs: object,
     ) -> httpx.Response:
         host = request.url.host
-        if not any(host == ep or host.endswith(f".{ep}") for ep in self.allowed_endpoints):
+        if not host_matches_allowlist(host, self.allowed_endpoints):
             raise PermissionError(f"Network access to {host} is not allowed")
         return await super().send(request, stream=stream, **kwargs)  # type: ignore[arg-type]

--- a/tests/test_sandbox_security.py
+++ b/tests/test_sandbox_security.py
@@ -25,7 +25,10 @@ import httpx
 import pytest
 
 from engine.core.signal import Signal
-from engine.plugins.manifest import StrategyManifest
+from engine.plugins.manifest import (
+    NetworkConfig,
+    StrategyManifest,
+)
 from engine.plugins.restricted_importer import (
     _INTERNAL_BYPASS_MODULES,
     BLOCKED_MODULES,
@@ -444,6 +447,52 @@ class TestGetaddrinfoGuard:
         importer.uninstall()
         assert socket.getaddrinfo is real_original
 
+    def test_is_host_allowed_rejects_when_allowlist_empty(self) -> None:
+        """An empty allowlist rejects every host (covers the empty-list branch)."""
+        importer = RestrictedImporter()  # no allowed_hosts -> empty allowlist
+        assert importer.allowed_hosts == []
+        assert importer._is_host_allowed("api.anthropic.com") is False
+
+    def test_is_host_allowed_rejects_none_host(self) -> None:
+        """``None`` host is rejected before any string comparison (None branch)."""
+        importer = RestrictedImporter(allowed_hosts=["api.anthropic.com"])
+        assert importer._is_host_allowed(None) is False
+
+    def test_is_host_allowed_rejects_empty_host(self) -> None:
+        """An empty-string host is rejected (empty-name branch)."""
+        importer = RestrictedImporter(allowed_hosts=["api.anthropic.com"])
+        assert importer._is_host_allowed("") is False
+
+    def test_is_host_allowed_is_case_insensitive(self) -> None:
+        """Mixed-case request hosts match a canonical lowercase entry."""
+        importer = RestrictedImporter(allowed_hosts=["api.anthropic.com"])
+        # Exact match, differing only by case.
+        assert importer._is_host_allowed("API.ANTHROPIC.COM") is True
+        # Subdomain match, differing only by case.
+        assert importer._is_host_allowed("V2.Api.Anthropic.Com") is True
+        # A mixed-case *entry* still matches a lowercase host (defence for
+        # callers that bypass the manifest validator).
+        mixed = RestrictedImporter(allowed_hosts=["API.Anthropic.Com"])
+        assert mixed._is_host_allowed("api.anthropic.com") is True
+
+    def test_getaddrinfo_raises_when_original_not_captured(self) -> None:
+        """``_restricted_getaddrinfo`` raises if ``_original_getaddrinfo`` is None.
+
+        This branch is unreachable in normal operation (``install()`` captures
+        the original first) but is guarded defensively.  Exercise it directly
+        by clearing the captured original while still passing an allowlisted
+        host so the hostname check succeeds and the delegation guard runs.
+        """
+        importer = RestrictedImporter(allowed_hosts=["api.anthropic.com"])
+        # Force the delegation-guard branch: host is allowed, but there is no
+        # captured original to delegate to.
+        importer._original_getaddrinfo = None
+        with pytest.raises(
+            ConnectionError,
+            match=r"no original getaddrinfo to delegate to",
+        ):
+            importer._restricted_getaddrinfo("api.anthropic.com", 443)
+
 
 class TestPurgeNonAllowlisted:
     """Cover ``RestrictedImporter.purge_non_allowlisted`` (lines 201-208).
@@ -688,6 +737,32 @@ class TestSandboxedHttpClient:
             request = httpx.Request("GET", "https://api.anthropic.com/v1/models")
             with pytest.raises(PermissionError):
                 await client.send(request)
+
+    async def test_mixed_case_host_matches_at_runtime(self) -> None:
+        """A manifest-canonicalised (lowercase) entry matches an uppercase host.
+
+        ``NetworkConfig`` normalises entries to lowercase hostnames at load
+        time; the runtime matcher must therefore be case-insensitive so a
+        request whose URL host happens to be upper-case still matches.
+        """
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(str(request.url))
+            return httpx.Response(200, json={"status": "ok"})
+
+        config = NetworkConfig(allowed_endpoints=["API.Anthropic.COM"])
+        client = SandboxedHttpClient(
+            allowed_endpoints=config.allowed_endpoints,
+            transport=httpx.MockTransport(handler),
+        )
+        async with client:
+            # Entry canonicalised to lowercase at load time.
+            assert config.allowed_endpoints == ["api.anthropic.com"]
+            # Upper-case host still matches at runtime.
+            response = await client.get("https://API.ANTHROPIC.COM/v1/models")
+            assert response.status_code == 200
+        assert seen, "request should have reached the handler"
 
     async def test_sandbox_creates_http_client_when_manifest_has_endpoints(
         self, networked_manifest: StrategyManifest


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix the 3 review findings in engine/plugins/sandbox.py _extract_hostnames: (1) silently broadening allowlist by discarding port/path, (2) schemeless URL handling inconsistency, (3) case-normalization inconsistency for bare hostnames

Closes #1076
