### PR TITLE
fix(observability): use raw-ASGI middleware for correlation context

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -307,6 +307,13 @@ def create_app() -> FastAPI:
     # is generous for every existing route and still well under the
     # log-bombing limits the per-route Pydantic models impose.
     app.add_middleware(BodySizeLimitMiddleware, max_bytes=1_048_576)
+    # Raw ASGI correlation middleware — the default for both HTTP and
+    # WebSocket protocols. Unlike the BaseHTTPMiddleware variant (kept in
+    # engine.middleware.correlation for deployments that prefer it), this
+    # one reads the inbound id from WS handshake headers too, binds it into
+    # structlog contextvars + the legacy observability context, and keeps
+    # the binding live for the full request lifecycle including background
+    # tasks (its __call__ only returns after they finish).
     app.add_middleware(CorrelationIdMiddleware)
     # Stack order matters — HttpMetricsMiddleware is added last so it
     # wraps everything else and times the full request lifecycle. The

--- a/engine/middleware/__init__.py
+++ b/engine/middleware/__init__.py
@@ -1,0 +1,10 @@
+"""HTTP / ASGI middleware packages for the Nexus engine API."""
+
+from __future__ import annotations
+
+from engine.middleware.correlation import (
+    CORRELATION_HEADER,
+    CorrelationIdMiddleware,
+)
+
+__all__ = ["CORRELATION_HEADER", "CorrelationIdMiddleware"]

--- a/engine/middleware/correlation.py
+++ b/engine/middleware/correlation.py
@@ -1,0 +1,138 @@
+"""FastAPI/Starlette correlation-id middleware.
+
+This module hosts the :class:`CorrelationIdMiddleware` built on Starlette's
+:class:`~starlette.middleware.base.BaseHTTPMiddleware`. It is kept for
+deployments that prefer the ``Request``/``call_next`` dispatch style and
+the ergonomic response-header mutation it enables.
+
+A second, lower-level implementation — the **raw-ASGI** middleware in
+:mod:`engine.observability.middleware` — is the one the app factory
+(:func:`engine.app.create_app`) registers by default. The two variants are
+both exported from this package so callers can discover them in one place:
+
+* :class:`engine.middleware.correlation.CorrelationIdMiddleware` —
+  ``BaseHTTPMiddleware`` based; HTTP only.
+* :class:`engine.observability.middleware.CorrelationIdMiddleware` —
+  raw ASGI; handles both HTTP and WebSocket and preserves the correlation
+  binding for the full request lifecycle (streaming responses and
+  ``BackgroundTasks``). This is the recommended default.
+
+A thin ``BaseHTTPMiddleware`` that gives every HTTP request a single
+``X-Correlation-Id`` and threads it through every observable channel:
+
+1. **Read or generate.** The id is taken from the incoming
+   ``X-Correlation-Id`` header when the client supplied a *safe* value,
+   otherwise a fresh UUID4 is minted. Untrusted values (CRLF, control
+   chars, non-ASCII, oversized) are discarded and regenerated to prevent
+   response-splitting / header-smuggling attacks. The hardening lives in
+   :func:`engine.observability.middleware._safe_correlation_id`, shared
+   with the raw-ASGI middleware so both transports apply identical rules.
+
+2. **structlog context.** The id is bound to the *structlog* context via
+   :func:`structlog.contextvars.bind_contextvars` so every log record
+   produced while handling the request carries ``correlation_id``
+   (structlog is wired up with ``merge_contextvars`` in
+   :mod:`engine.observability.logging`). A per-request ``request_id`` is
+   bound alongside so a single causal chain can still be split into its
+   individual HTTP requests.
+
+3. **Legacy observability context.** The same triple (correlation id,
+   request id, span id) is mirrored onto :mod:`engine.observability.context`
+   so existing integrations keep working without changes:
+
+   * :mod:`engine.observability.http_client` injects ``X-Correlation-Id``
+     on outbound calls.
+   * :mod:`engine.api.rate_limit` tags rate-limit rejections.
+   * :mod:`engine.observability.taskiq_middleware` propagates the id into
+     background tasks.
+   * the ``add_correlation_context`` structlog processor enriches records.
+
+4. **Response header.** The id is echoed back on the outbound
+   ``X-Correlation-Id`` header so callers can correlate client-side and
+   server-side logs.
+
+Both context bindings are reset in a ``finally`` block so nothing leaks
+between requests that happen to share a task context (notably in tests).
+
+Note: the raw-ASGI variant additionally covers WebSocket connections and
+``BackgroundTasks`` (whose log lines would otherwise be emitted after this
+middleware has reset its bindings), which is why it is the default in
+:func:`engine.app.create_app`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from engine.observability import context as ctx
+from engine.observability.middleware import (
+    CORRELATION_HEADER,
+    _safe_correlation_id,
+)
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+    from starlette.responses import Response
+    from starlette.types import ASGIApp
+
+__all__ = ["CORRELATION_HEADER", "CorrelationIdMiddleware"]
+
+
+def _new_span_id() -> str:
+    """Short, unique-per-request span id (matches the raw-ASGI middleware)."""
+    return uuid.uuid4().hex[:16]
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Bind an ``X-Correlation-Id`` to structlog + observability context.
+
+    HTTP-only. For WebSocket connections and ``BackgroundTasks`` use the
+    raw-ASGI :class:`engine.observability.middleware.CorrelationIdMiddleware`
+    instead — it is the default registered by the app factory.
+
+    Parameters
+    ----------
+    app:
+        The wrapped ASGI application.
+    header_name:
+        Header used to read the incoming id and write the outgoing one.
+        Defaults to ``X-Correlation-Id``. HTTP headers are case-insensitive
+        so this interoperates with callers that send ``X-Correlation-ID``.
+    """
+
+    def __init__(self, app: ASGIApp, header_name: str = CORRELATION_HEADER) -> None:
+        super().__init__(app)
+        self.header_name = header_name
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        correlation_id = _safe_correlation_id(request.headers.get(self.header_name))
+        request_id = uuid.uuid4().hex
+        span_id = _new_span_id()
+
+        structlog_tokens = structlog.contextvars.bind_contextvars(
+            correlation_id=correlation_id,
+            request_id=request_id,
+        )
+
+        context_tokens = ctx.bind_request_scope(
+            correlation_id=correlation_id,
+            request_id=request_id,
+            span_id=span_id,
+        )
+
+        try:
+            response = await call_next(request)
+        finally:
+            # NOTE: reset happens before BackgroundTasks execute because
+            # BaseHTTPMiddleware runs them in a separate context. For
+            # correlation on background task log lines, use the raw-ASGI
+            # middleware (the app default) instead.
+            structlog.contextvars.reset_contextvars(**structlog_tokens)
+            ctx.reset_tokens(context_tokens)
+
+        response.headers[self.header_name] = correlation_id
+        return response

