### PR TITLE
fix(middleware): resolve CorrelationIdMiddleware naming collision

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -308,6 +308,22 @@ def create_app() -> FastAPI:
     # log-bombing limits the per-route Pydantic models impose.
     app.add_middleware(BodySizeLimitMiddleware, max_bytes=1_048_576)
     app.add_middleware(CorrelationIdMiddleware)
+    # Class-identity guard: the app factory MUST register the raw-ASGI
+    # CorrelationIdMiddleware. The BaseHTTPMiddleware-based variant
+    # (``BaseHTTPCorrelationIdMiddleware``) resets its structlog /
+    # observability context bindings before streaming responses and
+    # BackgroundTasks finish, which would leak and unbind ids, so it must
+    # never be the default. Any future change that re-points the import at
+    # a BaseHTTPMiddleware subclass trips this assertion immediately.
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    from engine.middleware.correlation import BaseHTTPCorrelationIdMiddleware
+
+    assert CorrelationIdMiddleware is not BaseHTTPCorrelationIdMiddleware
+    assert not issubclass(CorrelationIdMiddleware, BaseHTTPMiddleware), (
+        "create_app() must register the raw-ASGI CorrelationIdMiddleware "
+        "(engine.observability.middleware), not a BaseHTTPMiddleware variant"
+    )
     # Stack order matters — HttpMetricsMiddleware is added last so it
     # wraps everything else and times the full request lifecycle. The
     # /metrics route itself is included so operators can monitor scrape

--- a/engine/middleware/__init__.py
+++ b/engine/middleware/__init__.py
@@ -1,0 +1,27 @@
+"""HTTP / ASGI middleware packages for the Nexus engine API.
+
+The default ``CorrelationIdMiddleware`` exported from this package is the
+**raw-ASGI** variant (:class:`engine.observability.middleware.CorrelationIdMiddleware`),
+which is what :func:`engine.app.create_app` registers. The older
+``BaseHTTPMiddleware``-based implementation is available as
+:class:`engine.middleware.correlation.BaseHTTPCorrelationIdMiddleware`.
+
+The previous ``CorrelationIdMiddleware`` name that lived in
+:mod:`engine.middleware.correlation` is kept as a deprecated alias for one
+release cycle (it now refers to the ``BaseHTTPMiddleware`` variant and emits
+a :class:`DeprecationWarning` when accessed).
+"""
+
+from __future__ import annotations
+
+from engine.middleware.correlation import (
+    CORRELATION_HEADER,
+    BaseHTTPCorrelationIdMiddleware,
+)
+from engine.observability.middleware import CorrelationIdMiddleware
+
+__all__ = [
+    "CORRELATION_HEADER",
+    "BaseHTTPCorrelationIdMiddleware",
+    "CorrelationIdMiddleware",
+]