--- a/engine/observability/middleware.py
+++ b/engine/observability/middleware.py
@@ -1,13 +1,37 @@
 """ASGI middleware that binds a per-request correlation id + request id.
 
-Reads ``X-Correlation-Id`` from the incoming request or generates a fresh
-UUID4. The outbound response carries the same header. Each request gets a
-distinct ``request_id`` so a single causal chain (one correlation id) can
-span multiple HTTP requests while still being individually identifiable.
+Reads ``X-Correlation-Id`` from the incoming HTTP request *or* the
+WebSocket handshake headers, generating a fresh UUID4 when the client did
+not supply a safe value. The outbound HTTP response carries the same
+header; WebSocket frames have no per-message header channel, so for WS
+connections the id is bound into the observability context for the full
+connection lifecycle and the client correlates via its own inbound value
+plus the server-side logs.
+
+Each request/connection gets a distinct ``request_id`` so a single causal
+chain (one correlation id) can span multiple HTTP requests while still
+being individually identifiable.
 
 This is a raw ASGI middleware (not a Starlette ``BaseHTTPMiddleware``) so
+that it transparently handles both HTTP and WebSocket protocols and so
 that streaming responses and ``BackgroundTasks`` continue to see the
 bound correlation id while their generators / callbacks run.
+``BaseHTTPMiddleware`` wraps the downstream app in a separate task and
+resets its contextvars before background tasks execute; a raw middleware
+does not, because its ``__call__`` only returns once the downstream app
+(including background tasks) has finished.
+
+The correlation id is bound to *both* observability channels:
+
+* **structlog context** via :func:`structlog.contextvars.bind_contextvars`
+  (merged into every record by ``merge_contextvars`` in
+  :mod:`engine.observability.logging`); and
+* **legacy observability context** via
+  :func:`engine.observability.context.bind_request_scope`, which is read
+  by the outbound HTTP client (:mod:`engine.observability.http_client`),
+  the rate limiter (:mod:`engine.api.rate_limit`), the taskiq middleware
+  (:mod:`engine.observability.taskiq_middleware`) and the
+  ``add_correlation_context`` structlog processor.
 """
 
 from __future__ import annotations