--- a/engine/middleware/correlation.py
+++ b/engine/middleware/correlation.py
@@ -1,0 +1,169 @@
+"""FastAPI/Starlette correlation-id middleware (BaseHTTPMiddleware variant).
+
+This module hosts :class:`BaseHTTPCorrelationIdMiddleware`, built on
+Starlette's :class:`~starlette.middleware.base.BaseHTTPMiddleware`. It is
+kept for deployments that prefer the ``Request``/``call_next`` dispatch
+style and the ergonomic response-header mutation it enables.
+
+A second, lower-level implementation -- the **raw-ASGI** middleware in
+:mod:`engine.observability.middleware` -- is the one the app factory
+(:func:`engine.app.create_app`) registers by default. The two variants are
+both exported from the :mod:`engine.middleware` package so callers can
+discover them in one place:
+
+* :class:`engine.middleware.correlation.BaseHTTPCorrelationIdMiddleware` --
+  ``BaseHTTPMiddleware`` based; HTTP only.
+* :class:`engine.observability.middleware.CorrelationIdMiddleware` -- raw
+  ASGI; handles both HTTP and WebSocket and preserves the correlation
+  binding for the full request lifecycle (streaming responses and
+  ``BackgroundTasks``). This is the recommended default, re-exported as the
+  bare ``CorrelationIdMiddleware`` name from :mod:`engine.middleware`.
+
+A thin ``BaseHTTPMiddleware`` that gives every HTTP request a single
+``X-Correlation-Id`` and threads it through every observable channel:
+
+1. **Read or generate.** The id is taken from the incoming
+   ``X-Correlation-Id`` header when the client supplied a *safe* value,
+   otherwise a fresh UUID4 is minted. Untrusted values (CRLF, control
+   chars, non-ASCII, oversized) are discarded and regenerated to prevent
+   response-splitting / header-smuggling attacks. The hardening lives in
+   :func:`engine.observability.middleware._safe_correlation_id`, shared
+   with the raw-ASGI middleware so both transports apply identical rules.
+
+2. **structlog context.** The id is bound to the *structlog* context via
+   :func:`structlog.contextvars.bind_contextvars` so every log record
+   produced while handling the request carries ``correlation_id``
+   (structlog is wired up with ``merge_contextvars`` in
+   :mod:`engine.observability.logging`). A per-request ``request_id`` is
+   bound alongside so a single causal chain can still be split into its
+   individual HTTP requests.
+
+3. **Legacy observability context.** The same triple (correlation id,
+   request id, span id) is mirrored onto :mod:`engine.observability.context`
+   so existing integrations keep working without changes:
+
+   * :mod:`engine.observability.http_client` injects ``X-Correlation-Id``
+     on outbound calls.
+   * :mod:`engine.api.rate_limit` tags rate-limit rejections.
+   * :mod:`engine.observability.taskiq_middleware` propagates the id into
+     background tasks.
+   * the ``add_correlation_context`` structlog processor enriches records.
+
+4. **Response header.** The id is echoed back on the outbound
+   ``X-Correlation-Id`` header so callers can correlate client-side and
+   server-side logs.
+
+Both context bindings are reset in a ``finally`` block so nothing leaks
+between requests that happen to share a task context (notably in tests).
+
+Note: the raw-ASGI variant additionally covers WebSocket connections and
+``BackgroundTasks`` (whose log lines would otherwise be emitted after this
+middleware has reset its bindings), which is why it is the default in
+:func:`engine.app.create_app`.
+
+Backward compatibility
+----------------------
+The previous name ``CorrelationIdMiddleware`` is retained here as a
+**deprecated alias** for :class:`BaseHTTPCorrelationIdMiddleware` for one
+release cycle. Importing or otherwise accessing it emits a
+:class:`DeprecationWarning`. It will be removed in the next release; switch
+to :class:`BaseHTTPCorrelationIdMiddleware` or the raw-ASGI
+:class:`engine.observability.middleware.CorrelationIdMiddleware`.
+"""
+
+from __future__ import annotations
+
+import uuid
+import warnings
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from engine.observability import context as ctx
+from engine.observability.middleware import CORRELATION_HEADER, _safe_correlation_id
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+    from starlette.responses import Response
+    from starlette.types import ASGIApp
+
+__all__ = ["CORRELATION_HEADER", "BaseHTTPCorrelationIdMiddleware"]
+
+
+def _new_span_id() -> str:
+    """Return a short, opaque span id derived from a fresh UUID4."""
+    return uuid.uuid4().hex[:16]
+
+
+class BaseHTTPCorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Bind an ``X-Correlation-Id`` to structlog + observability context.
+
+    HTTP-only. For WebSocket connections and ``BackgroundTasks`` use the
+    raw-ASGI :class:`engine.observability.middleware.CorrelationIdMiddleware`
+    instead -- it is the default registered by the app factory and the one
+    re-exported as ``CorrelationIdMiddleware`` from :mod:`engine.middleware`.
+
+    Parameters
+    ----------
+    app:
+        The wrapped ASGI application.
+    header_name:
+        Header used to read the incoming id and write the outgoing one.
+        Defaults to ``X-Correlation-Id``. HTTP headers are case-insensitive
+        so this interoperates with callers that send ``X-Correlation-ID``.
+    """
+
+    def __init__(self, app: ASGIApp, header_name: str = CORRELATION_HEADER) -> None:
+        super().__init__(app)
+        self.header_name = header_name
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        correlation_id = _safe_correlation_id(request.headers.get(self.header_name))
+        request_id = uuid.uuid4().hex
+        span_id = _new_span_id()
+
+        structlog_tokens = structlog.contextvars.bind_contextvars(
+            correlation_id=correlation_id,
+            request_id=request_id,
+        )
+
+        context_tokens = ctx.bind_request_scope(
+            correlation_id=correlation_id,
+            request_id=request_id,
+            span_id=span_id,
+        )
+
+        try:
+            response = await call_next(request)
+        finally:
+            structlog.contextvars.reset_contextvars(**structlog_tokens)
+            ctx.reset_tokens(context_tokens)
+
+        response.headers[self.header_name] = correlation_id
+        return response
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 module hook surfacing the deprecated alias for one release cycle.
+
+    Accessing ``engine.middleware.correlation.CorrelationIdMiddleware`` (the
+    old ``BaseHTTPMiddleware``-based name) emits a :class:`DeprecationWarning`
+    and returns :class:`BaseHTTPCorrelationIdMiddleware`. Use that class, or
+    the raw-ASGI :class:`engine.observability.middleware.CorrelationIdMiddleware`
+    (the app-factory default, re-exported as ``CorrelationIdMiddleware`` from
+    :mod:`engine.middleware`), instead. The alias will be removed in the next
+    release.
+    """
+    if name == "CorrelationIdMiddleware":
+        warnings.warn(
+            "engine.middleware.correlation.CorrelationIdMiddleware is "
+            "deprecated and will be removed in the next release. Use "
+            "BaseHTTPCorrelationIdMiddleware, or the raw-ASGI "
+            "CorrelationIdMiddleware from engine.observability.middleware "
+            "(re-exported from engine.middleware) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return BaseHTTPCorrelationIdMiddleware
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_middleware_correlation.py
+++ b/tests/test_middleware_correlation.py
@@ -1,0 +1,112 @@
+"""Tests for the engine.middleware correlation middleware refactor.
+
+Covers the rename of the ``BaseHTTPMiddleware``-based class to
+``BaseHTTPCorrelationIdMiddleware`` (with a deprecated alias for one release
+cycle), the ``engine.middleware`` package re-exporting the raw-ASGI variant
+as the default ``CorrelationIdMiddleware``, and the class-identity assertion
+in :func:`engine.app.create_app`.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from engine import middleware as mw_pkg
+from engine.app import create_app
+from engine.middleware import correlation as corr_module
+from engine.middleware.correlation import BaseHTTPCorrelationIdMiddleware
+from engine.observability import middleware as obs_middleware
+
+
+class TestPackageReexport:
+    """``engine.middleware`` must re-export the raw-ASGI variant as the
+    default ``CorrelationIdMiddleware``."""
+
+    def test_default_correlation_id_middleware_is_raw_asgi(self):
+        assert (
+            mw_pkg.CorrelationIdMiddleware is obs_middleware.CorrelationIdMiddleware
+        ), "engine.middleware.CorrelationIdMiddleware must be the raw-ASGI variant"
+
+    def test_default_is_not_base_http_subclass(self):
+        assert not issubclass(mw_pkg.CorrelationIdMiddleware, BaseHTTPMiddleware)
+
+    def test_base_http_variant_is_reexported(self):
+        assert mw_pkg.BaseHTTPCorrelationIdMiddleware is BaseHTTPCorrelationIdMiddleware
+        assert issubclass(
+            mw_pkg.BaseHTTPCorrelationIdMiddleware, BaseHTTPMiddleware
+        )
+
+    def test_all_exports(self):
+        for name in ("CORRELATION_HEADER", "BaseHTTPCorrelationIdMiddleware",
+                     "CorrelationIdMiddleware"):
+            assert name in mw_pkg.__all__
+
+
+class TestBaseHTTPClass:
+    def test_class_is_base_http_subclass(self):
+        assert issubclass(BaseHTTPCorrelationIdMiddleware, BaseHTTPMiddleware)
+
+    def test_not_in_all_as_deprecated_alias(self):
+        # The deprecated alias must not be advertised via __all__; only the
+        # new name is a supported public symbol of correlation.py.
+        assert "BaseHTTPCorrelationIdMiddleware" in corr_module.__all__
+        assert "CorrelationIdMiddleware" not in corr_module.__all__
+
+
+class TestDeprecatedAlias:
+    """``CorrelationIdMiddleware`` in ``engine.middleware.correlation`` is a
+    deprecated alias for ``BaseHTTPCorrelationIdMiddleware`` for one release
+    cycle."""
+
+    def test_alias_returns_base_http_class(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            alias = corr_module.CorrelationIdMiddleware
+        assert alias is BaseHTTPCorrelationIdMiddleware
+
+    def test_alias_emits_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match=r"CorrelationIdMiddleware is deprecated"):
+            _ = corr_module.CorrelationIdMiddleware
+
+    def test_import_emits_deprecation_warning(self):
+        import importlib
+
+        # ``from engine.middleware.correlation import CorrelationIdMiddleware``
+        # must trip the deprecation hook (PEP 562 __getattr__). Use the
+        # cached module (not reload) so the returned class identity matches
+        # the module's own BaseHTTPCorrelationIdMiddleware.
+        module = importlib.import_module("engine.middleware.correlation")
+        with pytest.warns(DeprecationWarning, match=r"CorrelationIdMiddleware is deprecated"):
+            cls = module.CorrelationIdMiddleware
+        assert cls is module.BaseHTTPCorrelationIdMiddleware
+
+    def test_unknown_attribute_still_raises(self):
+        with pytest.raises(AttributeError):
+            _ = corr_module.DefinitelyNotARealThing  # type: ignore[attr-defined]
+
+
+class TestCreateAppRegistersCorrectClass:
+    """The class-identity assertion in ``create_app`` must guarantee that the
+    raw-ASGI variant is what gets registered."""
+
+    @staticmethod
+    def _correlation_entry(app):
+        return next(
+            (m for m in app.user_middleware if "Correlation" in m.cls.__name__),
+            None,
+        )
+
+    def test_create_app_registers_raw_asgi_variant(self):
+        app = create_app()
+        entry = self._correlation_entry(app)
+        assert entry is not None, "a correlation middleware must be registered"
+        assert entry.cls is obs_middleware.CorrelationIdMiddleware
+        assert entry.cls is not BaseHTTPCorrelationIdMiddleware
+
+    def test_registered_class_is_not_base_http_subclass(self):
+        app = create_app()
+        entry = self._correlation_entry(app)
+        assert not issubclass(entry.cls, BaseHTTPMiddleware)


### PR DESCRIPTION
## Delivery

- Action: fix
- Target: Resolve critical CorrelationIdMiddleware naming collision: rename the BaseHTTPMiddleware variant in engine/middleware/correlation.py to BaseHTTPCorrelationIdMiddleware, update engine/middleware/__init__.py exports so only the recommended raw-ASGI class is exported as CorrelationIdMiddleware, and add a runtime class-identity guard in create_app() to prevent silent swap

Closes #1088