@@ -15,6 +39,8 @@ from __future__ import annotations
 import re
 import uuid
 from typing import TYPE_CHECKING
+
+import structlog
 
 from engine.observability import context as ctx
 
@@ -28,6 +54,10 @@ MAX_CORRELATION_ID_LENGTH = 128
 # (terminal-control corruption), non-ASCII (header smuggling).
 _VALID_CORRELATION_ID = re.compile(r"^[\x21-\x7e]{1,128}$")
 
+# Scope types that carry HTTP-style headers we can read the incoming id
+# from. ``lifespan`` and other scope types are passed through untouched.
+_HANDLED_SCOPES = frozenset({"http", "websocket"})
+
 
 def _safe_correlation_id(raw: str | None) -> str:
     """Return a safe correlation id: the raw value if it passes validation,
@@ -37,10 +67,25 @@ def _safe_correlation_id(raw: str | None) -> str:
     return str(uuid.uuid4())
 
 
+def _read_header(scope: Scope, name_bytes: bytes) -> str | None:
+    """Return the first value of a (lower-cased) header name, or ``None``."""
+    for raw_name, raw_value in scope.get("headers", []):
+        if raw_name == name_bytes:
+            try:
+                return raw_value.decode("latin-1")
+            except UnicodeDecodeError:
+                return None
+    return None
+
+
 class CorrelationIdMiddleware:
-    """Raw ASGI middleware. Each request runs in its own asyncio task and
-    therefore its own contextvars copy — there is no need to clear the
-    bound values; they go out of scope when the task finishes."""
+    """Raw ASGI middleware handling both HTTP and WebSocket connections.
+
+    Each request/connection runs in its own asyncio task and therefore its
+    own contextvars copy — bindings go out of scope when the task ends, so
+    there is no cross-request leakage. The explicit ``finally`` reset is
+    kept so inlined-caller tests (which reuse a single task) stay clean.
+    """
 
     def __init__(self, app: ASGIApp, header_name: str = CORRELATION_HEADER) -> None:
         self.app = app
@@ -48,27 +93,32 @@ class CorrelationIdMiddleware:
         self._header_name_bytes = header_name.lower().encode("latin-1")
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
+        if scope["type"] not in _HANDLED_SCOPES:
             await self.app(scope, receive, send)
             return
 
-        incoming: str | None = None
-        for raw_name, raw_value in scope.get("headers", []):
-            if raw_name == self._header_name_bytes:
-                try:
-                    incoming = raw_value.decode("latin-1")
-                except UnicodeDecodeError:
-                    incoming = None
-                break
+        cid = _safe_correlation_id(_read_header(scope, self._header_name_bytes))
+        request_id = uuid.uuid4().hex
+        span_id = uuid.uuid4().hex[:16]
 
-        cid = _safe_correlation_id(incoming)
-        tokens = ctx.bind_request_scope(
+        # structlog channel — merged into every record via merge_contextvars.
+        structlog_tokens = structlog.contextvars.bind_contextvars(
             correlation_id=cid,
-            request_id=uuid.uuid4().hex,
-            span_id=uuid.uuid4().hex[:16],
+            request_id=request_id,
+        )
+        # Legacy observability channel — read by the http client, rate
+        # limiter, taskiq middleware and the add_correlation_context
+        # structlog processor.
+        context_tokens = ctx.bind_request_scope(
+            correlation_id=cid,
+            request_id=request_id,
+            span_id=span_id,
         )
 
         async def send_wrapper(message: Message) -> None:
+            # Only HTTP responses carry a start line with headers we can
+            # extend to echo the id back. WebSocket frames have no such
+            # header channel; the client correlates via its inbound value.
             if message["type"] == "http.response.start":
                 headers = list(message.get("headers", []))
                 headers.append((self._header_name_bytes, cid.encode("latin-1")))
@@ -78,10 +128,12 @@ class CorrelationIdMiddleware:
         try:
             await self.app(scope, receive, send_wrapper)
         finally:
-            # By the time `await self.app(...)` returns, all body chunks
-            # have been sent — including streaming responses. Reset is
-            # therefore safe and prevents leakage in inlined-caller tests.
-            ctx.reset_tokens(tokens)
+            # `await self.app(...)` only returns after the response body
+            # AND any BackgroundTasks have completed, so resetting here
+            # keeps the bindings live for the full request lifecycle —
+            # including background task log lines.
+            structlog.contextvars.reset_contextvars(**structlog_tokens)
+            ctx.reset_tokens(context_tokens)
 
 
 __all__ = ["CORRELATION_HEADER", "CorrelationIdMiddleware", "_safe_correlation_id"]

--- a/tests/observability/test_correlation_lifecycle.py
+++ b/tests/observability/test_correlation_lifecycle.py
@@ -1,0 +1,216 @@
+"""Lifecycle tests for the raw-ASGI ``CorrelationIdMiddleware``.
+
+These cover the requirements that the *default* (raw-ASGI) middleware:
+
+* binds ``correlation_id`` / ``request_id`` into the structlog contextvars
+  (not just the legacy observability context) so records rendered via
+  ``merge_contextvars`` carry them;
+* handles **WebSocket** connections — reading the id from the handshake
+  headers and binding it for the full connection lifecycle; and
+* keeps the binding live for **BackgroundTasks**, so log lines emitted by
+  a background callback carry the originating ``correlation_id``.
+
+The ``BaseHTTPMiddleware`` variant (:mod:`engine.middleware.correlation`)
+fails the last two cases by construction, which is exactly why the raw-ASGI
+middleware is the default registered by ``create_app``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+import structlog
+from fastapi import BackgroundTasks, FastAPI, WebSocket
+from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
+
+from engine.observability import context as ctx
+from engine.observability.middleware import CorrelationIdMiddleware
+
+
+def _build_http_app(captured: dict[str, Any] | None = None) -> FastAPI:
+    """App exposing endpoints that report the live correlation bindings."""
+    app = FastAPI()
+    app.add_middleware(CorrelationIdMiddleware)
+
+    @app.get("/inspect")
+    async def inspect() -> dict:
+        return {
+            "ctx_cid": ctx.get_correlation_id(),
+            "ctx_rid": ctx.get_request_id(),
+            # structlog contextvars — must be bound by the raw-ASGI middleware.
+            "structlog_cid": structlog.contextvars.get_contextvars().get(
+                "correlation_id"
+            ),
+            "structlog_rid": structlog.contextvars.get_contextvars().get(
+                "request_id"
+            ),
+        }
+
+    @app.get("/background")
+    async def with_background(background_tasks: BackgroundTasks) -> dict:
+        async def _bg() -> None:
+            # Runs *after* the response is sent. The raw-ASGI middleware
+            # has not reset yet (its __call__ is still awaiting the app),
+            # so both channels must still carry the correlation id.
+            assert captured is not None
+            captured["bg_ctx_cid"] = ctx.get_correlation_id()
+            captured["bg_structlog_cid"] = structlog.contextvars.get_contextvars().get(
+                "correlation_id"
+            )
+
+        background_tasks.add_task(_bg)
+        return {"ok": True}
+
+    return app
+
+
+def _build_ws_app() -> FastAPI:
+    """App exposing a WS endpoint that reports the bound correlation id."""
+    app = FastAPI()
+    app.add_middleware(CorrelationIdMiddleware)
+
+    @app.websocket("/ws")
+    async def ws_endpoint(ws: WebSocket) -> None:
+        await ws.accept()
+        await ws.send_json(
+            {
+                "ctx_cid": ctx.get_correlation_id(),
+                "structlog_cid": structlog.contextvars.get_contextvars().get(
+                    "correlation_id"
+                ),
+            }
+        )
+        await ws.close()
+
+    return app
+
+
+@pytest.fixture
+async def http_client():
+    app = _build_http_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestStructlogContextvarsBinding:
+    """The raw-ASGI middleware must bind structlog contextvars (parity with
+    the BaseHTTPMiddleware variant), in addition to the legacy ctx."""
+
+    async def test_header_propagates_into_structlog_contextvars(
+        self, http_client: AsyncClient
+    ):
+        cid = "structlog-binding-abc-123"
+        resp = await http_client.get("/inspect", headers={"X-Correlation-Id": cid})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["structlog_cid"] == cid
+        assert body["ctx_cid"] == cid
+
+    async def test_generated_id_is_bound_to_structlog_contextvars(
+        self, http_client: AsyncClient
+    ):
+        resp = await http_client.get("/inspect")
+        body = resp.json()
+        # Must be a valid uuid4 (generated, not inherited).
+        uuid.UUID(body["structlog_cid"])
+        assert body["structlog_cid"] == body["ctx_cid"]
+
+    async def test_request_id_bound_to_both_channels(
+        self, http_client: AsyncClient
+    ):
+        resp = await http_client.get("/inspect")
+        body = resp.json()
+        assert body["structlog_rid"] is not None
+        assert body["structlog_rid"] == body["ctx_rid"]
+
+    async def test_structlog_contextvars_reset_after_request(
+        self, http_client: AsyncClient
+    ):
+        await http_client.get("/inspect", headers={"X-Correlation-Id": "leak-abc"})
+        # No leakage into the outer (test) task.
+        assert structlog.contextvars.get_contextvars().get("correlation_id") is None
+        assert ctx.get_correlation_id() is None
+
+
+class TestBackgroundTaskCorrelation:
+    """Background tasks run after the response is sent; the raw-ASGI
+    middleware must keep the binding live so their log lines carry the
+    originating correlation id."""
+
+    async def test_background_task_carries_correlation_id(self):
+        captured: dict[str, Any] = {}
+        app = _build_http_app(captured)
+        transport = ASGITransport(app=app)
+        cid = "bg-task-correlation-id"
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/background", headers={"X-Correlation-Id": cid})
+            assert resp.status_code == 200
+
+        # Background task ran within the awaited app call; both channels
+        # observed the request-scoped correlation id.
+        assert captured.get("bg_ctx_cid") == cid
+        assert captured.get("bg_structlog_cid") == cid
+
+    async def test_background_task_correlation_with_generated_id(self):
+        captured: dict[str, Any] = {}
+        app = _build_http_app(captured)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/background")
+            assert resp.status_code == 200
+
+        bg_cid = captured.get("bg_ctx_cid")
+        assert bg_cid is not None
+        uuid.UUID(bg_cid)  # well-formed generated id
+        assert captured.get("bg_structlog_cid") == bg_cid
+
+
+class TestWebSocketCorrelation:
+    """WebSocket connections must receive correlation-id propagation from
+    the handshake headers — the HTTP-only ``BaseHTTPMiddleware`` variant
+    cannot do this, which is why the raw-ASGI middleware is the default."""
+
+    def test_websocket_reads_correlation_header(self):
+        app = _build_ws_app()
+        cid = "ws-handshake-correlation-id"
+        client = TestClient(app)
+        with client.websocket_connect("/ws", headers={"X-Correlation-Id": cid}) as ws:
+            data = ws.receive_json()
+        assert data["ctx_cid"] == cid
+        assert data["structlog_cid"] == cid
+
+    def test_websocket_generates_id_when_header_missing(self):
+        app = _build_ws_app()
+        client = TestClient(app)
+        with client.websocket_connect("/ws") as ws:
+            data = ws.receive_json()
+        # Generated id, present on both channels and identical.
+        assert data["ctx_cid"] is not None
+        uuid.UUID(data["ctx_cid"])
+        assert data["structlog_cid"] == data["ctx_cid"]
+
+    def test_websocket_unsafe_header_is_replaced(self):
+        app = _build_ws_app()
+        client = TestClient(app)
+        # Control characters / oversized values must be discarded and
+        # regenerated rather than echoed verbatim.
+        with client.websocket_connect(
+            "/ws", headers={"X-Correlation-Id": "x" * 10_000}
+        ) as ws:
+            data = ws.receive_json()
+        assert data["ctx_cid"] is not None
+        assert len(data["ctx_cid"]) <= 128
+
+    def test_websocket_context_reset_after_disconnect(self):
+        app = _build_ws_app()
+        client = TestClient(app)
+        with client.websocket_connect(
+            "/ws", headers={"X-Correlation-Id": "ws-leak-check"}
+        ):
+            pass
+        # The WS connection's bindings must not leak into the next client.
+        assert ctx.get_correlation_id() is None


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Fix high-severity review findings in engine/middleware/correlation.py: switch default registration from BaseHTTPMiddleware to raw-ASGI variant so WebSocket upgrades and streaming responses get correlation IDs, and ensure BackgroundTasks retain structlog contextvars

Closes #1086
